### PR TITLE
spec: context caching, prompt split, overflow predicate (006)

### DIFF
--- a/specs/006-context-management/data-model.md
+++ b/specs/006-context-management/data-model.md
@@ -1,6 +1,6 @@
 # Data Model: Context Management
 
-**Feature**: 006-context-management | **Date**: 2026-03-20
+**Feature**: 006-context-management | **Date**: 2026-03-20 | **Updated**: 2026-03-31
 
 ## Entities
 
@@ -166,6 +166,56 @@ Legacy closure-based conversion function used by `AgentOptions`.
 type ConvertToLlmFn = Arc<dyn Fn(&[AgentMessage], &str) -> Vec<LlmMessage> + Send + Sync>;
 ```
 
+### CacheConfig
+
+Configuration for provider-side context caching. Optional on `AgentOptions`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `ttl` | `Duration` | How long cached content remains valid provider-side |
+| `min_tokens` | `usize` | Minimum estimated token count to justify caching (below this, no cache markers emitted) |
+| `cache_intervals` | `usize` | Reuse the same cache for N turns before refreshing with a new `Write` |
+
+### CacheHint (enum)
+
+Annotation on messages indicating cache intent. Adapters translate this to provider-specific format (e.g., Anthropic `cache_control`, Google `CachedContent`).
+
+| Variant | Fields | Description |
+|---------|--------|-------------|
+| `Write` | `ttl: Duration` | Mark this content for caching with the given TTL |
+| `Read` | — | Reference previously cached content (don't re-send full payload) |
+
+### CacheState
+
+Internal state tracker for cache lifecycle. Managed by the context pipeline, not user-facing. Tracks turn count only — TTL expiry is the provider's responsibility.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `turns_since_write` | `usize` | Turns elapsed since last `CacheHint::Write` |
+| `cached_prefix_len` | `usize` | Number of messages in the cached prefix (protected from compaction) |
+
+### SystemPromptConfig
+
+Replaces the single `system_prompt` string with a static/dynamic split for caching support.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `static_system_prompt` | `String` | Stable instructions cached across turns (persona, base behavior, tool descriptions) |
+| `dynamic_system_prompt` | `Option<Box<dyn Fn() -> String + Send + Sync>>` | Per-turn context generator (current time, user state, etc.) — `None` if no dynamic content |
+
+## Functions
+
+### is_context_overflow
+
+Pre-flight predicate that estimates whether the current context would exceed the model's context window.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `messages` | `&[AgentMessage]` | Current context messages |
+| `model` | `&ModelSpec` | Model spec with `capabilities.max_context_window` |
+| `token_counter` | `Option<&dyn TokenCounter>` | Optional custom counter (defaults to `DefaultTokenCounter`) |
+| **Returns** | `bool` | `true` if estimated tokens exceed `max_context_window`; `false` if within budget or window is unknown |
+
 ## Relationships
 
 ```
@@ -179,4 +229,11 @@ InMemoryVersionStore --implements--> ContextVersionStore
 AsyncContextTransformer --parallel-to--> ContextTransformer (async variant)
 MessageConverter --used-by--> convert_messages() (generic function)
 AgentOptions --configures--> ContextTransformer | AsyncContextTransformer | ConvertToLlmFn
+AgentOptions --optionally-configures--> CacheConfig
+AgentOptions --optionally-configures--> SystemPromptConfig (static + dynamic)
+CacheConfig --controls--> CacheState (internal lifecycle)
+CacheState --emits--> CacheHint (on messages)
+CacheHint --consumed-by--> Adapters (MessageConverter impls)
+is_context_overflow() --uses--> TokenCounter + ModelSpec.capabilities.max_context_window
+SlidingWindowTransformer --respects--> CacheState.cached_prefix_len (skip compaction of cached prefix)
 ```

--- a/specs/006-context-management/plan.md
+++ b/specs/006-context-management/plan.md
@@ -5,7 +5,14 @@
 
 ## Summary
 
-Context management handles conversation history pruning, transformation, and preparation for LLM providers. The sliding window algorithm preserves anchor (first N) and tail (most recent) messages while removing the middle to fit a token budget, keeping tool-result pairs together even if this exceeds the budget. Pluggable synchronous and asynchronous transformation hooks run before each LLM call, receiving an overflow signal on retry. A message conversion pipeline filters custom messages and maps agent messages to provider format. Versioned context snapshots capture dropped messages for debugging and RAG-style recall. This feature is already fully implemented in `src/context.rs`, `src/context_transformer.rs`, `src/async_context_transformer.rs`, `src/context_version.rs`, and `src/convert.rs`.
+Context management handles conversation history pruning, transformation, caching, and preparation for LLM providers. The sliding window algorithm preserves anchor (first N) and tail (most recent) messages while removing the middle to fit a token budget, keeping tool-result pairs together even if this exceeds the budget. Pluggable synchronous and asynchronous transformation hooks run before each LLM call, receiving an overflow signal on retry. A message conversion pipeline filters custom messages and maps agent messages to provider format. Versioned context snapshots capture dropped messages for debugging and RAG-style recall.
+
+**New in this update (2026-03-31)**: Three additions to the context management system:
+1. **Explicit Context Caching** — `CacheConfig` with TTL, min_tokens threshold, and cache_intervals controls provider-side caching. `CacheHint` annotations on messages let adapters translate to provider-specific format (Anthropic `cache_control`, Google `CachedContent`).
+2. **Static/Dynamic Prompt Split** — `static_system_prompt` (cached across turns) and `dynamic_system_prompt` (closure, regenerated per turn) replace the single system prompt when caching is active.
+3. **Context Overflow Predicate** — `is_context_overflow(messages, model, counter?)` estimates whether context exceeds the model's window before sending the request.
+
+Existing implementation is in `src/context.rs`, `src/context_transformer.rs`, `src/async_context_transformer.rs`, `src/context_version.rs`, and `src/convert.rs`. New code will be added to `src/context.rs` (overflow predicate), `src/context_cache.rs` (caching types and logic), and `src/agent_options.rs` (new fields).
 
 ## Technical Context
 
@@ -15,22 +22,9 @@ Context management handles conversation history pruning, transformation, and pre
 **Testing**: `cargo test --workspace` -- unit tests inline in each source module
 **Target Platform**: Cross-platform library (any target supporting tokio)
 **Project Type**: Library crate (`swink-agent`)
-**Performance Goals**: Minimize allocations on hot paths; chars/4 heuristic avoids tokenizer dependency
-**Constraints**: `#[forbid(unsafe_code)]`; no provider-specific dependencies in core; synchronous transform by default
-**Scale/Scope**: Context pipeline for single-agent conversations -- called once per turn
-
-## Constitution Check
-
-*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
-
-| Principle | Status | Notes |
-|-----------|--------|-------|
-| I. Library-First | PASS | All context management is in the core `swink-agent` crate with no service/daemon coupling. No new crates needed. |
-| II. Test-Driven Development | PASS | Comprehensive unit tests in each module: sliding window edge cases, transformer trait/blanket-impl, async transformer, versioning capture, message conversion filtering. |
-| III. Efficiency & Performance | PASS | Token estimation uses chars/4 heuristic (simple, no tokenizer dependency). Sliding window operates in O(n) with in-place mutation. Custom messages use 100-token flat cost. |
-| IV. Leverage the Ecosystem | PASS | Uses serde_json for content block serialization. No custom reimplementations of existing crate functionality. |
-| V. Provider Agnosticism | PASS | `MessageConverter` trait is provider-generic. `ConvertToLlmFn` / `convert_messages` work with any adapter. No provider-specific types in context pipeline. |
-| VI. Safety & Correctness | PASS | `#[forbid(unsafe_code)]`. Poisoned mutex recovery via `into_inner()`. Tool-result pairs preserved together (correctness > token count). |
+**Performance Goals**: Minimize allocations on hot paths; chars/4 heuristic avoids tokenizer dependency; caching avoids re-tokenizing stable prefixes
+**Constraints**: `#[forbid(unsafe_code)]`; no provider-specific dependencies in core; synchronous transform by default; caching abstraction must be provider-agnostic
+**Scale/Scope**: Context pipeline for single-agent conversations -- called once per turn. Caching amortizes cost across multiple turns.
 
 ## Project Structure
 
