### PR TITLE
spec: auto-schema, hot-reload, filtering, noop, confirmation for 007

### DIFF
--- a/specs/007-tool-system-extensions/checklists/requirements.md
+++ b/specs/007-tool-system-extensions/checklists/requirements.md
@@ -29,6 +29,17 @@
 - [x] Feature meets measurable outcomes defined in Success Criteria
 - [x] No implementation details leak into specification
 
+## New Features Addition (C12, I12, I13, N5, N6)
+
+- [x] US7–US11 acceptance scenarios are testable and unambiguous
+- [x] FR-012 through FR-021 are measurable
+- [x] SC-008 through SC-013 are technology-agnostic success criteria
+- [x] Edge cases for new features (macro errors, invalid definitions, panic in approval_context) are identified
+- [x] Feature gate boundaries clearly defined (hot-reload, hot-reload-dylib, macros crate)
+- [x] Backward compatibility maintained (default methods, optional features, new crate)
+- [x] New crate (`swink-agent-macros`) justified per Constitution Principle I
+
 ## Notes
 
 - All items pass. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- C12 (Auto-schema), I12 (Hot-reload), I13 (Filtering), N5 (Noop), N6 (Confirmation payloads) added 2026-03-31: US7–US11, FR-012–FR-021, SC-008–SC-013, tasks T065–T098.

