### PR TITLE
spec: emergency context overflow recovery for 004-agent-loop

### DIFF
--- a/specs/004-agent-loop/data-model.md
+++ b/specs/004-agent-loop/data-model.md
@@ -1,7 +1,7 @@
 # Data Model: Agent Loop
 
 **Feature**: 004-agent-loop
-**Date**: 2026-03-20
+**Date**: 2026-03-20 | **Updated**: 2026-03-31
 
 ## Overview
 
@@ -33,7 +33,8 @@ Internal mutable state for a single loop invocation.
 | Field | Type | Description |
 |-------|------|-------------|
 | context_messages | Vec<AgentMessage> | Current message history |
-| overflow_signal | bool | Set on context overflow, reset after transform_context |
+| overflow_signal | bool | Set during emergency overflow recovery, reset after transform_context processes it |
+| overflow_recovery_attempted | bool | Guards against infinite overflow loops — true after one emergency recovery attempt within a turn |
 | pending_messages | Vec<AgentMessage> | Steering/follow-up messages queued for next turn |
 | system_prompt | String | System prompt text |
 | tools | Vec<Arc<dyn AgentTool>> | Available tools |
@@ -112,5 +113,7 @@ Why the turn ended. Enum.
 - Events MUST be emitted in lifecycle order (FR-003)
 - Tool calls MUST execute concurrently (FR-007)
 - Overflow signal MUST reset after transform_context (CLAUDE.md lesson)
+- `overflow_recovery_attempted` MUST reset at the start of each turn (allows recovery once per turn)
+- Emergency overflow recovery MUST NOT occur when `overflow_recovery_attempted` is true (prevents infinite loops)
 - Error/abort MUST skip follow-up polling (FR-011)
 - Transform MUST run before convert-to-llm (FR-005)

--- a/specs/004-agent-loop/plan.md
+++ b/specs/004-agent-loop/plan.md
@@ -1,14 +1,14 @@
 # Implementation Plan: Agent Loop
 
-**Branch**: `004-agent-loop` | **Date**: 2026-03-20 | **Spec**: [spec.md](spec.md)
+**Branch**: `004-agent-loop` | **Date**: 2026-03-20 | **Updated**: 2026-03-31 | **Spec**: [spec.md](spec.md)
 **Input**: Feature specification from `/specs/004-agent-loop/spec.md`
 
 ## Summary
 
 Implement the core execution engine: the nested inner/outer loop that
 orchestrates LLM calls, concurrent tool dispatch, steering interrupts,
-follow-up continuation, retry integration, context overflow recovery,
-and max tokens recovery. The loop is stateless — all state is passed
+follow-up continuation, retry integration, emergency context overflow
+recovery (in-place compaction + retry), and max tokens recovery. The loop is stateless — all state is passed
 via `AgentLoopConfig` and `AgentContext`. It returns an async stream of
 `AgentEvent` values.
 

--- a/specs/004-agent-loop/quickstart.md
+++ b/specs/004-agent-loop/quickstart.md
@@ -89,6 +89,6 @@ let mut stream = agent_loop(vec![], context, config, token);
 - [ ] Follow-up messages cause loop continuation
 - [ ] Error/abort exits skip follow-up polling
 - [ ] Retry strategy consulted for transient failures
-- [ ] Context overflow signals transformation hook
+- [ ] Context overflow triggers emergency recovery (compact + retry), second failure surfaces error
 - [ ] Max tokens recovery replaces incomplete tool calls
 - [ ] Cancellation produces clean aborted shutdown

--- a/specs/004-agent-loop/research.md
+++ b/specs/004-agent-loop/research.md
@@ -1,7 +1,7 @@
 # Research: Agent Loop
 
 **Feature**: 004-agent-loop
-**Date**: 2026-03-20
+**Date**: 2026-03-20 | **Updated**: 2026-03-31
 
 ## Technical Context Resolution
 
@@ -78,6 +78,29 @@ HLD execution layer, CLAUDE.md lessons learned, and clarification session.
 - **Alternatives considered**: Callback-based emission — rejected
   because callbacks would require the loop to hold references to
   the subscriber, complicating lifetime management.