@@ -51,15 +45,28 @@ specs/006-context-management/
 
 ```text
 src/
-├── context.rs                  # Sliding window algorithm, token estimation, CompactionResult
+├── context.rs                  # Sliding window algorithm, token estimation, CompactionResult, is_context_overflow()
+├── context_cache.rs            # CacheConfig, CacheHint, CacheState, cache lifecycle logic (NEW)
 ├── context_transformer.rs      # ContextTransformer trait, CompactionReport, SlidingWindowTransformer
 ├── async_context_transformer.rs # AsyncContextTransformer trait (async variant)
 ├── context_version.rs          # ContextVersion, ContextVersionStore, InMemoryVersionStore, VersioningTransformer
 ├── convert.rs                  # MessageConverter trait, convert_messages(), ToolSchema, extract_tool_schemas()
+├── agent_options.rs            # AgentOptions with new static/dynamic prompt fields and CacheConfig
 └── lib.rs                      # Re-exports all public types
 ```
 
-**Structure Decision**: All context management lives in the core `swink-agent` crate across five source files, each owning a single concern. No new crates or modules needed. Public API re-exported through `lib.rs`.
+**Structure Decision**: Context management lives in the core `swink-agent` crate. The new `context_cache.rs` file owns caching types and lifecycle logic (one concern per file). The overflow predicate goes in `context.rs` alongside token estimation since it's a direct consumer of `TokenCounter`. Static/dynamic prompt configuration goes in `agent_options.rs` as builder fields.
+
+## Constitution Check (Re-checked 2026-03-31)
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Library-First | PASS | All context management in core `swink-agent` crate. New types (`CacheConfig`, `CacheHint`, `CacheState`) in core. No provider-specific code. |
+| II. Test-Driven Development | PASS | Comprehensive unit tests in each module. New user stories include TDD phases (tests before impl). |
+| III. Efficiency & Performance | PASS | chars/4 heuristic, O(n) sliding window. `CacheConfig` optional — zero overhead when absent. `is_context_overflow` is O(n) single pass. |
+| IV. Leverage the Ecosystem | PASS | Uses serde_json, `std::time::Duration` for TTL. No new external dependencies. |
+| V. Provider Agnosticism | PASS | `MessageConverter` + `CacheHint` are provider-agnostic. Adapters translate to Anthropic/Google/etc format. |
+| VI. Safety & Correctness | PASS | `#[forbid(unsafe_code)]`. Poisoned mutex recovery. `CacheState` uses `Mutex`. Dynamic prompt closure is `Send + Sync`. |
 
 ## Complexity Tracking
 

--- a/specs/006-context-management/quickstart.md
+++ b/specs/006-context-management/quickstart.md
@@ -1,6 +1,6 @@
 # Quickstart: Context Management
 
-**Feature**: 006-context-management | **Date**: 2026-03-20
+**Feature**: 006-context-management | **Date**: 2026-03-20 | **Updated**: 2026-03-31
 
 ## Build & Test
 
@@ -175,6 +175,49 @@ let transformer = VersioningTransformer::new(
 );
 let options = AgentOptions::new_simple("prompt", model, stream_fn)
     .with_transform_context(transformer);
