### PR TITLE
feat(tui-plan-mode-approval): plan 029 — spec + implementation plan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,7 @@ MSRV **1.88** (edition 2024). Workspace deps centralized in root `Cargo.toml`.
 - TOML config file at `dirs::config_dir()/swink-agent/tui.toml`; OS keychain for credentials (macOS Keychain, Windows Credential Manager, Linux secret-service) (025-tui-scaffold-config)
 - Rust 1.88 (edition 2024) + `ratatui` 0.30, `crossterm` 0.29 (event-stream), `syntect` 5 (syntax highlighting for code blocks), `swink-agent` (core types — `Agent`, `ToolApproval`, `ToolApprovalRequest`, event system) (027-tui-tools-diffs-status)
 - N/A (all state is in-memory per session) (027-tui-tools-diffs-status)
+- Rust 1.88 (edition 2024) + `swink-agent` (core), `ratatui` 0.30, `crossterm` 0.29, `tokio`, `tokio-util` (029-tui-plan-mode-approval)
 
 ## Recent Changes
 - 001-workspace-scaffold: Added Rust 1.88 (edition 2024) + serde, serde_json, tokio, futures, thiserror, uuid, reqwest, jsonschema, schemars, rand, tracing, toml (all centralized in workspace `[workspace.dependencies]`)

--- a/specs/029-tui-plan-mode-approval/data-model.md
+++ b/specs/029-tui-plan-mode-approval/data-model.md
@@ -1,0 +1,133 @@
+# Data Model: TUI Plan Mode & Approval
+
+**Feature**: 029-tui-plan-mode-approval
+**Date**: 2026-03-22
+
+## Entities
+
+### Existing (no changes needed)
+
+| Entity | Location | Fields |
+|---|---|---|
+| `ApprovalMode` | `src/tool.rs:239` | Enabled, Smart, Bypassed |
+| `ToolApproval` | `src/tool.rs:200` | Approved, Rejected, ApprovedWith(Value) |
+| `ToolApprovalRequest` | `src/tool.rs:213` | tool_call_id, tool_name, arguments, requires_approval |
+| `OperatingMode` | `tui/src/app/state.rs` | Execute, Plan |
+| `PendingApproval` | `tui/src/ui/tool_panel.rs` | tool_name, args_summary, created_at |
+| `ResolvedApproval` | `tui/src/ui/tool_panel.rs` | tool_name, approved, resolved_at |
+| `ToolExecution` | `tui/src/ui/tool_panel.rs` | id, name, started_at, completed_at, is_error |
+
+### Modified
+
+#### `ApprovalMode` — Default Change
+
+```rust
+// src/tool.rs — change #[default] from Enabled to Smart
+pub enum ApprovalMode {
+    Enabled,
+    #[default]  // ← move here
+    Smart,
+    Bypassed,
+}
+```
+
+**Rationale**: FR-002 — Smart must be the default.
+
+### New
+
+#### `TrustFollowUp`
+
+```rust
+// tui/src/app/state.rs
+pub(crate) struct TrustFollowUp {
+    pub tool_name: String,
+    pub expires_at: Instant,
+}
+```
+
+**Purpose**: Tracks the inline "Always approve this tool? y/n" prompt after a tool approval in Smart mode. Auto-dismissed when `Instant::now() > expires_at` (3 seconds).
+
+**Lifecycle**:
+1. Created when user approves a tool via `y`/`Y`/`Enter` in Smart mode
+2. User accepts (`y`) → tool added to `session_trusted_tools`, follow-up cleared
+3. User declines (`n`) → follow-up cleared, no trust change
+4. Timeout (tick) → follow-up cleared, no trust change
+
+#### `PendingPlanApproval` (bool flag on App)
+
+No new struct — just a `pending_plan_approval: bool` field on `App`. When `true`:
+- Tool panel renders "Approve plan? [Y/n]" in the pending approvals area
+- Key handling intercepts Y/n like tool approvals
+- On approve: `exit_plan_mode()` + concatenate plan messages + `send_to_agent()`
+- On reject: clear flag, remain in plan mode
+
+## State Transitions
+
+### Plan Mode Lifecycle
+
+```
+Execute ──[Shift+Tab / /plan]──→ Plan
+  │                                │
+  │                           [Shift+Tab / /plan]
+  │                                │
+  │                                ▼
+  │                        PendingPlanApproval
+  │                           ╱          ╲
+  │                     [Y/Enter]       [N/Esc]
+  │                         │              │
+  │                         ▼              ▼
+  │                    Exit Plan       Stay in Plan
+  │                  + Send Plan       (clear prompt)
+  │                         │
+  ◄─────────────────────────┘
+```
+
+### Tool Approval Lifecycle (Smart Mode)
+
+```
+ToolCall ──[requires_approval?]──→ No → Auto-execute
+                │
+                Yes
+                │
+         [In session_trusted_tools?]──→ Yes → Auto-execute
+                │
+                No
+                │
+                ▼
+        PendingApproval (tool panel)
+           ╱      │      ╲
+      [Y/Enter]  [A]    [N/Esc]
+          │       │        │
+          ▼       ▼        ▼
+       Approve  Approve  Reject
+          │    + Trust     │
+          ▼       │        ▼
+    TrustFollowUp │   Error result
+    (3s timeout)  │   → agent
+       ╱    ╲     │
+     [y]    [n/∅] │
+      │      │    │
+      ▼      ▼    ▼
+    Trust  No-op  Trusted
+```
+
+## Field Changes on App struct
+
+```rust
+// New fields to add to App:
+pub(crate) trust_follow_up: Option<TrustFollowUp>,
+pub(crate) pending_plan_approval: bool,
+```
+
+## Command Changes
+
+### `#approve untrust` variants
+
+| Command | Action |
+|---|---|
+| `#approve untrust <name>` | Remove `name` from `session_trusted_tools` |
+| `#approve untrust` | Clear all `session_trusted_tools` |
+
+New `CommandResult` variants:
+- `UntrustTool(String)` — revoke specific tool
+- `UntrustAll` — revoke all