+
+### Emergency Context Overflow Recovery (Updated 2026-03-31)
+
+- **Decision**: When `ContextWindowExceeded` is detected in the stream
+  error path, perform in-place recovery: set `overflow_signal = true`,
+  re-run both async and sync context transformers, emit `ContextCompacted`
+  events, and retry the LLM call within the same turn. Limited to one
+  recovery attempt per turn via `overflow_recovery_attempted` guard.
+- **Rationale**: The original design set `overflow_signal` and returned
+  `TurnOutcome::ContinueInner`, which re-entered the turn from the top.
+  This worked but had a subtle gap: the overflow error was surfaced as
+  a `MessageEnd` event with the error *before* recovery, leaking the
+  internal retry to event subscribers. In-place recovery keeps the
+  overflow handling fully internal — subscribers only see the
+  `ContextCompacted` event and the successful (or failed) result.
+  AWS Strands uses the same pattern: `reduce_context()` is called
+  in the exception handler, then the request is retried immediately.
+- **Alternatives considered**: (1) Keep the sentinel-based approach —
+  rejected because it leaks a `MessageEnd` error event before recovery
+  and requires the turn to re-enter from the top, re-running policies
+  and re-emitting `TurnStart`. (2) Add overflow as a `RetryStrategy`
+  error kind — rejected because overflow recovery has fundamentally
+  different semantics (compact + retry once, not exponential backoff).
 
 ### Max Tokens Recovery
 

--- a/specs/004-agent-loop/spec.md
+++ b/specs/004-agent-loop/spec.md
@@ -2,8 +2,9 @@
 
 **Feature Branch**: `004-agent-loop`
 **Created**: 2026-03-20
+**Updated**: 2026-03-31
 **Status**: Draft
-**Input**: The core execution engine for the agent harness. Implements the nested inner/outer loop, tool dispatch, steering/follow-up injection, event emission, retry integration, error/abort handling, and max tokens recovery. Stateless — all state is passed in via configuration and context. References: PRD §8 (Event System), PRD §9 (Cancellation), PRD §10.1-10.2 (Context Overflow, Max Tokens), PRD §12 (Agent Loop), HLD Execution Layer and Single Turn Data Flow.
+**Input**: The core execution engine for the agent harness. Implements the nested inner/outer loop, tool dispatch, steering/follow-up injection, event emission, retry integration, error/abort handling, emergency context overflow recovery, and max tokens recovery. Stateless — all state is passed in via configuration and context. References: PRD §8 (Event System), PRD §9 (Cancellation), PRD §10.1-10.2 (Context Overflow, Max Tokens), PRD §12 (Agent Loop), HLD Execution Layer and Single Turn Data Flow, AWS Strands conversation_manager.reduce_context() pattern.
 
 ## User Scenarios & Testing *(mandatory)*
 
@@ -88,18 +89,24 @@ When the LLM provider returns a transient error (rate limit, network failure), t
 
 ---
 
-### User Story 6 - Context Overflow Recovery (Priority: P2)
+### User Story 6 - Emergency Context Overflow Recovery (Priority: P2)
 
-When the provider rejects a request because the context exceeds the model's window, the loop signals the overflow condition to the context transformation hook. On the next attempt, the hook applies more aggressive pruning, and the loop retries with the reduced context.
+When the streaming layer returns `StreamErrorKind::ContextWindowExceeded`, the loop does NOT surface the error immediately. Instead, it performs emergency recovery: sets `overflow_signal = true`, re-runs the context transformation pipeline (both async and sync transformers) to compact the context, emits a `ContextCompacted` event, and retries the LLM call with the reduced context. If the retry also fails with overflow (compaction was insufficient), THEN the error is surfaced. This is a single-retry recovery — no infinite loops.
 
-**Why this priority**: Context overflow is a common production issue with long conversations. Automatic recovery prevents hard failures.
+**Why this priority**: Context overflow is a common production issue with long conversations. The current implementation sets `overflow_signal` but only takes effect on the *next* turn — which never happens because the overflow error terminates the current turn. This change wires the overflow recovery directly into the stream error path so recovery happens in-place.
 
-**Independent Test**: Can be tested with a mock provider that rejects with overflow on the first call and succeeds on the second, verifying the overflow signal is passed to the transformation hook.
+**Key reference**: AWS Strands' `conversation_manager.reduce_context()` which is called automatically when `ContextWindowOverflowException` is caught, then the request is retried.
+
+**Independent Test**: Can be tested with a mock provider that rejects with overflow on the first call and succeeds on the second, verifying: (a) the transformation hook receives the overflow signal, (b) a `ContextCompacted` event is emitted, (c) the provider is retried with the reduced context, (d) if both attempts fail, the error is surfaced.
 
 **Acceptance Scenarios**:
 