--- a/specs/007-tool-system-extensions/contracts/public-api.md
+++ b/specs/007-tool-system-extensions/contracts/public-api.md
@@ -15,6 +15,7 @@ pub trait AgentTool: Send + Sync {
     fn parameters_schema(&self) -> &Value;
     fn requires_approval(&self) -> bool { false }
     fn metadata(&self) -> Option<ToolMetadata> { None }
+    fn approval_context(&self, _params: &Value) -> Option<Value> { None }
     fn execute(
         &self,
         tool_call_id: &str,
@@ -66,6 +67,7 @@ pub struct ToolApprovalRequest {
     pub tool_name: String,
     pub arguments: Value,
     pub requires_approval: bool,
+    pub context: Option<Value>,  // from AgentTool::approval_context()
 }
 
 #[non_exhaustive]
@@ -238,4 +240,97 @@ pub use fn_tool::FnTool;
 
 #[cfg(feature = "builtin-tools")]
 pub use tools::{BashTool, ReadFileTool, WriteFileTool, builtin_tools};
+
+pub use tool_filter::{ToolFilter, ToolPattern};
+pub use noop_tool::NoopTool;
+
+#[cfg(feature = "hot-reload")]
+pub use hot_reload::{ToolWatcher, ScriptTool};
+```
+
+## `src/tool_filter.rs` — Registration-Time Filtering
+
+```rust
+/// Pattern for matching tool names.
+#[derive(Debug, Clone)]
+pub enum ToolPattern {
+    Exact(String),
+    Glob(String),
+    Regex(regex::Regex),
+}
+
+impl ToolPattern {
+    /// Auto-detects pattern type: glob if contains * or ?, regex if starts with ^ or ends with $, else exact.
+    pub fn parse(s: &str) -> Self;
+    pub fn matches(&self, name: &str) -> bool;
+}
+
+/// Filters tools at registration time by name patterns.
+#[derive(Debug, Clone, Default)]
+pub struct ToolFilter {
+    pub allowed: Vec<ToolPattern>,
+    pub rejected: Vec<ToolPattern>,
+}
+
+impl ToolFilter {
+    pub fn new() -> Self;
+    pub fn with_allowed(mut self, patterns: Vec<ToolPattern>) -> Self;
+    pub fn with_rejected(mut self, patterns: Vec<ToolPattern>) -> Self;
+    pub fn matches(&self, tool_name: &str) -> bool;
+    pub fn filter_tools(&self, tools: Vec<Arc<dyn AgentTool>>) -> Vec<Arc<dyn AgentTool>>;
+}
+```
+
+## `src/noop_tool.rs` — Session History Compatibility
+
+```rust
+/// Placeholder tool for tools that no longer exist in the registry.
+pub struct NoopTool {
+    name: String,
+    schema: Value,
+}
+
+impl NoopTool {
+    pub fn new(name: impl Into<String>) -> Self;
+}
+
+impl AgentTool for NoopTool { ... }
+// name() → stored name
+// description() → "This tool is no longer available."
+// requires_approval() → false
+// execute() → AgentToolResult::error("Tool '{name}' is no longer available...")
+```
+
+## `swink-agent-macros` — Proc Macro Crate
+
+```rust
+// In swink-agent core crate (src/tool.rs or src/tool_parameters.rs):
+pub trait ToolParameters {
+    fn json_schema() -> Value;
+}
+
+// In swink-agent-macros crate:
+#[proc_macro_derive(ToolSchema, attributes(tool))]
+pub fn derive_tool_schema(input: TokenStream) -> TokenStream;
+
+#[proc_macro_attribute]
+pub fn tool(attr: TokenStream, item: TokenStream) -> TokenStream;
+```
+
+## `src/hot_reload.rs` — Tool Hot-Reloading (feature-gated: `hot-reload`)
+
+```rust
+/// Tool loaded from a definition file (TOML/YAML/JSON).
+pub struct ScriptTool { ... }
+impl AgentTool for ScriptTool { ... }
+
+/// Watches a directory for tool definition changes.
+pub struct ToolWatcher { ... }
+
+impl ToolWatcher {
+    pub fn new(watch_dir: impl Into<PathBuf>) -> Self;
+    pub fn with_filter(mut self, filter: ToolFilter) -> Self;
+    pub fn start(&self, agent: &Agent) -> tokio::task::JoinHandle<()>;
+    pub fn stop(&self);
+}
 ```

--- a/specs/007-tool-system-extensions/data-model.md
+++ b/specs/007-tool-system-extensions/data-model.md
@@ -16,6 +16,7 @@ The core trait that all tools implement. Object-safe, `Send + Sync`.
 | `parameters_schema` | `&self -> &Value` | JSON Schema for input validation |
 | `requires_approval` | `&self -> bool` | Whether approval gate applies (default: `false`) |
 | `metadata` | `&self -> Option<ToolMetadata>` | Optional namespace/version (default: `None`) |
+| `approval_context` | `&self, params: &Value -> Option<Value>` | Rich context for approval UI (default: `None`) |
 | `execute` | `&self, &str, Value, CancellationToken, Option<Box<dyn Fn(AgentToolResult) + Send + Sync>> -> Pin<Box<dyn Future<Output = AgentToolResult> + Send + '_>>` | Execute with validated params |
 
 ---
@@ -206,6 +207,7 @@ Information about a tool call pending approval. Debug impl redacts `arguments`.
 | `tool_name` | `String` | Tool being called |
 | `arguments` | `Value` | Arguments passed to the tool |
 | `requires_approval` | `bool` | Whether the tool declared approval requirement |
+| `context` | `Option<Value>` | Rich context from `approval_context()` for the approval UI |
 
 ---
 
@@ -218,6 +220,145 @@ Controls whether the approval gate is active.
 | `Enabled` | Every tool call goes through approval callback (default) |
 | `Smart` | Auto-approve tools where `requires_approval()` is false |
 | `Bypassed` | All tool calls auto-approved |
+
+---
+
+### ToolParameters (trait) — from `swink-agent-macros`
+
+Trait implemented by `#[derive(ToolSchema)]`. Provides a static method to generate JSON Schema.
+
+| Method | Signature | Description |
+|---|---|---|
+| `json_schema` | `() -> Value` | Returns JSON Schema for the struct's fields |
+
+---
+
+### ToolSchema (derive macro) — `swink-agent-macros` crate
+
+Proc macro that generates a `ToolParameters` implementation. Maps:
+- Field names → property names
+- `String` → `{"type": "string"}`
+- `u64`/`i64`/`u32`/`i32`/`usize`/`isize` → `{"type": "integer"}`
+- `f64`/`f32` → `{"type": "number"}`
+- `bool` → `{"type": "boolean"}`
+- `Option<T>` → type of `T`, field omitted from `required`
+- `Vec<T>` → `{"type": "array", "items": <T>}`
+- `///` doc comments → `"description"` field
+- `#[tool(description = "...")]` → overrides doc comment description
+
+---
+
+### #[tool] (attribute macro) — `swink-agent-macros` crate
+
+Attribute macro that wraps an async function as an `AgentTool` implementation. Accepts `name` and `description` attributes.
+
+```rust
+#[tool(name = "weather", description = "Get weather for a city")]
+async fn get_weather(city: String, units: Option<String>) -> AgentToolResult { ... }
+```
+
+Generates: a struct (e.g., `GetWeatherTool`), a `ToolParameters` impl for the parameters, and an `AgentTool` impl that deserializes parameters and calls the original function.
+
+---
+
+### ToolWatcher (struct, feature-gated: `hot-reload`)
+
+Monitors a directory for tool definition file changes and updates an agent's tool list.
+
+| Field | Type | Description |
+|---|---|---|
+| `watch_dir` | `PathBuf` | Directory to monitor |
+| `tools` | `Arc<Mutex<Vec<Arc<dyn AgentTool>>>>` | Current loaded tools |
+| `filter` | `Option<ToolFilter>` | Optional filter applied to loaded tools |
+
+**Constructors**: `new(watch_dir: impl Into<PathBuf>)`, `with_filter(self, ToolFilter) -> Self`
+
+**Methods**:
+- `start(&self, agent: &Agent) -> JoinHandle<()>` — begins watching, updates agent on changes
+- `stop(&self)` — stops the watcher
+
+Uses `notify` crate for filesystem events. Debounces rapid changes.
+
+---
+
+### ScriptTool (struct, feature-gated: `hot-reload`)
+
+A tool loaded from a TOML/YAML/JSON definition file that executes a shell command.
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | `String` | Tool name from definition |
+| `description` | `String` | Tool description from definition |
+| `command` | `String` | Shell command template |
+| `schema` | `Value` | JSON Schema for parameters |
+| `requires_approval` | `bool` | Whether approval is required (default: true) |
+
+**Definition file format** (TOML example):
+```toml
+name = "list_files"
+description = "List files in a directory"
+command = "ls -la {path}"
+requires_approval = false
+
+[parameters]
+path = { type = "string", description = "Directory path" }
+```
+
+Implements `AgentTool`. The `execute()` method interpolates parameters into the command template and runs it via `sh -c`.
+
+---
+
+### ToolFilter (struct)
+
+Pattern-based tool filtering applied at registration time.
+
+| Field | Type | Description |
+|---|---|---|
+| `allowed` | `Vec<ToolPattern>` | Patterns for allowed tool names (empty = allow all) |
+| `rejected` | `Vec<ToolPattern>` | Patterns for rejected tool names (takes precedence) |
+
+**Constructors**: `new()`, `with_allowed(patterns)`, `with_rejected(patterns)`
+
+**Methods**:
+- `matches(&self, tool_name: &str) -> bool` — returns `true` if the tool should be included
+- `filter_tools(&self, tools: Vec<Arc<dyn AgentTool>>) -> Vec<Arc<dyn AgentTool>>` — filters a tool list
+
+Implements: `Debug`, `Clone`, `Default` (default allows all).
+
+---
+
+### ToolPattern (enum)
+
+A pattern for matching tool names.
+
+| Variant | Data | Description |
+|---|---|---|
+| `Exact` | `String` | Exact string match |
+| `Glob` | `String` | Glob pattern (e.g., `read_*`) |
+| `Regex` | `Regex` | Compiled regex pattern |
+
+**Constructor**: `ToolPattern::parse(s: &str) -> Self` — auto-detects: if contains `*` or `?` → Glob, if starts with `^` or ends with `$` → Regex, else Exact.
+
+Implements: `Debug`, `Clone`.
+
+---
+
+### NoopTool (struct)
+
+Placeholder tool for session history compatibility.
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | `String` | Name of the missing tool |
+| `schema` | `Value` | Empty object schema |
+
+**Constructor**: `new(name: impl Into<String>)`
+
+Implements `AgentTool`:
+- `name()` → stored name
+- `description()` → `"This tool is no longer available."`
+- `requires_approval()` → `false`
+- `execute()` → `AgentToolResult::error("Tool '{name}' is no longer available...")`
 
 ---
 
@@ -243,4 +384,14 @@ BashTool / ReadFileTool / WriteFileTool → implement AgentTool directly
 
 ToolExecutionPolicy::Priority → uses PriorityFn(ToolCallSummary)
 ToolExecutionPolicy::Custom → uses ToolExecutionStrategy::partition(ToolCallSummary[])
+
+ToolFilter → contains Vec<ToolPattern> for allowed/rejected
+ToolFilter → applied at Agent::set_tools() / tool registration
+ToolWatcher → monitors directory → loads ScriptTool definitions → updates Agent tools
+ToolWatcher → optionally uses ToolFilter to restrict loaded tools
+ScriptTool → implements AgentTool → executes shell commands from definition files
+NoopTool → implements AgentTool → injected by session loader for missing tools
+ToolParameters → trait generated by #[derive(ToolSchema)] → returns JSON Schema Value
+#[tool] macro → generates struct + AgentTool impl from async fn
+ToolApprovalRequest.context → populated from AgentTool::approval_context()
 ```

--- a/specs/007-tool-system-extensions/plan.md
+++ b/specs/007-tool-system-extensions/plan.md
@@ -11,19 +11,19 @@
 
 ## Summary
 
-Extend the core tool system with composable pipeline hooks and convenience abstractions. The feature adds components to the `swink-agent` core crate: ~~a `ToolCallTransformer` trait for pre-validation argument rewriting, a `ToolValidator` trait for accept/reject gating,~~ **[Superseded by 031 PreDispatchPolicy]** a `ToolMiddleware` decorator for wrapping `execute()`, a `ToolExecutionPolicy` enum controlling dispatch concurrency, a `FnTool` closure-based tool builder, and three built-in tools (`BashTool`, `ReadFileTool`, `WriteFileTool`) behind the `builtin-tools` feature gate. ~~The dispatch pipeline is fixed: approval, transformer, validator, schema validation, execute.~~ **[Superseded by 031]** New order: PreDispatch policies → approval → schema validation → execute.
+Extend the core tool system with composable pipeline hooks and convenience abstractions. The feature adds components to the `swink-agent` core crate: ~~a `ToolCallTransformer` trait for pre-validation argument rewriting, a `ToolValidator` trait for accept/reject gating,~~ **[Superseded by 031 PreDispatchPolicy]** a `ToolMiddleware` decorator for wrapping `execute()`, a `ToolExecutionPolicy` enum controlling dispatch concurrency, a `FnTool` closure-based tool builder, and three built-in tools (`BashTool`, `ReadFileTool`, `WriteFileTool`) behind the `builtin-tools` feature gate. ~~The dispatch pipeline is fixed: approval, transformer, validator, schema validation, execute.~~ **[Superseded by 031]** New order: PreDispatch policies → approval → schema validation → execute. New additions: `swink-agent-macros` crate for `#[derive(ToolSchema)]` and `#[tool]` proc macros, `ToolWatcher` + `ScriptTool` for hot-reloading (feature-gated `hot-reload`), `ToolFilter` for pattern-based registration filtering, `NoopTool` for session history compatibility, and `approval_context()` for rich approval payloads.
 
 ## Technical Context
 
 **Language/Version**: Rust 1.88, edition 2024
-**Primary Dependencies**: `tokio`, `tokio-util` (CancellationToken), `serde_json`, `schemars`, `jsonschema`, `regex`
+**Primary Dependencies**: `tokio`, `tokio-util` (CancellationToken), `serde_json`, `schemars`, `jsonschema`, `regex`; optional: `notify` (hot-reload), `syn`/`quote`/`proc-macro2` (macros crate)
 **Storage**: N/A
 **Testing**: `cargo test --workspace`, `cargo test -p swink-agent --no-default-features`
 **Target Platform**: Cross-platform library crate
 **Project Type**: Library
 **Performance Goals**: Concurrent tool dispatch via `tokio::spawn`; zero-copy borrowed views in `ToolCallSummary`
 **Constraints**: `#[forbid(unsafe_code)]`, no provider-specific or UI-specific dependencies in core
-**Scale/Scope**: 8 source files across `src/` and `src/tools/`
+**Scale/Scope**: 8+ source files across `src/` and `src/tools/`, plus `swink-agent-macros` crate for proc macros
 
 ## Constitution Check
 
@@ -31,12 +31,12 @@ Extend the core tool system with composable pipeline hooks and convenience abstr
 
 | Principle | Status | Notes |
 |---|---|---|
-| I. Library-First | PASS | All components live in the `swink-agent` core crate as public API surface. No new crates introduced. Built-in tools are feature-gated to keep core dependency-free when unused. |
-| II. Test-Driven Development | PASS | Each source file includes inline `#[cfg(test)]` modules. Tests cover closure blanket impls, middleware delegation, policy variants, and built-in tool execution. `cargo test --workspace` and `--no-default-features` both required to pass. |
-| III. Efficiency & Performance | PASS | Default execution policy is concurrent via `tokio::spawn`. `ToolCallSummary` uses borrowed references to avoid cloning arguments. `Arc` used for middleware and policy closures to enable zero-copy sharing. |
-| IV. Leverage the Ecosystem | PASS | Uses `schemars` for schema derivation, `jsonschema` for validation, `tokio::process` for shell execution. No hand-rolled alternatives. |
+| I. Library-First | PASS | All components live in the `swink-agent` core crate as public API surface. `swink-agent-macros` is a new proc macro crate (justified: Rust requires proc macros in separate crates). Built-in tools and hot-reload are feature-gated to keep core dependency-free when unused. ToolFilter and NoopTool are zero-dependency core types. |
+| II. Test-Driven Development | PASS | Each source file includes inline `#[cfg(test)]` modules. Tests cover closure blanket impls, middleware delegation, policy variants, built-in tool execution, macro output validation (T070–T072), pattern matching (T082), noop behavior (T086), and approval context (T092). `cargo test --workspace` and `--no-default-features` both required to pass. |
+| III. Efficiency & Performance | PASS | Default execution policy is concurrent via `tokio::spawn`. `ToolCallSummary` uses borrowed references to avoid cloning arguments. `Arc` used for middleware and policy closures to enable zero-copy sharing. ToolWatcher debounces at 500ms to coalesce filesystem events. |
+| IV. Leverage the Ecosystem | PASS | Uses `schemars` for schema derivation, `jsonschema` for validation, `tokio::process` for shell execution, `notify` for filesystem watching (hot-reload), `syn`/`quote` for proc macros. No hand-rolled alternatives. |
 | V. Provider Agnosticism | PASS | All components are provider-agnostic. No API keys, SDK clients, or provider types. The tool system is orthogonal to `StreamFn`. |
-| VI. Safety & Correctness | PASS | `#[forbid(unsafe_code)]` enforced. Panics in spawned tool tasks caught via join error handling. Cancellation tokens for cooperative abort. `AgentToolResult::error()` for error signaling, never panics. |
+| VI. Safety & Correctness | PASS | `#[forbid(unsafe_code)]` enforced. Panics in spawned tool tasks caught via join error handling. Cancellation tokens for cooperative abort. `AgentToolResult::error()` for error signaling, never panics. ScriptTool shell-escapes interpolated parameters to prevent command injection. `approval_context()` panics caught via `catch_unwind`. Dynamic library loading (`libloading`) deferred — would require `unsafe`. |
 
 ## Project Structure
 
@@ -68,14 +68,23 @@ src/
 │   ├── bash.rs                  # BashTool (sh -c execution)
 │   ├── read_file.rs             # ReadFileTool (file reading)
 │   └── write_file.rs            # WriteFileTool (file writing)
+├── tool_filter.rs               # ToolFilter, ToolPattern for registration-time filtering
+├── noop_tool.rs                 # NoopTool placeholder for session compatibility
 ├── lib.rs                       # Public re-exports for all tool system types
 └── loop_.rs                     # Agent loop — consumes the dispatch pipeline
 
-Cargo.toml                       # Feature flag: builtin-tools (default)
+macros/                          # swink-agent-macros crate (proc macros)
+├── Cargo.toml
+├── src/
+│   ├── lib.rs                   # #[derive(ToolSchema)] + #[tool] attribute macro
+│   ├── tool_schema.rs           # ToolSchema derive implementation
+│   └── tool_attr.rs             # #[tool] attribute implementation
+
+Cargo.toml                       # Feature flags: builtin-tools (default), hot-reload
 ```
 
 **Structure Decision**: All tool system extensions are in the core crate (`swink-agent`). Each concern has its own file (one concern per file). Built-in tools are in the `src/tools/` subdirectory behind a feature gate. Re-exports in `lib.rs` ensure consumers never reach into submodules.
 
 ## Complexity Tracking
 
-No constitution violations. All components fit within existing crate boundaries.
+The `swink-agent-macros` crate is a new workspace member. Constitution Principle I requires justification: proc macros MUST live in a separate crate (Rust language constraint). The crate has no runtime dependencies on `swink-agent` — it only generates code at compile time. This is the same pattern used by `serde`/`serde_derive` and `thiserror`/`thiserror-impl`.

--- a/specs/007-tool-system-extensions/quickstart.md
+++ b/specs/007-tool-system-extensions/quickstart.md
@@ -8,11 +8,17 @@
 # Build the workspace
 cargo build --workspace
 
+# Build with hot-reload feature
+cargo build -p swink-agent --features hot-reload
+
 # Run all tests (includes tool system tests)
 cargo test --workspace
 
 # Verify built-in tools can be excluded
 cargo test -p swink-agent --no-default-features
+
+# Test macros crate
+cargo test -p swink-agent-macros
 
 # Lint (zero warnings policy)
 cargo clippy --workspace -- -D warnings
@@ -159,3 +165,118 @@ The tool dispatch pipeline is fixed and executes in this order for every tool ca
 5. **Execute** — `AgentTool::execute()` runs the tool
 
 If any step rejects the call, subsequent steps are skipped and an error result is returned.
+
+### Auto-Schema from Rust Types (proc macro)
+
+```rust
+use swink_agent_macros::ToolSchema;
+use swink_agent::ToolParameters;
+
+/// Parameters for the weather tool.
+#[derive(ToolSchema)]
+struct WeatherParams {
+    /// The city to get weather for.
+    city: String,
+    /// Temperature units (celsius or fahrenheit).
+    units: Option<String>,
+}
+
+let schema = WeatherParams::json_schema();
+// Produces: {"type": "object", "properties": {"city": {"type": "string", "description": "The city to get weather for."}, "units": {"type": "string", "description": "Temperature units (celsius or fahrenheit)."}}, "required": ["city"]}
+```
+
+### Tool from Function (attribute macro)
+
+```rust
+use swink_agent_macros::tool;
+use swink_agent::AgentToolResult;
+
+#[tool(name = "weather", description = "Get weather for a city")]
+async fn get_weather(city: String, units: Option<String>) -> AgentToolResult {
+    let u = units.unwrap_or_else(|| "fahrenheit".into());
+    AgentToolResult::text(format!("72°F in {city} ({u})"))
+}
+
+// Use the generated tool:
+let tool = GetWeatherTool;
+// tool.name() == "weather"
+// tool.parameters_schema() has city (required) and units (optional)
+```
+
+### Tool Filtering at Registration Time
+
+```rust
+use swink_agent::tool_filter::{ToolFilter, ToolPattern};
+
+// Allow only read-related tools
+let filter = ToolFilter::new()
+    .with_allowed(vec![ToolPattern::parse("read_*")]);
+
+// Block dangerous tools, allow everything else
+let filter = ToolFilter::new()
+    .with_rejected(vec![
+        ToolPattern::parse("bash"),
+        ToolPattern::parse("^exec_.*$"),  // regex
+    ]);
+
+// Apply to a tool list
+let filtered = filter.filter_tools(tools);
+```
+
+### Hot-Reload Tools from Directory
+
+```rust
+use swink_agent::hot_reload::ToolWatcher;
+
+// Watch a directory for tool definition files
+let watcher = ToolWatcher::new("./tools/")
+    .with_filter(ToolFilter::new().with_rejected(vec![ToolPattern::parse("bash")]));
+
+// Start watching — updates agent tools on file changes
+let handle = watcher.start(&agent);
+```
+
+Example tool definition (`tools/list_files.toml`):
+```toml
+name = "list_files"
+description = "List files in a directory"
+command = "ls -la {path}"
+requires_approval = false
+
+[parameters]
+path = { type = "string", description = "Directory path" }
+```
+
+### Noop Tool for Session Compatibility
+
+```rust
+use swink_agent::NoopTool;
+
+// Auto-injected by the session loader, but can be created manually:
+let noop = NoopTool::new("deprecated_tool");
+// noop.execute(...) returns AgentToolResult::error("Tool 'deprecated_tool' is no longer available...")
+```
+
+### Tool Confirmation Payloads
+
+```rust
+use swink_agent::{AgentTool, AgentToolResult};
+
+struct WriteFileTool;
+
+impl AgentTool for WriteFileTool {
+    // ... name, description, schema, execute ...
+
+    fn approval_context(&self, params: &serde_json::Value) -> Option<serde_json::Value> {
+        // Provide a diff preview for the approval UI
+        let path = params.get("path")?.as_str()?;
+        let content = params.get("content")?.as_str()?;
+        Some(serde_json::json!({
+            "preview_type": "file_write",
+            "path": path,
+            "content_length": content.len(),
+            "first_100_chars": &content[..content.len().min(100)],
+        }))
+    }
+}
+```

--- a/specs/007-tool-system-extensions/research.md
+++ b/specs/007-tool-system-extensions/research.md
@@ -87,3 +87,70 @@
 **Alternatives rejected**:
 - **Configurable pipeline ordering**: Adds complexity with no clear use case. Every reasonable ordering is equivalent to the fixed one.
 - **Multiple transformer/validator stages**: Over-engineering. Composing multiple transformers can be done within a single transformer implementation.
+
+---
+
+### D8: Auto-Schema via Proc Macro in Separate Crate
+
+**Decision**: Create a `swink-agent-macros` crate containing `#[derive(ToolSchema)]` and `#[tool]` proc macros. The `ToolParameters` trait (with `fn json_schema() -> Value`) is defined in the core crate. The macro crate is an optional dependency — tools can still use `FnTool::with_schema_for::<T>()` or manual JSON Schema.
+
+**Rationale**: Proc macros must live in a separate crate (Rust constraint). Defining the trait in core and the derive in the macro crate follows the standard pattern (`serde` / `serde_derive`). Making the macro crate optional preserves the existing `FnTool` and manual `AgentTool` impl paths — no existing code needs changes. The `#[tool]` attribute macro is strictly additive, converting a common 30-line boilerplate pattern into a single annotation.
+
+**Key references**: AWS Strands' `@tool` decorator auto-generates schema from Python type hints + docstrings. Google ADK's `build_function_declaration()` extracts from Python function signatures. In Rust, `schemars` already does type → JSON Schema; our macro wraps this with tool-specific ergonomics.
+
+**Alternatives rejected**:
+- **Extend `schemars` derive directly**: Does not generate tool-specific schema structure (name, description from doc comments, required/optional from `Option<T>`). A custom derive provides the right abstraction level.
+- **Runtime reflection**: Not available in Rust. Proc macros are the idiomatic approach.
+- **Put macro in core crate**: Proc macro crates cannot export non-macro items. The trait must be in core, the derive in a separate crate.
+
+---
+
+### D9: Tool Hot-Reloading via notify + TOML Definitions
+
+**Decision**: Feature-gate hot-reloading behind `hot-reload`. Use the `notify` crate for filesystem watching. Tool definitions are TOML/YAML/JSON files specifying `name`, `description`, `command`, and optional `parameters_schema`. Loaded tools become `ScriptTool` instances that execute shell commands. Dynamic library loading (`libloading`) is a separate sub-feature (`hot-reload-dylib`).
+
+**Rationale**: Rust can't reload compiled code without `libloading` (which requires `unsafe`). Script-based tools (shell commands from definition files) are the natural hot-reloadable unit — they match MCP-style tool definitions. `notify` is the standard Rust filesystem watcher (3M+ downloads). The two-tier feature gate (`hot-reload` for scripts, `hot-reload-dylib` for shared libraries) keeps the common case simple while allowing the advanced case.
+
+**Alternatives rejected**:
+- **WASM-based tool loading**: Over-engineered. Shell commands cover the hot-reload use case without a WASM runtime.
+- **Always-on file watching**: Pulls in `notify` for all users. Feature gating respects the zero-cost principle.
+- **Compiling tools from source at runtime**: Not feasible without shipping a Rust compiler. Shell commands are the practical alternative.
+
+---
+
+### D10: ToolFilter with Pattern Matching at Registration Time
+
+**Decision**: `ToolFilter` applies at tool registration time (when tools are added to the agent), not at execution time. It uses `ToolPattern` (Exact/Glob/Regex) with auto-detection via `parse()`. `rejected` patterns take precedence over `allowed`.
+
+**Rationale**: Filtering at registration time is a coarser-grained boundary than per-call policies (ToolDenyListPolicy). A tool that fails the filter never appears in the LLM prompt — the model never sees it, can't call it, and the tool's schema doesn't consume token budget. This complements `ToolDenyListPolicy` (which blocks at execution time) for defense-in-depth. The reject-wins precedence rule is the safest default — explicitly blocked tools can't be unblocked by a permissive `allowed` pattern.
+
+**Alternatives rejected**:
+- **Extend ToolDenyListPolicy**: ToolDenyListPolicy runs at execution time (per-call). Registration-time filtering serves a different purpose — removing tools from the prompt entirely.
+- **Only exact matching**: Insufficient for dynamically loaded tools where names follow patterns (e.g., `mcp_*`).
+- **Allowed-wins precedence**: Dangerous — an overly broad `allowed` pattern could override a specific `rejected` entry.
+
+---
+
+### D11: NoopTool as Auto-Injected Placeholder
+
+**Decision**: When loading a session that references a tool not in the current registry, auto-inject a `NoopTool` with the missing tool's name. The `NoopTool` returns `AgentToolResult::error(...)` explaining the tool is no longer available.
+
+**Rationale**: Without this, loading a session with a removed tool causes either a deserialization error or a silent `unknown_tool_result()` at dispatch time. The `NoopTool` makes the situation explicit to the model — it can adapt its strategy rather than repeatedly calling a broken tool. The tool is transparent (no special-casing in the loop) because it implements `AgentTool` like any other tool.
+
+**Alternatives rejected**:
+- **Silently drop tool calls**: The model would see no result and might retry indefinitely.
+- **Error during session loading**: Too harsh — the session is otherwise valid.
+- **Map to a default tool**: Unpredictable behavior. An explicit error is safer.
+
+---
+
+### D12: Approval Context as Optional Default Method
+
+**Decision**: Add `fn approval_context(&self, params: &Value) -> Option<Value> { None }` as a default method on `AgentTool`. Populate `ToolApprovalRequest.context` from this method before sending to the approval callback.
+
+**Rationale**: A default method is backward compatible — no existing tool implementations need changes. The `Option<Value>` return type allows tools to provide arbitrary structured context (diffs, cost estimates, query plans) without constraining the format. Panics in `approval_context` are caught via `catch_unwind` to prevent tool-provided context from crashing the dispatch pipeline.
+
+**Alternatives rejected**:
+- **Separate trait for contextual tools**: Adds complexity. A default method on the existing trait is simpler and more discoverable.
+- **Typed context (enum of known formats)**: Over-constrains. Tools should be free to provide whatever context their approval UI needs.
+- **Context as part of `execute()`**: Too late — context is needed before execution, at approval time.

--- a/specs/007-tool-system-extensions/spec.md
+++ b/specs/007-tool-system-extensions/spec.md
@@ -3,7 +3,7 @@
 **Feature Branch**: `007-tool-system-extensions`
 **Created**: 2026-03-20
 **Status**: Draft
-**Input**: Extended tool system capabilities beyond the base trait: tool call transformers, validators, middleware, execution policies, closure-based tools, and built-in tools (shell, file read, file write) behind a feature gate. References: PRD §4 (Tool System), HLD Implementations Layer (transformer, tool_mw, sub_agent), HLD Tool System architecture doc.
+**Input**: Extended tool system capabilities beyond the base trait: tool call transformers, validators, middleware, execution policies, closure-based tools, built-in tools (shell, file read, file write) behind a feature gate, auto-schema generation via proc macro, tool hot-reloading, tool filtering with patterns, noop tool for history compatibility, and tool confirmation payloads. References: PRD §4 (Tool System), HLD Implementations Layer (transformer, tool_mw, sub_agent), HLD Tool System architecture doc.
 
 ## Supersession Notice
 
@@ -117,12 +117,104 @@ A developer enables the built-in tools feature to get pre-made tools for shell c
 
 ---
 
+### User Story 7 - Auto-Schema Generation from Rust Types (Priority: P1) — C12
+
+A developer uses a `#[derive(ToolSchema)]` proc macro to generate JSON Schema from a Rust struct definition. Field names map to properties, Rust types map to JSON Schema types (`String` → `"string"`, `u64` → `"integer"`, `bool` → `"boolean"`, `Option<T>` → nullable, `Vec<T>` → `"array"`), and `///` doc comments become `description` fields. A `#[tool]` attribute macro wraps an async function as an `AgentTool` implementation, generating the struct, schema, and trait impl from the function signature.
+
+**Why this priority**: Schema generation from type definitions eliminates the most common source of tool definition bugs — hand-written JSON Schema that drifts from the actual parameter types. Every tool author benefits.
+
+**Independent Test**: Can be tested by defining a struct with `#[derive(ToolSchema)]`, calling `ToolParameters::json_schema()`, and verifying the output matches the expected JSON Schema.
+
+**Acceptance Scenarios**:
+
+1. **Given** a struct with `#[derive(ToolSchema)]`, **When** `json_schema()` is called, **Then** a valid JSON Schema is returned with correct type mappings and descriptions from doc comments.
+2. **Given** an async function with `#[tool(name = "...", description = "...")]`, **When** the macro is expanded, **Then** a struct implementing `AgentTool` is generated with the correct schema derived from function parameters.
+3. **Given** a field with `#[tool(description = "...")]` attribute, **When** the schema is generated, **Then** the attribute description overrides the doc comment.
+4. **Given** an `Option<T>` field, **When** the schema is generated, **Then** the field is not in `required` and its type is nullable.
+
+---
+
+### User Story 8 - Tool Hot-Reloading (Priority: P2) — I12
+
+An operator configures a directory containing tool definitions (TOML/YAML/JSON files specifying a command to execute). A `ToolWatcher` monitors this directory for changes and reloads tool definitions at runtime, updating the agent's tool list via `Agent::set_tools()`.
+
+**Why this priority**: Hot-reloading enables tool iteration without restarting the agent — valuable for development and for dynamically loaded MCP-style tools in production.
+
+**Independent Test**: Can be tested by starting a watcher on a temp directory, adding a tool definition file, and verifying the agent's tool list is updated.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `ToolWatcher` monitoring a directory, **When** a new tool definition file is added, **Then** the corresponding tool is added to the agent's tool list.
+2. **Given** a watched directory, **When** a tool definition file is modified, **Then** the tool is reloaded with the updated definition.
+3. **Given** a watched directory, **When** a tool definition file is deleted, **Then** the tool is removed from the agent's tool list.
+4. **Given** a TOML tool definition specifying a shell command, **When** the tool is invoked, **Then** the command executes with the provided arguments.
+5. **Given** the `hot-reload` feature is disabled, **When** the crate is compiled, **Then** no `notify` dependencies are included.
+
+---
+
+### User Story 9 - Tool Filtering with Patterns (Priority: P2) — I13
+
+A developer configures a `ToolFilter` with `allowed` and `rejected` patterns that are applied at tool registration time. Patterns support exact string matching, glob syntax (`read_*`), and regex (`^file_.*$`). This restricts which tools are available to the agent — useful for dynamically loaded tools (MCP, hot-reload) where the full set may not be trusted.
+
+**Why this priority**: Filtering at registration time provides a coarser-grained security boundary than per-call policies — tools that don't pass the filter never appear in the LLM prompt.
+
+**Independent Test**: Can be tested by creating a `ToolFilter` with an allowed pattern, registering tools, and verifying only matching tools are available.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `ToolFilter` with `allowed: ["read_*"]`, **When** tools are registered, **Then** only tools matching `read_*` are added.
+2. **Given** a `ToolFilter` with `rejected: ["bash"]`, **When** tools are registered, **Then** the `bash` tool is excluded.
+3. **Given** both `allowed` and `rejected` patterns, **When** a tool matches both, **Then** `rejected` takes precedence — the tool is excluded.
+4. **Given** a regex pattern `^file_.*$` in `allowed`, **When** tools are registered, **Then** only tools with names matching the regex are added.
+5. **Given** no `ToolFilter` configured, **When** tools are registered, **Then** all tools are accepted (backward compatible).
+
+---
+
+### User Story 10 - Noop Tool for Session History Compatibility (Priority: P3) — N5
+
+When loading a session that references a tool no longer in the agent's registry, the system auto-injects a `NoopTool` placeholder. The `NoopTool` returns an error result explaining the tool is no longer available, preventing deserialization failures when tool sets evolve across sessions.
+
+**Why this priority**: Nice-to-have for long-lived agents with persistent sessions — prevents crashes when tools are added/removed between runs.
+
+**Independent Test**: Can be tested by loading a session with a tool call referencing a non-existent tool and verifying the agent handles it gracefully with a `NoopTool`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a session referencing tool `"old_tool"` that is no longer registered, **When** the session is loaded, **Then** a `NoopTool` for `"old_tool"` is auto-injected.
+2. **Given** a `NoopTool` for `"old_tool"`, **When** the LLM calls `"old_tool"`, **Then** it receives an error result saying the tool is no longer available.
+3. **Given** the session contains tool results from `"old_tool"`, **When** the session is loaded, **Then** existing results are preserved — the `NoopTool` only handles new invocations.
+
+---
+
+### User Story 11 - Tool Confirmation Payloads (Priority: P3) — N6
+
+A tool provides rich context to the approval UI by implementing an optional `approval_context` method. When a tool call requires approval, the system calls `approval_context(&self, params: &Value) -> Option<Value>` and attaches the result to the `ToolApprovalRequest`. The approval UI can display this context (e.g., a diff preview for file writes, estimated cost for API calls, a query plan for database tools).
+
+**Why this priority**: Nice-to-have that enriches the approval experience — tools work fine without it, but approval decisions are better informed when context is available.
+
+**Independent Test**: Can be tested by implementing `approval_context` on a tool, triggering an approval request, and verifying the context is attached to the `ToolApprovalRequest`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a tool implementing `approval_context` that returns `Some(context)`, **When** the tool call requires approval, **Then** the `ToolApprovalRequest` includes the context in its `context` field.
+2. **Given** a tool that does not override `approval_context` (default `None`), **When** the tool call requires approval, **Then** the `ToolApprovalRequest.context` is `None`.
+3. **Given** a `ToolApprovalRequest` with context, **When** the approval UI renders it, **Then** the context is available for display.
+
+---
+
 ### Edge Cases
 
 - What happens when a transformer rewrites a tool name to one that doesn't exist — the transformer only modifies arguments, not the tool name. Unknown tools produce an error result via `unknown_tool_result()`.
 - What happens when middleware modifies the tool result — yes, the loop sees the modified result since middleware wraps `execute()`.
 - How does the system handle a closure-based tool that panics — panics in spawned tool tasks are caught via join error handling and converted to error results.
 - What happens when the execution policy is sequential but a steering interrupt arrives — remaining sequential tools are skipped; the `steering_detected` atomic flag causes cancellation between groups.
+- What happens when the `#[tool]` macro is applied to a non-async function — compile error. The macro requires `async fn`.
+- What happens when a hot-reloaded tool definition has an invalid schema — the tool is rejected with a logged warning; existing tools are unaffected.
+- How does ScriptTool handle parameter interpolation security — all parameter values are shell-escaped before interpolation into the command template to prevent command injection via LLM-controlled parameters.
+- What happens when two definition files define tools with the same name — last-write-wins; the most recently modified file's definition takes precedence. A warning is logged when a duplicate is detected.
+- What happens when a `ToolFilter` is applied after tools are already registered — the filter is applied to the current tool list, removing non-matching tools.
+- What happens when a `NoopTool` receives arguments — it ignores them and returns the standard "tool no longer available" error message.
+- What happens when `approval_context` panics — the panic is caught via `catch_unwind`, logged, and `context` is set to `None`. The approval request proceeds without context.
 
 ## Requirements *(mandatory)*
 
@@ -139,6 +231,16 @@ A developer enables the built-in tools feature to get pre-made tools for shell c
 - **FR-009**: System MUST provide built-in tools for shell execution, file reading, and file writing, gated behind an optional feature flag that is enabled by default.
 - **FR-010**: Built-in tools MUST respect the cancellation token for cooperative cancellation.
 - **FR-011**: Built-in tools MUST define appropriate parameter schemas for argument validation.
+- **FR-012**: System MUST provide a `#[derive(ToolSchema)]` proc macro in a separate `swink-agent-macros` crate that generates JSON Schema from Rust struct definitions, mapping field types and doc comments to schema properties and descriptions.
+- **FR-013**: System MUST provide a `#[tool]` attribute macro that wraps an async function as an `AgentTool` implementation, generating the struct, schema, and trait impl from the function signature.
+- **FR-014**: The proc macro crate MUST be optional — tools can still be defined manually via `AgentTool` trait or `FnTool` builder.
+- **FR-015**: System MUST provide a feature-gated (`hot-reload`) `ToolWatcher` that monitors a directory for tool definition files (TOML/YAML/JSON) and reloads them at runtime.
+- **FR-016**: Tool definition files MUST specify at minimum: `name`, `description`, `command` (shell command to execute), and optionally `parameters_schema`.
+- **FR-017**: System MUST provide a `ToolFilter` struct with `allowed` and `rejected` pattern lists supporting exact string, glob, and regex matching, applied at tool registration time.
+- **FR-018**: When both `allowed` and `rejected` patterns match a tool name, `rejected` MUST take precedence.
+- **FR-019**: System MUST auto-inject `NoopTool` placeholders when loading sessions that reference tools no longer in the registry, returning an error result explaining the tool is unavailable.
+- **FR-020**: The `AgentTool` trait MUST include a default method `approval_context(&self, params: &Value) -> Option<Value>` returning `None`, allowing tools to provide rich context for the approval UI.
+- **FR-021**: `ToolApprovalRequest` MUST include a `context: Option<Value>` field populated from `approval_context()` when the tool requires approval.
 
 ### Key Entities
 
@@ -150,6 +252,13 @@ A developer enables the built-in tools feature to get pre-made tools for shell c
 - **BashTool**: Built-in shell command execution tool (feature-gated).
 - **ReadFileTool**: Built-in file reading tool (feature-gated).
 - **WriteFileTool**: Built-in file writing tool (feature-gated).
+- **ToolSchema (derive macro)**: Proc macro generating JSON Schema from Rust struct definitions. Lives in `swink-agent-macros` crate.
+- **#[tool] (attribute macro)**: Wraps an async function as an `AgentTool` implementation. Lives in `swink-agent-macros` crate.
+- **ToolParameters (trait)**: Trait with `fn json_schema() -> Value` implemented by `#[derive(ToolSchema)]`.
+- **ToolWatcher**: Feature-gated (`hot-reload`) directory watcher that monitors for tool definition file changes and reloads tools at runtime.
+- **ScriptTool**: A tool loaded from a definition file (TOML/YAML/JSON) that executes a shell command.
+- **ToolFilter**: Pattern-based tool filtering at registration time. Supports exact, glob, and regex patterns.
+- **NoopTool**: Placeholder tool auto-injected for session history compatibility when a referenced tool no longer exists.
 
 ## Success Criteria *(mandatory)*
 
@@ -162,6 +271,12 @@ A developer enables the built-in tools feature to get pre-made tools for shell c
 - **SC-005**: Execution policies correctly control concurrency: concurrent runs in parallel, sequential runs in order.
 - **SC-006**: Closure-based tools implement the tool trait and execute correctly when invoked.
 - **SC-007**: Built-in tools are available when the feature flag is enabled and absent when disabled.
+- **SC-008**: `#[derive(ToolSchema)]` generates correct JSON Schema from Rust types, mapping `String` → `"string"`, `u64` → `"integer"`, `Option<T>` → not required, `Vec<T>` → `"array"`, and doc comments → `description`.
+- **SC-009**: `#[tool]` attribute macro generates a valid `AgentTool` implementation from an async function signature.
+- **SC-010**: `ToolWatcher` detects file additions, modifications, and deletions in the watched directory and updates the agent's tool list accordingly.
+- **SC-011**: `ToolFilter` correctly applies exact, glob, and regex patterns, with `rejected` taking precedence over `allowed`.
+- **SC-012**: `NoopTool` placeholders are auto-injected for missing tools during session loading, returning descriptive error results.
+- **SC-013**: `approval_context()` values are correctly attached to `ToolApprovalRequest` and available to the approval UI.
 
 ## Clarifications
 
@@ -172,6 +287,13 @@ A developer enables the built-in tools feature to get pre-made tools for shell c
 - Q: Are closure tool panics caught? → A: Yes, panics in spawned tasks are caught and converted to error results.
 - Q: Does steering skip remaining sequential tools? → A: Yes, the steering_detected flag causes remaining groups to be cancelled.
 
+### Session 2026-03-31
+
+- Q: Should ScriptTool shell-escape interpolated parameter values to prevent command injection? → A: Always shell-escape parameter values before interpolation. Command injection via LLM-controlled parameters is a real attack surface. Escaping is the safe default.
+- Q: How should ToolWatcher handle duplicate tool names across definition files? → A: Last-write-wins — the most recently modified file's definition takes precedence. A warning is logged when a duplicate is detected.
+- Q: Should `hot-reload-dylib` (dynamic library loading via `libloading`) be in scope? → A: Out of scope for this iteration. Dynamic library loading requires `unsafe` code (violates `#[forbid(unsafe_code)]`) and adds significant complexity. Script-based tools cover the practical hot-reload use case. Revisit in a future spec if demand materializes.
+- Q: What debounce interval should ToolWatcher use for filesystem events? → A: 500ms — standard debounce for file watchers. Long enough to coalesce editor save events, short enough to feel responsive during development.
+
 ## Assumptions
 
 - **[Superseded by 031]** Tool call transformers and validators are replaced by PreDispatch policies (Slot 2). Policies run unconditionally before approval, matching the original transformer behavior.
@@ -179,3 +301,9 @@ A developer enables the built-in tools feature to get pre-made tools for shell c
 - Built-in tools are enabled by default via the `builtin-tools` feature flag on the core crate.
 - Closure-based tools support async execution and cancellation tokens.
 - Middleware composition order is determined by the order middleware is applied (outermost wraps first).
+- The `swink-agent-macros` proc macro crate is a new workspace member. It depends only on `syn`, `quote`, and `proc-macro2` — no runtime dependency on `swink-agent`.
+- Hot-reloading uses the `notify` crate for filesystem watching, feature-gated behind `hot-reload`.
+- Dynamic library loading (`libloading`) is out of scope for this iteration — it requires `unsafe` code and is deferred to a future spec.
+- Tool filtering is always available (no feature gate) since it has no external dependencies.
+- `NoopTool` is always available — it is a zero-dependency struct in the core crate.
+- `approval_context()` is a default method on `AgentTool` returning `None` — backward compatible, no existing tool implementations need changes.

--- a/specs/007-tool-system-extensions/tasks.md
+++ b/specs/007-tool-system-extensions/tasks.md
@@ -172,7 +172,101 @@
 
 ---
 
-## Phase 9: Polish & Cross-Cutting Concerns
+## Phase 9: User Story 7 — Auto-Schema Generation (Priority: P1) — C12
+
+**Goal**: Proc macros for generating JSON Schema from Rust types and wrapping async functions as `AgentTool` implementations
+
+**Independent Test**: Define a struct with `#[derive(ToolSchema)]`, call `json_schema()`, verify correct JSON Schema output
+
+### Implementation for User Story 7
+
+- [ ] T065 [US7] Create `macros/` directory with `Cargo.toml` declaring `proc-macro = true`, deps: `syn`, `quote`, `proc-macro2`. Add to workspace members.
+- [ ] T066 [US7] Define `ToolParameters` trait with `fn json_schema() -> Value` in `src/tool.rs` (or `src/tool_parameters.rs`). Re-export from `src/lib.rs`.
+- [ ] T067 [US7] Implement `#[derive(ToolSchema)]` proc macro in `macros/src/tool_schema.rs`: map field types to JSON Schema types, extract doc comments as descriptions, support `#[tool(description = "...")]` override.
+- [ ] T068 [US7] Implement `#[tool]` attribute macro in `macros/src/tool_attr.rs`: generate struct + `AgentTool` impl from async function signature with `name` and `description` attributes.
+- [ ] T069 [US7] Wire up `macros/src/lib.rs` to export both proc macros.
+- [ ] T070 [US7] Add unit tests in `macros/tests/`: `derive_tool_schema_basic` (String/u64/bool fields), `derive_tool_schema_option` (Option field not required), `derive_tool_schema_vec` (Vec → array), `derive_tool_schema_doc_comments` (doc comments → description), `derive_tool_schema_attr_override` (`#[tool(description = "...")]` overrides doc comment).
+- [ ] T071 [US7] Add unit tests in `macros/tests/`: `tool_attr_generates_struct` (function becomes AgentTool), `tool_attr_schema_from_params` (schema matches function params), `tool_attr_requires_async` (non-async fn = compile error), `derive_tool_schema_unsupported_type` (HashMap or custom enum produces compile error with helpful message).
+- [ ] T072 [US7] Add integration test: create an `AgentTool` via `#[tool]` macro, register it with an agent, verify it executes correctly.
+
+**Checkpoint**: Proc macros functional — tools can be created from structs and functions with zero schema boilerplate
+
+---
+
+## Phase 10: User Story 8 — Tool Hot-Reloading (Priority: P2) — I12
+
+**Goal**: Feature-gated directory watcher that loads tool definitions from files and updates the agent at runtime
+
+**Independent Test**: Start a watcher on a temp directory, add a tool definition file, verify the agent's tool list updates
+
+### Implementation for User Story 8
+
+- [ ] T073 [US8] Add `hot-reload` feature gate to `Cargo.toml` with optional `notify` dependency.
+- [ ] T074 [US8] Implement `ScriptTool` struct in `src/hot_reload.rs`: parse TOML/YAML/JSON definition files, implement `AgentTool` with shell command execution.
+- [ ] T075 [US8] Implement `ToolWatcher` struct in `src/hot_reload.rs`: use `notify` to watch directory, debounce changes, load/reload/remove `ScriptTool` instances.
+- [ ] T076 [US8] Implement `ToolWatcher::start()` — spawns async task, watches for file events, calls `Agent::set_tools()` on changes. Apply optional `ToolFilter`.
+- [ ] T077 [US8] Add unit tests: `script_tool_from_toml` (parse TOML definition), `script_tool_executes_command` (run command with interpolated args), `script_tool_invalid_definition` (reject malformed files), `script_tool_escapes_parameters` (verify parameter values are shell-escaped before interpolation — e.g., `"; rm -rf /"` in a parameter does not execute as a command).
+- [ ] T078 [US8] Add integration test: start watcher on tempdir, add/modify/delete TOML files, verify tool list updates. Include `duplicate_tool_names_last_write_wins` — add two files defining the same tool name, verify the most recently modified one takes precedence with a warning logged.
+- [ ] T079 [US8] Re-export `ToolWatcher` and `ScriptTool` from `src/lib.rs` behind `#[cfg(feature = "hot-reload")]`.
+
+**Checkpoint**: Hot-reloading functional — tools can be added/modified/removed via definition files at runtime
+
+---
+
+## Phase 11: User Story 9 — Tool Filtering (Priority: P2) — I13
+
+**Goal**: Pattern-based tool filtering at registration time using exact, glob, and regex patterns
+
+**Independent Test**: Create a `ToolFilter`, register tools, verify only matching tools are available
+
+### Implementation for User Story 9
+
+- [ ] T080 [US9] Implement `ToolPattern` enum (Exact/Glob/Regex) with `parse()` auto-detection and `matches()` in `src/tool_filter.rs`.
+- [ ] T081 [US9] Implement `ToolFilter` struct with `allowed`/`rejected` fields, `with_allowed()`/`with_rejected()` builders, and `filter_tools()` method in `src/tool_filter.rs`.
+- [ ] T082 [US9] Add unit tests: `exact_pattern_matches` , `glob_pattern_matches` (`read_*` matches `read_file`), `regex_pattern_matches` (`^file_.*$`), `rejected_takes_precedence`, `empty_filter_allows_all`.
+- [ ] T083 [US9] Re-export `ToolFilter` and `ToolPattern` from `src/lib.rs`.
+
+**Checkpoint**: Tool filtering functional — registration-time pattern matching restricts available tools
+
+---
+
+## Phase 12: User Story 10 — Noop Tool (Priority: P3) — N5
+
+**Goal**: Auto-inject placeholder tools for session history compatibility
+
+**Independent Test**: Load a session referencing a non-existent tool, verify NoopTool is injected and returns error result
+
+### Implementation for User Story 10
+
+- [ ] T084 [US10] Implement `NoopTool` struct in `src/noop_tool.rs`: `new(name)`, `AgentTool` impl returning error result.
+- [ ] T085 [US10] Integrate `NoopTool` injection into session loading — detect tool references not in registry, auto-inject NoopTool for each.
+- [ ] T086 [US10] Add unit tests: `noop_tool_returns_error`, `noop_tool_name_matches`, `noop_tool_no_approval_required`.
+- [ ] T087 [US10] Re-export `NoopTool` from `src/lib.rs`.
+
+**Checkpoint**: NoopTool functional — sessions with removed tools load gracefully
+
+---
+
+## Phase 13: User Story 11 — Tool Confirmation Payloads (Priority: P3) — N6
+
+**Goal**: Rich context for the approval UI via `approval_context()` default method on AgentTool
+
+**Independent Test**: Implement `approval_context` on a tool, trigger approval, verify context attached to request
+
+### Implementation for User Story 11
+
+- [ ] T088 [US11] Add `fn approval_context(&self, params: &Value) -> Option<Value> { None }` default method to `AgentTool` trait in `src/tool.rs`.
+- [ ] T089 [US11] Add `context: Option<Value>` field to `ToolApprovalRequest` in `src/tool.rs`. Populate from `approval_context()` in tool dispatch pipeline (`src/loop_/tool_dispatch.rs`).
+- [ ] T090 [US11] Add `catch_unwind` around `approval_context()` call — log panics, set context to `None`.
+- [ ] T091 [US11] Update `FnTool` to support `approval_context` via a new `with_approval_context()` builder method.
+- [ ] T092 [US11] Add unit tests: `approval_context_default_none`, `approval_context_returns_value`, `approval_context_panic_caught`, `approval_request_includes_context`.
+- [ ] T093 [US11] Update `ToolMiddleware` to delegate `approval_context()` to inner tool (same as other metadata methods).
+
+**Checkpoint**: Approval context functional — tools can provide rich previews to the approval UI
+
+---
+
+## Phase 14: Polish & Cross-Cutting Concerns
 
 **Purpose**: Final integration validation and cross-cutting quality checks
 
@@ -181,6 +275,11 @@
 - [x] T062 [P] Run `cargo test --workspace` and verify all tests pass
 - [x] T063 [P] Run `cargo test -p swink-agent --no-default-features` and verify feature-gated compilation
 - [x] T064 Validate quickstart.md examples compile and match public API in `specs/007-tool-system-extensions/quickstart.md`
+- [ ] T094 Add compile-time `Send + Sync` assertions for new public types: `ToolFilter`, `ToolPattern`, `NoopTool`, `ScriptTool` (behind feature gate)
+- [ ] T095 Run `cargo build -p swink-agent --features hot-reload` and verify zero compilation errors
+- [ ] T096 Run `cargo test -p swink-agent-macros` and verify all macro tests pass
+- [ ] T097 Run `cargo clippy --workspace -- -D warnings` with all features enabled and fix any warnings
+- [ ] T098 Validate quickstart.md new examples (auto-schema, filtering, hot-reload, noop, confirmation) match actual API
 
 ---
 
@@ -196,7 +295,12 @@
 - **US4 Execution Policy (Phase 6)**: Depends on Phase 2 (independent of US1–US3)
 - **US5 FnTool (Phase 7)**: Depends on Phase 2 (independent of US1–US4)
 - **US6 Built-in Tools (Phase 8)**: Depends on Phase 1 (feature flag) and Phase 2
-- **Polish (Phase 9)**: Depends on all user stories being complete
+- **US7 Auto-Schema (Phase 9)**: Depends on Phase 2 (needs `ToolParameters` trait in core). Independent of US1–US6.
+- **US8 Hot-Reloading (Phase 10)**: Depends on Phase 2. Optionally uses US9 (ToolFilter) but can proceed independently.
+- **US9 Tool Filtering (Phase 11)**: Depends on Phase 2. Independent of all other stories.
+- **US10 Noop Tool (Phase 12)**: Depends on Phase 2. Independent of all other stories.
+- **US11 Confirmation Payloads (Phase 13)**: Depends on Phase 2. Touches `src/tool.rs` (AgentTool trait) and `src/loop_/tool_dispatch.rs`.
+- **Polish (Phase 14)**: Depends on all user stories being complete
 
 ### User Story Dependencies
 
@@ -206,6 +310,11 @@
 - **US4 (P2)**: Foundational only — no cross-story dependencies
 - **US5 (P2)**: Foundational only — no cross-story dependencies
 - **US6 (P3)**: Foundational + Setup (feature flag) — no cross-story dependencies
+- **US7 (P1)**: Foundational + new macros crate — no cross-story dependencies
+- **US8 (P2)**: Foundational + feature flag — optionally uses US9 ToolFilter
+- **US9 (P2)**: Foundational only — no cross-story dependencies
+- **US10 (P3)**: Foundational only — no cross-story dependencies
+- **US11 (P3)**: Foundational only — modifies AgentTool trait (default method, backward compatible)
 
 ### Within Each User Story
 
@@ -217,8 +326,10 @@
 - All Foundational [P] tasks can run in parallel (within Phase 2)
 - US1 through US5 can proceed in parallel after Phase 2 completes
 - US6 can proceed after Phase 1 + Phase 2 complete
+- US7 through US11 can proceed in parallel after Phase 2 (US7 needs macros crate setup first)
 - Within US3: with_timeout and with_logging factories are [P]
 - Within US6: ReadFileTool and WriteFileTool are [P]
+- US9 (ToolFilter) and US10 (NoopTool) and US11 (Confirmation Payloads) touch separate files with no cross-deps
 
 ---
 
@@ -232,6 +343,11 @@ US3: "Define MiddlewareFn type alias in src/tool_middleware.rs"
 US4: "Define ToolCallSummary struct in src/tool_execution_policy.rs"
 US5: "Define ExecuteFn type alias in src/fn_tool.rs"
 US6: "Implement BashTool in src/tools/bash.rs"
+US7: "Create macros/ crate, define ToolParameters trait"
+US8: "Add hot-reload feature gate, implement ScriptTool"
+US9: "Implement ToolFilter in src/tool_filter.rs"
+US10: "Implement NoopTool in src/noop_tool.rs"
+US11: "Add approval_context() to AgentTool trait"
 ```
 
 ---
@@ -254,7 +370,12 @@ US6: "Implement BashTool in src/tools/bash.rs"
 4. Add US4 Execution Policy → Configurable dispatch ordering
 5. Add US5 FnTool → Closure-based convenience
 6. Add US6 Built-in Tools → Ready-to-use shell/file tools
-7. Each story adds value without breaking previous stories
+7. Add US7 Auto-Schema → Zero-boilerplate tool definition
+8. Add US11 Confirmation Payloads → Rich approval context
+9. Add US9 Tool Filtering → Registration-time security
+10. Add US10 Noop Tool → Session compatibility
+11. Add US8 Hot-Reloading → Runtime tool management
+12. Each story adds value without breaking previous stories
 
 ---
 
@@ -266,3 +387,6 @@ US6: "Implement BashTool in src/tools/bash.rs"
 - Commit after each task or logical group
 - Stop at any checkpoint to validate story independently
 - Dispatch pipeline order is fixed: approval → transformer → validator → schema → execute
+- US7 (Auto-Schema) is new work — creates the `swink-agent-macros` workspace crate
+- US8 (Hot-Reloading) is new work — feature-gated behind `hot-reload`
+- US9 (Tool Filtering), US10 (Noop Tool), US11 (Confirmation Payloads) are new work in core crate


### PR DESCRIPTION
## Summary
- Add 5 new features to 007-tool-system-extensions spec: C12 (auto-schema proc macros), I12 (tool hot-reloading), I13 (tool filtering), N5 (noop tool), N6 (confirmation payloads)
- All 8 spec artifacts updated: spec (US7–US11, FR-012–021, SC-008–013), data-model, research (D8–D12), plan, contracts, quickstart, tasks (T065–T098), checklist
- 4 clarifications: shell-escape parameters, last-write-wins duplicates, dylib out of scope, 500ms debounce

## Test plan
- [ ] Verify spec consistency across all 8 artifacts
- [ ] Verify task coverage for all new FRs and acceptance scenarios
- [ ] Verify no task ID collisions or gaps (T001–T098)
- [ ] Verify hot-reload-dylib references fully removed after out-of-scope clarification

🤖 Generated with [Claude Code](https://claude.com/claude-code)