--- a/specs/029-tui-plan-mode-approval/plan.md
+++ b/specs/029-tui-plan-mode-approval/plan.md
@@ -1,0 +1,77 @@
+# Implementation Plan: TUI Plan Mode & Approval
+
+**Branch**: `029-tui-plan-mode-approval` | **Date**: 2026-03-22 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/029-tui-plan-mode-approval/spec.md`
+
+## Summary
+
+Add an approval-gated plan mode exit and a trust follow-up prompt to the TUI. Most infrastructure (ApprovalMode, plan mode toggle, session trust, tool panel) already exists. The implementation closes five gaps: (1) plan exit shows "Approve plan?" prompt instead of direct toggle, (2) approved plans are auto-sent as the next user message, (3) post-approval trust follow-up with 3-second auto-dismiss, (4) `#approve untrust` command, (5) default approval mode changed to Smart. One core change (ApprovalMode default), remainder is TUI-only.
+
+## Technical Context
+
+**Language/Version**: Rust 1.88 (edition 2024)
+**Primary Dependencies**: `swink-agent` (core), `ratatui` 0.30, `crossterm` 0.29, `tokio`, `tokio-util`
+**Storage**: N/A (all state is in-memory per session)
+**Testing**: `cargo test --workspace` + `cargo clippy --workspace -- -D warnings`
+**Target Platform**: macOS, Linux, Windows (terminal)
+**Project Type**: Library (core) + TUI binary
+**Performance Goals**: Mode switching within one render frame (<16ms)
+**Constraints**: No unsafe code, zero clippy warnings
+**Scale/Scope**: ~8 files modified, ~200-300 lines added
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|---|---|---|
+| I. Library-First | PASS | One core change (ApprovalMode default). TUI-only for the rest. No new crates. |
+| II. Test-Driven Development | PASS | Tests written before implementation for each gap. Existing tests updated for default change. |
+| III. Efficiency & Performance | PASS | No hot-path changes. Trust follow-up timer uses existing tick loop. |
+| IV. Leverage the Ecosystem | PASS | No new dependencies. Uses existing ratatui/crossterm. |
+| V. Provider Agnosticism | PASS | No provider-specific code. |
+| VI. Safety & Correctness | PASS | No unsafe. All new state is `Option`-wrapped with clear lifecycle. |
+| Crate count | PASS | No new crates (7 workspace members unchanged). |
+| MSRV | PASS | 1.88, edition 2024. |
+| Concurrency | PASS | No new concurrency. Plan approval is synchronous UI state. |
+| Events outward-only | PASS | No new event types. |
+| No global mutable state | PASS | All state on `App` struct. |
+
+**Post-Phase 1 re-check**: PASS — no violations introduced by design artifacts.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/029-tui-plan-mode-approval/
+├── plan.md              # This file
+├── research.md          # Gap analysis and design decisions
+├── data-model.md        # Entity changes and state transitions
+├── quickstart.md        # Build and verify guide
+└── tasks.md             # Phase 2 output (via /speckit.tasks)
+```
+
+### Source Code (affected files)
+
+```text
+src/
+└── tool.rs                          # ApprovalMode default change
+
+tui/src/
+├── app/
+│   ├── state.rs                     # TrustFollowUp struct, new App fields
+│   ├── event_loop.rs                # Key handling for plan approval + trust follow-up
+│   ├── agent_bridge.rs              # Plan approval flow, plan message concatenation
+│   ├── lifecycle.rs                 # Trust follow-up timeout, new field init
+│   └── tests.rs                     # New tests
+├── commands.rs                      # #approve untrust command
+└── ui/
+    └── tool_panel.rs                # Render plan approval + trust follow-up prompts
+```
+
+**Structure Decision**: No structural changes. All modifications are within existing files in the `swink-agent` core crate and `swink-agent-tui` crate.
+
+## Complexity Tracking
+
+No constitution violations — table not applicable.

--- a/specs/029-tui-plan-mode-approval/quickstart.md
+++ b/specs/029-tui-plan-mode-approval/quickstart.md
@@ -1,0 +1,41 @@
+# Quickstart: TUI Plan Mode & Approval
+
+**Feature**: 029-tui-plan-mode-approval
+
+## What Changes
+
+This feature modifies existing plan mode and approval infrastructure to add:
+1. An "Approve plan?" prompt when exiting plan mode (instead of direct toggle)
+2. Auto-sending the plan as the next user message on approval
+3. A trust follow-up prompt after tool approvals in Smart mode
+4. `#approve untrust` command for revoking session trust
+5. Default approval mode changed from Enabled to Smart
+
+## Files Modified
+
+### Core (`src/`)
+- `src/tool.rs` — Move `#[default]` from `Enabled` to `Smart` on `ApprovalMode`
+
+### TUI (`tui/src/`)
+- `tui/src/app/state.rs` — Add `TrustFollowUp` struct, `trust_follow_up` and `pending_plan_approval` fields
+- `tui/src/app/event_loop.rs` — Add key handling for plan approval and trust follow-up states; add streaming guard on plan toggle
+- `tui/src/app/agent_bridge.rs` — Change `toggle_operating_mode()` to show plan approval prompt instead of direct exit; add `approve_plan()` and `reject_plan()` methods; add plan message concatenation
+- `tui/src/app/lifecycle.rs` — Add `TrustFollowUp` timeout check in `tick()`; initialize new fields
+- `tui/src/commands.rs` — Add `#approve untrust` variants and `CommandResult` variants
+- `tui/src/ui/tool_panel.rs` — Render plan approval prompt and trust follow-up prompt
+- `tui/src/app/tests.rs` — New tests for all changed behavior
+
+## Build & Verify
+
+```bash
+cargo test --workspace                          # All tests pass
+cargo clippy --workspace -- -D warnings         # Zero warnings
+cargo run -p swink-agent-tui                    # Manual smoke test
+```
+
+## Key Design Choices
+
+- **Plan approval uses a bool flag**, not a synthetic `ToolApprovalRequest` — different response flow
+- **Trust follow-up is additive** — the "A" key shortcut for instant trust still works
+- **Plan messages concatenated with `---` separators** — preserves multi-turn plan structure
+- **Streaming guard is silent** — no error message when toggle is ignored during streaming