-1. **Given** a context overflow error, **When** the loop retries, **Then** the transformation hook receives an overflow signal.
-2. **Given** the transformation hook reduces context, **When** the provider is called again, **Then** the reduced context is used.
+1. **Given** a `ContextWindowExceeded` error from the streaming layer, **When** the loop handles it, **Then** it does NOT surface the error immediately — it enters the emergency recovery path.
+2. **Given** the emergency recovery path, **When** `overflow_signal` is set to true, **Then** both the async context transformer (if present) and the sync context transformer are re-run with `overflow=true`.
+3. **Given** the transformers compact the context, **When** compaction produces a `CompactionReport`, **Then** a `ContextCompacted` event is emitted for each transformer that reports compaction.
+4. **Given** the compacted context, **When** the LLM is retried, **Then** it uses the reduced context from the emergency compaction.
+5. **Given** the retry also returns `ContextWindowExceeded`, **When** the second failure occurs, **Then** the error IS surfaced — no further retries (prevents infinite loops).
+6. **Given** no context transformer is configured, **When** overflow occurs, **Then** the error is surfaced immediately (no compaction possible, no point retrying).
 
 ---
 
@@ -125,6 +132,9 @@ When the provider stops mid-response because it hit the output token limit and t
 - How does the loop handle a provider that returns zero content blocks (empty response)? → Treat as natural stop with empty assistant message; emit `TurnEnd` with `Complete` reason.
 - What happens when all tool calls in a batch are cancelled by steering — does the loop still emit turn end? → Yes, emit `TurnEnd` with `SteeringInterrupt` reason.
 - What happens when the cancellation token is triggered during the provider call — does the loop emit an aborted stop reason? → Yes, cancellation during provider call emits `TurnEnd` with `Aborted` reason followed by `AgentEnd`.
+- What happens when overflow occurs but no context transformer is configured — the error is surfaced immediately. Without a transformer, compaction is not possible and retrying would produce the same result.
+- Does emergency overflow recovery count as a retry for the RetryStrategy — no. Overflow recovery is a separate code path from the general retry strategy. The overflow recovery has its own single-retry limit (one compaction + one retry), independent of `RetryStrategy` attempts.
+- Does emergency overflow recovery emit TurnStart/TurnEnd events for the retry — no. The recovery is internal to the stream error handling path. The retry re-runs the transform + stream within the same turn. Only the `ContextCompacted` event is emitted during recovery.
 
 ## Requirements *(mandatory)*
 
@@ -142,7 +152,10 @@ When the provider stops mid-response because it hit the output token limit and t
 - **FR-010**: When the inner loop exits normally, the outer loop MUST poll for follow-up messages. If available, the inner loop re-enters.
 - **FR-011**: When the inner loop exits due to error or abort, the outer loop MUST NOT poll for follow-up — it MUST emit AgentEnd and exit immediately.
 - **FR-012**: The loop MUST apply the retry strategy for retryable provider errors and respect the computed delay.
-- **FR-013**: Context overflow errors MUST signal the overflow condition to the transformation hook on retry.
+- **FR-013**: Context overflow errors MUST trigger emergency recovery: set `overflow_signal = true`, re-run both async and sync context transformers, emit `ContextCompacted` events, and retry the LLM call with the compacted context.
+- **FR-013a**: Emergency overflow recovery MUST be limited to a single retry. If the retry also fails with overflow, the error MUST be surfaced.
+- **FR-013b**: Emergency overflow recovery MUST NOT occur when no context transformer is configured — the error MUST be surfaced immediately.
+- **FR-013c**: Emergency overflow recovery MUST be independent of the `RetryStrategy` — it has its own single-retry limit and does not consume retry attempts.
 - **FR-014**: When the provider returns stop reason "length" with incomplete tool calls, the loop MUST replace each incomplete tool call with an error result and continue.
 - **FR-015**: Cancellation via the cancellation token MUST cause the loop to exit cleanly with an aborted stop reason.
 - **FR-016**: The convert-to-LLM function MUST be able to filter messages by returning nothing for messages that should not reach the provider.
@@ -164,7 +177,7 @@ When the provider stops mid-response because it hit the output token limit and t
 - **SC-005**: Error or abort stop reasons cause immediate exit without follow-up polling.
 - **SC-006**: Retryable errors trigger the retry strategy; the loop recovers on success.
 - **SC-007**: Non-retryable errors cause immediate loop exit.