+```
+
+### Context caching with static/dynamic prompt split
+
+```rust
+use swink_agent::{AgentOptions, CacheConfig};
+use std::time::Duration;
+
+// Configure caching: 10-minute TTL, minimum 4096 tokens, refresh every 3 turns
+let cache_config = CacheConfig {
+    ttl: Duration::from_secs(600),
+    min_tokens: 4096,
+    cache_intervals: 3,
+};
+
+let options = AgentOptions::new_simple("default prompt", model, stream_fn)
+    .with_static_system_prompt("You are a helpful assistant with deep expertise in...".into())
+    .with_dynamic_system_prompt(|| {
+        format!("Current time: {}. User timezone: UTC-5.", chrono::Utc::now())
+    })
+    .with_cache_config(cache_config);
+
+// Turn 1: static prompt sent with CacheHint::Write { ttl: 600s }
+// Turns 2-3: static prompt sent with CacheHint::Read
+// Turn 4: cache refreshed with new CacheHint::Write
+```
+
+### Pre-flight context overflow check
+
+```rust
+use swink_agent::{is_context_overflow, estimate_tokens};
+use swink_agent::types::ModelSpec;
+
+// Check before sending
+if is_context_overflow(&messages, &model, None) {
+    // Trigger compaction or warn the user
+    transformer.transform(&mut messages, true); // overflow=true for aggressive pruning
+}
+
+// With a custom token counter
+if is_context_overflow(&messages, &model, Some(&my_tiktoken_counter)) {
+    // Handle overflow
+}
 ```
 
 ### Message conversion (adapter implementation)

--- a/specs/006-context-management/research.md
+++ b/specs/006-context-management/research.md
@@ -1,6 +1,6 @@
 # Research: Context Management
 
-**Feature**: 006-context-management | **Date**: 2026-03-20
+**Feature**: 006-context-management | **Date**: 2026-03-20 | **Updated**: 2026-03-31
 
 ## Design Decisions
 
@@ -60,3 +60,40 @@
 **Alternatives rejected**:
 - **Closure-based conversion (ConvertToLlmFn)**: The original design used a bare closure. The trait approach is more structured and provides compile-time type checking for the message type.
 - **Enum-based conversion**: Would require a single message enum that all providers share, which is too constraining for providers with different capabilities.
+
+### D7: Provider-agnostic CacheHint abstraction for context caching
+
+**Decision**: The core framework defines a `CacheHint` enum (`Write { ttl }` | `Read`) that annotates messages in the context. Adapters translate these hints to provider-specific cache control mechanisms. A `CacheConfig` struct configures the cache lifecycle (TTL, min_tokens threshold, refresh interval). Internal `CacheState` tracks turns since last write and determines when to emit Write vs Read hints.
+
+**Rationale**: Provider-side context caching is one of the highest-impact cost/latency optimizations available. Anthropic uses inline `cache_control: {"type": "ephemeral"}` blocks. Google uses a `CachedContent` API with server-side TTL. These mechanisms are fundamentally different but share the same semantic: "this prefix is stable, cache it." The framework abstracts the *intent* (what to cache, when to refresh) while adapters own the *mechanism* (how to tell the provider). This follows the same pattern as `MessageConverter` — core defines structure, adapters implement details.
+
+**Key design choice — CacheHint as annotation, not message wrapper**: The hint is an optional field/annotation on messages rather than a wrapping type. This keeps the existing `AgentMessage` pipeline unchanged. Messages without hints flow through untouched. Adapters that don't support caching ignore hints — zero behavioral change.
+
+**Reference implementations studied**:
+- **Google ADK**: `ContextCacheConfig(min_tokens=4096, ttl_seconds=600, cache_intervals=3)` at the application level. Static instruction goes in `system_instruction` (cacheable), dynamic instruction appended to user contents (not cached). Prompt structure: `system_instruction + tools + tool_config` = cached prefix, `contents` = dynamic.
+- **Anthropic SDK**: `cache_control: {"type": "ephemeral"}` on individual content blocks within messages. No explicit TTL (provider manages eviction). Implicit caching in newer models.
+
+**Alternatives rejected**:
+- **Adapter-only caching**: Each adapter independently implements caching. Leads to inconsistent behavior, duplicated lifecycle logic, and no way for the core to reason about cache boundaries during compaction.
+- **Transparent caching (hidden from user)**: Automatically cache everything above a threshold. Too opaque — users need control over what's cached and when to refresh, especially when system prompts change.
+- **Cache as a separate pipeline stage**: A dedicated "cache transformer" in the transform chain. Adds pipeline complexity for something that's really a message annotation concern, not a message mutation concern.
+
+### D8: Static vs dynamic system prompt separation
+
+**Decision**: `AgentOptions` gains optional `static_system_prompt: String` and `dynamic_system_prompt: Option<Box<dyn Fn() -> String + Send + Sync>>` fields. The existing `system_prompt` field remains and is treated as static when the new fields are not set. When `static_system_prompt` is set, it takes precedence for the cached portion. The dynamic prompt is a closure called each turn, producing fresh context.
+
+**Rationale**: Following Google ADK's pattern: the static portion (`system_instruction`) is placed in the cacheable prefix, while dynamic content is appended to user contents outside the cache boundary. This is the single most effective thing a framework can do for caching — ensure the cacheable prefix is actually stable. A closure for dynamic content (rather than a string) lets per-turn context be generated lazily without requiring the caller to manually update the prompt each turn.
+
+**Alternatives rejected**:
+- **Single system_prompt with cache markers**: Users would need to manually split their prompt and annotate sections. Error-prone and not ergonomic.
+- **Enum-based prompt type**: `SystemPrompt::Static(String) | SystemPrompt::Dynamic(Fn)`. Doesn't support the mixed case where you want both static and dynamic portions.
+
+### D9: Pre-flight context overflow predicate
+
+**Decision**: A standalone function `is_context_overflow(messages, model, counter?) -> bool` estimates the total token count of the message list using the provided (or default) `TokenCounter` and compares against `model.capabilities.max_context_window`. Returns `false` when `max_context_window` is `None` (unknown — let the provider decide).
+
+**Rationale**: The current overflow detection relies on the provider returning an error (`CONTEXT_OVERFLOW_SENTINEL`), which wastes a round-trip. A pre-flight check avoids this. The function is deliberately simple — it doesn't trigger compaction or modify state, just answers "will this fit?" Callers can use it to decide whether to compact, warn the user, or proceed. Returning `false` for unknown context windows is the safe default: better to attempt and let the provider reject than to falsely block requests for models whose limits we don't know.
+
+**Alternatives rejected**:
+- **Automatic pre-flight compaction**: Check and auto-compact in one step. Too much magic — callers should decide what to do when overflow is predicted.
+- **Result type with token details**: Return `OverflowInfo { estimated_tokens, max_tokens, overflow: bool }`. Over-engineered for the common case. The bool is the 90% use case; callers who want details can call `estimate_tokens` directly.

--- a/specs/006-context-management/spec.md
+++ b/specs/006-context-management/spec.md
@@ -2,8 +2,9 @@
 
 **Feature Branch**: `006-context-management`
 **Created**: 2026-03-20
+**Updated**: 2026-03-31
 **Status**: Draft
-**Input**: Context windowing, transformation hooks, versioned history, and message conversion pipeline. Manages how conversation history is pruned, transformed, and prepared for LLM providers. References: PRD §5 (Agent Context), PRD §10.1 (Context Window Overflow), PRD §12.2 (Loop Config — transform_context, convert_to_llm), HLD Agent Context.
+**Input**: Context windowing, transformation hooks, versioned history, message conversion pipeline, context caching, and overflow prediction. Manages how conversation history is pruned, transformed, cached, and prepared for LLM providers. References: PRD §5 (Agent Context), PRD §10.1 (Context Window Overflow), PRD §12.2 (Loop Config — transform_context, convert_to_llm), HLD Agent Context, Google ADK ContextCacheConfig, Anthropic cache_control blocks.
 
 ## User Scenarios & Testing *(mandatory)*
 
@@ -71,12 +72,70 @@ A developer needs to track how the context evolves across turns for debugging or
 
 ---
 
+### User Story 5 - Explicit Context Caching with TTL (Priority: P1)
+
+A developer configures context caching so that the static portion of the prompt (system instructions, tool descriptions) is cached provider-side across turns. This avoids re-tokenizing thousands of tokens every turn, reducing latency and cost. The framework splits context into cacheable (static) and non-cacheable (dynamic) portions. On the first turn the cacheable prefix is sent with cache control markers; subsequent turns reference the cached version until TTL expires or the cache interval is exceeded.
+
+**Why this priority**: Provider-side caching (Anthropic prompt caching, Google context caching) is a major cost/latency optimization. Without framework support, every adapter must independently solve the static/dynamic split and cache lifecycle, leading to inconsistency and bugs.
+
+**Independent Test**: Configure a `CacheConfig` with TTL=600s, min_tokens=4096, cache_intervals=3. Run 5 turns and verify: (a) turns 1-3 mark the prefix as cached, (b) turn 4 refreshes the cache, (c) the `CacheHint` annotations are present on the correct messages.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `CacheConfig` on `AgentOptions`, **When** context is prepared for the provider, **Then** the framework splits messages into a cacheable prefix (static system prompt, tool descriptions) and a dynamic suffix (conversation history, dynamic prompt).
+2. **Given** a cacheable prefix exceeding `min_tokens`, **When** the first turn is sent, **Then** the prefix carries a `CacheHint::Write` marker with the configured TTL.
+3. **Given** a cached prefix within its TTL and `cache_intervals` count, **When** subsequent turns are sent, **Then** the prefix carries a `CacheHint::Read` marker (no re-send of full content).
+4. **Given** the `cache_intervals` count is exceeded, **When** the next turn begins, **Then** the cache is refreshed with a new `CacheHint::Write`.
+5. **Given** no `CacheConfig` is set, **When** context is prepared, **Then** no cache markers are added (backward compatible, zero overhead).
+
+---
+
+### User Story 6 - Static vs Dynamic Instruction Split (Priority: P1)
+
+A developer provides both a static system prompt (persona, base instructions — stable across turns) and a dynamic system prompt (per-turn context like current time, user state — changes every turn). The static portion is the primary cache target. The dynamic portion is appended separately so it does not invalidate the cache.
+
+**Why this priority**: This is the prerequisite for effective caching. Without separating static from dynamic instructions, any per-turn change in the system prompt invalidates the entire cache, negating the cost/latency benefit.
+
+**Independent Test**: Create an agent with `static_system_prompt = "You are a helpful assistant..."` and `dynamic_system_prompt = Some(closure returning current timestamp)`. Verify the static portion remains unchanged across turns while the dynamic portion updates each turn.
+
+**Acceptance Scenarios**:
+
+1. **Given** both static and dynamic system prompts configured, **When** context is built for a turn, **Then** the static prompt is sent as the system prompt message (cacheable) and the dynamic prompt is injected as a separate user-role message immediately after it (non-cacheable).
+2. **Given** only a `static_system_prompt` (no dynamic), **When** context is built, **Then** it behaves identically to the existing `system_prompt` field.
+3. **Given** the dynamic prompt changes between turns, **When** context caching is active, **Then** only the dynamic portion changes — the cached static prefix is not invalidated.
+4. **Given** neither static nor dynamic prompt is set but `system_prompt` is, **When** context is built, **Then** `system_prompt` is treated as static (backward compatible).
+
+---
+
+### User Story 7 - Context Overflow Predicate (Priority: P2)
+
+A developer wants to check whether the current context would exceed the model's context window *before* sending the request. The framework provides `is_context_overflow(messages, model) -> bool` that estimates token count and compares against the model's `max_context_window` from `ModelCapabilities`. This allows pre-emptive compaction or user notification without a wasted round-trip.
+
+**Why this priority**: Currently overflow is only detected after the provider returns an error (the `CONTEXT_OVERFLOW_SENTINEL` path). Pre-flight prediction avoids the failed request, saving latency and one wasted API call per overflow.
+
+**Independent Test**: Create a message list with known token estimate, a `ModelSpec` with `max_context_window = Some(1000)`, and verify `is_context_overflow` returns true when estimated tokens > 1000 and false otherwise. Test with a custom `TokenCounter`.
+
+**Acceptance Scenarios**:
+
+1. **Given** messages whose estimated token count exceeds `model.capabilities.max_context_window`, **When** `is_context_overflow` is called, **Then** it returns `true`.
+2. **Given** messages within the model's context window, **When** `is_context_overflow` is called, **Then** it returns `false`.
+3. **Given** a model with `max_context_window = None` (unknown), **When** `is_context_overflow` is called, **Then** it returns `false` (cannot predict, let the provider decide).
+4. **Given** a custom `TokenCounter`, **When** `is_context_overflow` is called with it, **Then** it uses the custom counter instead of the default chars/4 heuristic.
+
+---
+
 ### Edge Cases
 
 - What happens when the token budget is smaller than the anchor + one recent message — anchor messages are always preserved even if they exceed the budget. Correctness > token count.
 - How does the system estimate tokens for custom messages that have no text content — custom messages are estimated at 100 tokens flat.
 - What happens when the transformation hook adds messages that push the context over budget — the sliding window and the transform hook are independent; the hook is responsible for its own budget management. The sliding window is itself a type of transform hook.
 - How does the system handle an empty conversation history — the sliding window returns no compaction (no-op). The agent validates empty history at the entry point level, returning `AgentError::NoMessages`.
+- What happens when the cached prefix is compacted by the sliding window — the sliding window must not compact messages within the cached prefix. Anchor messages should encompass the cached prefix when caching is active.
+- What if `min_tokens` is not met — no cache markers are emitted; the context is sent without caching (falls back to normal behavior).
+- What if the provider does not support caching — adapters that don't support caching ignore `CacheHint` markers. The core emits them unconditionally; adapters opt in to honoring them.
+- How does `is_context_overflow` interact with caching — it estimates the full context size (cached + dynamic) since that's what the model processes regardless of caching.
+- Can `static_system_prompt` change mid-conversation — no. It is immutable for the lifetime of the agent loop. Changing it requires a new agent/session. This simplifies cache lifecycle and avoids stale-prefix bugs.
+- What happens when the provider's cache expires between turns (TTL elapsed server-side) — the adapter returns a retryable cache-miss error. The framework detects it, resets `CacheState`, and retries with `CacheHint::Write`. Same retry path as `ModelThrottled`/`NetworkError`.
 
 ## Requirements *(mandatory)*
 
@@ -92,6 +151,15 @@ A developer needs to track how the context evolves across turns for debugging or
 - **FR-008**: System MUST provide a message conversion function that maps each agent message to the provider format, with the ability to filter messages by returning nothing.
 - **FR-009**: The conversion function MUST run after the transformation hook on every turn.
 - **FR-010**: System MUST support versioned context history that tracks context snapshots at turn boundaries.
+- **FR-011**: System MUST support an optional `CacheConfig` that controls provider-side context caching with configurable TTL, minimum token threshold, and cache refresh interval.
+- **FR-012**: When `CacheConfig` is active, the system MUST split context into a cacheable prefix (static system prompt, tool descriptions) and a non-cacheable suffix (dynamic prompt, conversation messages).
+- **FR-013**: The system MUST annotate cacheable messages with `CacheHint::Write` on cache creation/refresh and `CacheHint::Read` on cache reuse, allowing adapters to translate to provider-specific cache control.
+- **FR-014**: System MUST support separate `static_system_prompt` and `dynamic_system_prompt` fields, where the static portion is the primary cache target and the dynamic portion changes per turn without invalidating the cache.
+- **FR-015**: System MUST provide an `is_context_overflow(messages, model, counter?) -> bool` predicate that estimates whether context exceeds the model's `max_context_window` before sending the request.
+- **FR-016**: The sliding window MUST NOT compact messages within the cached prefix when caching is active.
+- **FR-017**: When no `CacheConfig` is set, caching-related behavior MUST be completely absent — zero overhead, full backward compatibility.
+- **FR-018**: When `CacheConfig` is active, the system MUST emit an `AgentEvent::CacheAction { hint, prefix_tokens }` event each turn, enabling observability of cache write/read/refresh transitions.
+- **FR-019**: When an adapter returns a cache-miss error, the framework MUST reset `CacheState` and retry the turn with `CacheHint::Write`, following the existing `RetryStrategy` path.
 
 ### Key Entities
 
@@ -100,6 +168,9 @@ A developer needs to track how the context evolves across turns for debugging or
 - **AsyncContextTransformer**: Asynchronous variant of the context transformation hook.
 - **ContextVersion**: Versioned snapshot of the context at a turn boundary.
 - **ConvertToLlmFn**: Function that maps an agent message to a provider message or filters it out.
+- **CacheConfig**: Configuration for provider-side context caching — TTL, min token threshold, cache interval.
+- **CacheHint**: Enum annotation on messages indicating cache write/read intent for adapters.
+- **CacheState**: Internal tracker for cache lifecycle — turn counter, cached prefix length.
 
 ## Success Criteria *(mandatory)*
 
@@ -111,6 +182,10 @@ A developer needs to track how the context evolves across turns for debugging or
 - **SC-004**: The overflow signal is correctly propagated to the transformation hook after a context overflow error.
 - **SC-005**: Custom messages are filtered out by the conversion pipeline and never reach the provider.
 - **SC-006**: Token estimation produces consistent results for the same message content.
+- **SC-007**: When `CacheConfig` is active with `cache_intervals=N`, the first turn emits `CacheHint::Write` and turns 2..N emit `CacheHint::Read`.
+- **SC-008**: The static/dynamic prompt split produces a stable cacheable prefix that does not change between turns.
+- **SC-009**: `is_context_overflow` returns true when estimated tokens exceed `max_context_window` and false otherwise, with zero false negatives when `max_context_window` is `None`.
+- **SC-010**: An agent configured without `CacheConfig` behaves identically to pre-caching behavior — no extra allocations, no extra fields in messages.
 
 ## Clarifications
 
@@ -121,6 +196,20 @@ A developer needs to track how the context evolves across turns for debugging or
 - Q: What if transform hook adds messages pushing over budget? → A: Sliding window and transform hook are independent; hook manages its own budget.
 - Q: How does empty conversation history behave? → A: Sliding window is a no-op; agent returns `AgentError::NoMessages` at entry point.
 
+### Session 2026-03-31
+
+- Q: How do different providers implement caching? → A: Anthropic uses `cache_control: {"type": "ephemeral"}` blocks on messages. Google uses `CachedContent` API with explicit TTL. The framework abstracts this via `CacheHint` — adapters translate to their provider's format.
+- Q: Where does `CacheHint` live — on messages or alongside them? → A: As a `cache_hint: Option<CacheHint>` field directly on `AgentMessage`, with `#[serde(default, skip_serializing_if = "Option::is_none")]` for zero-cost serialization when absent. Adapters inspect it during conversion. Messages without hints are sent normally.
+- Q: Does `static_system_prompt` replace `system_prompt`? → A: No. `system_prompt` continues to work as-is (treated as static). The new fields are opt-in additions. If `static_system_prompt` is set, it takes precedence over `system_prompt` for the cached portion.
+- Q: How does caching interact with the sliding window? → A: The cached prefix (static prompt content) must be excluded from sliding window compaction. When `CacheConfig` is active, the anchor count should be at least large enough to cover the cached prefix.
+- Q: What happens to `CacheHint` markers for providers that don't support caching? → A: Adapters that don't support caching simply ignore the hints. The markers are a no-op for those adapters.
+- Q: Should `is_context_overflow` account for tool schemas? → A: No — tool schemas are sent out-of-band in most providers. The predicate estimates message tokens only. Callers can add tool schema overhead manually if needed.
+- Q: Who is responsible for TTL expiry — framework or provider? → A: Framework tracks turn count only (via `cache_intervals`); TTL is a provider-side hint passed through `CacheHint::Write { ttl }`. The provider handles actual time-based expiry. If the provider's cache expired between turns, the adapter receives an error and the framework falls back to a fresh `CacheHint::Write` on retry. `CacheState.is_valid` reflects turn-count validity only, not wall-clock TTL.
+- Q: Should cache lifecycle transitions emit AgentEvents? → A: Yes. Emit `AgentEvent::CacheAction { hint: CacheHint, prefix_tokens: usize }` each turn when caching is active. Consistent with existing `ContextCompacted` pattern. No event emitted when `CacheConfig` is absent.
+- Q: How is the dynamic prompt placed relative to the static prompt? → A: Static prompt is the system prompt message (the cache target). Dynamic prompt is injected as a separate user-role message immediately after the system prompt. This ensures the system prompt message is byte-identical across turns, preserving the cache. Follows Google ADK's pattern: static in `system_instruction`, dynamic appended to `contents`.
+- Q: Can `static_system_prompt` change mid-conversation? → A: No. `static_system_prompt` is immutable for the lifetime of the agent loop. Changing persona or tool set requires starting a new agent/session. This is a documented constraint — enforced by taking `static_system_prompt` as an owned `String` at construction, not a closure.
+- Q: How does the adapter signal a provider-side cache miss to the framework? → A: Adapter returns a retryable error (new `AgentError::CacheMiss` variant or tagged `NetworkError`). The framework's retry path detects the cache-miss error kind and calls `CacheState::reset()` before the retry turn, so the next attempt emits `CacheHint::Write` with fresh content. Follows the existing `RetryStrategy` pattern — no new retry mechanism needed.
+
 ## Assumptions
 
 - Token estimation uses a characters-divided-by-4 heuristic as an approximation. Exact tokenization is not required.