--- a/specs/029-tui-plan-mode-approval/research.md
+++ b/specs/029-tui-plan-mode-approval/research.md
@@ -1,0 +1,91 @@
+# Research: TUI Plan Mode & Approval
+
+**Feature**: 029-tui-plan-mode-approval
+**Date**: 2026-03-22
+
+## Gap Analysis: Existing vs Required
+
+The codebase already implements significant infrastructure for this feature. This research documents what exists, what's missing, and design decisions for the gaps.
+
+### What Already Exists
+
+| Capability | Location | Status |
+|---|---|---|
+| `ApprovalMode` enum (Enabled/Smart/Bypassed) | `src/loop_/mod.rs:239-249` | Complete |
+| `requires_approval()` trait method (default false) | `src/tool.rs:125` | Complete |
+| `ToolApproval` enum (Approved/Rejected/ApprovedWith) | `src/tool.rs:200-207` | Complete |
+| `ToolApprovalRequest` struct | `src/tool.rs:213-234` | Complete |
+| Tool dispatch approval gate (Smart mode logic) | `src/loop_/tool_dispatch.rs:88-104` | Complete |
+| `approve_tool` callback in `AgentLoopConfig` | `src/loop_/mod.rs:222` | Complete |
+| `agent.enter_plan_mode()` / `exit_plan_mode()` | `src/agent.rs:437-464` | Complete |
+| TUI `OperatingMode` enum (Execute/Plan) | `tui/src/app/state.rs` | Complete |
+| `toggle_operating_mode()` with enter/exit | `tui/src/app/agent_bridge.rs:245-279` | Complete |
+| `session_trusted_tools: HashSet<String>` | `tui/src/app/state.rs` | Complete |
+| `pending_approval` slot with oneshot responder | `tui/src/app/state.rs` | Complete |
+| Tool panel PendingApproval/ResolvedApproval | `tui/src/ui/tool_panel.rs` | Complete |
+| Approval key handling (y/n/a) | `tui/src/app/event_loop.rs:165-193` | Complete |
+| Smart auto-approve for trusted tools | `tui/src/app/agent_bridge.rs` | Complete |
+| `#approve on\|off\|smart` commands | `tui/src/commands.rs:115-121` | Complete |
+| `/plan` command | `tui/src/commands.rs:150` | Complete |
+| Shift+Tab plan toggle | `tui/src/app/event_loop.rs:222-223` | Complete |
+| PLAN badge in status bar | `tui/src/ui/status_bar.rs` | Complete |
+| Plan-mode message labeling ("Plan" in blue) | `tui/src/ui/conversation.rs` | Complete |
+| `saved_tools` / `saved_system_prompt` on App | `tui/src/app/state.rs` | Complete |
+| `plan_mode` flag on DisplayMessage | `tui/src/app/state.rs` | Complete |
+
+### What Needs to Be Built
+
+| Gap | Spec Requirement | Complexity |
+|---|---|---|
+| **Plan approval prompt** | FR-011: Exit plan mode shows "Approve plan?" prompt styled like tool approval | Medium — new `pending_plan_approval: bool` state, reuse tool approval UI pattern |
+| **Plan auto-send on approve** | FR-012: On approval, concatenate plan-mode assistant messages → send as user message | Low — collect messages, call `send_to_agent()` |
+| **Plan rejection keeps plan mode** | FR-011: On rejection, remain in plan mode | Low — just don't call `exit_plan_mode()` |
+| **Trust follow-up with auto-dismiss** | FR-006: After tool approval in Smart mode, show "Always approve? y/n" for 3 seconds | Medium — new `TrustFollowUp` state with timer |
+| **`#approve untrust` command** | FR-014: Revoke per-tool trust or clear all | Low — add command variants, remove from HashSet |
+| **Streaming guard on plan toggle** | FR-015: Ignore plan toggle while agent is running | Low — check `self.status` before toggling |
+| **Default to Smart mode** | FR-002: Smart must be the default | Low — change `ApprovalMode::default()` if needed |
+| **Empty plan guard** | Edge case: No assistant messages in plan → skip send | Low — guard before concatenation |
+
+## Design Decisions
+
+### Decision 1: Plan Approval Prompt Implementation
+
+**Decision**: Use a new `pending_plan_approval: bool` flag on App state, rendered in the tool panel alongside tool approvals.
+
+**Rationale**: The spec says "styled like a tool approval prompt." Reusing the same tool panel area and key handling pattern (Y/n) keeps the UX consistent and minimizes new code. However, a plan approval is semantically different from a tool approval (no `ToolApprovalRequest`, no oneshot channel), so a dedicated flag is cleaner than overloading `pending_approval`.
+
+**Alternatives considered**:
+- Overloading `pending_approval` with a synthetic ToolApprovalRequest → Rejected because the response flows differently (plan approval triggers `exit_plan_mode()` + `send_to_agent()`, not a oneshot channel)
+- Using the same `PendingApproval` struct in tool panel → Rejected because plan approval has no tool name or arguments to display
+
+### Decision 2: Trust Follow-Up with Auto-Dismiss
+
+**Decision**: After resolving a tool approval as "Approved" in Smart mode, set a `trust_follow_up: Option<TrustFollowUp>` containing the tool name and an `Instant` deadline (now + 3 seconds). The tool panel renders this as an inline prompt. Key handling checks for this state before the normal input path. On timeout (checked in tick), it's cleared.
+
+**Rationale**: The current "A" key for "Approve + Always Trust" is a shortcut that already works. The spec adds an explicit follow-up prompt after a plain approval. This is an additive UI element that doesn't disrupt the existing fast path.
+
+**Alternatives considered**:
+- Removing the "A" shortcut in favor of the follow-up only → Rejected because the "A" key is a faster workflow for power users
+- Modal dialog → Rejected, would break the terminal UI flow
+
+### Decision 3: Plan Message Concatenation
+
+**Decision**: On plan approval, iterate `self.messages` in order, collect all `DisplayMessage` entries where `plan_mode == true && role == MessageRole::Assistant`, join their `content` fields with `\n\n---\n\n`, and pass to `send_to_agent()`.
+
+**Rationale**: The `plan_mode` flag is already set on messages during plan mode. Simple concatenation with separators preserves the plan structure. The separator makes multi-turn plans readable.
+
+**Alternatives considered**:
+- Including tool results in the plan → Rejected, spec says "assistant messages"
+- Structured format with metadata → Rejected, over-engineering for this use case
+
+### Decision 4: Streaming Guard
+
+**Decision**: Check `self.status != AgentStatus::Running` before processing `toggle_operating_mode()`. If running, ignore silently.
+
+**Rationale**: Simple, matches spec FR-015. No need for a user-visible message — the plan badge state already communicates the current mode.
+
+### Decision 5: Default Approval Mode
+
+**Decision**: Verify `ApprovalMode::default()` returns `Smart`. If not, change it.
+
+**Rationale**: Spec FR-002. The current implementation uses `ApprovalMode::default()` which may return `Enabled`. Need to verify.

