### PR TITLE
fix(qa): resolve last open QA finding — add minimal_agent example

### DIFF
--- a/examples/minimal_agent.rs
+++ b/examples/minimal_agent.rs
@@ -1,0 +1,37 @@
+//! Minimal real-provider agent — ~30 lines, no TUI.
+//!
+//! Bridges the gap between `simple_prompt.rs` (mock) and `custom_agent.rs`
+//! (full TUI + multi-provider). Uses a single real adapter and `prompt_text()`
+//! to send one request and print the response.
+//!
+//! Run: `cargo run --example minimal_agent`
+//! Requires: `ANTHROPIC_API_KEY` (or swap the preset for OpenAI/Ollama).
+
+use swink_agent::{
+    Agent, AgentMessage, AgentOptions, ContentBlock, LlmMessage, ModelConnections,
+};
+use swink_agent_adapters::{build_remote_connection, remote_preset_keys};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    dotenvy::dotenv().ok();
+
+    // Build a single remote connection from a preset (reads the API key from env).
+    let connection = build_remote_connection(remote_preset_keys::anthropic::HAIKU_45)?;
+
+    // Create agent options with just the primary model — no fallbacks, no tools.
+    let connections = ModelConnections::new(connection, vec![]);
+    let options = AgentOptions::from_connections("You are a helpful assistant.", connections);
+
+    // Create and prompt.
+    let mut agent = Agent::new(options);
+    let result = agent.prompt_text("What is Rust?").await?;
+
+    // Print the response.
+    for msg in &result.messages {
+        if let AgentMessage::Llm(LlmMessage::Assistant(a)) = msg {
+            println!("{}", ContentBlock::extract_text(&a.content));
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Adds `examples/minimal_agent.rs` — a ~30-line example using a single real provider (Anthropic) with `prompt_text()`, no TUI
- This was the only remaining open finding from `QA_Report.md`; all 22+ other findings were already resolved in prior commits

## QA Report Audit
All findings verified against the current codebase:

| Finding | Status |
|---|---|
| agent.rs >1500 lines | **Resolved** — now 1,411 lines (AgentOptions extracted) |
| test_ prefix naming (68+ violations) | **Resolved** — commit abf6dc0 |
| ModelCycled event missing | **Resolved** — `LoopEvent::ModelCycled` exists |
| handle_stream_event undocumented | **Resolved** — has full rustdoc + example |
| PLAN_MODE_ADDENDUM hardcoded | **Resolved** — `with_plan_mode_addendum()` builder |
| Test helper duplication | **Resolved** — consolidated in tests/common/ |
| .env.example wrong model | **Resolved** — gpt-4o |
| contains() predicate naming | **Resolved** — renamed to has_type_name() |
| with_progress() doc comments | **Resolved** — rustdoc added |
| All doc issues (BudgetExceeded, EfficiencyEvaluator, event forwarders, loop paths, README API, etc.) | **Resolved** |
| eval gate.rs f64 validation | **Resolved** — assert bounds added |
| Adapter classify/sse stability notes | **Resolved** — module-level docs present |
| TUI CLAUDE.md provider priority | **Resolved** — corrected |
| Missing minimal_agent.rs | **Fixed in this PR** |

## Test plan
- [x] `cargo clippy --workspace -- -D warnings` — zero warnings
- [x] `cargo test --workspace` — all tests pass
- [x] `cargo test -p swink-agent --no-default-features` — passes
- [x] `cargo check --example minimal_agent` — compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)