### PR TITLE
spec: rich entries, versioning, interrupt, filtered retrieval for 021

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ Pure-Rust library for LLM-powered agentic loops. Provider-agnostic core with plu
 - **Lessons learned go in nested CLAUDE.md files.** Update when you discover something non-obvious.
 - **Context7 first.** When researching any crate API, dependency docs, or library usage, always query the context7 MCP server before falling back to web search or training data. Training data may be stale; context7 pulls current docs.
 - **No parallel builds in agents.** Never have multiple subagents run `cargo build`/`test`/`clippy` concurrently — Cargo's global lock serializes them anyway, causing extended build times. Run all compilation in the main conversation first; subagents should only read and analyze code.
+- **Check specs and docs first.** Before making large changes, read the relevant spec files in `specs/NNN-*/` (spec.md, plan.md, tasks.md) and architecture docs in `docs/` (HLD, subsystem READMEs, planning docs). The project uses spec-driven development — changes should align with the agreed design.
 
 ## Style (project-specific conventions)
 

--- a/specs/021-memory-crate/checklists/requirements.md
+++ b/specs/021-memory-crate/checklists/requirements.md
@@ -29,6 +29,17 @@
 - [x] Feature meets measurable outcomes defined in Success Criteria
 - [x] No implementation details leak into specification
 
+## Rich Entries, Versioning, Interrupt, Filtered Retrieval (I9, I10, I11, N12)
+
+- [x] US6–US9 acceptance scenarios are testable and unambiguous
+- [x] FR-011 through FR-021 are measurable
+- [x] SC-006 through SC-010 are technology-agnostic success criteria
+- [x] Edge cases for new features (custom type conflicts, corrupted interrupt, version too new, large sessions) identified
+- [x] Backward compatibility explicitly specified (serde defaults for version/sequence, fallback for missing entry_type)
+- [x] Interrupt state stored separately from JSONL stream (transient vs permanent separation)
+- [x] Rich entries excluded from LLM context (FR-012)
+
 ## Notes
 
 - All items pass. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- I9 (Rich entries), I10 (Versioning), I11 (Interrupt), N12 (Filtered retrieval) added 2026-03-31: US6–US9, FR-011–FR-021, SC-006–SC-010, tasks T058–T095.

--- a/specs/021-memory-crate/contracts/public-api.md
+++ b/specs/021-memory-crate/contracts/public-api.md
@@ -17,6 +17,10 @@ pub struct SessionMeta {
     pub title: String,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    #[serde(default = "default_version")]
+    pub version: u32,               // schema version, default 1
+    #[serde(default)]
+    pub sequence: u64,              // monotonic write counter, default 0
 }
 ```
 
@@ -31,6 +35,9 @@ pub trait SessionStore: Send + Sync {
     fn load(&self, id: &str) -> io::Result<(SessionMeta, Vec<LlmMessage>)>;
     fn list(&self) -> io::Result<Vec<SessionMeta>>;
     fn delete(&self, id: &str) -> io::Result<()>;
+    fn save_interrupt(&self, id: &str, state: &InterruptState) -> io::Result<()>;
+    fn load_interrupt(&self, id: &str) -> io::Result<Option<InterruptState>>;
+    fn clear_interrupt(&self, id: &str) -> io::Result<()>;
 }
 ```
 