--- a/specs/029-tui-plan-mode-approval/spec.md
+++ b/specs/029-tui-plan-mode-approval/spec.md
@@ -5,6 +5,17 @@
 **Status**: Draft
 **Input**: Plan mode (read-only tool restriction, distinct styling, execute transition), tiered approval system (Enabled/Smart/Bypassed, per-tool session trust, classification via requires_approval trait method). References: PRD §16.9, §16.11, HLD TUI, TUI_PHASES T4.
 
+## Clarifications
+
+### Session 2026-03-22
+
+- Q: Should plan mode toggle be guarded while the agent is streaming? → A: Yes — ignore toggle while streaming, apply only when idle.
+- Q: How should the "always approve this tool" offer be presented? → A: Brief inline follow-up prompt after approval, auto-dismisses after 3 seconds.
+- Q: Should there be an explicit latency target for approval resolution? → A: No — resolution is synchronous via oneshot channel, effectively instant (<1 frame).
+- Q: How should per-tool trust be revoked? → A: `#approve untrust <tool_name>` for specific tool, `#approve untrust` to clear all.
+- Q: What constitutes "the plan" when sending as user message? → A: All assistant messages from the plan mode session, concatenated.
+- Q: What if no assistant messages during plan mode when approving? → Deferred — low impact, handle in planning.
+
 ## User Scenarios & Testing *(mandatory)*
 
 ### User Story 1 - Control Which Tools Require Approval (Priority: P1)