@@ -128,3 +217,8 @@ A developer needs to track how the context evolves across turns for debugging or
 - The sliding window anchor size and tail size are configurable by the caller.
 - Context transformation is synchronous by default; the async variant is an opt-in alternative.
 - Versioned context history is opt-in and does not impose overhead when not used.
+- Context caching is opt-in via `CacheConfig`. When not configured, no cache-related types are allocated or processed.
+- The `CacheHint` abstraction is provider-agnostic — the core does not know about Anthropic's `cache_control` or Google's `CachedContent` API.
+- `is_context_overflow` is a best-effort estimate. It uses the same `TokenCounter` as the sliding window and may under/over-estimate compared to the provider's exact tokenizer.
+- `static_system_prompt` and `dynamic_system_prompt` are optional fields that coexist with the existing `system_prompt` for backward compatibility.
+- `static_system_prompt` is immutable for the agent loop lifetime. Mid-conversation persona/tool changes require a new agent session.

--- a/specs/006-context-management/tasks.md
+++ b/specs/006-context-management/tasks.md
@@ -130,7 +130,80 @@
 
 ---
 
-## Phase 7: Polish & Cross-Cutting Concerns
+## Phase 7: User Story 5 — Explicit Context Caching with TTL (Priority: P1)
+
+**Goal**: Provider-agnostic context caching abstraction with TTL, minimum token threshold, and cache interval lifecycle.
+
+**Independent Test**: Configure `CacheConfig` with TTL=600s, min_tokens=4096, cache_intervals=3. Simulate 5 turns and verify Write/Read hint emission pattern.
+
+### Implementation for User Story 5
+
+- [ ] T047 [US5] Create `src/context_cache.rs` with `#![forbid(unsafe_code)]`, module-level doc comment. Register in `src/lib.rs` as `mod context_cache;`
+- [ ] T051 [US5] Add unit tests for `CacheConfig`, `CacheHint`, and `CacheState` in `src/context_cache.rs`: (a) first turn emits Write, (b) turns 2..N emit Read, (c) turn N+1 emits Write (refresh), (d) `reset()` forces Write on next turn (adapter-reported cache miss), (e) `cached_prefix_len` tracks correctly, (f) `min_tokens` below threshold suppresses hints
+- [ ] T048 [US5] Implement `CacheConfig` struct in `src/context_cache.rs` — fields: `ttl: Duration`, `min_tokens: usize`, `cache_intervals: usize`. Derive `Debug, Clone`.
+- [ ] T049 [US5] Implement `CacheHint` enum in `src/context_cache.rs` — variants: `Write { ttl: Duration }`, `Read`. Derive `Debug, Clone, PartialEq`.
+- [ ] T050 [US5] Implement `CacheState` struct in `src/context_cache.rs` — fields: `turns_since_write: usize`, `cached_prefix_len: usize`. Methods: `new()`, `advance_turn(&mut self, config: &CacheConfig) -> CacheHint` (returns Write on first turn and every `cache_intervals` turns, Read otherwise), `reset(&mut self)` (force Write on next turn, used when adapter reports provider cache miss).
+- [ ] T074 [US5] Add unit tests for `cache_hint` field on `AgentMessage` in `tests/types.rs` or `src/types.rs`: (a) serde round-trip with `cache_hint: Some(Write)` preserves value, (b) serde round-trip with `cache_hint: None` omits field from JSON, (c) deserializing JSON without `cache_hint` field produces `None` (backward compat with old checkpoints).
+- [ ] T067 [US5] Add `cache_hint: Option<CacheHint>` field to `AgentMessage` in `src/types.rs` with `#[serde(default, skip_serializing_if = "Option::is_none")]`. Ensure backward-compatible deserialization.
+- [ ] T052 [US5] Add `cache_config: Option<CacheConfig>` field to `AgentOptions` in `src/agent_options.rs`. Add builder method `with_cache_config(config: CacheConfig)`.
+- [ ] T075 [US5] Add unit tests for sliding window cache prefix protection in `src/context_transformer.rs`: (a) `cached_prefix_len=3` with 10 messages — first 3 never compacted even if anchor=1, (b) `cached_prefix_len=0` — behaves identically to current (no regression), (c) `cached_prefix_len` larger than message count — all messages preserved.
+- [ ] T070 [US5] Modify `SlidingWindowTransformer` in `src/context_transformer.rs` to accept optional `cached_prefix_len: usize` and protect those messages from compaction (FR-016). When caching is active, anchor count is `max(anchor, cached_prefix_len)`.
+- [ ] T076 [US5] Add integration test for turn pipeline cache hint annotation and event emission in `tests/ac_context.rs` or new `tests/context_cache.rs`: (a) configure `CacheConfig` with `cache_intervals=2`, run 3 turns — verify turn 1 messages carry `CacheHint::Write`, turn 2 carry `CacheHint::Read`, turn 3 carry `CacheHint::Write` (refresh), (b) verify `AgentEvent::CacheAction` emitted each turn with correct hint and prefix_tokens, (c) no `CacheConfig` → no `CacheHint` on messages and no `CacheAction` events.
+- [ ] T068 [US5] Integrate cache hint annotation into the turn pipeline in `src/loop_/turn.rs` — after context transform, if `CacheConfig` is present: call `CacheState::advance_turn()`, annotate cacheable prefix messages with the returned `CacheHint`, set `cached_prefix_len` on `CacheState`.
+- [ ] T069 [US5] Add `CacheAction { hint: CacheHint, prefix_tokens: usize }` variant to `AgentEvent` in `src/types.rs`. Emit in `src/loop_/turn.rs` after cache hint annotation (FR-018).
+- [ ] T053 [US5] Add re-exports to `src/lib.rs`: `pub use context_cache::{CacheConfig, CacheHint, CacheState};`
+
+**Checkpoint**: `cargo test -p swink-agent context_cache` passes. Cache lifecycle logic works standalone, messages annotated, sliding window respects cached prefix.
+
+---
+
+## Phase 8: User Story 6 — Static vs Dynamic Instruction Split (Priority: P1)
+
+**Goal**: Separate static (cached) and dynamic (per-turn) system prompts on `AgentOptions`.
+
+**Independent Test**: Create an agent with both static and dynamic prompts. Verify static portion is stable across turns, dynamic portion updates each turn.
+
+### Implementation for User Story 6
+
+- [ ] T057 [US6] Add unit tests for prompt split in `src/agent_options.rs`: (a) only `system_prompt` set → used as-is, (b) `static_system_prompt` set → takes precedence as system prompt, (c) dynamic closure called fresh each invocation returns separate string, (d) `effective_system_prompt()` returns only static portion (not concatenated with dynamic).
+- [ ] T054 [US6] Add `static_system_prompt: Option<String>` and `dynamic_system_prompt: Option<Box<dyn Fn() -> String + Send + Sync>>` fields to `AgentOptions` in `src/agent_options.rs`.
+- [ ] T055 [US6] Add builder methods `.with_static_system_prompt(prompt: String)` and `.with_dynamic_system_prompt(f: impl Fn() -> String + Send + Sync + 'static)` to `AgentOptions`.
+- [ ] T056 [US6] Add `effective_system_prompt(&self) -> String` method to `AgentOptions` — returns `static_system_prompt` if set, otherwise falls back to `system_prompt`. Does NOT include dynamic content (dynamic prompt is injected as a separate user-role message by the turn pipeline).
+- [ ] T058 [US6] Update turn pipeline in `src/loop_/turn.rs` to: (a) use `effective_system_prompt()` for the system prompt message (cacheable), (b) if `dynamic_system_prompt` is set, inject its output as a separate user-role message immediately after the system prompt (non-cacheable).
+
+**Checkpoint**: `cargo test -p swink-agent agent_options` passes. Static/dynamic split works with and without caching.
+
+---
+
+## Phase 9: User Story 7 — Context Overflow Predicate (Priority: P2)
+
+**Goal**: `is_context_overflow()` function that estimates whether context exceeds the model's window before sending.
+
+**Independent Test**: Create messages with known token estimate, a ModelSpec with `max_context_window = Some(1000)`, verify returns true/false correctly.
+
+### Implementation for User Story 7
+
+- [ ] T059 [US7] Add unit tests for `is_context_overflow()` in `src/context.rs`: (a) messages within budget → false, (b) messages exceeding budget → true, (c) `max_context_window = None` → false, (d) custom TokenCounter used, (e) empty messages → false.
+- [ ] T060 [US7] Implement `is_context_overflow()` in `src/context.rs` — signature: `pub fn is_context_overflow(messages: &[AgentMessage], model: &ModelSpec, counter: Option<&dyn TokenCounter>) -> bool`. Sum token estimates, compare against `model.capabilities.as_ref().and_then(|c| c.max_context_window)`.
+- [ ] T061 [US7] Add re-export to `src/lib.rs`: `pub use context::is_context_overflow;`
+
+**Checkpoint**: `cargo test -p swink-agent context` passes with new overflow predicate tests.
+
+---
+
+## Phase 9b: Cache-Miss Retry Integration (FR-019)
+
+**Goal**: When an adapter returns a cache-miss error, the framework resets `CacheState` and retries with `CacheHint::Write`.
+
+- [ ] T071 [US5] Add `CacheMiss` variant to `AgentError` in `src/error.rs`. Mark as retryable in `is_retryable()` (alongside `ModelThrottled` and `NetworkError`).
+- [ ] T072 [US5] Add unit test for cache-miss retry in `src/loop_/turn.rs`: simulate a `CacheMiss` error, verify `CacheState::reset()` is called before retry and next attempt emits `CacheHint::Write`.
+- [ ] T073 [US5] Implement cache-miss detection in retry path in `src/loop_/turn.rs` — when `AgentError::CacheMiss` is caught, call `CacheState::reset()` before the retry turn so the next attempt re-sends the prefix with `CacheHint::Write`.
+
+**Checkpoint**: Cache-miss → retry → Write cycle works end-to-end.
+
+---
+
+## Phase 10: Polish & Cross-Cutting Concerns
 
 **Purpose**: Integration, API surface completeness, and validation across all stories
 