@@ -110,6 +117,70 @@ pub struct CompactionResult {
     pub messages: Vec<LlmMessage>,
     pub removed_count: usize,
     pub summary: Option<String>,
+}
+```
+
+---
+
+### `SessionEntry`
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "entry_type", content = "data", rename_all = "snake_case")]
+pub enum SessionEntry {
+    Message(AgentMessage),
+    ModelChange { from: ModelSpec, to: ModelSpec, timestamp: u64 },
+    ThinkingLevelChange { from: String, to: String, timestamp: u64 },
+    Compaction { dropped_count: usize, tokens_before: usize, tokens_after: usize, timestamp: u64 },
+    Label { text: String, message_index: usize, timestamp: u64 },
+    Custom { type_name: String, data: Value, timestamp: u64 },
+}
+```
+
+---
+
+### `InterruptState`
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InterruptState {
+    pub interrupted_at: u64,
+    pub pending_tool_calls: Vec<PendingToolCall>,
+    pub context_snapshot: Vec<AgentMessage>,
+    pub system_prompt: String,
+    pub model: ModelSpec,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PendingToolCall {
+    pub tool_call_id: String,
+    pub tool_name: String,
+    pub arguments: Value,
+}
+```
+
+---
+
+### `SessionMigrator` (trait)
+
+```rust
+pub trait SessionMigrator: Send + Sync {
+    fn source_version(&self) -> u32;
+    fn target_version(&self) -> u32;
+    fn migrate(&self, meta: &mut SessionMeta, entries: &mut Vec<SessionEntry>) -> io::Result<()>;
+}
+```
+
+---
+
+### `LoadOptions`
+
+```rust
+#[derive(Debug, Clone, Default)]
+pub struct LoadOptions {
+    pub last_n_entries: Option<usize>,
+    pub after_timestamp: Option<u64>,
+    pub entry_types: Option<Vec<String>>,
 }
 ```
 

--- a/specs/021-memory-crate/data-model.md
+++ b/specs/021-memory-crate/data-model.md
@@ -14,6 +14,8 @@ Descriptive information about a persisted session.
 | `title` | `String` | Human-readable session title. |
 | `created_at` | `DateTime<Utc>` | Timestamp when the session was first created. |
 | `updated_at` | `DateTime<Utc>` | Timestamp of the most recent save. Updated on every save. |
+| `version` | `u32` | Schema version for migration (default: `1`, `#[serde(default = "default_version")]`). |
+| `sequence` | `u64` | Monotonic counter incremented on every write (default: `0`, `#[serde(default)]`). |
 
 ### SessionStore (trait, sync)
 
@@ -25,7 +27,10 @@ Synchronous session persistence abstraction.
 | `append` | `(&self, id: &str, messages: &[LlmMessage]) -> io::Result<()>` | Append messages to an existing session. Updates `updated_at`. |
 | `load` | `(&self, id: &str) -> io::Result<(SessionMeta, Vec<LlmMessage>)>` | Load a session by ID. Returns `NotFound` if missing, `InvalidData` if empty. |
 | `list` | `(&self) -> io::Result<Vec<SessionMeta>>` | List all sessions with metadata. |
-| `delete` | `(&self, id: &str) -> io::Result<()>` | Delete a session by ID. |
+| `delete` | `(&self, id: &str) -> io::Result<()>` | Delete a session by ID (also deletes interrupt file). |
+| `save_interrupt` | `(&self, id: &str, state: &InterruptState) -> io::Result<()>` | Persist interrupt state for a session. |
+| `load_interrupt` | `(&self, id: &str) -> io::Result<Option<InterruptState>>` | Load interrupt state, or `None` if none exists. |
+| `clear_interrupt` | `(&self, id: &str) -> io::Result<()>` | Delete the interrupt state file. |
 
 ### AsyncSessionStore (trait, async)
 
@@ -76,6 +81,80 @@ Output of a compaction operation.
 | `removed_count` | `usize` | Number of messages replaced by the summary. |
 | `summary` | `Option<String>` | The generated summary text, if compaction occurred. |
 
+### SessionEntry (enum)
+
+Discriminated union of entry types persisted in a session. Used in JSONL serialization with an `entry_type` field.
+
+| Variant | Fields | Description |
+|---------|--------|-------------|
+| `Message` | `AgentMessage` | An LLM message (user, assistant, tool result). The primary entry type. |
+| `ModelChange` | `from: ModelSpec, to: ModelSpec, timestamp: u64` | Records a model switch during the session. |
+| `ThinkingLevelChange` | `from: String, to: String, timestamp: u64` | Records a thinking level change. |
+| `Compaction` | `dropped_count: usize, tokens_before: usize, tokens_after: usize, timestamp: u64` | Records a context compaction event. |
+| `Label` | `text: String, message_index: usize, timestamp: u64` | A user bookmark/annotation on a specific message. |
+| `Custom` | `type_name: String, data: Value, timestamp: u64` | Arbitrary structured data for extensibility. |
+
+**Derives**: `Debug`, `Clone`, `Serialize`, `Deserialize`.
+**Serde**: Adjacently tagged via `#[serde(tag = "entry_type", content = "data", rename_all = "snake_case")]`. The `Message` variant nests the `AgentMessage` under the `data` key: `{"entry_type": "message", "data": {...}}`. Old-format lines (without `entry_type`) are deserialized as `Message` via a custom fallback.
+
+---
+
+### InterruptState (struct)
+
+Snapshot of agent state at an interrupt point, persisted as a separate JSON file.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `interrupted_at` | `u64` | Unix timestamp of the interrupt. |
+| `pending_tool_calls` | `Vec<PendingToolCall>` | Tool calls waiting for approval. |
+| `context_snapshot` | `Vec<AgentMessage>` | Full conversation context at interrupt point. |
+| `system_prompt` | `String` | Active system prompt. |
+| `model` | `ModelSpec` | Active model at interrupt time. |
+
+**Derives**: `Debug`, `Clone`, `Serialize`, `Deserialize`.
+
+---
+
+### PendingToolCall (struct)
+
+A tool call that was awaiting approval at interrupt time.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `tool_call_id` | `String` | Unique tool call ID. |
+| `tool_name` | `String` | Name of the tool being called. |
+| `arguments` | `Value` | Arguments passed to the tool. |
+
+**Derives**: `Debug`, `Clone`, `Serialize`, `Deserialize`.
+
+---
+
+### SessionMigrator (trait)
+
+Trait for upgrading sessions from one schema version to another.
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `source_version` | `&self -> u32` | Version this migrator upgrades from. |
+| `target_version` | `&self -> u32` | Version this migrator upgrades to. |
+| `migrate` | `&self, meta: &mut SessionMeta, entries: &mut Vec<SessionEntry>) -> io::Result<()>` | Transform entries in place. |
+
+---
+
+### LoadOptions (struct)
+
+Filter parameters for partial session loading.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `last_n_entries` | `Option<usize>` | Only return the last N entries. |
+| `after_timestamp` | `Option<u64>` | Only return entries after this Unix timestamp. |
+| `entry_types` | `Option<Vec<String>>` | Only return entries matching these type names. |
+
+**Derives**: `Debug`, `Clone`, `Default`.
+
+---
+
 ## Relationships
 
 ```
@@ -91,6 +170,22 @@ SummarizingCompactor ----produces----> CompactionResult
     |
     v  returns closure for
 Agent::with_transform_context()
+
+SessionEntry (enum)
+    ├── Message(AgentMessage)       -- the only variant sent to LLM
+    ├── ModelChange                 -- audit/display only
+    ├── ThinkingLevelChange         -- audit/display only
+    ├── Compaction                  -- audit/display only
+    ├── Label                       -- user bookmark
+    └── Custom                      -- extensibility
+
+InterruptState ----persisted-as----> {session_id}.interrupt.json
+    ├── pending_tool_calls: Vec<PendingToolCall>
+    ├── context_snapshot: Vec<AgentMessage>
+    └── model: ModelSpec
+
+SessionMigrator ----upgrades----> SessionMeta + Vec<SessionEntry>
+LoadOptions ----filters----> SessionStore::load() output
 ```
 
 ## JSONL File Layout

--- a/specs/021-memory-crate/plan.md
+++ b/specs/021-memory-crate/plan.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-Implement the `swink-agent-memory` workspace crate providing session persistence and summarization-aware context compaction. The crate defines `SessionStore` (sync) and `AsyncSessionStore` traits with save/load/list/delete operations, a `JsonlSessionStore` concrete backend using JSONL (one message per line, metadata on line 1), and a `SummarizingCompactor` that produces a closure compatible with `Agent::with_transform_context()`. Summaries are pre-computed asynchronously after each turn and injected synchronously during context transformation.
+Implement the `swink-agent-memory` workspace crate providing session persistence, summarization-aware context compaction, rich session entry types, session versioning with migration, interrupt state persistence, and filtered session retrieval. The crate defines `SessionStore` (sync) and `AsyncSessionStore` traits with save/load/list/delete operations, a `JsonlSessionStore` concrete backend using JSONL (one message per line, metadata on line 1), and a `SummarizingCompactor` that produces a closure compatible with `Agent::with_transform_context()`. Summaries are pre-computed asynchronously after each turn and injected synchronously during context transformation.
 
 ## Technical Context
 
@@ -26,7 +26,7 @@ Implement the `swink-agent-memory` workspace crate providing session persistence
 | # | Principle | Status | Notes |
 |---|-----------|--------|-------|
 | I | Library-First | PASS | Memory is its own workspace crate with a clean public API. No reverse dependency on core. |
-| II | Test-Driven Development | PASS | Tests cover save/load round-trip, compaction budget enforcement, partial corruption recovery, async operations, and edge cases (empty file, single message, unsafe IDs). |
+| II | Test-Driven Development | PASS | Tests cover save/load round-trip, compaction budget enforcement, partial corruption recovery, async operations, edge cases (empty file, single message, unsafe IDs), rich entry type serialization (T058–T060), backward compatibility for old-format sessions (T059, T064), interrupt state save/load/clear/delete roundtrips (T072–T075), version migration (T067), optimistic concurrency conflict detection (T066), and filtered loading by count/timestamp/type (T081–T084). |
 | III | Efficiency & Performance | PASS | Append-only writes avoid full-file rewrites. JSONL enables streaming reads. No unnecessary allocations on the compaction hot path. |
 | IV | Leverage the Ecosystem | PASS | Uses `serde`/`serde_json` for serialization, `tokio::fs` for async I/O, `chrono` for timestamps. No hand-rolled JSON or async filesystem code. |
 | V | Provider Agnosticism | PASS | Compactor accepts a summarization function (`async Fn(Vec<LlmMessage>) -> String`) — no embedded provider. |
@@ -59,7 +59,11 @@ memory/
     ├── store_async.rs    # AsyncSessionStore trait
     ├── jsonl.rs          # JsonlSessionStore implementation
     ├── compaction.rs     # SummarizingCompactor
-    ├── meta.rs           # SessionMeta struct
+    ├── meta.rs           # SessionMeta struct (with version + sequence)
+    ├── entry.rs          # SessionEntry enum (rich entry types)
+    ├── interrupt.rs      # InterruptState, PendingToolCall
+    ├── migrate.rs        # SessionMigrator trait
+    ├── load_options.rs   # LoadOptions struct
     └── time.rs           # Timestamp utilities
 
 memory/tests/

--- a/specs/021-memory-crate/quickstart.md
+++ b/specs/021-memory-crate/quickstart.md
@@ -95,6 +95,78 @@ compactor.set_summary(summary);
 // retained window, replacing older messages.
 ```
 
+## Save rich session entries
+
+```rust
+use swink_agent_memory::{SessionEntry, JsonlSessionStore, SessionStore};
+
+// Rich entries alongside messages
+let entries = vec![
+    SessionEntry::Message(user_message),
+    SessionEntry::Message(assistant_message),
+    SessionEntry::ModelChange {
+        from: old_model,
+        to: new_model,
+        timestamp: 1711900000,
+    },
+    SessionEntry::Label {
+        text: "Important decision here".into(),
+        message_index: 1,
+        timestamp: 1711900100,
+    },
+];
+
+// Rich entries are NOT sent to the LLM — only Message entries
+```
+
+## Persist and resume from interrupts
+
+```rust
+use swink_agent_memory::{InterruptState, PendingToolCall, SessionStore};
+
+// Save interrupt state when agent is paused at approval gate
+let interrupt = InterruptState {
+    interrupted_at: 1711900000,
+    pending_tool_calls: vec![PendingToolCall {
+        tool_call_id: "tc_001".into(),
+        tool_name: "bash".into(),
+        arguments: serde_json::json!({"command": "ls -la"}),
+    }],
+    context_snapshot: agent_messages.clone(),
+    system_prompt: "Be helpful.".into(),
+    model: current_model.clone(),
+};
+store.save_interrupt(&session_id, &interrupt)?;
+
+// On restart, check for pending interrupt
+if let Some(state) = store.load_interrupt(&session_id)? {
+    // Resume from interrupt state
+    println!("Resuming with {} pending tool calls", state.pending_tool_calls.len());
+}
+
+// Clear after resuming
+store.clear_interrupt(&session_id)?;
+```
+
+## Load a filtered subset of a session
+
+```rust
+use swink_agent_memory::LoadOptions;
+
+// Only load the last 20 entries
+let options = LoadOptions {
+    last_n_entries: Some(20),
+    ..Default::default()
+};
+let (meta, entries) = store.load_with_options(&session_id, &options)?;
+
+// Only load message entries (skip model changes, labels, etc.)
+let options = LoadOptions {
+    entry_types: Some(vec!["message".into()]),
+    ..Default::default()
+};
+```
+
 ## Build and test
 
 ```bash

--- a/specs/021-memory-crate/research.md
+++ b/specs/021-memory-crate/research.md
@@ -65,6 +65,52 @@
 
 **Rationale**: `CustomMessage` is an opaque type used for in-flight control signals. It survives compaction but never reaches the provider and has no meaningful serialization. Filtering matches the core crate's `in_flight_llm_messages` behavior.
 
+### 8. Rich Session Entry Types via Tagged Enum
+
+**Decision**: Introduce `SessionEntry` as a serde-tagged enum with `#[serde(tag = "entry_type")]`. Old-format JSONL lines (without `entry_type`) are deserialized as `SessionEntry::Message` via a custom deserializer fallback.
+
+**Rationale**: A tagged enum provides compile-time exhaustiveness and serde compatibility. The `entry_type` discriminator is minimal overhead (one extra field per line). Backward compatibility with old sessions is achieved by checking whether the `entry_type` field exists — if absent, the line is assumed to be a `Message`. This avoids requiring migration of existing session files.
+
+**Key reference**: Pi Agent's session entry types (message, model_change, thinking_level_change, compaction, label, custom).
+
+**Alternatives Rejected**:
+- **Separate files per entry type**: Loses ordering; entries must interleave chronologically.
+- **Wrapper struct with optional fields**: Loses type safety; every field is `Option` and the correct combination is runtime-checked.
+- **Binary format with type tags**: Not human-readable; violates the JSONL design decision.
+
+### 9. Interrupt State as Separate JSON File
+
+**Decision**: Persist interrupt state as `{session_id}.interrupt.json`, not inline in the JSONL stream.
+
+**Rationale**: Interrupt state is transient — it represents a snapshot at a point in time that should be consumed (resumed) and then deleted. Putting it in the JSONL stream would make it permanent, requiring special handling during load to distinguish "active interrupt" from "historical interrupt record." A separate file is simpler: exists = interrupted, deleted = resumed. The JSON format (not JSONL) is appropriate because interrupt state is a single structured object, not a stream.
+
+**Alternatives Rejected**:
+- **Inline in JSONL**: Mixes transient state with permanent log; complicates load logic.
+- **Database table**: Adds dependency; overkill for a single JSON object.
+- **In-memory only (no persistence)**: Loses state on crash — defeats the purpose.
+
+### 10. Optimistic Concurrency via Sequence Counter
+
+**Decision**: Add `sequence: u64` to `SessionMeta`, incremented on every write. On save, optionally check that the stored sequence matches the expected value.
+
+**Rationale**: File locking is complex and cross-platform-inconsistent (decision 5). A sequence counter provides lightweight optimistic concurrency — the second writer detects the conflict and can retry or report. This is optional: callers who don't care about concurrency ignore the sequence. The implementation is simple: read sequence on load, pass it back on save, compare before writing.
+
+**Alternatives Rejected**:
+- **File locking (flock)**: Cross-platform differences; advisory on some systems; deadlock risk.
+- **Last-write-wins only**: Silently loses data; acceptable for single-writer but dangerous for multi-writer.
+- **CAS with external lock service**: Massive over-engineering for a local filesystem store.
+
+### 11. Filtered Loading via LoadOptions
+
+**Decision**: Add `LoadOptions` parameter to `load()` with `last_n_entries`, `after_timestamp`, and `entry_types` filters. For JSONL, implement by reading the full file and filtering in memory (with future optimization to seek-from-end for `last_n_entries`).
+
+**Rationale**: Large sessions (thousands of entries) are expensive to load fully when only recent context is needed. The filtering API is simple and composable. The initial implementation reads and filters in memory — this is correct and sufficient for typical session sizes (<10K entries). Seek-from-end optimization can be added later without API changes.
+
+**Alternatives Rejected**:
+- **Separate "load_last_n" method**: Proliferates trait methods. A single `load_with_options` is cleaner.
+- **Streaming iterator**: More complex API; callers typically want all matching entries in a `Vec`.
+- **Index file for random access**: Significant complexity; premature optimization.
+
 ## Open Questions
 
 None — all clarifications resolved in the spec.

--- a/specs/021-memory-crate/spec.md
+++ b/specs/021-memory-crate/spec.md
@@ -3,7 +3,7 @@
 **Feature Branch**: `021-memory-crate`
 **Created**: 2026-03-20
 **Status**: Draft
-**Input**: Session persistence and memory management. SessionStore trait (sync + async), JsonlSessionStore, JSONL serialization/deserialization of message logs, SummarizingCompactor with summary injection and sliding window wrapper, session metadata, timestamp utilities. References: HLD Memory Layer, Design Decisions (memory is a separate crate), PRD §2 (non-goals: advanced memory lives elsewhere).
+**Input**: Session persistence and memory management. SessionStore trait (sync + async), JsonlSessionStore, JSONL serialization/deserialization of message logs, SummarizingCompactor with summary injection and sliding window wrapper, session metadata, timestamp utilities, rich session entry types, session versioning, interrupt state persistence, and filtered session retrieval. References: HLD Memory Layer, Design Decisions (memory is a separate crate), PRD §2 (non-goals: advanced memory lives elsewhere).
 
 ## User Scenarios & Testing *(mandatory)*
 
@@ -89,6 +89,77 @@ A developer wants session data stored in a human-readable, line-delimited format
 
 ---
 
+### User Story 6 - Rich Session Entry Types (Priority: P2) — I9
+
+A developer saves non-message events to a session — model changes, thinking level changes, compaction events, user-defined labels (bookmarks), and custom structured data. Each entry carries a timestamp and is persisted alongside messages in the JSONL stream. Rich entries are NOT sent to the LLM — only `Message` entries go through `convert_to_llm`.
+
+**Why this priority**: Rich entries provide a complete audit trail of what happened during a session, not just what was said. Without them, operators lose visibility into model switches, compaction decisions, and user annotations.
+
+**Independent Test**: Can be tested by saving a session with mixed entry types (messages + model changes + labels), loading it, and verifying all entries are recovered in order with correct types and timestamps.
+
+**Acceptance Scenarios**:
+
+1. **Given** a session with `Message`, `ModelChange`, and `Label` entries, **When** saved and loaded, **Then** all entries are recovered in order with correct types and data.
+2. **Given** a `SessionEntry::ModelChange` entry, **When** the session is sent to the LLM, **Then** the model change entry is NOT included in the LLM context.
+3. **Given** a `SessionEntry::Compaction` entry recording that 15 messages were dropped, **When** loaded, **Then** the `dropped_count`, `tokens_before`, `tokens_after`, and `timestamp` are preserved.
+4. **Given** a `SessionEntry::Custom` with arbitrary JSON data, **When** saved and loaded, **Then** the `type_name`, `data`, and `timestamp` are preserved.
+5. **Given** an old-format session (raw `LlmMessage` lines without `entry_type`), **When** loaded, **Then** each line is interpreted as a `SessionEntry::Message` (backward compatible).
+
+---
+
+### User Story 7 - Session Versioning (Priority: P2) — I10
+
+A developer uses session versioning to enable schema migration and detect concurrent modifications. `SessionMeta` includes a `version` field (schema version for migration) and a `sequence` field (monotonic counter for optimistic concurrency). When loading an older session, the store runs migrations to upgrade it to the current format. When saving, the store checks that the sequence hasn't been incremented by another writer.
+
+**Why this priority**: Versioning prevents silent data loss when the session format evolves and enables multi-process safety without locking.
+
+**Independent Test**: Can be tested by creating a session with version 1 format, loading it with a version-2 migrator, and verifying the session is upgraded correctly.
+
+**Acceptance Scenarios**:
+
+1. **Given** a new session, **When** saved, **Then** `version` is set to the current schema version and `sequence` is set to 1.
+2. **Given** a saved session with sequence N, **When** saved again, **Then** `sequence` is incremented to N+1.
+3. **Given** a session at version 1 and a migrator from v1→v2, **When** loaded, **Then** the session is transparently upgraded to version 2.
+4. **Given** two writers saving with the same sequence number, **When** the second writer saves, **Then** a conflict error is returned (optimistic concurrency check).
+5. **Given** an old session without `version` or `sequence` fields, **When** loaded, **Then** defaults are applied (`version: 1`, `sequence: 0`) — backward compatible.
+
+---
+
+### User Story 8 - Interrupt State Persistence (Priority: P2) — I11
+
+An agent is interrupted at a tool approval gate or by cancellation. The interrupt state — pending tool calls, context snapshot, system prompt, and model — is persisted as a separate file so the agent can resume exactly where it left off after a restart. When a session is loaded and has a pending interrupt, the caller is notified so it can offer to resume.
+
+**Why this priority**: Without interrupt persistence, any crash or restart during a tool approval gate loses the entire pending state, forcing the user to re-prompt.
+
+**Independent Test**: Can be tested by saving an interrupt state with pending tool calls, restarting, loading the interrupt, and verifying all fields are recovered.
+
+**Acceptance Scenarios**:
+
+1. **Given** an interrupted agent with 2 pending tool calls, **When** `save_interrupt()` is called, **Then** the interrupt state is persisted as `{session_id}.interrupt.json`.
+2. **Given** a session with a persisted interrupt, **When** `load_interrupt()` is called, **Then** the pending tool calls, context snapshot, system prompt, and model are returned.
+3. **Given** a session without a persisted interrupt, **When** `load_interrupt()` is called, **Then** `None` is returned.
+4. **Given** a resumed agent, **When** `clear_interrupt()` is called, **Then** the interrupt file is deleted.
+5. **Given** an interrupt state file, **When** the session is deleted, **Then** the interrupt file is also deleted.
+
+---
+
+### User Story 9 - Filtered Session Retrieval (Priority: P3) — N12
+
+A developer loads only a subset of a session's entries — the last N entries, entries after a timestamp, or entries of specific types. This avoids loading entire multi-thousand-entry sessions into memory when only recent context is needed.
+
+**Why this priority**: Nice-to-have optimization for large sessions. Full loading works for most use cases, but filtered retrieval prevents memory issues with very long-running sessions.
+
+**Independent Test**: Can be tested by saving a session with 100 entries, loading with `last_n_entries: Some(10)`, and verifying only the last 10 are returned.
+
+**Acceptance Scenarios**:
+
+1. **Given** a session with 100 entries, **When** loaded with `last_n_entries: Some(10)`, **Then** only the last 10 entries are returned.
+2. **Given** a session with entries spanning timestamps T1–T100, **When** loaded with `after_timestamp: Some(T50)`, **Then** only entries after T50 are returned.
+3. **Given** a session with mixed entry types, **When** loaded with `entry_types: Some(vec!["message"])`, **Then** only `Message` entries are returned.
+4. **Given** `LoadOptions` with no filters set (all `None`), **When** loaded, **Then** the full session is returned (backward compatible).
+
+---
+
 ### Edge Cases
 
 - What happens when two processes attempt to save to the same session simultaneously — last-writer-wins; no file locking. Single-writer assumption is documented. Concurrent writes may corrupt the file.
@@ -96,6 +167,11 @@ A developer wants session data stored in a human-readable, line-delimited format
 - What happens when the compactor receives a conversation with only one message — within any budget; no compaction occurs (returned unchanged).
 - How does the store behave when the underlying storage medium is full — OS `io::Error` propagates through `io::Result`; caller handles.
 - What happens when a session file contains lines in an unrecognized format — corrupted/unrecognized lines are skipped with a warning logged; remaining messages are loaded successfully. Partial recovery over total failure.
+- What happens when a `SessionEntry::Custom` has a `type_name` that conflicts with built-in types — `type_name` is a free-form string; the `entry_type` discriminator in JSONL uses fixed values (`message`, `model_change`, `compaction`, `label`, `custom`). Custom type names live inside the `Custom` variant and cannot collide.
+- What happens when a session has an interrupt file but the interrupt state is corrupted — `load_interrupt()` returns an `InvalidData` error. The caller decides whether to clear it and start fresh.
+- What happens when `load_interrupt()` is called for a session that doesn't exist — returns `None` (not an error). The interrupt file can't exist without the session.
+- What happens when `last_n_entries` is larger than the session — the full session is returned (no error).
+- What happens when a session has a version higher than the current code supports — returns an error indicating unsupported version. Future-version sessions cannot be silently downgraded.
 - How does the compactor handle messages that contain the summary marker — summaries are injected as regular `AssistantMessage` values, not specially marked. No collision issue; summary is just a message in the conversation.
 - What happens when the session identifier contains filesystem-unsafe characters — IDs are validated; unsafe characters (`/`, `\`, `..`, null bytes) are rejected with an error. Auto-generated IDs use safe `YYYYMMDD_HHMMSS` format.
 
@@ -113,13 +189,29 @@ A developer wants session data stored in a human-readable, line-delimited format
 - **FR-008**: The system MUST associate metadata with each session: identifier, title, creation timestamp, and last-updated timestamp.
 - **FR-009**: The system MUST return a clear error when attempting to load a non-existent session.
 - **FR-010**: The system MUST support appending messages to an existing session without rewriting the entire file.
+- **FR-011**: The system MUST support rich session entry types: `Message`, `ModelChange`, `ThinkingLevelChange`, `Compaction`, `Label`, and `Custom`, each with a timestamp.
+- **FR-012**: Rich entry types (non-Message) MUST NOT be sent to the LLM — only `Message` entries participate in `convert_to_llm`.
+- **FR-013**: The JSONL format MUST use an `entry_type` discriminator field for rich entries, with backward compatibility for old-format sessions (lines without `entry_type` are interpreted as `Message`).
+- **FR-014**: `SessionMeta` MUST include `version: u32` (schema version) and `sequence: u64` (monotonic counter for optimistic concurrency).
+- **FR-015**: The system MUST support session migration via a `SessionMigrator` trait, running migrations transparently on load when the session version is older than the current version.
+- **FR-016**: The system MUST reject saves where the session's `sequence` does not match the stored sequence (optimistic concurrency conflict detection).
+- **FR-017**: The system MUST support persisting and loading interrupt state (pending tool calls, context snapshot, system prompt, model) as a separate file alongside the session.
+- **FR-018**: `save_interrupt`, `load_interrupt`, and `clear_interrupt` MUST be added to the `SessionStore` trait.
+- **FR-019**: Session deletion MUST also delete any associated interrupt state file.
+- **FR-020**: The system MUST support filtered session loading via `LoadOptions` with `last_n_entries`, `after_timestamp`, and `entry_types` filter parameters.
+- **FR-021**: `LoadOptions` with all fields `None` MUST return the full session (backward compatible).
 
 ### Key Entities
 
 - **SessionStore**: The abstraction for persisting and retrieving conversation sessions. Supports save, load, list, and delete operations in both synchronous and asynchronous forms.
 - **Session**: A persisted conversation containing a message log and associated metadata (identifier, title, creation timestamp, last-updated timestamp).
 - **SummarizingCompactor**: The component that condenses older conversation messages into a summary, using a sliding window to retain recent messages verbatim.
-- **SessionMetadata**: Descriptive information about a session, including its identifier, human-readable title, and timestamps.
+- **SessionMetadata**: Descriptive information about a session, including its identifier, human-readable title, timestamps, schema version, and sequence counter.
+- **SessionEntry**: Discriminated union of entry types persisted in a session: `Message`, `ModelChange`, `ThinkingLevelChange`, `Compaction`, `Label`, `Custom`.
+- **InterruptState**: Snapshot of agent state at an interrupt point: pending tool calls, context, system prompt, model.
+- **PendingToolCall**: A tool call awaiting approval: tool call ID, name, arguments.
+- **SessionMigrator**: Trait for upgrading old session formats to the current version.
+- **LoadOptions**: Filter parameters for partial session loading.
 
 ## Success Criteria *(mandatory)*
 
@@ -130,6 +222,11 @@ A developer wants session data stored in a human-readable, line-delimited format
 - **SC-003**: Async store operations do not block the calling thread.
 - **SC-004**: Partial file corruption results in partial recovery, not total data loss.
 - **SC-005**: Session metadata (title, timestamps) is preserved across save/load cycles.
+- **SC-006**: Rich session entries (ModelChange, Label, Compaction, Custom) survive save/load roundtrips with correct types, data, and timestamps.
+- **SC-007**: Old-format sessions (without `entry_type` discriminator or version/sequence fields) load successfully with defaults applied.
+- **SC-008**: Interrupt state survives process restart — saved interrupt can be loaded in a new process with all pending tool calls and context intact.
+- **SC-009**: Filtered loading with `last_n_entries` returns exactly the requested number of entries (or fewer if the session is smaller).
+- **SC-010**: Optimistic concurrency check rejects saves with stale sequence numbers.
 
 ## Clarifications
 
@@ -143,6 +240,11 @@ A developer wants session data stored in a human-readable, line-delimited format
 - Q: Storage medium full? → A: OS io::Error propagates; caller handles.
 - Q: Summary marker collision? → A: No issue; summaries are regular AssistantMessage values.
 
+### Session 2026-03-31
+
+- Q: How should optimistic concurrency checking work in `save()`? → A: Always check — compare `meta.sequence` against the stored file's sequence. If they don't match, the save is rejected with an error. No API change needed; callers use the sequence from their loaded `SessionMeta`, which matches unless another writer intervened. New sessions (no existing file) skip the check.
+- Q: Should `SessionEntry::Message` flatten `AgentMessage` fields or nest under a `data` key? → A: Nest — `{"entry_type": "message", "data": {AgentMessage fields}}`. Avoids field name collisions with `entry_type` and simplifies backward compatibility (old lines without `entry_type` are raw `AgentMessage`, distinct from nested format).
+
 ## Assumptions
 
 - The memory crate is a separate, independently publishable package with no dependency on the core agent crate's internals.
@@ -150,3 +252,8 @@ A developer wants session data stored in a human-readable, line-delimited format
 - Advanced memory features (semantic search, long-term knowledge graphs) are out of scope for this crate, as stated in the PRD non-goals.
 - The line-delimited store implementation targets local filesystem storage; remote storage backends are a future extension via the store abstraction.
 - Timestamps use a standard representation that is both human-readable and sortable.
+- Rich entry types are an extension of the existing JSONL format — backward compatibility with old sessions is mandatory.
+- Interrupt state is stored as a separate JSON file (`{session_id}.interrupt.json`), not inline in the JSONL stream, because the interrupt state is transient and should not be part of the permanent session log.
+- Session version starts at 1 for the original format. The current schema version is a constant in the crate.
+- The `sequence` field is incremented on every write (save or append). Optimistic concurrency is always checked by comparing `meta.sequence` against the stored sequence — callers use the loaded sequence, which matches unless another writer intervened. New sessions skip the check.
+- `LoadOptions` filtering is best-effort for JSONL — `last_n_entries` may require reading from the end of the file. Implementations may read the entire file and filter in memory if tail-reading is impractical.

--- a/specs/021-memory-crate/tasks.md
+++ b/specs/021-memory-crate/tasks.md
@@ -171,7 +171,106 @@
 
 ---
 
-## Phase 8: Polish & Integration
+## Phase 8: User Story 6 — Rich Session Entry Types (Priority: P2) — I9
+
+**Goal**: Support non-message entries (model changes, compaction events, labels, custom data) in the session log
+
+**Independent Test**: Save a session with mixed entry types, load, verify all recovered with correct types and timestamps
+
+### Tests for User Story 6
+
+- [ ] T058 [P] [US6] Integration test `rich_entries_roundtrip` in `memory/tests/round_trip.rs`: save session with Message, ModelChange, Label, and Custom entries, load, verify all preserved in order with correct data
+- [ ] T059 [P] [US6] Integration test `rich_entries_backward_compat` in `memory/tests/round_trip.rs`: create an old-format JSONL file (raw LlmMessage lines without `entry_type`), load, verify all lines interpreted as `SessionEntry::Message`
+- [ ] T060 [P] [US6] Unit test `session_entry_serde_roundtrip` in `memory/src/entry.rs` tests: serialize/deserialize each variant, verify discriminator and fields preserved
+- [ ] T060b [P] [US6] Unit test `rich_entries_excluded_from_llm_context` in `memory/src/entry.rs` tests: verify that `SessionEntry::messages()` (or equivalent filter method) only returns `Message` variants, excluding `ModelChange`, `Label`, `Compaction`, `Custom` entries (covers FR-012)
+
+### Implementation for User Story 6
+
+- [ ] T061 [US6] Implement `SessionEntry` enum in `memory/src/entry.rs` with serde tagged serialization (`#[serde(tag = "entry_type")]`). Implement custom deserialization fallback for old-format lines (no `entry_type` → `Message`).
+- [ ] T062 [US6] Update `JsonlSessionStore::save()` and `load()` in `memory/src/jsonl.rs` to use `SessionEntry` instead of raw `LlmMessage`. Lines 2+ become `SessionEntry` values.
+- [ ] T063 [US6] Add `entry.rs` module declaration and re-export `SessionEntry` from `memory/src/lib.rs`.
+
+**Checkpoint**: US6 complete — sessions can store rich non-message entries
+
+---
+
+## Phase 9: User Story 7 — Session Versioning (Priority: P2) — I10
+
+**Goal**: Schema version and optimistic concurrency via version/sequence fields on SessionMeta
+
+**Independent Test**: Create a v1 session, load with v1→v2 migrator, verify upgrade
+
+### Tests for User Story 7
+
+- [ ] T064 [P] [US7] Integration test `version_defaults_for_old_sessions` in `memory/tests/round_trip.rs`: create JSONL without version/sequence fields, load, verify defaults (version=1, sequence=0)
+- [ ] T065 [P] [US7] Integration test `sequence_increments_on_save` in `memory/tests/round_trip.rs`: save session, verify sequence=1, save again, verify sequence=2
+- [ ] T066 [P] [US7] Integration test `optimistic_concurrency_rejects_stale_sequence` in `memory/tests/round_trip.rs`: save session (sequence becomes 1), load meta (sequence=1), simulate another writer by saving again (sequence becomes 2), then attempt save with the stale loaded meta (sequence=1) — verify conflict error returned
+- [ ] T067 [P] [US7] Unit test `migrator_upgrades_session` in `memory/src/migrate.rs` tests: implement a test migrator v1→v2, apply to v1 session, verify entries transformed and version updated
+- [ ] T067b [P] [US7] Integration test `unsupported_future_version_returns_error` in `memory/tests/round_trip.rs`: create a JSONL file with `version: 999`, attempt load, verify error indicating unsupported version
+
+### Implementation for User Story 7
+
+- [ ] T068 [US7] Add `version: u32` and `sequence: u64` fields to `SessionMeta` in `memory/src/meta.rs` with `#[serde(default)]` for backward compatibility.
+- [ ] T069 [US7] Update `JsonlSessionStore::save()` to increment `sequence` on every write. Before writing, compare `meta.sequence` against the stored file's sequence — reject with an error if they don't match (optimistic concurrency). New sessions (no existing file) skip the check.
+- [ ] T070 [US7] Implement `SessionMigrator` trait in `memory/src/migrate.rs`. Add migration runner to `JsonlSessionStore::load()` — check version, run applicable migrators in order.
+- [ ] T071 [US7] Re-export `SessionMigrator` from `memory/src/lib.rs`.
+
+**Checkpoint**: US7 complete — sessions are versioned with migration support and optimistic concurrency
+
+---
+
+## Phase 10: User Story 8 — Interrupt State Persistence (Priority: P2) — I11
+
+**Goal**: Persist and resume from interrupt state (pending tool calls, context snapshot)
+
+**Independent Test**: Save interrupt state, restart, load, verify all fields recovered
+
+### Tests for User Story 8
+
+- [ ] T072 [P] [US8] Integration test `interrupt_save_and_load_roundtrip` in `memory/tests/round_trip.rs`: save interrupt with 2 pending tool calls, load, verify all fields match
+- [ ] T073 [P] [US8] Integration test `interrupt_none_when_not_saved` in `memory/tests/round_trip.rs`: load interrupt for session without one, verify `None` returned
+- [ ] T074 [P] [US8] Integration test `interrupt_cleared_after_resume` in `memory/tests/round_trip.rs`: save interrupt, clear it, load, verify `None`
+- [ ] T075 [P] [US8] Integration test `delete_session_also_deletes_interrupt` in `memory/tests/round_trip.rs`: save session + interrupt, delete session, verify interrupt file also gone
+- [ ] T075b [P] [US8] Integration test `corrupted_interrupt_returns_error` in `memory/tests/round_trip.rs`: write garbage to `{session_id}.interrupt.json`, call `load_interrupt`, verify `InvalidData` error returned
+
+### Implementation for User Story 8
+
+- [ ] T076 [US8] Implement `InterruptState` and `PendingToolCall` structs in `memory/src/interrupt.rs`. Derive `Serialize`, `Deserialize`.
+- [ ] T077 [US8] Add `save_interrupt`, `load_interrupt`, `clear_interrupt` methods to `SessionStore` trait in `memory/src/store.rs`.
+- [ ] T078 [US8] Implement interrupt methods in `JsonlSessionStore`: persist as `{session_id}.interrupt.json`, delete on `clear_interrupt` and `delete`.
+- [ ] T079 [US8] Add interrupt methods to `AsyncSessionStore` trait and `BlockingSessionStore` adapter in `memory/src/store_async.rs`.
+- [ ] T080 [US8] Re-export `InterruptState`, `PendingToolCall` from `memory/src/lib.rs`.
+
+**Checkpoint**: US8 complete — agent interrupts persist across restarts
+
+---
+
+## Phase 11: User Story 9 — Filtered Session Retrieval (Priority: P3) — N12
+
+**Goal**: Load a subset of session entries by count, timestamp, or type
+
+**Independent Test**: Save 100 entries, load with `last_n_entries: Some(10)`, verify 10 returned
+
+### Tests for User Story 9
+
+- [ ] T081 [P] [US9] Integration test `load_last_n_entries` in `memory/tests/round_trip.rs`: save 50 entries, load with `last_n_entries: Some(10)`, verify exactly 10 returned (the last 10)
+- [ ] T082 [P] [US9] Integration test `load_after_timestamp` in `memory/tests/round_trip.rs`: save entries with timestamps T1–T50, load with `after_timestamp: Some(T25)`, verify only entries after T25 returned
+- [ ] T083 [P] [US9] Integration test `load_by_entry_type` in `memory/tests/round_trip.rs`: save mixed entries (messages + model changes + labels), load with `entry_types: Some(vec!["message"])`, verify only message entries returned
+- [ ] T084 [P] [US9] Integration test `load_options_all_none_returns_full` in `memory/tests/round_trip.rs`: load with `LoadOptions::default()`, verify full session returned
+
+### Implementation for User Story 9
+
+- [ ] T085 [US9] Implement `LoadOptions` struct in `memory/src/load_options.rs`. Derive `Debug`, `Clone`, `Default`.
+- [ ] T086 [US9] Add `load_with_options(&self, id: &str, options: &LoadOptions) -> io::Result<(SessionMeta, Vec<SessionEntry>)>` method to `SessionStore` trait.
+- [ ] T087 [US9] Implement `load_with_options` in `JsonlSessionStore`: read all entries, apply filters in memory (last_n via truncation, after_timestamp via comparison, entry_types via discriminator match).
+- [ ] T088 [US9] Add `load_with_options` to `AsyncSessionStore` and `BlockingSessionStore` adapter.
+- [ ] T089 [US9] Re-export `LoadOptions` from `memory/src/lib.rs`.
+
+**Checkpoint**: US9 complete — partial session loading avoids full-file reads for large sessions
+
+---
+
+## Phase 12: Polish & Integration
 
 **Purpose**: Final cleanup, documentation, and build verification
 
@@ -183,5 +282,35 @@
 - [x] T055 Run `cargo clippy -p swink-agent-memory -- -D warnings` — fix any warnings
 - [x] T056 Run `cargo test --workspace` — verify no regressions in other crates
 - [x] T057 Run `cargo clippy --workspace -- -D warnings` — verify no workspace-wide warnings
+- [ ] T090 Verify all new public types re-exported from `memory/src/lib.rs`: `SessionEntry`, `InterruptState`, `PendingToolCall`, `SessionMigrator`, `LoadOptions`
+- [ ] T091 Add compile-time `Send + Sync` assertions for `SessionEntry`, `InterruptState`, `PendingToolCall`, `LoadOptions`
+- [ ] T092 Run `cargo build -p swink-agent-memory` — fix any compilation errors from new features
+- [ ] T093 Run `cargo test -p swink-agent-memory` — fix any test failures from new features
+- [ ] T094 Run `cargo clippy -p swink-agent-memory -- -D warnings` — fix any warnings
+- [ ] T095 Validate quickstart.md new examples (rich entries, interrupt, filtered load) match actual API
 
 **Checkpoint**: All tests pass, clippy clean, workspace builds successfully
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies (new phases)
+
+- **US6 — Rich Entries (Phase 8)**: Depends on US1/US5 (save/load and JSONL). Modifies `jsonl.rs`.
+- **US7 — Versioning (Phase 9)**: Depends on US1. Modifies `meta.rs` and `jsonl.rs`.
+- **US8 — Interrupt (Phase 10)**: Depends on US1. Adds new files. Independent of US6/US7.
+- **US9 — Filtered Loading (Phase 11)**: Depends on US6 (needs `SessionEntry` type). Adds new trait method.
+- **Polish (Phase 12)**: Depends on all user stories being complete.
+
+### Parallel Opportunities (new phases)
+
+- US6 and US7 both modify `jsonl.rs` — run sequentially (US6 first, then US7).
+- US8 (interrupt) touches separate files — can run in parallel with US6/US7.
+- US9 depends on US6 (`SessionEntry`) — must run after US6.
+
+### Notes
+
+- US6–US9 are new work — rich entries, versioning, interrupt persistence, filtered loading.
+- All new features must be backward compatible with existing JSONL sessions (serde defaults).
+- Test tasks marked [P] within each phase can run in parallel (different test files/functions).


### PR DESCRIPTION
## Summary
- Add 4 new features to 021-memory-crate: I9 (rich entry types), I10 (session versioning), I11 (interrupt persistence), N12 (filtered retrieval)
- Also adds "check specs and docs first" principle to CLAUDE.md
- All 8 spec artifacts updated: spec (US6–US9, FR-011–021, SC-006–010), data-model, research (D8–D11), plan, contracts, quickstart, tasks (T058–T095 + T060b/T067b/T075b), checklist
- 2 clarifications: always-check optimistic concurrency, adjacently-tagged serde nesting

## Test plan
- [ ] Verify spec consistency across all 8 artifacts
- [ ] Verify task coverage for all new FRs and acceptance scenarios
- [ ] Verify serde tag+content attributes consistent across data-model and contracts
- [ ] Verify T069/T066 descriptions match clarification (no optional parameter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)