@@ -37,28 +48,29 @@ A developer is working in Smart mode and gets prompted to approve a write tool. 
 
 **Acceptance Scenarios**:
 
-1. **Given** Smart mode and an approval prompt, **When** the developer approves with "always approve this tool," **Then** the tool is marked as trusted for this session.
+1. **Given** Smart mode and an approval prompt, **When** the developer approves, **Then** a brief inline follow-up prompt ("Always approve this tool? y/n") appears and auto-dismisses after 3 seconds. If accepted, the tool is marked as trusted for this session.
 2. **Given** a trusted tool, **When** the agent calls it again, **Then** it executes without an approval prompt.
-3. **Given** a trusted tool, **When** the developer revokes trust, **Then** subsequent calls to that tool require approval again.
+3. **Given** a trusted tool, **When** the developer runs `#approve untrust <tool_name>`, **Then** subsequent calls to that tool require approval again.
 4. **Given** session trust for a tool, **When** the TUI is restarted, **Then** the trust is not carried over — the tool requires approval again.
 
 ---
 
 ### User Story 3 - Plan Before Executing with Plan Mode (Priority: P1)
 
-A developer wants the agent to analyze and plan before making changes. They toggle plan mode via Shift+Tab or the /plan command. In plan mode, the agent is restricted to read-only tools — write tools are removed from the agent's available tool set. The UI reflects plan mode with distinct styling (e.g., a different border color or a "PLAN" label). The agent can read files, analyze code, and propose changes without executing them. When the developer is satisfied with the plan, they switch back to execute mode, which re-registers the write tools. Optionally, the plan summary is sent as a follow-up message to guide execution.
+A developer wants the agent to analyze and plan before making changes. They enter plan mode via Shift+Tab or the /plan command. In plan mode, the agent is restricted to read-only tools — write tools are removed from the agent's available tool set. The UI reflects plan mode with distinct styling (e.g., a different border color or a "PLAN" label). The agent can read files, analyze code, and propose changes without executing them. When the developer is satisfied with the plan, they press Shift+Tab or /plan again, which presents an "Approve plan?" prompt — styled like a tool approval prompt. On approval, the TUI exits plan mode, re-registers write tools, and automatically sends all plan-mode assistant messages as the next user message in normal execute mode. The agent then executes against the plan without additional developer input.
 
 **Why this priority**: Plan-then-execute is a critical workflow for complex changes — it lets the developer review the agent's strategy before any modifications occur.
 