-- **SC-008**: Context overflow triggers the overflow signal to the transformation hook.
+- **SC-008**: Context overflow triggers emergency recovery — transformers re-run with overflow=true, ContextCompacted emitted, LLM retried with compacted context. Second overflow surfaces the error.
 - **SC-009**: Incomplete tool calls from max tokens are replaced with error results and the loop continues.
 - **SC-010**: Cancellation produces a clean shutdown with aborted stop reason.
 - **SC-011**: The transformation hook is called before the convert-to-LLM function on every turn.
@@ -176,10 +189,18 @@ When the provider stops mid-response because it hit the output token limit and t
 - Q: How should the loop behave when no context transformation hook is provided? → A: Use an identity transform — context passes through unchanged.
 - Q: How should steering messages be handled when no tools are executing? → A: Queued as pending messages, processed before the next provider call.
 
+### Session 2026-03-31
+
+- Q: Where does emergency overflow recovery execute — in the turn pipeline or the stream retry path? → A: In the stream error handling path (`handle_stream_result` or `stream_with_retry`). When `StreamResult::ContextOverflow` is returned, instead of encoding a sentinel and returning to the turn, the recovery re-runs transformers and retries the stream call in-place.
+- Q: Does the CONTEXT_OVERFLOW_SENTINEL mechanism remain? → A: The sentinel encoding is replaced by in-place recovery. The `overflow_signal` flag on `LoopState` still exists but is set and consumed within the same turn rather than across turns.
+- Q: How does this interact with the existing retry strategy? → A: They are independent. Overflow recovery has its own single-retry limit. A `ContextWindowExceeded` error does not consume `RetryStrategy` attempts. If overflow recovery succeeds, the turn continues normally. If it fails, the error is surfaced directly (not routed through `RetryStrategy`).
+- Q: What if only the async transformer is configured (no sync)? → A: Only the async transformer runs. The recovery runs whatever transformers are available — async, sync, or both. If neither is configured, recovery is skipped and the error surfaces immediately.
+
 ## Assumptions
 
 - The loop is stateless — all state is passed in via AgentLoopConfig and AgentContext. Mutable state lives in the caller (Agent struct).
 - Concurrent tool execution uses task spawning with per-tool cancellation tokens.
 - The overflow signal is a boolean flag on the loop state, not an event — it is reset after the transformation hook processes it.
 - "Steering interrupt" means cancelling remaining tools and injecting error results; the steering message itself is processed on the next turn.
-- The context overflow sentinel is a loop control signal, not an error that propagates to the caller.
+- Emergency overflow recovery is bounded to one compaction + one retry per overflow occurrence. No infinite loops.
+- The `CONTEXT_OVERFLOW_SENTINEL` mechanism is superseded by in-place recovery in the stream error path. The sentinel constant may remain for backward compatibility but is no longer the primary recovery path.

--- a/specs/004-agent-loop/tasks.md
+++ b/specs/004-agent-loop/tasks.md
@@ -168,11 +168,11 @@
 
 ---
 
-## Phase 8: User Story 6 — Context Overflow Recovery (Priority: P2)
+## Phase 8: User Story 6 — Emergency Context Overflow Recovery (Priority: P2)
 
-**Goal**: Provider rejects request due to context overflow; loop signals overflow condition to transformation hook and retries with reduced context.
+**Goal**: Provider rejects request due to context overflow; loop performs emergency in-place recovery: re-runs context transformers with overflow=true, emits ContextCompacted, retries LLM call with compacted context. Fails after one retry to prevent infinite loops.
 
-**Independent Test**: Mock provider rejects with overflow on first call, succeeds on second; verify overflow signal passed to transformation hook.
+**Independent Test**: Mock provider rejects with overflow on first call, succeeds on second; verify: (a) transformers re-run with overflow=true, (b) ContextCompacted emitted, (c) reduced context used on retry, (d) second overflow surfaces error.
 
 ### Tests for User Story 6
 
@@ -180,14 +180,22 @@
 
 - [x] T046 [P] [US6] Write test verifying overflow error sets `overflow_signal = true` on `LoopState` in `tests/loop_overflow.rs`
 - [x] T047 [P] [US6] Write test verifying `transform_context` receives overflow signal and reduced context is used on retry in `tests/loop_overflow.rs`
