### PR TITLE
spec: OpenTelemetry integration (C9) for 010-loop-policies-observability

### DIFF
--- a/specs/010-loop-policies-observability/checklists/requirements.md
+++ b/specs/010-loop-policies-observability/checklists/requirements.md
@@ -29,6 +29,16 @@
 - [x] Feature meets measurable outcomes defined in Success Criteria
 - [x] No implementation details leak into specification
 
+## OpenTelemetry Addition (C9)
+
+- [x] US7 acceptance scenarios are testable and unambiguous
+- [x] FR-011 through FR-015 are measurable
+- [x] SC-009 through SC-011 are technology-agnostic success criteria
+- [x] Edge cases for OTel (exporter unavailable, model fallback, concurrent tools) are identified
+- [x] Feature gate boundary is clearly defined (otel feature)
+- [x] Coexistence with MetricsCollector is explicitly specified
+
 ## Notes
 
 - All items pass. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- C9 (OpenTelemetry) added 2026-03-31: US7, FR-011–FR-015, SC-009–SC-011, tasks T073–T092.

--- a/specs/010-loop-policies-observability/contracts/public-api.md
+++ b/specs/010-loop-policies-observability/contracts/public-api.md
@@ -263,4 +263,73 @@ pub use stream_middleware::StreamMiddleware;
 pub use emit::Emission;
 pub use metrics::{MetricsCollector, TurnMetrics, ToolExecMetrics};
 pub use checkpoint::{Checkpoint, LoopCheckpoint, CheckpointStore};
+
+// New (feature = "otel"):
+#[cfg(feature = "otel")]
+pub use otel::{OtelInitConfig, init_otel_layer};
+```
+
+## OpenTelemetry Integration (feature = "otel")
+
+### Span Instrumentation (core loop)
+
+The agent loop emits `tracing` spans at key lifecycle points. These are always present as `tracing` spans (useful for `tracing_subscriber::fmt` logging) and become OTel spans when `tracing-opentelemetry` is configured as a subscriber layer.
+
+```rust
+// Span hierarchy (created via tracing::info_span! in the loop):
+//
+// agent.run                              — root span, covers full agent_loop() call
+//   └─ agent.turn                        — per turn, fields: agent.turn_index, agent.stop_reason
+//       ├─ agent.llm_call                — per LLM streaming call, fields: agent.model,
+//       │                                    agent.tokens.input, agent.tokens.output, agent.cost.total
+//       ├─ agent.tool.{name}             — per tool execution, fields: agent.tool.name
+//       └─ agent.tool.{name}             — concurrent tools are sibling spans
+```
+
+**Span field types** (recorded via `tracing::Span::record`):
+
+| Field | Type | When Recorded |
+|-------|------|---------------|
+| `agent.model` | `&str` | On `agent.llm_call` span entry |
+| `agent.turn_index` | `u64` | On `agent.turn` span entry |
+| `agent.tokens.input` | `u64` | On `agent.llm_call` span exit (after streaming completes) |
+| `agent.tokens.output` | `u64` | On `agent.llm_call` span exit |
+| `agent.cost.total` | `f64` | On `agent.llm_call` span exit |
+| `agent.tool.name` | `&str` | On `agent.tool.{name}` span entry |
+| `agent.stop_reason` | `&str` | On `agent.turn` span exit |
+
+### OtelInitConfig
+
+```rust
+#[cfg(feature = "otel")]
+pub struct OtelInitConfig {
+    pub service_name: String,       // default: "swink-agent"
+    pub endpoint: Option<String>,   // default: "http://localhost:4317" (gRPC OTLP)
+}
+```
+
+Derives: `Debug`, `Clone`, `Default`.
+
+### init_otel_layer
+
+```rust
+#[cfg(feature = "otel")]
+pub fn init_otel_layer(
+    config: OtelInitConfig,
+) -> impl tracing_subscriber::Layer<S>
+where
+    S: tracing::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span>;
+```
+
+Returns a configured `tracing_opentelemetry::OpenTelemetryLayer` with an OTLP exporter. Users compose this into their `tracing_subscriber` stack:
+
+```rust
+use tracing_subscriber::prelude::*;
+use swink_agent::otel::{OtelInitConfig, init_otel_layer};
+
+let otel_layer = init_otel_layer(OtelInitConfig::default());
+tracing_subscriber::registry()
+    .with(otel_layer)
+    .with(tracing_subscriber::fmt::layer()) // optional: also log to console
+    .init();
 ```

--- a/specs/010-loop-policies-observability/data-model.md
+++ b/specs/010-loop-policies-observability/data-model.md
@@ -253,6 +253,44 @@ pub trait CheckpointStore: Send + Sync {
 
 Where `AsyncResult<'a, T> = Pin<Box<dyn Future<Output = io::Result<T>> + Send + 'a>>`.
 
+### OTel Span Hierarchy (feature-gated: `otel`)
+
+The OpenTelemetry integration maps the agent loop lifecycle to a span tree. No new structs are introduced — the integration is implemented via `tracing` instrumentation spans with recorded fields.
+
+**Span tree**:
+
+| Span Name | Parent | Lifetime | Key Attributes |
+|-----------|--------|----------|----------------|
+| `agent.run` | (root or caller span) | Full `agent_loop` / `agent_loop_continue` call | — |
+| `agent.turn` | `agent.run` | Single turn (TurnStart → TurnEnd) | `agent.turn_index`, `agent.stop_reason` |
+| `agent.llm_call` | `agent.turn` | LLM streaming call duration | `agent.model`, `agent.tokens.input`, `agent.tokens.output`, `agent.cost.total` |
+| `agent.tool.{name}` | `agent.turn` | Tool execution duration | `agent.tool.name`, `otel.status_code` (OK/ERROR) |
+
+**Semantic attributes** (recorded as `tracing` span fields):
+
+| Attribute | Type | Source |
+|-----------|------|--------|
+| `agent.model` | `String` | `ModelSpec.model_id` from `AgentLoopConfig` / `BeforeLlmCall` event |
+| `agent.turn_index` | `u64` | `TurnMetrics.turn_index` or loop counter |
+| `agent.tokens.input` | `u64` | `TurnMetrics.usage.input` |
+| `agent.tokens.output` | `u64` | `TurnMetrics.usage.output` |
+| `agent.cost.total` | `f64` | `TurnMetrics.cost.total` |
+| `agent.tool.name` | `String` | `ToolExecutionStart.name` |
+| `agent.stop_reason` | `String` | `TurnEndReason` display value |
+
+**Integration point**: `tracing::info_span!` calls in `src/loop_/mod.rs` and `src/loop_/turn.rs`, gated by `#[cfg(feature = "otel")]`. When the feature is disabled, these are standard `tracing` spans (already present for diagnostics). When enabled, `tracing-opentelemetry` bridges them to OTel.
+
+### OtelInitConfig (feature-gated: `otel`)
+
+Configuration for the convenience `init_otel_layer()` function.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `service_name` | `String` | OTel service name (default: `"swink-agent"`) |
+| `endpoint` | `Option<String>` | OTLP exporter endpoint (default: `http://localhost:4317` for gRPC) |
+
+Implements: `Debug`, `Clone`, `Default`.
+
 ## Relationships
 
 ```
@@ -278,4 +316,13 @@ Checkpoint --contains--> Vec<LlmMessage>, Usage, Cost
 LoopCheckpoint --contains--> Vec<LlmMessage>, Usage, Cost, AssistantMessage
     LoopCheckpoint --converts-to--> Checkpoint (via to_checkpoint)
 CheckpointStore --persists--> Checkpoint
+
+OTel Span Hierarchy (feature = "otel"):
+    agent.run --parent-of--> agent.turn
+    agent.turn --parent-of--> agent.llm_call
+    agent.turn --parent-of--> agent.tool.{name}
+    agent.llm_call --records--> ModelSpec, Usage, Cost
+    agent.tool.{name} --records--> tool_name, duration, success
+    tracing-opentelemetry --bridges--> tracing spans to OTel SDK
+    OtelInitConfig --configures--> TracerProvider (OTLP exporter)
 ```