-**Independent Test**: Can be tested by toggling plan mode, asking the agent to make a change, verifying only read tools are called, then toggling to execute mode and verifying write tools become available.
+**Independent Test**: Can be tested by toggling plan mode, asking the agent to make a change, verifying only read tools are called, then approving the plan and verifying write tools become available and the plan is sent as the next user message.
 
 **Acceptance Scenarios**:
 
 1. **Given** execute mode is active, **When** the developer presses Shift+Tab or submits /plan, **Then** plan mode activates.
 2. **Given** plan mode is active, **When** the agent attempts to use a write tool, **Then** the tool is not available and the agent can only use read-only tools.
-3. **Given** plan mode is active, **When** the developer looks at the UI, **Then** a distinct visual indicator (border color or label) shows plan mode is on.
-4. **Given** plan mode is active, **When** the developer toggles back to execute mode, **Then** write tools are re-registered and available to the agent.
-5. **Given** plan mode produced a plan, **When** switching to execute mode, **Then** the developer is offered the option to send the plan as a follow-up message.
+3. **Given** plan mode is active, **When** the developer looks at the UI, **Then** a `PLAN` badge appears in the status bar and assistant messages are labeled "Plan" in blue.
+4. **Given** plan mode is active, **When** the developer presses Shift+Tab or submits /plan, **Then** an "Approve plan?" prompt appears, styled like a tool approval prompt.
+5. **Given** an "Approve plan?" prompt, **When** the developer approves, **Then** plan mode deactivates, write tools are re-registered, and all plan-mode assistant messages are automatically sent as the next user message in execute mode.
+6. **Given** an "Approve plan?" prompt, **When** the developer rejects, **Then** plan mode remains active and the developer can continue refining the plan.
 
 ---
 