@@ -139,6 +212,11 @@
 - [x] T044 Run `cargo test --workspace` to verify no regressions across the full workspace
 - [x] T045 Run `cargo test -p swink-agent --no-default-features` to verify context management works with builtin-tools disabled
 - [x] T046 Validate quickstart.md code examples compile by inspection — check `sliding_window`, `SlidingWindowTransformer`, `VersioningTransformer`, `convert_messages` usage patterns match the public API
+- [ ] T062 Verify new re-exports in `src/lib.rs`: `CacheConfig`, `CacheHint`, `CacheState`, `is_context_overflow`
+- [ ] T063 Run `cargo clippy --workspace -- -D warnings` and fix any warnings in new context cache and overflow modules
+- [ ] T064 Run `cargo test --workspace` to verify no regressions from new code
+- [ ] T065 Run `cargo test -p swink-agent --no-default-features` to verify caching and overflow work with builtin-tools disabled
+- [ ] T066 Validate new quickstart.md code examples compile by inspection — check `CacheConfig`, `is_context_overflow`, static/dynamic prompt patterns
 
 ---
 
@@ -146,20 +224,28 @@
 
 ### Phase Dependencies
 
-- **Setup (Phase 1)**: No dependencies — can start immediately
-- **Foundational (Phase 2)**: Depends on Setup completion — BLOCKS all user stories
-- **User Story 1 (Phase 3)**: Depends on Foundational (Phase 2) — sliding window uses `estimate_tokens`, `TokenCounter`, `CompactionResult`
-- **User Story 2 (Phase 4)**: Depends on Foundational (Phase 2) and User Story 1 (Phase 3) — `SlidingWindowTransformer` delegates to `compact_sliding_window_with()`
-- **User Story 3 (Phase 5)**: Depends on Foundational (Phase 2) only — message conversion is independent of sliding window and transformers
-- **User Story 4 (Phase 6)**: Depends on Foundational (Phase 2) and User Story 2 (Phase 4) — `VersioningTransformer` wraps `ContextTransformer`
-- **Polish (Phase 7)**: Depends on all user stories being complete
+- **Setup (Phase 1)**: No dependencies — can start immediately ✅
+- **Foundational (Phase 2)**: Depends on Setup completion — BLOCKS all user stories ✅
+- **User Story 1 (Phase 3)**: Depends on Foundational (Phase 2) ✅
+- **User Story 2 (Phase 4)**: Depends on Phase 2 and Phase 3 ✅
+- **User Story 3 (Phase 5)**: Depends on Phase 2 only ✅
+- **User Story 4 (Phase 6)**: Depends on Phase 2 and Phase 4 ✅
+- **User Story 5 (Phase 7)**: Depends on Phase 2 (TokenCounter for min_tokens check) — independent of US1-US4
+- **User Story 6 (Phase 8)**: Depends on Phase 7 (CacheConfig must exist before prompt split references it) — can start in parallel with US7
+- **User Story 7 (Phase 9)**: Depends on Phase 2 only (TokenCounter + ModelSpec) — independent of US5/US6
+- **Cache-Miss Retry (Phase 9b)**: Depends on Phase 7 (CacheState, AgentError) — can run after US5 core is done
+- **Polish (Phase 10)**: Depends on all user stories and Phase 9b being complete
 
 ### User Story Dependencies
 