--- a/specs/010-loop-policies-observability/plan.md
+++ b/specs/010-loop-policies-observability/plan.md
@@ -11,17 +11,17 @@
 
 ## Summary
 
-Cross-cutting infrastructure for agent loop governance, observability, and resumability. ~~Provides composable loop policies (`LoopPolicy` trait with `MaxTurnsPolicy`, `CostCapPolicy`, `ComposedPolicy`, and closure blanket impl) for post-turn termination decisions.~~ **[Superseded by 031]** Loop termination, post-turn hooks, and budget enforcement are now handled by configurable policy slots. Stream middleware (`StreamMiddleware`) wraps `StreamFn` using the decorator pattern for event interception, transformation, and filtering. Structured emission (`Emission`) carries named payloads for enriched events. An async `MetricsCollector` trait receives `TurnMetrics` snapshots (LLM call duration, per-tool timing, token usage, cost). ~~Async `PostTurnHook` callbacks return `PostTurnAction` (Continue/Stop/InjectMessages) to influence loop control flow. `BudgetGuard` provides pre-call cost/token gating for real-time budget enforcement.~~ **[Superseded by 031]** `Checkpoint` and `LoopCheckpoint` capture serializable snapshots of agent state, with `CheckpointStore` as an async trait for persistence.
+Cross-cutting infrastructure for agent loop governance, observability, and resumability. ~~Provides composable loop policies (`LoopPolicy` trait with `MaxTurnsPolicy`, `CostCapPolicy`, `ComposedPolicy`, and closure blanket impl) for post-turn termination decisions.~~ **[Superseded by 031]** Loop termination, post-turn hooks, and budget enforcement are now handled by configurable policy slots. Stream middleware (`StreamMiddleware`) wraps `StreamFn` using the decorator pattern for event interception, transformation, and filtering. Structured emission (`Emission`) carries named payloads for enriched events. An async `MetricsCollector` trait receives `TurnMetrics` snapshots (LLM call duration, per-tool timing, token usage, cost). ~~Async `PostTurnHook` callbacks return `PostTurnAction` (Continue/Stop/InjectMessages) to influence loop control flow. `BudgetGuard` provides pre-call cost/token gating for real-time budget enforcement.~~ **[Superseded by 031]** `Checkpoint` and `LoopCheckpoint` capture serializable snapshots of agent state, with `CheckpointStore` as an async trait for persistence. OpenTelemetry integration (US7, feature-gated `otel`) adds `tracing` span instrumentation to the agent loop, bridged to OTel via `tracing-opentelemetry` for zero-code integration with OTLP-compatible backends.
 
 ## Technical Context
 
 **Language/Version**: Rust 1.88 (edition 2024)
-**Primary Dependencies**: tokio (async runtime), tokio-util (CancellationToken), futures (Stream, StreamExt), serde / serde_json (serialization), tracing (diagnostics)
+**Primary Dependencies**: tokio (async runtime), tokio-util (CancellationToken), futures (Stream, StreamExt), serde / serde_json (serialization), tracing (diagnostics), tracing-opentelemetry + opentelemetry + opentelemetry-otlp (optional, `otel` feature)
 **Storage**: N/A (in-memory by default; `CheckpointStore` trait abstracts persistence)
 **Testing**: `cargo test --workspace` — unit tests in each source module, integration tests in `tests/`
 **Target Platform**: Cross-platform library (any target supporting tokio)
 **Project Type**: Library crate (`swink-agent`)
-**Performance Goals**: Non-blocking policy checks (synchronous predicate); non-blocking budget guard (const fn check); zero-overhead when checkpointing is not configured
+**Performance Goals**: Non-blocking policy checks (synchronous predicate); non-blocking budget guard (const fn check); zero-overhead when checkpointing is not configured; zero-overhead OTel instrumentation when feature is disabled (tracing spans are no-ops without subscriber)
 **Constraints**: `#[forbid(unsafe_code)]`; no provider-specific dependencies; no global mutable state (all shared state via `Arc<Mutex<>>`)
 **Scale/Scope**: Governance and observability layer — composable primitives for loop control, metrics, and state persistence
 
