### PR TITLE
spec: cost calculation and capability introspection for 008

### DIFF
--- a/specs/008-model-catalog-presets/checklists/requirements.md
+++ b/specs/008-model-catalog-presets/checklists/requirements.md
@@ -29,6 +29,16 @@
 - [x] Feature meets measurable outcomes defined in Success Criteria
 - [x] No implementation details leak into specification
 
+## Cost Calculation & Capability Introspection (I21, I22)
+
+- [x] US4–US5 acceptance scenarios are testable and unambiguous
+- [x] FR-010 through FR-014 are measurable
+- [x] SC-006 through SC-009 are technology-agnostic success criteria
+- [x] Edge cases for cost calculation (unknown model, missing pricing, provider-specific costs) identified
+- [x] Graceful degradation specified (zero cost for unknowns)
+- [x] Backward compatibility maintained (Option fields, existing ModelCapabilities reused)
+
 ## Notes
 
 - All items pass. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- I21 (Cost Calculation) and I22 (Capability Introspection) added 2026-03-31: US4–US5, FR-010–FR-014, SC-006–SC-009, tasks T031–T044.

--- a/specs/008-model-catalog-presets/contracts/public-api.md
+++ b/specs/008-model-catalog-presets/contracts/public-api.md
@@ -53,7 +53,7 @@ pub enum PresetStatus {
 }
 
 /// A single model preset within a provider.
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 pub struct PresetCatalog {
     pub id: String,
     pub display_name: String,
@@ -65,6 +65,10 @@ pub struct PresetCatalog {
     pub context_window_tokens: Option<u64>,
     pub max_output_tokens: Option<u64>,
     pub include_by_default: bool,                  // #[serde(default)]
+    pub cost_per_million_input: Option<f64>,        // #[serde(default)]
+    pub cost_per_million_output: Option<f64>,       // #[serde(default)]
+    pub cost_per_million_cache_read: Option<f64>,   // #[serde(default)]
+    pub cost_per_million_cache_write: Option<f64>,  // #[serde(default)]
     pub repo_id: Option<String>,
     pub filename: Option<String>,
 }
@@ -100,7 +104,7 @@ impl ModelCatalog {
 }
 
 /// Flattened view of a preset with its provider context.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct CatalogPreset {
     pub provider_key: String,
     pub provider_display_name: String,
@@ -121,6 +125,10 @@ pub struct CatalogPreset {
     pub requires_base_url: bool,
     pub region_env_var: Option<String>,
     pub include_by_default: bool,
+    pub cost_per_million_input: Option<f64>,
+    pub cost_per_million_output: Option<f64>,
+    pub cost_per_million_cache_read: Option<f64>,
+    pub cost_per_million_cache_write: Option<f64>,
     pub repo_id: Option<String>,
     pub filename: Option<String>,
 }
@@ -136,6 +144,10 @@ impl CatalogPreset {
 /// Returns the singleton model catalog loaded from embedded TOML.
 /// Panics if the TOML is malformed.
 pub fn model_catalog() -> &'static ModelCatalog;
+
+/// Calculate monetary cost from token usage using catalog pricing data.
+/// Returns Cost::default() (all zeros) if model not found or no pricing data.
+pub fn calculate_cost(model_id: &str, usage: &Usage) -> Cost;
 ```
 
 ## `src/model_presets.rs` — Connection Types
@@ -193,7 +205,7 @@ impl Debug for ModelFallback { /* displays "provider:model_id" for each entry */
 pub use fallback::ModelFallback;
 pub use model_catalog::{
     ApiVersion, AuthMode, CatalogPreset, ModelCatalog, PresetCapability, PresetCatalog,
-    PresetStatus, ProviderCatalog, ProviderKind, model_catalog,
+    PresetStatus, ProviderCatalog, ProviderKind, model_catalog, calculate_cost,
 };
 pub use model_presets::{ModelConnection, ModelConnections};
 ```

--- a/specs/008-model-catalog-presets/data-model.md
+++ b/specs/008-model-catalog-presets/data-model.md
@@ -60,10 +60,14 @@ Metadata for a specific model preset within a provider.
 | `context_window_tokens` | `Option<u64>` | Maximum context window size in tokens |
 | `max_output_tokens` | `Option<u64>` | Maximum output tokens per response |
 | `include_by_default` | `bool` | Whether to include in default model list (default: `false`) |
+| `cost_per_million_input` | `Option<f64>` | USD cost per million input tokens (default: `None`) |
+| `cost_per_million_output` | `Option<f64>` | USD cost per million output tokens (default: `None`) |
+| `cost_per_million_cache_read` | `Option<f64>` | USD cost per million cache read tokens (default: `None`) |
+| `cost_per_million_cache_write` | `Option<f64>` | USD cost per million cache write tokens (default: `None`) |
 | `repo_id` | `Option<String>` | HuggingFace repository ID (local models) |
 | `filename` | `Option<String>` | Model filename (local models) |
 
-**Derives**: `Debug`, `Clone`, `PartialEq`, `Eq`, `Deserialize`
+**Derives**: `Debug`, `Clone`, `PartialEq`, `Deserialize` (note: `Eq` removed since `f64` fields do not implement `Eq`)
 
 ---
 
@@ -92,6 +96,10 @@ Flattened, denormalized view combining provider and preset metadata. Not deseria
 | `requires_base_url` | `bool` | Whether base URL is required |
 | `region_env_var` | `Option<String>` | Region env var name |
 | `include_by_default` | `bool` | Default inclusion flag |
+| `cost_per_million_input` | `Option<f64>` | USD cost per million input tokens |
+| `cost_per_million_output` | `Option<f64>` | USD cost per million output tokens |
+| `cost_per_million_cache_read` | `Option<f64>` | USD cost per million cache read tokens |
+| `cost_per_million_cache_write` | `Option<f64>` | USD cost per million cache write tokens |
 | `repo_id` | `Option<String>` | HuggingFace repo ID |
 | `filename` | `Option<String>` | Model filename |
 
@@ -99,7 +107,7 @@ Flattened, denormalized view combining provider and preset metadata. Not deseria
 - `model_capabilities(&self) -> ModelCapabilities` — convert capability list to `ModelCapabilities` struct
 - `model_spec(&self) -> ModelSpec` — create a `ModelSpec` with capabilities pre-populated
 
-**Derives**: `Debug`, `Clone`, `PartialEq`, `Eq`
+**Derives**: `Debug`, `Clone`, `PartialEq`
 
 ---
 
@@ -228,6 +236,23 @@ Returns a reference to the singleton `ModelCatalog` loaded from the embedded TOM
 
 ---
 
+### calculate_cost() (free function)
+
+```text
+pub fn calculate_cost(model_id: &str, usage: &Usage) -> Cost
+```
+
+Looks up pricing data from the catalog by `model_id` (searching across all providers). Computes monetary cost:
+- `input_cost = usage.input as f64 * cost_per_million_input / 1_000_000.0`
+- `output_cost = usage.output as f64 * cost_per_million_output / 1_000_000.0`
+- `cache_read_cost = usage.cache_read as f64 * cost_per_million_cache_read / 1_000_000.0`
+- `cache_write_cost = usage.cache_write as f64 * cost_per_million_cache_write / 1_000_000.0`
+- `total = input_cost + output_cost + cache_read_cost + cache_write_cost`
+
+Returns `Cost::default()` (all zeros) if model not found or pricing data is `None`.
+
+---
+
 ## Relationships
 
 ```text
@@ -253,4 +278,13 @@ ModelConnection (ModelSpec + Arc<dyn StreamFn>)
 
 ModelFallback (Vec<(ModelSpec, Arc<dyn StreamFn>)>)
     └── consumed by agent loop for automatic failover
+
+calculate_cost(model_id, usage) -> Cost
+    ├── looks up PresetCatalog by model_id across all providers
+    ├── uses cost_per_million_input/output/cache_read/cache_write
+    └── returns Cost with input, output, cache_read, cache_write, total
+
+ModelSpec.capabilities -> Option<ModelCapabilities>
+    ├── populated by CatalogPreset::model_spec()
+    └── queryable via ModelSpec::capabilities() (returns stored or default)
 ```

--- a/specs/008-model-catalog-presets/plan.md
+++ b/specs/008-model-catalog-presets/plan.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-Provide a data-driven model and provider registry, preset-based connection configuration, and automatic model fallback. The model catalog is loaded from a TOML data file embedded at compile time via `include_str!`, containing provider metadata (credential environment variables, base URLs, auth modes) and model presets grouped by provider and family. Presets carry identifiers, display names, groups, model IDs, capabilities, status, and optional context window sizes. `ModelConnection` and `ModelConnections` resolve presets to fully configured connection objects carrying a `ModelSpec` and `StreamFn`. `ModelFallback` defines an ordered chain of fallback models with automatic failover when the primary model exhausts its retry budget.
+Provide a data-driven model and provider registry, preset-based connection configuration, automatic model fallback, model cost calculation from catalog pricing data, and capability introspection. The model catalog is loaded from a TOML data file embedded at compile time via `include_str!`, containing provider metadata (credential environment variables, base URLs, auth modes) and model presets grouped by provider and family. Presets carry identifiers, display names, groups, model IDs, capabilities, status, and optional context window sizes. `ModelConnection` and `ModelConnections` resolve presets to fully configured connection objects carrying a `ModelSpec` and `StreamFn`. `ModelFallback` defines an ordered chain of fallback models with automatic failover when the primary model exhausts its retry budget.
 
 ## Technical Context
 
@@ -26,7 +26,7 @@ Provide a data-driven model and provider registry, preset-based connection confi
 | Principle | Status | Notes |
 |---|---|---|
 | I. Library-First | PASS | All components live in the `swink-agent` core crate as public API surface. No new crates introduced. The catalog is embedded data, not a service dependency. `ModelConnection`, `ModelConnections`, and `ModelFallback` are self-contained types with no UI or provider-specific imports. |
-| II. Test-Driven Development | PASS | Each source file includes inline `#[cfg(test)]` modules. Tests cover catalog loading, preset lookup, provider metadata propagation, connection deduplication, fallback chain semantics, and capability conversion. |
+| II. Test-Driven Development | PASS | Each source file includes inline `#[cfg(test)]` modules. Tests cover catalog loading, preset lookup, provider metadata propagation, connection deduplication, fallback chain semantics, capability conversion, cost calculation (known/unknown/zero/cache), and capability introspection (flags, limits, defaults). |
 | III. Efficiency & Performance | PASS | Catalog parsed once via `OnceLock` and stored as `&'static ModelCatalog`. No runtime file I/O. `CatalogPreset` flattens provider+preset data to avoid repeated lookups. `ModelConnections` deduplicates extras in `new()` to avoid redundant fallback attempts. |
 | IV. Leverage the Ecosystem | PASS | Uses `toml` crate for deserialization (high download count, stable API). Uses `serde::Deserialize` for all catalog types. No hand-rolled parser. |
 | V. Provider Agnosticism | PASS | The catalog stores metadata (env var names, base URLs) but never holds API keys or SDK clients. `ModelConnection` pairs a `ModelSpec` with a `StreamFn` — the core crate does not know how to construct provider-specific stream functions. |

--- a/specs/008-model-catalog-presets/quickstart.md
+++ b/specs/008-model-catalog-presets/quickstart.md
@@ -171,3 +171,52 @@ max_output_tokens = 8192
 ```
 
 Run `cargo test --workspace` to verify the updated catalog loads correctly.
+
+### Calculate Cost from Usage
+
+```rust
+use swink_agent::{calculate_cost, Usage};
+
+let usage = Usage {
+    input: 1000,
+    output: 500,
+    cache_read: 200,
+    cache_write: 100,
+    ..Default::default()
+};
+
+let cost = calculate_cost("claude-sonnet-4-6", &usage);
+// cost.input = 1000 * 3.0 / 1_000_000 = 0.003
+// cost.output = 500 * 15.0 / 1_000_000 = 0.0075
+// cost.cache_read = 200 * 0.30 / 1_000_000 = 0.00006
+// cost.cache_write = 100 * 3.75 / 1_000_000 = 0.000375
+// cost.total = 0.010935
+
+// Unknown model returns zero cost
+let zero = calculate_cost("unknown-model", &usage);
+assert_eq!(zero.total, 0.0);
+```
+
+### Query Model Capabilities
+
+```rust
+use swink_agent::{model_catalog, ModelSpec};
+
+// From catalog preset
+let preset = model_catalog().preset("anthropic", "sonnet_46").unwrap();
+let caps = preset.model_capabilities();
+assert!(caps.supports_thinking);
+assert!(caps.supports_tool_use);
+assert!(caps.supports_streaming);
+assert_eq!(caps.max_context_window, Some(200_000));
+assert_eq!(caps.max_output_tokens, Some(64_000));
+
+// From ModelSpec (populated when created from catalog)
+let spec = preset.model_spec();
+assert!(spec.capabilities().supports_thinking);
+
+// Manual ModelSpec (no catalog) — defaults
+let manual = ModelSpec::new("custom", "my-model");
+assert!(!manual.capabilities().supports_thinking);
+assert_eq!(manual.capabilities().max_context_window, None);
+```

--- a/specs/008-model-catalog-presets/research.md
+++ b/specs/008-model-catalog-presets/research.md
@@ -88,3 +88,39 @@
 **Alternatives rejected**:
 - **String-based capabilities**: No compile-time safety. Typos in TOML silently fail.
 - **Bitflags**: Less readable in TOML (numeric values). The number of capabilities is small enough that a `Vec<PresetCapability>` is fine.
+
+---
+
+### D8: Pricing Data Inline in Catalog TOML
+
+**Decision**: Add pricing fields (`cost_per_million_input`, `cost_per_million_output`, `cost_per_million_cache_read`, `cost_per_million_cache_write`) as optional `f64` fields directly on `PresetCatalog`. The `calculate_cost()` function looks up pricing by `model_id` across all providers.
+
+**Rationale**: Pricing is per-model, not per-provider — different tiers from the same provider have different prices. Keeping pricing inline with the preset definition ensures pricing and model metadata stay in sync. The fields are `Option<f64>` so models without pricing data (e.g., local models, preview models) simply omit them. A separate pricing file was considered but adds indirection without benefit — pricing changes at the same cadence as model additions.
+
+**Key reference**: Pi Agent's `calculateCost(model, usage)` with pricing baked into model metadata. AWS Bedrock SDK bakes pricing into model definitions.
+
+**Alternatives rejected**:
+- **Separate pricing TOML file**: Adds a second file to maintain. Pricing and model metadata change together, so co-location is cleaner.
+- **Runtime pricing lookup (API call)**: Violates library-first principle. Adds network dependency for a simple calculation.
+- **Pricing as a trait/callback**: Over-engineering. A pure function with catalog lookup is simpler and covers all use cases.
+
+---
+
+### D9: calculate_cost() Lookup by model_id, Not Provider+Preset
+
+**Decision**: `calculate_cost(model_id: &str, usage: &Usage) -> Cost` searches the catalog by `model_id` across all providers, not by `(provider_key, preset_id)`.
+
+**Rationale**: Callers typically have a `ModelSpec` (which carries `model_id`) but not necessarily the preset ID. Searching by `model_id` is the most ergonomic API. Since `model_id` is unique across the catalog (each model ID maps to exactly one preset), the search is unambiguous. Graceful degradation (zero cost) when the model is not found avoids forcing callers to handle errors for what is essentially a monitoring convenience.
+
+**Alternatives rejected**:
+- **Lookup by `(provider_key, preset_id)`**: Requires callers to know the preset ID, which is a catalog-internal concept. `model_id` is what the LLM API uses.
+- **Lookup by `&ModelSpec`**: Would work but ties the function signature to `ModelSpec`. Using `&str` for `model_id` is more flexible.
+- **Returning `Result<Cost, _>`**: Cost calculation is a best-effort convenience. Returning an error for unknown models adds error handling burden with no benefit — zero cost is the correct answer for "I don't know this model's pricing."
+
+---
+
+### D10: ModelCapabilities as Optional Field on ModelSpec
+
+**Decision**: `ModelSpec` carries `capabilities: Option<ModelCapabilities>`. The `capabilities()` method returns stored capabilities or `ModelCapabilities::default()` (all flags false, no limits). `CatalogPreset::model_spec()` pre-populates capabilities from the catalog.
+
+**Rationale**: Capabilities are metadata that flows with the model specification. Making them `Option` preserves backward compatibility — manually created `ModelSpec` instances work without specifying capabilities. The `capabilities()` accessor returning defaults for `None` means callers never need to handle the absence case. This pattern mirrors how `serde(default)` works — absent data gets safe defaults.

--- a/specs/008-model-catalog-presets/spec.md
+++ b/specs/008-model-catalog-presets/spec.md
@@ -3,7 +3,7 @@
 **Feature Branch**: `008-model-catalog-presets`
 **Created**: 2026-03-20
 **Status**: Draft
-**Input**: Data-driven model and provider registry, preset-based connection configuration, and automatic model fallback. References: HLD Catalogs & Registries (ModelCatalog, PresetCatalog, ProviderCatalog), HLD Design Decisions (catalogs are core concerns), Provider Expansion Roadmap (catalog shape guidance).
+**Input**: Data-driven model and provider registry, preset-based connection configuration, automatic model fallback, model cost calculation from catalog pricing data, and capability introspection. References: HLD Catalogs & Registries (ModelCatalog, PresetCatalog, ProviderCatalog), HLD Design Decisions (catalogs are core concerns), Provider Expansion Roadmap (catalog shape guidance).
 
 ## User Scenarios & Testing *(mandatory)*
 
@@ -55,12 +55,49 @@ A developer configures a primary model with one or more fallback models. When th
 
 ---
 
+### User Story 4 - Calculate Model Cost from Usage (Priority: P2) — I21
+
+A developer calculates the monetary cost of an LLM call by passing a model specification and token usage to a `calculate_cost()` function. The function looks up per-million-token pricing data from the catalog and computes input, output, cache read, cache write, and total costs. If the model is not found in the catalog, zero cost is returned (graceful degradation).
+
+**Why this priority**: Cost visibility is essential for production monitoring and budget enforcement. Without catalog-driven pricing, operators must maintain separate pricing tables or hardcode costs.
+
+**Independent Test**: Can be tested by calling `calculate_cost()` with a known model and usage, and verifying the computed cost matches the expected value from the catalog's pricing data.
+
+**Acceptance Scenarios**:
+
+1. **Given** a model in the catalog with pricing data and a `Usage` with input/output tokens, **When** `calculate_cost()` is called, **Then** the returned `Cost` has correct `input`, `output`, and `total` fields computed as `tokens * price_per_million / 1_000_000`.
+2. **Given** a `Usage` with `cache_read` and `cache_write` tokens, **When** `calculate_cost()` is called, **Then** the returned `Cost` includes correct `cache_read` and `cache_write` fields.
+3. **Given** a model not in the catalog (unknown model), **When** `calculate_cost()` is called, **Then** a zero `Cost` is returned (all fields are 0.0).
+4. **Given** a model with pricing data but zero usage tokens, **When** `calculate_cost()` is called, **Then** a zero `Cost` is returned.
+
+---
+
+### User Story 5 - Query Model Capabilities at Runtime (Priority: P2) — I22
+
+A developer queries a model's capabilities at runtime to determine what features it supports (thinking, tool use, vision, streaming, structured output) and its limits (context window, max output tokens). Capabilities are populated from the catalog when a `ModelSpec` is created via `CatalogPreset::model_spec()`, and are queryable via `ModelSpec::capabilities()`.
+
+**Why this priority**: Capability introspection enables adaptive agent behavior — e.g., only requesting thinking mode from models that support it, or adjusting context size to fit the model's window.
+
+**Independent Test**: Can be tested by loading a catalog preset, calling `model_capabilities()`, and verifying the correct flags and limits are set.
+
+**Acceptance Scenarios**:
+
+1. **Given** a catalog preset with capabilities `["thinking", "tools", "images_in", "streaming"]`, **When** `model_capabilities()` is called, **Then** the returned `ModelCapabilities` has `supports_thinking: true`, `supports_tool_use: true`, `supports_vision: true`, `supports_streaming: true`.
+2. **Given** a catalog preset with `context_window_tokens = 200000` and `max_output_tokens = 64000`, **When** `model_capabilities()` is called, **Then** the returned `ModelCapabilities` has `max_context_window: Some(200000)` and `max_output_tokens: Some(64000)`.
+3. **Given** a `ModelSpec` created via `CatalogPreset::model_spec()`, **When** `spec.capabilities()` is called, **Then** it returns the same capabilities as the catalog preset.
+4. **Given** a `ModelSpec` created manually (not from catalog), **When** `spec.capabilities()` is called, **Then** it returns default capabilities (all flags false, no limits).
+
+---
+
 ### Edge Cases
 
 - What happens when the catalog data file is malformed — the catalog is embedded at compile time; malformed TOML panics at initialization with a clear message. This is a build-time invariant, not a runtime error.
 - How does the system handle a provider that has presets but no credential environment variable is set — resolution indicates the missing credentials; callers handle it (e.g., TUI shows a setup wizard).
 - What happens when a fallback chain contains only one model — behaves identically to no fallback; the single model is tried and errors propagate normally.
 - How does the catalog handle duplicate preset identifiers across providers — preset lookup uses first-match via `iter().find()`. Duplicates are prevented by TOML structure (unique keys per provider section).
+- What happens when pricing data is missing for a model in the catalog — `calculate_cost()` returns zero cost. Models without pricing fields are treated as free (graceful degradation, not an error).
+- What happens when pricing data changes between catalog versions — pricing is compiled into the binary. To update pricing, update `model_catalog.toml` and recompile. Runtime pricing updates are out of scope.
+- What happens when `Usage.extra` contains provider-specific token categories — `calculate_cost()` only computes costs for standard categories (input, output, cache_read, cache_write). Provider-specific costs in `Cost.extra` must be computed by the adapter.
 
 ## Requirements *(mandatory)*
 
@@ -75,6 +112,11 @@ A developer configures a primary model with one or more fallback models. When th
 - **FR-007**: System MUST support automatic model fallback with a configurable chain of model specifications.
 - **FR-008**: Fallback MUST try each model in order, stopping at the first success. If all fail, the last error is surfaced.
 - **FR-009**: The catalog MUST be extensible — new providers and presets can be added by updating the data file without code changes.
+- **FR-010**: The catalog MUST support per-preset pricing fields: `cost_per_million_input`, `cost_per_million_output`, `cost_per_million_cache_read`, `cost_per_million_cache_write` (all `Option<f64>`, defaulting to `None`/zero).
+- **FR-011**: System MUST provide a `calculate_cost(model_id: &str, usage: &Usage) -> Cost` function that looks up pricing from the catalog and computes monetary cost from token counts.
+- **FR-012**: `calculate_cost()` MUST return zero cost for models not found in the catalog or models without pricing data (graceful degradation, not an error).
+- **FR-013**: The catalog MUST expose capability metadata per preset via `CatalogPreset::model_capabilities()`, mapping capability flags and token limits to the `ModelCapabilities` struct.
+- **FR-014**: `ModelSpec` MUST carry optional `capabilities: Option<ModelCapabilities>` and provide `capabilities() -> ModelCapabilities` returning stored capabilities or defaults.
 
 ### Key Entities
 
@@ -83,6 +125,9 @@ A developer configures a primary model with one or more fallback models. When th
 - **Preset**: Metadata for a specific model — ID, display name, group, model ID, capabilities, status, context window.
 - **ModelConnection**: Fully resolved connection configuration — base URL, credentials, model specification.
 - **ModelFallback**: Ordered chain of model specifications with automatic failover.
+- **ModelPricing**: Per-preset pricing data (cost per million tokens for input, output, cache read, cache write) embedded in the catalog TOML.
+- **calculate_cost()**: Free function computing `Cost` from `Usage` using catalog pricing data.
+- **ModelCapabilities**: Capability flags and token limits queryable from `ModelSpec` or `CatalogPreset`.
 
 ## Success Criteria *(mandatory)*
 
@@ -93,6 +138,10 @@ A developer configures a primary model with one or more fallback models. When th
 - **SC-003**: Preset-to-connection resolution produces correct credentials and base URLs from environment variables.
 - **SC-004**: Automatic fallback tries the next model when the primary fails and stops at the first success.
 - **SC-005**: New providers can be added to the catalog data file without modifying code.
+- **SC-006**: `calculate_cost()` correctly computes input, output, cache read, cache write, and total costs from catalog pricing data and token usage.
+- **SC-007**: `calculate_cost()` returns zero cost for unknown models or models without pricing data.
+- **SC-008**: `CatalogPreset::model_capabilities()` correctly maps catalog capability flags and token limits to `ModelCapabilities`.
+- **SC-009**: `ModelSpec::capabilities()` returns catalog-populated capabilities when created from a preset, or defaults when created manually.
 
 ## Clarifications
 
@@ -102,6 +151,12 @@ A developer configures a primary model with one or more fallback models. When th
 - Q: What if provider credentials are missing? → A: Resolution indicates missing credentials; callers handle (e.g., setup wizard).
 - Q: Single-model fallback behavior? → A: Identical to no fallback; single model tried, errors propagate.
 - Q: Duplicate preset IDs across providers? → A: First-match via find(); TOML structure prevents duplicates per provider.
+### Session 2026-03-31
+
+- Q: Should `Eq` be removed from `PresetCatalog` and `CatalogPreset` after adding `f64` pricing fields? → A: Yes — remove `Eq`, keep `PartialEq`. `f64` does not implement `Eq`, but `PartialEq` works fine. NaN pricing values are not a realistic concern since TOML parsing produces finite floats.
+
+### Session 2026-03-20
+
 - Q: How does FR-004 filtering by group/capability/status work? → A: The catalog exposes `providers` and their `presets` as public fields. Callers filter by iterating over presets and matching on group, capability, or status fields directly. The core catalog provides lookup by provider key and preset ID; advanced filtering is a caller concern.
 - Q: Does FR-006 (preset-to-connection resolution via env vars) live in core? → A: No. The core crate provides `ModelConnection` as a provider-agnostic container. Actual env-var resolution is an adapter-layer responsibility per Constitution Principle V (Provider Agnosticism).
 - Q: Does FR-008 (fallback execution) live in this feature? → A: No. `ModelFallback` is configuration only. The agent loop (spec 004) consumes it to implement failover execution.
@@ -113,3 +168,7 @@ A developer configures a primary model with one or more fallback models. When th
 - Preset capabilities include at minimum: text generation, tool calling, and reasoning/thinking.
 - Preset status indicates whether the model is generally available, in preview, or deprecated.
 - Fallback is triggered by errors from the provider, not by response quality.
+- Pricing data is per-preset, not per-provider — different model tiers from the same provider have different prices.
+- Pricing is in USD per million tokens, consistent across all providers.
+- `calculate_cost()` looks up pricing by `model_id` (searching across all providers), not by provider key + preset ID.
+- `ModelCapabilities` already exists in `src/types.rs` — this spec formalizes its usage, not its creation.

--- a/specs/008-model-catalog-presets/tasks.md
+++ b/specs/008-model-catalog-presets/tasks.md
@@ -111,7 +111,50 @@
 
 ---
 
-## Phase 6: Polish & Cross-Cutting Concerns
+## Phase 6: User Story 4 — Calculate Model Cost from Usage (Priority: P2) — I21
+
+**Goal**: Compute monetary cost from token usage using catalog pricing data
+
+**Independent Test**: Call `calculate_cost()` with a known model and usage, verify computed cost matches expected values
+
+### Tests for User Story 4
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation (Constitution Principle II: TDD)**
+
+- [ ] T031 [US4] Write unit tests in `src/model_catalog.rs` `#[cfg(test)]` module: `calculate_cost_known_model` (verify input/output/cache costs match expected), `calculate_cost_unknown_model` (returns zero cost), `calculate_cost_zero_usage` (returns zero cost), `calculate_cost_cache_tokens` (verify cache_read and cache_write costs), `calculate_cost_no_pricing_data` (model exists in catalog but has no pricing fields — e.g., local model — returns zero cost)
+
+### Implementation for User Story 4
+
+- [ ] T032 [US4] Add pricing fields to `PresetCatalog` in `src/model_catalog.rs`: `cost_per_million_input: Option<f64>`, `cost_per_million_output: Option<f64>`, `cost_per_million_cache_read: Option<f64>`, `cost_per_million_cache_write: Option<f64>` with `#[serde(default)]`
+- [ ] T033 [US4] Add pricing fields to `CatalogPreset` (flattened view) — propagate from `PresetCatalog` during `ModelCatalog::preset()` construction
+- [ ] T034 [US4] Add helper method to `ModelCatalog`: `fn find_preset_by_model_id(&self, model_id: &str) -> Option<CatalogPreset>` — search across all providers
+- [ ] T035 [US4] Implement `calculate_cost(model_id: &str, usage: &Usage) -> Cost` in `src/model_catalog.rs` — look up pricing via `find_preset_by_model_id`, compute per-category costs, return `Cost::default()` if not found
+- [ ] T036 [US4] Populate pricing data for all Anthropic presets in `src/model_catalog.toml` (opus_46, sonnet_46, haiku_45)
+- [ ] T037 [P] [US4] Populate pricing data for all OpenAI presets in `src/model_catalog.toml`
+- [ ] T038 [P] [US4] Populate pricing data for all Google, Mistral, xAI presets in `src/model_catalog.toml`
+- [ ] T039 [US4] Re-export `calculate_cost` from `src/lib.rs`
+
+**Checkpoint**: Cost calculation functional — monetary cost can be computed from token usage for any cataloged model
+
+---
+
+## Phase 7: User Story 5 — Query Model Capabilities at Runtime (Priority: P2) — I22
+
+**Goal**: Formalize capability introspection from catalog presets through ModelSpec
+
+**Independent Test**: Load a catalog preset, call `model_capabilities()`, verify correct flags and limits
+
+> **NOTE**: `ModelCapabilities`, `CatalogPreset::model_capabilities()`, and `ModelSpec::capabilities()` already exist. This phase validates existing behavior against the new acceptance scenarios and adds any missing test coverage.
+
+### Tests for User Story 5
+
+- [ ] T040 [US5] Write unit tests in `src/model_catalog.rs` `#[cfg(test)]` module (if not already covered): `capabilities_from_catalog_preset` (verify all flags from catalog capabilities), `capabilities_context_window_and_output` (verify max_context_window and max_output_tokens from catalog), `model_spec_carries_capabilities` (verify capabilities survive model_spec() creation), `manual_model_spec_defaults` (verify ModelSpec::new() has default capabilities)
+
+**Checkpoint**: Capability introspection formally verified — catalog capabilities flow correctly through ModelSpec
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
 
 **Purpose**: Re-exports, final validation, and cleanup
 
@@ -119,6 +162,10 @@
 - [x] T028 [P] Run `cargo clippy --workspace -- -D warnings` and fix any warnings
 - [x] T029 Run `cargo test --workspace` to verify all tests pass
 - [x] T030 Run quickstart.md validation — verify all code examples compile conceptually against the implemented API
+- [ ] T041 Verify `calculate_cost` is re-exported from `src/lib.rs`
+- [ ] T042 Run `cargo clippy --workspace -- -D warnings` with updated catalog and fix any warnings
+- [ ] T043 Run `cargo test --workspace` to verify all new tests pass
+- [ ] T044 Validate new quickstart.md examples (cost calculation, capability query) match actual API
 
 ---
 
@@ -131,13 +178,17 @@
 - **User Story 1 (Phase 3)**: Depends on Foundational phase completion
 - **User Story 2 (Phase 4)**: Depends on Foundational phase completion — can run in parallel with US1 (different files)
 - **User Story 3 (Phase 5)**: Depends on Foundational phase completion — can run in parallel with US1 and US2 (different file)
-- **Polish (Phase 6)**: Depends on all user stories being complete
+- **User Story 4 — Cost (Phase 6)**: Depends on US1 (needs catalog with presets). Modifies `model_catalog.rs` and `model_catalog.toml`.
+- **User Story 5 — Capabilities (Phase 7)**: Depends on US1 (needs catalog). Primarily test verification of existing behavior.
+- **Polish (Phase 8)**: Depends on all user stories being complete
 
 ### User Story Dependencies
 
 - **User Story 1 (P1)**: Depends on Phase 2 only. Self-contained in `src/model_catalog.rs` and `src/model_catalog.toml`
 - **User Story 2 (P1)**: Depends on Phase 2 only. Self-contained in `src/model_presets.rs`. Uses `ModelSpec` and `StreamFn` from existing core types
 - **User Story 3 (P2)**: Depends on Phase 2 only. Self-contained in `src/fallback.rs`. Uses `ModelSpec` and `StreamFn` from existing core types
+- **User Story 4 (P2)**: Depends on US1 (catalog with presets). Adds pricing fields to `PresetCatalog`/`CatalogPreset` and `calculate_cost()` function in `src/model_catalog.rs`
+- **User Story 5 (P2)**: Depends on US1 (catalog). Primarily test-only — validates existing `ModelCapabilities` behavior against formal acceptance scenarios
 
 ### Within Each User Story
 
@@ -153,7 +204,8 @@
 - T019 can run in parallel with US1 tasks (different file: model_presets.rs vs model_catalog.rs)
 - T024 can run in parallel with US1 and US2 tasks (different file: fallback.rs)
 - T027 and T028 can run in parallel (different concerns)
-- All three user stories can proceed in parallel after Phase 2 since each lives in a separate source file
+- US1, US2, US3 can proceed in parallel after Phase 2 since each lives in a separate source file
+- US4 and US5 can proceed in parallel after US1 (both modify model_catalog.rs but US5 is test-only)
 
 ---
 
@@ -190,7 +242,9 @@ Task T024-T026
 2. Add User Story 1 → Catalog browsing works → MVP
 3. Add User Story 2 → Connection resolution works → Enhanced
 4. Add User Story 3 → Fallback configuration works → Production-ready
-5. Polish → Clean re-exports, zero warnings, all tests green
+5. Add User Story 4 → Cost calculation works → Cost-aware
+6. Add User Story 5 → Capabilities formally verified → Introspectable
+7. Polish → Clean re-exports, zero warnings, all tests green
 
 ### Parallel Team Strategy
 
@@ -209,5 +263,7 @@ With multiple developers after Phase 2:
 - Each user story is independently completable and testable
 - All source files live in `src/` of the `swink-agent` core crate
 - The TOML data file (`src/model_catalog.toml`) is embedded at compile time — changes require recompilation but no code changes
+- US4 (Cost Calculation) is new work — adds pricing fields to catalog and `calculate_cost()` function
+- US5 (Capability Introspection) is primarily test verification of existing behavior — `ModelCapabilities` already exists
 - Commit after each task or logical group
 - Stop at any checkpoint to validate story independently


### PR DESCRIPTION
## Summary
- Add US4 (model cost calculation, I21) and US5 (capability introspection, I22) to 008-model-catalog-presets spec
- All 8 spec artifacts updated: spec (FR-010–014, SC-006–009), data-model (pricing fields, calculate_cost), research (D8–D10), plan, contracts, quickstart, tasks (T031–T044), checklist
- 1 clarification: Eq removal for f64 pricing fields

## Test plan
- [ ] Verify spec consistency across all 8 artifacts
- [ ] Verify task coverage for all new FRs and acceptance scenarios
- [ ] Verify Eq removed from PresetCatalog/CatalogPreset in all locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)