-- **US1 (Sliding Window)**: After Foundational — no story dependencies
-- **US2 (Transformers)**: After US1 — `SlidingWindowTransformer` wraps `compact_sliding_window_with()`
-- **US3 (Message Conversion)**: After Foundational — independent of US1/US2, can run in parallel with them
-- **US4 (Versioning)**: After US2 — `VersioningTransformer` wraps `ContextTransformer`
+- **US1 (Sliding Window)**: After Foundational — no story dependencies ✅
+- **US2 (Transformers)**: After US1 ✅
+- **US3 (Message Conversion)**: After Foundational ✅
+- **US4 (Versioning)**: After US2 ✅
+- **US5 (Context Caching)**: After Foundational — new module, no deps on US1-US4. Includes turn pipeline integration (T068), event emission (T069), sliding window protection (T070), and AgentMessage field (T067)
+- **US6 (Static/Dynamic Split)**: After US5 — references CacheConfig for cache-aware prompt building
+- **US7 (Overflow Predicate)**: After Foundational — independent of US5/US6, same file as token estimation
+- **Cache-Miss Retry (Phase 9b)**: After US5 core — adds error variant and retry path integration
 
 ### Within Each User Story
 
@@ -170,11 +256,13 @@
 
 ### Parallel Opportunities
 