@@ -31,12 +31,12 @@ Cross-cutting infrastructure for agent loop governance, observability, and resum
 
 | Principle | Status | Notes |
 |-----------|--------|-------|
-| I. Library-First | PASS | All types are library structs/traits in the core crate. LoopPolicy, StreamMiddleware, MetricsCollector, PostTurnHook, BudgetGuard, Checkpoint, and CheckpointStore are independently usable API surfaces with no service/daemon coupling. |
-| II. Test-Driven Development | PASS | Each module has comprehensive unit tests: loop_policy (7 tests), stream_middleware (4 tests), metrics (4 tests), post_turn_hook (5 tests), budget_guard (12 tests), checkpoint (10 tests). All test names are descriptive snake_case without `test_` prefix. |
-| III. Efficiency & Performance | PASS | LoopPolicy::should_continue is synchronous (no async overhead at turn boundary). BudgetGuard::check is `const fn`. StreamMiddleware adds zero cost when not used. Checkpoint overhead is zero when not configured (opt-in). |
-| IV. Leverage the Ecosystem | PASS | Uses futures Stream/StreamExt for middleware composition, serde for checkpoint serialization, tokio CancellationToken for budget guard cancellation. No custom reimplementations. |
-| V. Provider Agnosticism | PASS | No provider-specific types. StreamMiddleware wraps the generic `StreamFn` trait. Policies operate on `PolicyContext` (turn index, usage, cost) — provider-independent data. |
-| VI. Safety & Correctness | PASS | `#[forbid(unsafe_code)]`. BudgetExceeded is a proper error enum with Display. PostTurnHook panics are caught and the hook is skipped (per spec). Poisoned mutex recovery via `into_inner()` in CheckpointStore implementations. Compile-time Send+Sync assertions on all public types. |
+| I. Library-First | PASS | All types are library structs/traits in the core crate. LoopPolicy, StreamMiddleware, MetricsCollector, PostTurnHook, BudgetGuard, Checkpoint, and CheckpointStore are independently usable API surfaces with no service/daemon coupling. OTel module (`otel.rs`) is feature-gated library code — no daemon or service coupling. |
+| II. Test-Driven Development | PASS | Each module has comprehensive unit tests: loop_policy (7 tests), stream_middleware (4 tests), metrics (4 tests), post_turn_hook (5 tests), budget_guard (12 tests), checkpoint (10 tests). OTel tasks include unit tests (T082) and integration tests (T083–T085). All test names are descriptive snake_case without `test_` prefix. |
+| III. Efficiency & Performance | PASS | LoopPolicy::should_continue is synchronous (no async overhead at turn boundary). BudgetGuard::check is `const fn`. StreamMiddleware adds zero cost when not used. Checkpoint overhead is zero when not configured (opt-in). OTel spans via `tracing` are no-ops without a subscriber — zero overhead when `otel` feature is disabled. |
+| IV. Leverage the Ecosystem | PASS | Uses futures Stream/StreamExt for middleware composition, serde for checkpoint serialization, tokio CancellationToken for budget guard cancellation. OTel uses `tracing-opentelemetry` (standard Rust OTel bridge) rather than hand-rolling span export. No custom reimplementations. |
+| V. Provider Agnosticism | PASS | No provider-specific types. StreamMiddleware wraps the generic `StreamFn` trait. Policies operate on `PolicyContext` (turn index, usage, cost) — provider-independent data. OTel spans record model ID as a string attribute — no provider-specific types. |
+| VI. Safety & Correctness | PASS | `#[forbid(unsafe_code)]`. BudgetExceeded is a proper error enum with Display. PostTurnHook panics are caught and the hook is skipped (per spec). Poisoned mutex recovery via `into_inner()` in CheckpointStore implementations. Compile-time Send+Sync assertions on all public types including OtelInitConfig. OTel span attributes limited to structural metadata — no content leakage (FR-016). |
 
 ## Project Structure
 
@@ -64,6 +64,7 @@ src/
 ├── post_turn_hook.rs    # PostTurnHook trait, PostTurnContext, PostTurnAction enum
 ├── budget_guard.rs      # BudgetGuard (pre-call check), BudgetExceeded error enum
 ├── checkpoint.rs        # Checkpoint, LoopCheckpoint, CheckpointStore trait
+├── otel.rs              # [feature = "otel"] OtelInitConfig, init_otel_layer() convenience function
 └── lib.rs               # Re-exports all public types
 ```
 

--- a/specs/010-loop-policies-observability/quickstart.md
+++ b/specs/010-loop-policies-observability/quickstart.md
@@ -8,6 +8,9 @@
 # Build the workspace
 cargo build --workspace
 
+# Build with OTel feature enabled
+cargo build -p swink-agent --features otel
+
 # Run all tests
 cargo test --workspace
 
@@ -18,6 +21,10 @@ cargo test -p swink-agent metrics
 cargo test -p swink-agent post_turn_hook
 cargo test -p swink-agent budget_guard
 cargo test -p swink-agent checkpoint
+cargo test -p swink-agent otel --features otel
+
+# Verify OTel feature gate (no OTel deps without feature)
+cargo test -p swink-agent --no-default-features
 
 # Lint
 cargo clippy --workspace -- -D warnings
@@ -271,4 +278,68 @@ store.save_checkpoint(&checkpoint).await?;
 
 // Restore pending messages
 let pending = loop_cp.restore_pending_messages();
+```
+
+### Enable OpenTelemetry tracing
+
+Add the `otel` feature to your `Cargo.toml`:
+
+```toml
+[dependencies]
+swink-agent = { version = "0.4", features = ["otel"] }
+```
+
+Set up the OTel subscriber layer:
+
+```rust
+use tracing_subscriber::prelude::*;
+use swink_agent::otel::{OtelInitConfig, init_otel_layer};
+
+// Quick setup: OTLP exporter to localhost:4317
+let otel_layer = init_otel_layer(OtelInitConfig::default());
+tracing_subscriber::registry()
+    .with(otel_layer)
+    .init();
+
+// Now run agents as normal — spans are automatically exported
+let mut agent = Agent::new(options);
+let result = agent.prompt_text("Hello").await?;
+// Spans emitted: agent.run → agent.turn → agent.llm_call
+```
+
+### Custom OTel endpoint
+
+```rust
+use swink_agent::otel::{OtelInitConfig, init_otel_layer};
+
+let config = OtelInitConfig {
+    service_name: "my-agent-service".into(),
+    endpoint: Some("https://otel-collector.example.com:4317".into()),
+};
+let otel_layer = init_otel_layer(config);
+```
+
+### OTel + console logging together
+
+```rust
+use tracing_subscriber::prelude::*;
+use swink_agent::otel::{OtelInitConfig, init_otel_layer};
+
+tracing_subscriber::registry()
+    .with(init_otel_layer(OtelInitConfig::default()))
+    .with(tracing_subscriber::fmt::layer())  // also log to stderr
+    .init();
+```
+
+### OTel with MetricsCollector (both enabled)
+
+```rust
+// OTel and MetricsCollector are independent — use both:
+let options = AgentOptions::new_simple("prompt", model, stream_fn)
+    .with_metrics_collector(Arc::new(LogMetrics));
+
+// OTel spans are emitted via tracing subscriber (configured above)
+// MetricsCollector::on_metrics is called at each turn end (as usual)
+// No duplication — OTel observes the loop lifecycle, MetricsCollector
+// receives structured TurnMetrics data
 ```