@@ -81,14 +93,14 @@ The approval system needs to determine whether a tool requires approval. Each to
 
 ### Edge Cases
 
-- What happens when the developer toggles plan mode while the agent is mid-response with a write tool queued?
-- How does the approval prompt behave when multiple tools are called concurrently — are they prompted individually or batched?
-- What happens when a tool's approval classification changes during a session (e.g., via dynamic tool registration)?
-- How does plan mode interact with tools that are both read and write (e.g., a tool that reads and then modifies)?
-- What happens when the developer rejects a tool in Enabled mode that the agent considers essential?
-- How does the system handle rapid mode switching (e.g., toggling plan mode multiple times quickly)?
-- What happens when all tools are write tools and plan mode is activated — does the agent have zero tools?
-- How does per-tool trust interact with Enabled mode (is trust only relevant in Smart mode)?
+- **Mid-response plan toggle**: When the developer toggles plan mode while the agent is mid-response, write tools are removed from the tool set immediately. Any queued write tool call that has not yet entered approval will fail lookup. Already-dispatched calls complete normally.
+- **Concurrent tool approval**: Approval prompts are presented **sequentially, one at a time**. Tool dispatch loops through each tool call in order during pre-processing; the TUI holds a single `pending_approval` slot. Phase 3 (execution) runs approved tools concurrently, but approval itself is serial.
+- **Dynamic tool re-registration**: If a tool's `requires_approval()` classification changes mid-session (e.g., via dynamic registration), the new classification takes effect immediately on the next tool dispatch. No additional safeguards or notifications are provided.
+- **Mixed read/write tools**: Tool classification is **binary by design** — `requires_approval()` returns a `bool`. A tool that performs both reads and writes must declare `requires_approval() = true` (write). Plan mode removes all `requires_approval() == true` tools; there is no hybrid category.
+- **Rejection of essential tool**: Rejected tool calls produce an error tool result (`is_error: true`) sent back to the agent. The agent must adapt its approach (e.g., choose alternative tools or inform the user). No special handling for "essential" tools.
+- **Rapid mode switching**: Plan mode toggle is **ignored while the agent is actively streaming a response**. The toggle only takes effect when the agent is idle. This prevents mid-turn tool set changes that could confuse the agent. Each toggle still performs an immediate save/restore — no debounce beyond the streaming guard.
+- **All tools are write tools**: If all registered tools have `requires_approval() == true`, activating plan mode results in an **empty tool set**. The agent continues but cannot call any tools until the developer switches back to execute mode.
+- **Per-tool trust in Enabled mode**: Session trust is **only checked in Smart mode**. In Enabled mode, all tool calls go through the approval callback regardless of trust status. The trust set may be populated but is ignored outside Smart mode.
 
 ## Requirements *(mandatory)*
 