-- T003, T004, T005 can run in parallel (independent module files)
-- US1 and US3 can run in parallel after Foundational (different files, no dependencies)
-- Within US1: T014 and T015 are sequential (same function), but T016 and T017 can follow immediately
-- Within US3: T027, T029 can run in parallel (different types in same file)
-- Within US4: T033, T034 can run in parallel (independent structs)
+- T003, T004, T005 can run in parallel (independent module files) ✅
+- US1 and US3 can run in parallel after Foundational ✅
+- US5 and US7 can run in parallel (different files, no dependencies)
+- US6 depends on US5 but can overlap — T057 (tests) can start while US5 pipeline tasks run
+- Phase 9b can run in parallel with US6 (different files: error.rs vs agent_options.rs)
+- Within US5: T048, T049 can run in parallel (independent types); T067 can run in parallel with T048-T050 (different file: types.rs)
+- Within US7: T059 and T060 are sequential (same function, TDD)
 
 ---
 
@@ -214,30 +302,29 @@ Task T032: Re-exports in src/lib.rs
 
 ## Implementation Strategy
 
-### MVP First (User Story 1 + User Story 3)
+### MVP First (User Story 1 + User Story 3) ✅ COMPLETE
 
-1. Complete Phase 1: Setup (module scaffolding)
-2. Complete Phase 2: Foundational (token estimation, result types)
-3. Complete Phase 3: User Story 1 (sliding window)
-4. Complete Phase 5: User Story 3 (message conversion) — can run in parallel with US1
-5. **STOP and VALIDATE**: `cargo test -p swink-agent context` and `cargo test -p swink-agent convert` both pass
-6. Core context management is functional
+1. Complete Phase 1: Setup (module scaffolding) ✅
+2. Complete Phase 2: Foundational (token estimation, result types) ✅
+3. Complete Phase 3: User Story 1 (sliding window) ✅
+4. Complete Phase 5: User Story 3 (message conversion) ✅
+5. Core context management is functional ✅
 