--- a/specs/010-loop-policies-observability/research.md
+++ b/specs/010-loop-policies-observability/research.md
@@ -69,3 +69,44 @@
 - **Single checkpoint type**: Would either bloat the portable format with loop internals or lose loop state for pause/resume. Two types serve both needs cleanly.
 - **Custom error type**: `io::Result` is sufficient and well-understood. Storage errors are inherently I/O errors.
 - **Automatic checkpointing in the loop**: Would couple the loop to a specific checkpointing strategy. Opt-in via `PostTurnHook` or explicit calls keeps the loop lean.
+
+### D7: OpenTelemetry via `tracing` + `tracing-opentelemetry` (not direct OTel API)
+
+**Decision**: Instrument the agent loop with `tracing` spans and fields (which is already used for diagnostics). Feature-gate `tracing-opentelemetry` behind `otel` so that, when enabled, existing `tracing` spans are automatically exported as OTel spans. The core crate never imports `opentelemetry` directly — it only uses `tracing` macros.
+
+**Rationale**: The `tracing` crate is already a dependency. Adding `tracing::info_span!` calls with structured fields costs nothing when no subscriber is attached and integrates naturally with the Rust ecosystem. The `tracing-opentelemetry` layer is the standard Rust bridge — it maps `tracing::Span` to `opentelemetry::trace::Span` with zero application code changes. This approach means:
+1. Users who don't need OTel pay zero cost (no feature, no dep, no overhead).
+2. Users who do need OTel get it by adding a `tracing_subscriber` layer — no code changes to the agent.
+3. The core loop is instrumented once with `tracing` spans, benefiting both OTel users and plain `tracing` users (e.g., `tracing_subscriber::fmt` for console logging).
+
+**Key references**:
+- AWS Strands SDK uses Python `opentelemetry` SDK with manual spans for agent/loop/tool.
+- Google ADK uses Google Cloud Trace with custom spans.
+- Rust ecosystem standard: `tracing` + `tracing-opentelemetry` (used by Axum, Tonic, and most production Rust services).
+
+**Alternatives rejected**:
+- **Direct `opentelemetry` API in the core crate**: Would add a hard dependency on the OTel SDK, increase compile times for all users, and couple the core to a specific observability system. The `tracing` layer approach is strictly more flexible.
+- **EventForwarder-based OTel bridge**: Would require a separate struct that subscribes to `AgentEvent` and manually creates OTel spans post-hoc. This loses proper span hierarchy (parent-child) because events are point-in-time, not scoped. `tracing` spans are scoped by design.
+- **MetricsCollector-based OTel bridge**: Same problem — MetricsCollector runs at turn end, so it can only emit after-the-fact data, not properly nested spans. OTel tracing requires spans to be entered/exited at the correct points in the lifecycle.
+- **Separate `swink-agent-otel` crate**: Over-scoped for what is essentially a few `info_span!` calls and a convenience init function. The feature gate in the core crate is simpler and keeps instrumentation co-located with the code it observes.
+
+### D8: Span hierarchy design — flat turns with nested calls
+
+**Decision**: Four-level span hierarchy: `agent.run` (root) → `agent.turn` → `agent.llm_call` / `agent.tool.{name}`. Tool spans are children of the turn, not children of the LLM call. Multiple tool executions within a turn appear as sibling spans.
+
+**Rationale**: Tools execute after the LLM call completes (the LLM decides which tools to call, then tools run). Making tools children of the LLM call would be semantically wrong — tools are a phase of the turn, not part of the LLM request. Concurrent tools are siblings with overlapping timelines, which OTel handles natively.
+
+**Alternatives rejected**:
+- **Tools as children of LLM call**: Incorrect semantics. The LLM call ends before tools begin.
+- **Flat spans (no hierarchy)**: Would lose the parent-child relationship, making it impossible to filter "all spans for turn 3" or "all tool calls in this run" in Jaeger/Grafana.
+- **Per-message spans**: Too granular. MessageStart/Update/End are streaming deltas within a single LLM call — they don't warrant separate OTel spans (they'd create thousands of microsecond spans). The `agent.llm_call` span covers the entire streaming duration.
+
+### D9: Convenience `init_otel_layer` vs leave setup to users
+
+**Decision**: Provide an optional convenience function `init_otel_layer(config: OtelInitConfig) -> impl Layer<S>` that wires up `tracing-opentelemetry` with an OTLP exporter. This function lives behind the `otel` feature gate. Users can ignore it and set up their own `tracing_subscriber` pipeline.
+
+**Rationale**: OTel pipeline setup involves ~15 lines of boilerplate (TracerProvider, OTLP exporter, resource, tracing-opentelemetry layer). A convenience function reduces friction for the common case (OTLP to localhost:4317) while remaining fully optional. Advanced users (custom exporters, Prometheus, batching config) compose their own subscriber stack.
+
+**Alternatives rejected**:
+- **No convenience function**: Would require every user to write the same boilerplate. The function saves time without constraining power users.
+- **Auto-init via environment variable**: Implicit behavior is surprising. Explicit `init_otel_layer()` call is clearer and testable.