+- [ ] T064 [P] [US6] Write test verifying emergency overflow recovery: mock provider rejects with overflow on first call, succeeds on second — verify both async and sync transformers re-run with `overflow=true`, `ContextCompacted` event emitted, and retry uses compacted context in `tests/loop_overflow.rs`
+- [ ] T065 [P] [US6] Write test verifying double overflow surfaces error: mock provider rejects with overflow on both calls — verify error is surfaced after one recovery attempt, no infinite loop in `tests/loop_overflow.rs`
+- [ ] T066 [P] [US6] Write test verifying no transformer configured: overflow error is surfaced immediately without retry in `tests/loop_overflow.rs`
+- [ ] T067 [P] [US6] Write test verifying `overflow_recovery_attempted` resets at turn start — second turn can also recover from overflow independently in `tests/loop_overflow.rs`
 
 ### Implementation for User Story 6
 
-- [x] T048 [US6] Implement overflow detection in `src/loop_/stream.rs` — detect `CONTEXT_OVERFLOW_SENTINEL` from provider error, set `LoopState.overflow_signal = true`
+- [x] T048 [US6] Implement overflow detection in `src/loop_/stream.rs` — detect `ContextWindowExceeded` from provider error via `classify_stream_error`, return `StreamErrorAction::ContextOverflow`
 - [x] T049 [US6] Implement overflow signal passing in `src/loop_/turn.rs` — pass `overflow_signal` to `transform_context`, reset to `false` after call; when `transform_context` returns `Some(report)`, emit `ContextCompacted` event
-- [x] T050 [US6] Implement overflow retry loop in `src/loop_/mod.rs` — when overflow detected, re-enter turn with overflow signal set (not a retry strategy error, a loop control signal)
+- [x] T050 [US6] Implement overflow retry via `TurnOutcome::ContinueInner` in `src/loop_/mod.rs` — when overflow detected, re-enter turn with overflow signal set
+- [ ] T068 [US6] Add `overflow_recovery_attempted: bool` field to `LoopState` in `src/loop_/mod.rs`. Initialize to `false`. Reset to `false` at the start of each turn in `src/loop_/turn.rs`.
+- [ ] T069 [US6] Implement emergency in-place overflow recovery in `src/loop_/stream.rs` or `src/loop_/turn.rs` — when `StreamResult::ContextOverflow` is returned and `overflow_recovery_attempted` is false: (a) set `overflow_signal = true`, (b) set `overflow_recovery_attempted = true`, (c) re-run async context transformer (if present) with overflow=true, (d) re-run sync context transformer (if present) with overflow=true, (e) emit `ContextCompacted` for each transformer that reports compaction, (f) re-run the convert-to-LLM pipeline, (g) retry the stream call with compacted context.
+- [ ] T070 [US6] Implement overflow guard — when `StreamResult::ContextOverflow` is returned and `overflow_recovery_attempted` is true, surface the error (do not retry). When no transformer is configured, surface immediately.
+- [ ] T071 [US6] Remove or deprecate the `CONTEXT_OVERFLOW_SENTINEL` encoding path in `handle_stream_result` — overflow recovery now happens in-place rather than via sentinel + `TurnOutcome::ContinueInner`. Retain the sentinel constant for backward compatibility but mark as deprecated.
 
-**Checkpoint**: Context overflow triggers transformation hook with overflow signal (SC-008)
+**Checkpoint**: Emergency overflow recovery works — compact + retry on first overflow, error on second (SC-008)
 
 ---
 
@@ -300,7 +308,7 @@ Task T020: "Test loop exit on no more tools in tests/loop_tool_execution.rs"
 4. US3 (Steering) → Test independently → Interactive interrupts work
 5. US4 (Follow-Up) → Test independently → Autonomous continuation works
 6. US5 (Retry) → Test independently → Production reliability
-7. US6 (Overflow) → Test independently → Long conversation recovery
+7. US6 (Emergency Overflow Recovery) → Test independently → In-place compact + retry recovery
 8. US7 (Max Tokens) → Test independently → Edge case recovery
 9. Polish → All edge cases, clippy clean, full test suite green
 


### PR DESCRIPTION
## Summary
- Upgrade US6 from passive overflow signaling to active in-place recovery
- On ContextWindowExceeded: re-run transformers with overflow=true, emit ContextCompacted, retry LLM — all within the same turn
- Bounded to one retry to prevent infinite loops; no retry when no transformer configured
- Supersedes CONTEXT_OVERFLOW_SENTINEL sentinel approach
- Adds FR-013a/b/c, overflow_recovery_attempted guard, 8 new tasks (T064-T071), design decision referencing AWS Strands pattern

## Test plan
- [ ] All FRs have task coverage including new FR-013a/b/c
- [ ] TDD ordering maintained (test tasks before impl)
- [ ] No code changes — spec-only update

🤖 Generated with [Claude Code](https://claude.com/claude-code)