-### Incremental Delivery
+### Incremental Delivery (Updated 2026-03-31)
 
-1. Setup + Foundational -> Foundation ready
-2. Add US1 (Sliding Window) -> Test independently -> Core pruning works
-3. Add US3 (Message Conversion) -> Test independently -> Provider pipeline works
-4. Add US2 (Transformers) -> Test independently -> Pluggable transform hooks work
-5. Add US4 (Versioning) -> Test independently -> Debug/observability layer works
-6. Polish -> Full workspace validation
+1. Setup + Foundational → Foundation ready ✅
+2. Add US1 (Sliding Window) → Core pruning works ✅
+3. Add US3 (Message Conversion) → Provider pipeline works ✅
+4. Add US2 (Transformers) → Pluggable transform hooks work ✅
+5. Add US4 (Versioning) → Debug/observability layer works ✅
+6. **Add US5 (Context Caching) → Cache lifecycle, hint emission, event, sliding window protection, AgentMessage field**
+7. **Add US6 (Static/Dynamic Split) → Prompt separation for caching (dynamic as user-role message)**
+8. **Add US7 (Overflow Predicate) → Pre-flight overflow detection** (can run in parallel with US5/US6)
+9. **Add Phase 9b (Cache-Miss Retry) → Error variant + retry path integration**
+10. Polish → Full workspace validation
 
-### Parallel Team Strategy
+### Parallel Team Strategy (New Stories)
 
-With multiple developers:
-
-1. Team completes Setup + Foundational together
-2. Once Foundational is done:
-   - Developer A: US1 (Sliding Window) then US2 (Transformers)
-   - Developer B: US3 (Message Conversion) then US4 (Versioning, after US2 merges)
-3. Stories complete and integrate independently
+- **Developer A**: US5 (Context Caching + pipeline integration) then US6 (Static/Dynamic Split) — sequential dependency
+- **Developer B**: US7 (Overflow Predicate) then Phase 9b (Cache-Miss Retry, after US5 merges) — independent until 9b
+- Both merge → Phase 10 Polish


### PR DESCRIPTION
## Summary
- Expand 006-context-management spec with 3 new user stories: explicit context caching with TTL (US5), static/dynamic prompt split (US6), pre-flight overflow predicate (US7)
- Add FR-011 through FR-019 (9 new functional requirements), 30 new tasks (T047-T076)
- Design decisions D7-D9 in research.md: provider-agnostic CacheHint, static/dynamic split, overflow predicate
- 6 interactive clarifications: CacheHint as field on AgentMessage, turn-count-only TTL, CacheAction event, dynamic prompt as user-role message, static prompt immutability, cache-miss retry via RetryStrategy
- Cross-artifact analysis: fixed 3 critical coverage gaps, 5 high-severity issues (TDD ordering, T056 semantics), 2 medium/low

## Test plan
- [ ] All 19 FRs have task coverage (verified: 19/19)
- [ ] TDD ordering correct for US5, US6, US7 (tests before impl)
- [ ] No code changes — spec-only update, existing tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)