--- a/specs/010-loop-policies-observability/spec.md
+++ b/specs/010-loop-policies-observability/spec.md
@@ -3,7 +3,7 @@
 **Feature Branch**: `010-loop-policies-observability`
 **Created**: 2026-03-20
 **Status**: Draft
-**Input**: Composable loop termination policies, stream middleware, structured event emission, metrics collection, post-turn hooks, budget guards, and checkpoint snapshots. Cross-cutting infrastructure for governance, observability, and resumability. References: HLD Infrastructure Layer (LoopPolicy, StreamMiddleware, Emission, MetricsCollector, PostTurnHook, BudgetGuard, Checkpoint).
+**Input**: Composable loop termination policies, stream middleware, structured event emission, metrics collection, post-turn hooks, budget guards, checkpoint snapshots, and OpenTelemetry integration. Cross-cutting infrastructure for governance, observability, and resumability. References: HLD Infrastructure Layer (LoopPolicy, StreamMiddleware, Emission, MetricsCollector, PostTurnHook, BudgetGuard, Checkpoint, OpenTelemetry).
 
 ## Supersession Notice
 
@@ -118,12 +118,34 @@ A developer enables checkpoints so the agent's loop state is snapshotted at turn
 
 ---
 
+### User Story 7 - OpenTelemetry Integration (Priority: P2) — C9
+
+An operator enables OpenTelemetry-compliant tracing so that Swink agents emit structured spans and attributes compatible with standard observability backends (Datadog, Grafana, Honeycomb, Jaeger). The integration is opt-in via a feature gate and works alongside the existing `MetricsCollector` and `AgentEvent` systems without replacing them.
+
+**Why this priority**: Production teams need agents to fit into existing observability stacks. Without OTel, operators must build custom adapters from `MetricsCollector` or `AgentEvent` data. OTel gives them zero-custom-code integration with any OTLP-compatible backend.
+
+**Independent Test**: Can be tested by enabling the `otel` feature, running an agent with a mock OTel exporter, and verifying the exporter receives the expected span hierarchy and attributes.
+
+**Acceptance Scenarios**:
+
+1. **Given** the `otel` feature is enabled and a `TracerProvider` is configured, **When** the agent runs a prompt, **Then** a root span `agent.run` is created covering the full prompt-to-response lifecycle.
+2. **Given** an active `agent.run` span, **When** a turn begins and ends, **Then** a child span `agent.turn` is created with attributes `agent.turn_index` and `agent.stop_reason`.
+3. **Given** an active `agent.turn` span, **When** the LLM streaming call executes, **Then** a child span `agent.llm_call` is created with attributes `agent.model`, `agent.tokens.input`, `agent.tokens.output`, and `agent.cost.total`.
+4. **Given** an active `agent.turn` span, **When** a tool executes, **Then** a child span `agent.tool.{name}` is created with attributes `agent.tool.name`, the tool duration, and success/error status.
+5. **Given** the `otel` feature is **not** enabled, **When** the crate is compiled, **Then** no OpenTelemetry dependencies are included and there is zero runtime overhead.
+6. **Given** OTel tracing is enabled, **When** a `MetricsCollector` is also configured, **Then** both operate independently — OTel does not suppress or duplicate the `MetricsCollector` callback.
+
+---
+
 ### Edge Cases
 
 - What happens when a policy and a budget guard both trigger — **[Superseded by 031]** Both are now policies in slots. BudgetPolicy runs in PreTurn (Slot 1), MaxTurnsPolicy runs in PostTurn (Slot 3). They are independent policies at different slots and cannot trigger simultaneously.
 - How does the system handle a post-turn hook that panics — the panic is caught and logged; the hook's action is skipped and the loop continues. A panicking hook does not crash the agent.
 - What happens when the checkpoint store fails to persist — `CheckpointStore` returns `io::Result`; failures propagate as errors. The caller decides whether to continue or stop.
 - How does stream middleware interact with retry — each retry re-invokes StreamFn, producing a new stream that gets wrapped by middleware again. Retries are also wrapped.
+- What happens when the OTel exporter is unavailable — spans are still created via the `tracing` crate; the exporter failure is handled by the OTel SDK (typically logged and dropped). The agent loop is never blocked or slowed by exporter issues.
+- How does OTel interact with model fallback — when a model fallback occurs, the failed `agent.llm_call` span ends with an error status, and a new `agent.llm_call` span is created for the fallback model. Both appear as children of the same `agent.turn`.
+- What happens with concurrent tool executions — each tool gets its own `agent.tool.{name}` span. Concurrent tools produce overlapping child spans under the same `agent.turn` parent, which is standard OTel behavior.
 
 ## Requirements *(mandatory)*
 
@@ -139,6 +161,13 @@ A developer enables checkpoints so the agent's loop state is snapshotted at turn
 - **FR-008**: System MUST provide async post-turn hooks that execute after each turn and return a `PostTurnAction` (Continue, Stop, or InjectMessages) to influence loop behavior.
 - **FR-009**: System MUST provide a budget guard that monitors cost, token, and turn thresholds in real time during stream collection and cancels the agent when any threshold is exceeded.
 - **FR-010**: System MUST provide checkpoint snapshots at turn boundaries with save and restore capability.
