### PR TITLE
fix(tests): resolve QA report naming violations

### DIFF
--- a/tests/loop_policy.rs
+++ b/tests/loop_policy.rs
@@ -9,11 +9,7 @@ use swink_agent::{
     ModelSpec, StopReason, SubAgent, Usage, stream::StreamFn,
 };
 
-use common::{MockStreamFn, MockTool, text_only_events, tool_call_events};
-
-fn test_model() -> ModelSpec {
-    ModelSpec::new("test", "test-model")
-}
+use common::{MockStreamFn, MockTool, default_model, text_only_events, tool_call_events};
 
 #[tokio::test]
 async fn max_turns_limits_agent_loop() {
@@ -29,7 +25,7 @@ async fn max_turns_limits_agent_loop() {
     let stream_fn: Arc<dyn StreamFn> = Arc::new(MockStreamFn::new(responses));
     let tool = Arc::new(MockTool::new("mock_tool"));
 
-    let options = AgentOptions::new_simple("test", test_model(), stream_fn)
+    let options = AgentOptions::new_simple("test", default_model(), stream_fn)
         .with_tools(vec![tool.clone()])
         .with_loop_policy(MaxTurnsPolicy::new(2));
 
@@ -102,7 +98,7 @@ async fn cost_cap_stops_agent() {
     let tool = Arc::new(MockTool::new("mock_tool"));
 
     // Cost cap at 0.01 — should allow ~2 turns (0.005 each)
-    let options = AgentOptions::new_simple("test", test_model(), stream_fn)
+    let options = AgentOptions::new_simple("test", default_model(), stream_fn)
         .with_tools(vec![tool.clone()])
         .with_loop_policy(CostCapPolicy::new(0.01));
 
@@ -133,7 +129,7 @@ async fn composed_policy_applies_all() {
         Box::new(CostCapPolicy::new(0.0)),
     ]);
 
-    let options = AgentOptions::new_simple("test", test_model(), stream_fn)
+    let options = AgentOptions::new_simple("test", default_model(), stream_fn)
         .with_tools(vec![tool.clone()])
         .with_loop_policy(policy);
 
@@ -162,11 +158,11 @@ async fn policy_with_sub_agent() {
     let sfn = sub_stream.clone();
     let sub = Arc::new(
         SubAgent::new("researcher", "Researcher", "Research sub-agent")
-            .with_options(move || AgentOptions::new_simple("sub", test_model(), Arc::clone(&sfn))),
+            .with_options(move || AgentOptions::new_simple("sub", default_model(), Arc::clone(&sfn))),
     );
 
     // Parent with max 3 turns
-    let options = AgentOptions::new_simple("parent", test_model(), parent_stream)
+    let options = AgentOptions::new_simple("parent", default_model(), parent_stream)
         .with_tools(vec![sub as Arc<dyn swink_agent::AgentTool>])
         .with_loop_policy(MaxTurnsPolicy::new(3));
 

--- a/tests/stream_middleware.rs
+++ b/tests/stream_middleware.rs
@@ -11,13 +11,9 @@ use tokio_util::sync::CancellationToken;
 use swink_agent::types::{AgentContext, Cost, ModelSpec, StopReason, Usage};
 use swink_agent::{AssistantMessageEvent, StreamMiddleware, StreamOptions, stream::StreamFn};
 
-use common::MockStreamFn;
+use common::{MockStreamFn, default_model};
 
-fn test_model() -> ModelSpec {
-    ModelSpec::new("test", "test-model")
-}
-
-fn test_context() -> AgentContext {
+fn empty_context() -> AgentContext {
     AgentContext {
         system_prompt: String::new(),
         messages: vec![],
@@ -39,8 +35,8 @@ async fn logging_middleware_receives_all_events() {
         count_clone.fetch_add(1, Ordering::SeqCst);
     });
 
-    let model = test_model();
-    let ctx = test_context();
+    let model = default_model();
+    let ctx = empty_context();
     let opts = StreamOptions::default();
     let ct = CancellationToken::new();
     let stream = mw.stream(&model, &ctx, &opts, ct);
@@ -64,8 +60,8 @@ async fn map_middleware_transforms_events() {
         other => other,
     });
 
-    let model = test_model();
-    let ctx = test_context();
+    let model = default_model();
+    let ctx = empty_context();
     let opts = StreamOptions::default();
     let ct = CancellationToken::new();
     let stream = mw.stream(&model, &ctx, &opts, ct);
@@ -114,8 +110,8 @@ async fn filter_middleware_drops_thinking_events() {
         )
     });
 
-    let model = test_model();
-    let ctx = test_context();
+    let model = default_model();
+    let ctx = empty_context();
     let opts = StreamOptions::default();
     let ct = CancellationToken::new();
     let stream = mw.stream(&model, &ctx, &opts, ct);
@@ -155,8 +151,8 @@ async fn middleware_chains_compose() {
         other => other,
     });
 
-    let model = test_model();
-    let ctx = test_context();
+    let model = default_model();
+    let ctx = empty_context();
     let opts = StreamOptions::default();
     let ct = CancellationToken::new();
     let stream = mapped.stream(&model, &ctx, &opts, ct);

--- a/tests/sub_agent.rs
+++ b/tests/sub_agent.rs
@@ -13,11 +13,7 @@ use swink_agent::{
     LlmMessage, ModelSpec, StopReason, SubAgent, Usage, stream::StreamFn,
 };
 
-use common::{MockStreamFn, text_only_events};
-
-fn test_model() -> ModelSpec {
-    ModelSpec::new("test", "test-model")
-}
+use common::{MockStreamFn, default_model, text_only_events};
 
 #[tokio::test]
 async fn sub_agent_runs_and_returns_text() {
@@ -28,7 +24,7 @@ async fn sub_agent_runs_and_returns_text() {
     let sfn = stream_fn.clone();
     let sub =
         SubAgent::new("researcher", "Researcher", "A research sub-agent").with_options(move || {
-            AgentOptions::new_simple("You are a researcher.", test_model(), Arc::clone(&sfn))
+            AgentOptions::new_simple("You are a researcher.", default_model(), Arc::clone(&sfn))
         });
 
     let params = serde_json::json!({ "prompt": "what is rust?" });
@@ -62,7 +58,7 @@ async fn sub_agent_error_maps_to_tool_error() {
 
     let sfn = stream_fn.clone();
     let sub = SubAgent::new("broken", "Broken", "Always fails")
-        .with_options(move || AgentOptions::new_simple("fail", test_model(), Arc::clone(&sfn)));
+        .with_options(move || AgentOptions::new_simple("fail", default_model(), Arc::clone(&sfn)));
 
     let params = serde_json::json!({ "prompt": "do something" });
     let ct = CancellationToken::new();
@@ -84,7 +80,7 @@ async fn sub_agent_cancellation() {
 
     let sfn = stream_fn.clone();
     let sub = SubAgent::new("slow", "Slow", "Gets cancelled").with_options(move || {
-        AgentOptions::new_simple("slow agent", test_model(), Arc::clone(&sfn))
+        AgentOptions::new_simple("slow agent", default_model(), Arc::clone(&sfn))
     });
 
     let params = serde_json::json!({ "prompt": "go" });
@@ -111,7 +107,7 @@ async fn sub_agent_shares_stream_fn() {
     assert!(Arc::ptr_eq(&sfn1, &sfn2));
 
     let sub = SubAgent::new("shared", "Shared", "Uses shared stream")
-        .with_options(move || AgentOptions::new_simple("shared", test_model(), Arc::clone(&sfn1)));
+        .with_options(move || AgentOptions::new_simple("shared", default_model(), Arc::clone(&sfn1)));
 
     assert_eq!(sub.name(), "shared");
     assert_eq!(sub.label(), "Shared");
@@ -136,7 +132,7 @@ async fn default_map_result_with_error_and_no_message() {
     let sfn2 = Arc::clone(&stream_fn2);
 
     let sub2 = SubAgent::new("err", "Err", "errors")
-        .with_options(move || AgentOptions::new_simple("sys", test_model(), Arc::clone(&sfn2)));
+        .with_options(move || AgentOptions::new_simple("sys", default_model(), Arc::clone(&sfn2)));
 
     let ct = CancellationToken::new();
     let result = sub2.execute("c1", json!({"prompt": "go"}), ct, None).await;
@@ -159,7 +155,7 @@ async fn default_map_result_with_no_assistant_messages() {
     let sfn = Arc::clone(&stream_fn);
 
     let sub = SubAgent::new("t", "T", "test")
-        .with_options(move || AgentOptions::new_simple("sys", test_model(), Arc::clone(&sfn)))
+        .with_options(move || AgentOptions::new_simple("sys", default_model(), Arc::clone(&sfn)))
         .with_map_result(move |result| {
             *called_clone.lock().unwrap() = true;
             // Simulate default_map_result behavior for only-user-messages
@@ -192,7 +188,7 @@ async fn custom_map_result() {
     let sfn = Arc::clone(&stream_fn);
 
     let sub = SubAgent::new("custom", "Custom", "custom mapper")
-        .with_options(move || AgentOptions::new_simple("sys", test_model(), Arc::clone(&sfn)))
+        .with_options(move || AgentOptions::new_simple("sys", default_model(), Arc::clone(&sfn)))
         .with_map_result(|_result| AgentToolResult::text("custom mapped"));
 
     let ct = CancellationToken::new();
@@ -227,7 +223,7 @@ async fn execute_with_empty_prompt() {
     let sfn = Arc::clone(&stream_fn);
 
     let sub = SubAgent::new("ep", "EP", "empty prompt")
-        .with_options(move || AgentOptions::new_simple("sys", test_model(), Arc::clone(&sfn)));
+        .with_options(move || AgentOptions::new_simple("sys", default_model(), Arc::clone(&sfn)));
 
     let ct = CancellationToken::new();
     let result = sub.execute("c1", json!({"prompt": ""}), ct, None).await;
@@ -245,7 +241,7 @@ async fn execute_with_missing_prompt_param() {
     let sfn = Arc::clone(&stream_fn);
 
     let sub = SubAgent::new("np", "NP", "no prompt")
-        .with_options(move || AgentOptions::new_simple("sys", test_model(), Arc::clone(&sfn)));
+        .with_options(move || AgentOptions::new_simple("sys", default_model(), Arc::clone(&sfn)));
 
     let ct = CancellationToken::new();
     // params has no "prompt" key — as_str() returns None, unwrap_or("") kicks in


### PR DESCRIPTION
## Summary
- Renamed `test_model()` → `default_model()` (imported from `tests/common/mod.rs`) in `stream_middleware.rs`, `sub_agent.rs`, and `loop_policy.rs`
- Renamed `test_context()` → `empty_context()` in `stream_middleware.rs`
- These were the last 4 remaining `test_` prefix violations from the QA Report (2026-03-14)

## QA Report Audit

All other findings from `QA_Report.md` were verified against the current codebase and found to be **already resolved**:

| Finding | Status |
|---|---|
| Test helper duplication (ContextCapturingStreamFn, ApiKeyCapturingStreamFn) | Already consolidated in common/mod.rs |
| agent.rs >1500 lines | Already split (now 1411 lines) |
| CustomMessageRegistry::contains() naming | Already renamed to has_type_name() |
| .env.example wrong model ID | Already shows gpt-4o |
| README.md outdated API example | Already uses from_connections() |
| eval gate.rs f64 validation | Already has assert!() checks |
| with_progress() doc comments | Already added |
| handle_stream_event() documentation | Already has doc example |
| ModelCycled event | Already implemented |
| All documentation file path issues | Already corrected |
| TUI CLAUDE.md provider priority | Already corrected |
| AdapterBase extraction | Already exists |

## Test plan
- [x] `cargo test --workspace` — all tests pass
- [x] `cargo clippy --workspace -- -D warnings` — zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)