@@ -97,17 +109,18 @@ The approval system needs to determine whether a tool requires approval. Each to
 - **FR-001**: The TUI MUST support three approval modes: Enabled (prompt for all tools), Smart (auto-approve read-only, prompt for write), and Bypassed (auto-approve all).
 - **FR-002**: Smart MUST be the default approval mode.
 - **FR-003**: The approval mode MUST be changeable at any time via `#approve on`, `#approve smart`, or `#approve off`.
-- **FR-004**: When a tool requires approval, the TUI MUST display the tool name and arguments and wait for the developer to approve or reject.
+- **FR-004**: When a tool requires approval, the TUI MUST display an inline prompt in the tool panel showing the tool name, a summary of arguments (sensitive values redacted), and `Approve? [Y/n]`. The developer approves with `y` (or Enter) and rejects with `n`. Resolved decisions are shown briefly (✓ Approved / ✗ Rejected) and auto-pruned after 2 seconds.
 - **FR-005**: Tool approval classification MUST be determined by the tool's `requires_approval()` trait method.
-- **FR-006**: In Smart mode, after approving a tool, the developer MUST be offered the option to trust that tool for the remainder of the session.
+- **FR-006**: In Smart mode, after approving a tool, the TUI MUST display a brief inline follow-up prompt ("Always approve this tool? y/n") that auto-dismisses after 3 seconds if not answered. Accepting marks the tool as trusted for the session.
 - **FR-007**: Per-tool session trust MUST NOT persist across TUI restarts.
 - **FR-008**: Plan mode MUST be togglable via Shift+Tab or the /plan command.
 - **FR-009**: In plan mode, write tools MUST be removed from the agent's available tool set.
-- **FR-010**: Plan mode MUST be visually distinct from execute mode (different border color or label).
-- **FR-011**: Switching from plan mode to execute mode MUST re-register write tools.
-- **FR-012**: When switching from plan to execute mode, the developer MUST be offered the option to send the plan as a follow-up message.
+- **FR-010**: Plan mode MUST be visually distinct from execute mode: a `PLAN` badge in the status bar (blue accent via `plan_color()`), and assistant messages sent during plan mode labeled "Plan" instead of "Assistant" with the same blue accent.
+- **FR-011**: Exiting plan mode MUST present an "Approve plan?" prompt styled like a tool approval prompt. On approval, write tools are re-registered; on rejection, plan mode remains active.
+- **FR-012**: When the plan is approved, all assistant messages from the plan mode session MUST be automatically sent as the next user message in execute mode. This is not optional — the plan is always sent on approval.
 - **FR-013**: Rejected tool calls MUST inform the agent of the rejection so it can adjust its approach.
-- **FR-014**: Per-tool trust MUST be revocable by the developer during the session.
+- **FR-014**: Per-tool trust MUST be revocable via `#approve untrust <tool_name>` (specific tool) or `#approve untrust` (clear all trusted tools).
+- **FR-015**: Plan mode toggle MUST be ignored while the agent is actively streaming a response. The toggle takes effect only when the agent is idle.
 
 ### Key Entities
 


### PR DESCRIPTION
## Summary
- Updated spec with approval-gated plan mode exit: "Approve plan?" prompt instead of direct toggle, auto-sends plan as next user message on approval
- Generated implementation plan artifacts: gap analysis, data model, quickstart guide
- Identified 5 implementation gaps (plan approval prompt, plan auto-send, trust follow-up, #approve untrust, Smart default)

## Test plan
- [ ] Review spec changes (FR-011, FR-012 updated for approval-gated exit)
- [ ] Review plan artifacts for completeness and accuracy
- [ ] Verify constitution check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)