+- **FR-011**: System MUST provide opt-in OpenTelemetry integration behind a `feature = "otel"` gate that emits structured spans with a hierarchy of `agent.run` → `agent.turn` → `agent.llm_call` / `agent.tool.{name}`.
+- **FR-012**: OTel spans MUST carry semantic attributes: `agent.model`, `agent.turn_index`, `agent.tokens.input`, `agent.tokens.output`, `agent.cost.total`, `agent.tool.name`, `agent.stop_reason`.
+- **FR-013**: OTel integration MUST use the `tracing` crate with `tracing-opentelemetry` as the bridge layer, leveraging the existing `tracing` dependency rather than importing `opentelemetry` APIs directly into the core crate.
+- **FR-014**: OTel integration MUST coexist with the existing `MetricsCollector` trait — enabling OTel MUST NOT disable, replace, or duplicate `MetricsCollector` callbacks.
+- **FR-015**: When the `otel` feature is disabled, there MUST be zero additional dependencies and zero runtime overhead from OTel instrumentation.
+- **FR-016**: OTel span attributes MUST be limited to structural metadata (tool name, model ID, token counts, cost, turn index, stop reason). Spans MUST NOT include prompt text, tool arguments, or tool results to prevent data leakage to external backends.
+- **FR-017**: The `otel` feature MUST only emit OTel traces (spans). OTel Metrics (counters, histograms) are explicitly out of scope — the `MetricsCollector` trait serves that role.
 
 ### Key Entities
 
@@ -148,6 +177,8 @@ A developer enables checkpoints so the agent's loop state is snapshotted at turn
 - **PostTurnHook**: Callback executed after each turn for side effects.
 - **BudgetGuard**: Real-time cost/token/turn monitor that cancels the agent on threshold breach.
 - **Checkpoint**: Serializable snapshot of loop state at a turn boundary.
+- **OtelInitConfig**: Configuration struct for the convenience `init_otel_layer()` function (service name, OTLP endpoint). Feature-gated behind `otel`.
+- **init_otel_layer()**: Convenience function returning a `tracing_subscriber::Layer` that bridges `tracing` spans to OpenTelemetry via `tracing-opentelemetry` with an OTLP gRPC exporter.
 
 ## Success Criteria *(mandatory)*
 
@@ -161,6 +192,9 @@ A developer enables checkpoints so the agent's loop state is snapshotted at turn
 - **SC-006**: Post-turn hooks execute after every turn without affecting loop control flow.
 - **SC-007**: Budget guard cancels the agent in real time when any threshold is exceeded.
 - **SC-008**: Checkpoints can be saved and restored, enabling agent resumption from a prior state.
+- **SC-009**: With `otel` feature enabled, a mock OTel exporter captures the correct span hierarchy (`agent.run` → `agent.turn` → `agent.llm_call` / `agent.tool.{name}`).
+- **SC-010**: OTel span attributes (`agent.model`, `agent.turn_index`, `agent.tokens.input`, `agent.tokens.output`, `agent.cost.total`, `agent.tool.name`, `agent.stop_reason`) are correctly populated from loop state and `TurnMetrics` data.
+- **SC-011**: With `otel` feature disabled, the crate compiles without `tracing-opentelemetry` or `opentelemetry` in the dependency tree.
 
 ## Clarifications
 
@@ -172,6 +206,17 @@ A developer enables checkpoints so the agent's loop state is snapshotted at turn
 - Q: Checkpoint store failure behavior? → A: io::Result propagates; caller decides.
 - Q: Stream middleware + retry? → A: Each retry produces new stream, re-wrapped by middleware.
 
+### Session 2026-03-31
+
+- Q: Should OTel span attributes include content (prompts, tool arguments, tool results) or only structural metadata? → A: Structural metadata only — spans carry tool name, model ID, token counts, cost, turn index, and stop reason. Never include prompt text, tool arguments, or tool results as span attributes to prevent accidental data leakage to external OTel backends.
+- Q: Which `opentelemetry` crate version should the `otel` feature target? → A: `>=0.29` — target `opentelemetry 0.29+` / `opentelemetry_sdk 0.29+` / `opentelemetry-otlp 0.29+` aligned with `tracing-opentelemetry 0.30+`. Use latest compatible versions in workspace deps.
+- Q: Should the `otel` feature emit OTel Metrics (counters/histograms) in addition to traces? → A: Traces only — OTel Metrics are out of scope. The existing `MetricsCollector` trait already provides structured per-turn metrics that users can push to any system. OTel backends can derive metrics from span data.
+- Q: Should `init_otel_layer` support both gRPC and HTTP OTLP protocols? → A: gRPC only in the convenience helper. Users who need HTTP OTLP can compose their own `tracing_subscriber` pipeline — they are sophisticated enough to do so.
+- Q: Should OTel integration use the `opentelemetry` crate directly or go through `tracing`? → A: Use `tracing` crate instrumentation in the core loop (spans, fields) with `tracing-opentelemetry` as the bridge layer. This avoids importing the `opentelemetry` API into the core crate and leverages the existing `tracing` dependency. The `tracing-opentelemetry` dep is feature-gated behind `otel`.
+- Q: Should OTel replace MetricsCollector? → A: No — they coexist. MetricsCollector is a push-based Rust trait for in-process consumers. OTel is for external observability backends. Users can use both, either, or neither.
+- Q: Should there be a helper for configuring the OTel pipeline? → A: Yes — provide a convenience function `init_otel_layer()` that returns a configured `tracing_subscriber::Layer` with `tracing-opentelemetry` and OTLP exporter. This is opt-in setup code, not mandatory.
+- Q: Push (OTLP exporter) vs pull (Prometheus)? → A: The primary integration is push via OTLP (gRPC/HTTP). Prometheus pull can be supported by users configuring a Prometheus exporter as their OTel exporter — no special support needed from the core crate.
+
 ## Assumptions
 
 - **[Superseded by 031]** Loop policies and budget guards are replaced by configurable policy slots. PreTurn policies (Slot 1) run before each LLM call. PostTurn policies (Slot 3) run after each turn. All policies are sync and return PolicyVerdict.
@@ -179,3 +224,6 @@ A developer enables checkpoints so the agent's loop state is snapshotted at turn
 - Budget enforcement uses the same cancellation token mechanism as manual abort (unchanged).
 - Checkpoints are opt-in — when not configured, no checkpoint overhead is incurred.
 - Metrics are collected in-memory by default; persistence is the caller's responsibility.
+- OpenTelemetry integration builds on the existing `tracing` crate already used throughout the codebase for diagnostics.
+- OTel span semantics follow emerging LLM observability conventions (no formal OpenTelemetry semantic convention for LLM agents exists yet, so we define `agent.*` attributes).
+- The `tracing-opentelemetry` (>=0.30) and `opentelemetry` (>=0.29) crates are only compiled when `feature = "otel"` is enabled.

--- a/specs/010-loop-policies-observability/tasks.md
+++ b/specs/010-loop-policies-observability/tasks.md
@@ -175,7 +175,38 @@
 
 ---
 
-## Phase 9: Polish & Cross-Cutting Concerns
+## Phase 9: User Story 7 — OpenTelemetry Integration (Priority: P2) — C9
+
+**Goal**: Feature-gated OTel-compliant tracing via `tracing` span instrumentation, bridged to OpenTelemetry via `tracing-opentelemetry`
+
+**Independent Test**: Enable the `otel` feature, run an agent with a mock OTel exporter (in-memory `SpanExporter`), verify the exporter captures the correct span hierarchy and attributes
+
+### Implementation for User Story 7
+
+- [ ] T073 [US7] Add `otel` feature gate to `Cargo.toml` with optional dependencies: `tracing-opentelemetry`, `opentelemetry`, `opentelemetry_sdk`, `opentelemetry-otlp`. Verify the feature does not activate without opt-in.
+- [ ] T074 [US7] Create `src/otel.rs` module with `#[cfg(feature = "otel")]` gate. Declare module in `src/lib.rs` behind `#[cfg(feature = "otel")]`.
+- [ ] T075 [US7] Implement `OtelInitConfig` struct in `src/otel.rs`: fields `service_name: String` (default `"swink-agent"`), `endpoint: Option<String>` (default `"http://localhost:4317"`), derives `Debug`, `Clone`, `Default`.
+- [ ] T076 [US7] Implement `init_otel_layer()` function in `src/otel.rs`: accepts `OtelInitConfig`, returns `impl Layer<S>` using `tracing-opentelemetry` with an OTLP gRPC exporter configured from the config.
+- [ ] T077 [US7] Add `tracing::info_span!("agent.run")` to `run_loop()` in `src/loop_/mod.rs`, wrapping the entire loop execution. The span should be entered for the full duration of the agent loop.
+- [ ] T078 [US7] Add `tracing::info_span!("agent.turn", agent.turn_index = tracing::field::Empty, agent.stop_reason = tracing::field::Empty)` in `src/loop_/turn.rs` at turn start. Record `agent.turn_index` on entry. Record `agent.stop_reason` on turn exit via `span.record()`.
+- [ ] T079 [US7] Add `tracing::info_span!("agent.llm_call", agent.model = tracing::field::Empty, agent.tokens.input = tracing::field::Empty, agent.tokens.output = tracing::field::Empty, agent.cost.total = tracing::field::Empty)` in `src/loop_/turn.rs` around the LLM streaming call. Record `agent.model` on entry. Record token/cost fields on span exit after streaming completes.
+- [ ] T080 [US7] Add `tracing::info_span!("agent.tool", agent.tool.name = %name)` in `src/loop_/tool_dispatch.rs` around each tool execution. Set span status to error on tool failure.
+- [ ] T081 [US7] Re-export `OtelInitConfig` and `init_otel_layer` from `src/lib.rs` behind `#[cfg(feature = "otel")]`.
+- [ ] T082 [US7] Add unit test in `src/otel.rs`: `otel_init_config_defaults` — verifies `OtelInitConfig::default()` sets `service_name` to `"swink-agent"` and `endpoint` to `None`.
+- [ ] T083 [US7] Add integration test `tests/otel_spans.rs` (gated with `#[cfg(feature = "otel")]`): configures an in-memory `SpanExporter`, runs a mock agent for 1 turn with 1 tool call, verifies the exporter received spans named `agent.run`, `agent.turn`, `agent.llm_call`, and `agent.tool`.
+- [ ] T084 [US7] Add integration test `tests/otel_spans.rs`: `otel_span_attributes` — verifies `agent.turn_index`, `agent.model`, `agent.tokens.input`, `agent.tokens.output`, `agent.cost.total`, and `agent.tool.name` attributes are present and correctly valued on their respective spans.
+- [ ] T085 [US7] Add integration test `tests/otel_spans.rs`: `otel_span_hierarchy` — verifies parent-child relationships: `agent.turn` is child of `agent.run`, `agent.llm_call` and `agent.tool` are children of `agent.turn`.
+- [ ] T086 [US7] Add integration test `tests/otel_spans.rs`: `otel_coexists_with_metrics_collector` — configures both an in-memory OTel exporter and a mock `MetricsCollector`, runs an agent for 1 turn, verifies OTel exporter received spans AND MetricsCollector received `TurnMetrics`. Neither suppresses the other. (Covers FR-014, US7 acceptance scenario 6.)
+- [ ] T087 [US7] Add integration test `tests/otel_spans.rs`: `otel_spans_exclude_content` — verifies that span attributes do NOT contain prompt text, tool arguments, or tool result content. Only structural metadata (model ID, token counts, cost, turn index, tool name, stop reason) is present. (Covers FR-016.)
+- [ ] T088 [US7] Add integration test `tests/otel_spans.rs`: `otel_model_fallback_spans` — configures model fallback, triggers a retryable error on the primary model, verifies the failed `agent.llm_call` span has error status and a second `agent.llm_call` span is created for the fallback model, both as children of the same `agent.turn`.
+- [ ] T089 [US7] Verify `cargo build -p swink-agent --no-default-features` does not pull in any `opentelemetry` or `tracing-opentelemetry` dependencies (feature gate isolation).
+- [ ] T090 [US7] Verify `cargo build -p swink-agent --features otel` compiles cleanly with zero warnings.
+
+**Checkpoint**: OpenTelemetry integration is functional — agents emit properly hierarchical OTel spans with semantic attributes when the `otel` feature is enabled, with zero overhead when disabled
+
+---
+
+## Phase 10: Polish & Cross-Cutting Concerns
 
 **Purpose**: Final validation, compile-time assertions, and documentation
 
@@ -185,6 +216,11 @@
 - [x] T070 Run `cargo clippy --workspace -- -D warnings` and fix any warnings
 - [x] T071 Run `cargo test -p swink-agent --no-default-features` to verify feature-gated code compiles without defaults
 - [x] T072 Validate quickstart.md examples compile by spot-checking key API patterns against actual type signatures
+- [ ] T091 Add compile-time `Send + Sync` assertion for `OtelInitConfig` in `src/otel.rs` (behind `#[cfg(feature = "otel")]`)
+- [ ] T092 Run `cargo build -p swink-agent --features otel` and verify zero compilation errors
+- [ ] T093 Run `cargo test -p swink-agent --features otel` and verify all OTel tests pass
+- [ ] T094 Run `cargo clippy -p swink-agent --features otel -- -D warnings` and fix any warnings
+- [ ] T095 Validate quickstart.md OTel examples compile by spot-checking API patterns against actual type signatures
 
 ---
 
@@ -200,11 +236,12 @@
 - **US4 — Post-Turn Hooks (Phase 6)**: Depends on Phase 2 — no other story dependencies
 - **US5 — Budget Guard (Phase 7)**: Depends on Phase 2 — no other story dependencies
 - **US6 — Checkpoints (Phase 8)**: Depends on Phase 2 — no other story dependencies
-- **Polish (Phase 9)**: Depends on all user stories being complete
+- **US7 — OpenTelemetry (Phase 9)**: Depends on Phase 2 — adds spans to loop files from US3/US4 but does not modify their APIs. Can proceed independently.
+- **Polish (Phase 10)**: Depends on all user stories being complete
 
 ### User Story Independence
 
-All six user stories are **fully independent** — they operate in separate source files with no cross-dependencies. After Phase 2, all stories can proceed in parallel.
+All seven user stories are **fully independent** — they operate in separate source files with no cross-dependencies. US7 adds `tracing` spans to the loop files (`mod.rs`, `turn.rs`, `tool_dispatch.rs`) but does not modify existing types or APIs. After Phase 2, all stories can proceed in parallel.
 
 ### Within Each User Story
 
@@ -216,10 +253,11 @@ All six user stories are **fully independent** — they operate in separate sour
 ### Parallel Opportunities
 
 - All Phase 2 foundational tasks (T004–T011) marked [P] can run in parallel
-- All six user stories (Phases 3–8) can run in parallel after Phase 2
+- All seven user stories (Phases 3–9) can run in parallel after Phase 2
 - Within US1: T014 and T015 can run in parallel (MaxTurns and CostCap are independent)
 - Within US2: T025, T026, T027 can run in parallel (convenience constructors are independent)
 - Within US5: T044, T045 can run in parallel (builder methods are independent)
+- Within US7: T077, T078, T079, T080 can run in parallel (separate files, no cross-deps)
 
 ---
 
@@ -233,6 +271,7 @@ Story 3: T032–T035 (metrics.rs)
 Story 4: T036–T041 (post_turn_hook.rs)
 Story 5: T042–T051 (budget_guard.rs)
 Story 6: T052–T066 (checkpoint.rs)
+Story 7: T073–T090 (otel.rs, loop_/mod.rs, loop_/turn.rs, loop_/tool_dispatch.rs)
 ```
 
 ---
@@ -255,13 +294,15 @@ Story 6: T052–T066 (checkpoint.rs)
 4. Add User Story 2 (Stream Middleware) → Test independently → Stream interception
 5. Add User Story 3 (Metrics) + Story 4 (Post-Turn Hooks) → Test independently → Observability
 6. Add User Story 6 (Checkpoints) → Test independently → Resumability
+7. Add User Story 7 (OpenTelemetry) → Test independently → OTel integration
 
 ### Parallel Strategy
 
-All six user stories touch separate files and have no cross-dependencies. With multiple agents:
+All seven user stories touch separate files and have no cross-dependencies. With multiple agents:
 - Agent A: US1 (loop_policy.rs) + US5 (budget_guard.rs) — governance pair
 - Agent B: US2 (stream_middleware.rs) + US3 (metrics.rs) — observability pair
 - Agent C: US4 (post_turn_hook.rs) + US6 (checkpoint.rs) — lifecycle pair
+- Agent D: US7 (otel.rs + loop span instrumentation) — OTel integration
 
 ---
 
@@ -270,6 +311,7 @@ All six user stories touch separate files and have no cross-dependencies. With m
 - [P] tasks = different files, no dependencies
 - [Story] label maps task to specific user story for traceability
 - Each user story is independently completable and testable in its own source file
-- All code already exists — tasks verify conformance to spec and add missing tests
+- All code for US1–US6 already exists — tasks verify conformance to spec and add missing tests
+- US7 (OpenTelemetry) is new work — tasks create the feature gate, span instrumentation, and convenience init function
 - Commit after each phase or logical group
 - Stop at any checkpoint to validate story independently


### PR DESCRIPTION
## Summary
- Add User Story 7 (OpenTelemetry Integration) to the 010-loop-policies-observability spec
- Feature-gated `otel` using `tracing` + `tracing-opentelemetry` bridge with span hierarchy: `agent.run` → `agent.turn` → `agent.llm_call` / `agent.tool.{name}`
- All 8 spec artifacts updated: spec (FR-011–017, SC-009–011), data-model, research (D7–D9), plan, contracts, quickstart, tasks (T073–T095), checklist

## Test plan
- [ ] Verify spec consistency across all 8 artifacts
- [ ] Verify task coverage for all new FRs and acceptance scenarios
- [ ] Verify no task ID collisions or gaps (T001–T095)

🤖 Generated with [Claude Code](https://claude.com/claude-code)