### PR TITLE
spec: caching strategy, proxy streaming, raw payload for 011

### DIFF
--- a/specs/011-adapter-shared-infra/checklists/requirements.md
+++ b/specs/011-adapter-shared-infra/checklists/requirements.md
@@ -29,6 +29,17 @@
 - [x] Feature meets measurable outcomes defined in Success Criteria
 - [x] No implementation details leak into specification
 
+## Caching Strategy, Proxy Streaming, Raw Payload (I6, N3, N4)
+
+- [x] US5–US7 acceptance scenarios are testable and unambiguous
+- [x] FR-009 through FR-013 are measurable
+- [x] SC-005 through SC-007 are technology-agnostic success criteria
+- [x] Edge cases for new features (unsupported adapter caching, slow callback, proxy auth) identified
+- [x] CacheStrategy defined in core (provider-agnostic), translated by adapters
+- [x] OnRawPayload panic isolation specified (catch_unwind)
+- [x] ProxyStreamFn reuses AdapterBase for auth
+
 ## Notes
 
 - All items pass. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- I6 (Caching), N3 (Proxy), N4 (Raw Payload) added 2026-03-31: US5–US7, FR-009–FR-013, SC-005–SC-007, tasks T041–T063.

--- a/specs/011-adapter-shared-infra/contracts/public-api.md
+++ b/specs/011-adapter-shared-infra/contracts/public-api.md
@@ -148,3 +148,63 @@ pub fn preset(model_id: &str) -> Option<CatalogPreset>;
 - `remote_presets(Some("anthropic"))` returns only Anthropic presets.
 - `preset("claude-sonnet-4-6")` returns the matching `CatalogPreset` or `None`.
 - Adding a new provider requires: one new `remote_preset_keys` sub-module, one new match arm in `build_remote_connection_from_values`, and the corresponding `StreamFn` import.
+
+---
+
+## Core: `swink_agent::stream` (CacheStrategy + OnRawPayload)
+
+```rust
+/// Provider-agnostic caching configuration.
+#[derive(Debug, Clone, Default)]
+pub enum CacheStrategy {
+    #[default]
+    None,                           // no caching
+    Auto,                           // adapter decides optimal cache points
+    Anthropic,                      // Anthropic cache_control blocks on system prompt + tools
+    Google { ttl: Duration },       // Google CachedContent with TTL
+}
+
+/// Callback for raw SSE data line observation.
+pub type OnRawPayload = Arc<dyn Fn(&str) + Send + Sync>;
+
+// Added to StreamOptions:
+pub struct StreamOptions {
+    // ... existing fields ...
+    pub cache_strategy: CacheStrategy,
+    pub on_raw_payload: Option<OnRawPayload>,
+}
+```
+
+**Contract**:
+- `CacheStrategy::None` is the default — no caching overhead.
+- `CacheStrategy::Auto` enables adapter-determined caching (system prompt + tool defs for Anthropic, long context for Google).
+- Adapters that don't support caching silently ignore the strategy.
+- `on_raw_payload` fires synchronously with each raw SSE `data:` line before event parsing.
+- Panics in `on_raw_payload` are caught via `catch_unwind`; the stream continues.
+
+---
+
+## Module: `swink_agent_adapters` (ProxyStreamFn)
+
+```rust
+/// Raw SSE byte relay — skips event parsing.
+pub struct ProxyStreamFn {
+    base: AdapterBase,
+    target_provider: String,
+}
+
+impl ProxyStreamFn {
+    pub fn new(base_url: impl Into<String>, api_key: impl Into<String>, target_provider: impl Into<String>) -> Self;
+    pub async fn stream_raw(
+        &self,
+        model: &ModelSpec,
+        messages: Vec<LlmMessage>,
+        options: &StreamOptions,
+    ) -> Pin<Box<dyn Stream<Item = Result<Bytes, reqwest::Error>> + Send>>;
+}
+```
+
+**Contract**:
+- Returns raw SSE bytes — no `AssistantMessageEvent` conversion.
+- Reuses `AdapterBase` for HTTP connection management and authentication.
+- The `target_provider` field determines URL construction and auth header format.

--- a/specs/011-adapter-shared-infra/data-model.md
+++ b/specs/011-adapter-shared-infra/data-model.md
@@ -110,6 +110,52 @@ Nested modules (`anthropic`, `openai`, `google`, `azure`, `xai`, `mistral`, `bed
 
 ---
 
+## Entity: CacheStrategy (enum, defined in core)
+
+**Location**: `src/stream.rs` (core), as a field on `StreamOptions`
+
+| Variant | Data | Purpose |
+|---------|------|---------|
+| `None` | — | No caching (default) |
+| `Auto` | — | Adapter decides optimal cache points |
+| `Anthropic` | — | Anthropic-specific `cache_control` blocks |
+| `Google` | `ttl: Duration` | Google context caching with explicit TTL |
+
+**Derives**: `Debug, Clone, Default` (default = `None`)
+
+**Flow**: `AgentOptions` → `StreamOptions.cache_strategy` → adapter's `apply_cache_strategy()`
+
+---
+
+## Entity: ProxyStreamFn (struct)
+
+**Location**: `adapters/src/proxy.rs` (or new `adapters/src/proxy_raw.rs`)
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `base` | `AdapterBase` | Shared HTTP infrastructure |
+| `target_provider` | `String` | Provider format for URL/auth routing |
+
+**Returns**: `Stream<Item = Result<Bytes, reqwest::Error>>` — raw SSE bytes, not parsed events
+
+**Contract**: Does NOT implement `StreamFn` (which returns `AssistantMessageEvent`). Instead provides a separate method or trait for raw byte streaming.
+
+---
+
+## Entity: OnRawPayload (type alias, defined in core)
+
+**Location**: `src/stream.rs` (core), as a field on `StreamOptions`
+
+```
+pub type OnRawPayload = Arc<dyn Fn(&str) + Send + Sync>;
+```
+
+**Field on StreamOptions**: `on_raw_payload: Option<OnRawPayload>`
+
+**Contract**: Called with each raw SSE `data:` line string before event parsing. Panics caught via `catch_unwind`. Must return quickly.
+
+---
+
 ## Relationship Diagram
 
 ```text
@@ -125,4 +171,13 @@ swink-agent-adapters
   ├── src/sse.rs            ──► SseLine, SseStreamParser, sse_data_lines
   ├── src/remote_presets.rs ──► RemotePresetKey, remote_preset_keys, build_remote_connection
   └── src/lib.rs            ──► re-exports all public types
+
+swink-agent (core)
+  └── src/stream.rs
+        ├── StreamOptions.cache_strategy: CacheStrategy
+        └── StreamOptions.on_raw_payload: Option<OnRawPayload>
+
+CacheStrategy ──► flows via StreamOptions ──► adapter apply_cache_strategy()
+OnRawPayload  ──► called in sse_data_lines() or adapter stream loop before event parsing
+ProxyStreamFn ──► uses AdapterBase for HTTP ──► returns raw Bytes stream
 ```

--- a/specs/011-adapter-shared-infra/plan.md
+++ b/specs/011-adapter-shared-infra/plan.md
@@ -5,9 +5,9 @@
 
 ## Summary
 
-Extract and consolidate the shared infrastructure that all LLM provider adapters depend on: a `MessageConverter` trait for converting agent messages to provider-specific formats, an `HttpErrorClassifier` for mapping HTTP status codes to agent error types, an `SseStreamParser` for consuming SSE byte streams, and a catalog-driven `RemotePresets` system for constructing configured remote connections from preset keys.
+Extract and consolidate the shared infrastructure that all LLM provider adapters depend on: a `MessageConverter` trait for converting agent messages to provider-specific formats, an `HttpErrorClassifier` for mapping HTTP status codes to agent error types, an `SseStreamParser` for consuming SSE byte streams, a catalog-driven `RemotePresets` system for constructing configured remote connections from preset keys, a `CacheStrategy` enum for provider-agnostic prompt caching configuration, a `ProxyStreamFn` for raw SSE byte relay in gateway deployments, and an `OnRawPayload` callback for observing raw provider data before event parsing.
 
-All four concerns live in the `swink-agent-adapters` crate with the conversion trait defined in core (`swink-agent`) and re-exported through adapters.
+All concerns live in the `swink-agent-adapters` crate (or core for types that flow through `StreamOptions`) with the conversion trait defined in core (`swink-agent`) and re-exported through adapters.
 
 ## Technical Context
 
@@ -28,11 +28,11 @@ All four concerns live in the `swink-agent-adapters` crate with the conversion t
 | # | Principle | Status | Notes |
 |---|-----------|--------|-------|
 | I | Library-First | PASS | All shared infra lives in `swink-agent-adapters` (or core for `MessageConverter`). No service, no daemon. Independently compilable and testable. |
-| II | Test-Driven Development | PASS | Each module (`classify`, `sse`, `remote_presets`) already has unit tests. `convert` re-exports core's tested trait. |
+| II | Test-Driven Development | PASS | Each module (`classify`, `sse`, `remote_presets`) already has unit tests. `convert` re-exports core's tested trait. New tests for CacheStrategy translation, ProxyStreamFn raw byte delivery, and OnRawPayload callback invocation/panic isolation. |
 | III | Efficiency & Performance | PASS | `SseStreamParser` buffers bytes and drains lines incrementally; `classify_http_status` is `const fn`. No unnecessary allocations. |
 | IV | Leverage the Ecosystem | PASS | Uses `reqwest` for HTTP, `futures` for streams, `bytes` for zero-copy chunks, `thiserror` for error derive. No reinvented wheels. |
-| V | Provider Agnosticism | PASS | `MessageConverter` defines a generic contract — each adapter implements it. Core holds no provider types. `HttpErrorClassifier` is provider-neutral with an override mechanism. |
-| VI | Safety & Correctness | PASS | `#[forbid(unsafe_code)]` at crate root. Errors produce proper error types, never panics. Poisoned-mutex recovery via `into_inner()`. |
+| V | Provider Agnosticism | PASS | `MessageConverter` defines a generic contract — each adapter implements it. Core holds no provider types. `HttpErrorClassifier` is provider-neutral with an override mechanism. `CacheStrategy` is defined in core as a provider-agnostic enum; adapters translate to provider-specific formats. |
+| VI | Safety & Correctness | PASS | `#[forbid(unsafe_code)]` at crate root. Errors produce proper error types, never panics. Poisoned-mutex recovery via `into_inner()`. `OnRawPayload` panics caught via `catch_unwind`; stream continues uninterrupted. |
 
 ## Project Structure
 

--- a/specs/011-adapter-shared-infra/quickstart.md
+++ b/specs/011-adapter-shared-infra/quickstart.md
@@ -92,3 +92,53 @@ let connection = build_remote_connection(
 | `adapters/src/remote_presets.rs` | `RemotePresetKey`, preset constants, `build_remote_connection` |
 | `adapters/src/lib.rs` | Crate root with re-exports |
 | `src/convert.rs` | Core `MessageConverter` trait definition |
+
+### Configure Prompt Caching
+
+```rust
+use swink_agent::stream::{StreamOptions, CacheStrategy};
+
+// Enable automatic caching (adapter determines optimal cache points)
+let options = StreamOptions {
+    cache_strategy: CacheStrategy::Auto,
+    ..Default::default()
+};
+
+// Provider-specific: Anthropic cache_control blocks
+let options = StreamOptions {
+    cache_strategy: CacheStrategy::Anthropic,
+    ..Default::default()
+};
+
+// Provider-specific: Google with TTL
+use std::time::Duration;
+let options = StreamOptions {
+    cache_strategy: CacheStrategy::Google { ttl: Duration::from_secs(3600) },
+    ..Default::default()
+};
+```
+
+### Observe Raw Provider Payloads
+
+```rust
+use std::sync::Arc;
+use swink_agent::stream::StreamOptions;
+
+let options = StreamOptions {
+    on_raw_payload: Some(Arc::new(|raw: &str| {
+        eprintln!("[RAW] {raw}");
+    })),
+    ..Default::default()
+};
+// Each raw SSE data line is printed before event parsing
+```
+
+### Proxy Raw SSE Bytes
+
+```rust
+use swink_agent_adapters::ProxyStreamFn;
+
+let proxy = ProxyStreamFn::new(base_url, api_key, "anthropic");
+let byte_stream = proxy.stream_raw(model, messages, options).await;
+// byte_stream yields raw Bytes — consumer parses events
+```

--- a/specs/011-adapter-shared-infra/research.md
+++ b/specs/011-adapter-shared-infra/research.md
@@ -50,3 +50,39 @@
 **Alternatives rejected**:
 - *Registry trait with dynamic registration*: Over-engineered; the provider set is known at compile time.
 - *Config-file-based presets*: Adds I/O to what should be a pure construction step; credentials still come from env vars.
+
+## Decision 5: CacheStrategy as Provider-Agnostic Enum
+
+**Question**: How should caching be configured across adapters with different caching mechanisms?
+
+**Decision**: Define `CacheStrategy` as an enum in core (`StreamOptions`) with `None`, `Auto`, `Anthropic`, and `Google { ttl }` variants. Each adapter implements `apply_cache_strategy()` to translate the strategy into provider-specific request modifications. Adapters without caching support ignore the strategy.
+
+**Rationale**: Caching mechanisms differ fundamentally between providers — Anthropic uses inline `cache_control` blocks, Google uses separate `CachedContent` resources with TTLs. A shared enum with provider-specific variants keeps the user-facing API simple while allowing each adapter to do the right thing. `Auto` lets the adapter decide optimal cache points (system prompt + tool definitions for Anthropic, long context for Google).
+
+**Key reference**: AWS Strands' `CacheConfig` with `strategy="auto"|"anthropic"` that auto-detects and injects cache points.
+
+**Alternatives rejected**:
+- *Per-adapter caching config*: Users would need provider-specific knowledge to configure caching. The enum abstracts this.
+- *Trait-based caching*: Over-engineered. The variants are a closed set (tied to provider capabilities), not extensible.
+- *Always-on caching*: Not all prompts benefit from caching (short prompts, one-shot queries). Opt-in is correct.
+
+## Decision 6: ProxyStreamFn as Raw Byte Relay
+
+**Decision**: `ProxyStreamFn` relays raw SSE bytes without parsing into `AssistantMessageEvent`. It reuses `AdapterBase` for HTTP/auth but returns `Stream<Item = Result<Bytes, Error>>` instead of the parsed event stream.
+
+**Rationale**: Gateway deployments need Swink as a thin proxy — the consumer (e.g., a web frontend) has its own event parser. Parsing and re-serializing would add latency and lose provider-specific event fields. Raw relay is zero-overhead for this use case.
+
+**Alternatives rejected**:
+- *Parse then re-serialize*: Adds latency and loses provider-specific fields.
+- *WebSocket relay*: Different protocol; SSE relay is simpler and matches provider output.
+
+## Decision 7: OnRawPayload as Optional Synchronous Callback
+
+**Decision**: `on_raw_payload: Option<OnRawPayload>` in `StreamOptions` fires synchronously with each raw SSE data line string. Panics are caught via `catch_unwind`.
+
+**Rationale**: Raw payload observation is a debugging tool — it needs to see every byte the provider sends, before any parsing. Synchronous execution on the streaming task ensures correct ordering (callback sees data before the adapter). The `Option` check is zero-cost when not configured. Panic isolation follows the same pattern as event subscriber dispatch.
+
+**Alternatives rejected**:
+- *Channel-based async callback*: Adds ordering complexity — the callback might see data out of order if the channel buffers.
+- *Logging-only (tracing crate)*: Too structured — users want the raw string, not a tracing event that's been formatted.
+- *Middleware on the byte stream*: Would require wrapping the reqwest byte stream, adding complexity. A simple callback is lighter.

--- a/specs/011-adapter-shared-infra/spec.md
+++ b/specs/011-adapter-shared-infra/spec.md
@@ -3,7 +3,7 @@
 **Feature Branch**: `011-adapter-shared-infra`
 **Created**: 2026-03-20
 **Status**: Draft
-**Input**: Shared infrastructure that all LLM provider adapters depend on: message conversion trait, HTTP error classification, SSE parsing helpers, and catalog-driven remote connection construction. References: PRD §15.1 (Adapters Crate), HLD Adapters Crate (convert, classify, sse, remote_presets).
+**Input**: Shared infrastructure that all LLM provider adapters depend on: message conversion trait, HTTP error classification, SSE parsing helpers, catalog-driven remote connection construction, prompt caching strategy configuration, proxy streaming mode, and raw provider payload callback. References: PRD §15.1 (Adapters Crate), HLD Adapters Crate (convert, classify, sse, remote_presets).
 
 ## User Scenarios & Testing *(mandatory)*
 
@@ -71,11 +71,66 @@ A developer selects a model from the catalog and the system constructs a fully c
 
 ---
 
+### User Story 5 - Configure Prompt Caching Strategy (Priority: P2) — I6
+
+An adapter developer configures a caching strategy that adapters use to inject cache control markers into LLM requests. The strategy is provider-agnostic at the configuration level — the adapter translates it to provider-specific format (e.g., Anthropic `cache_control` blocks, Google `CachedContent` resources). Adapters that don't support caching treat the strategy as a no-op.
+
+**Why this priority**: Prompt caching can reduce cost by 90% for repeated system prompts and tool definitions. Without a shared abstraction, each adapter would implement caching differently, making it hard for users to switch providers.
+
+**Independent Test**: Can be tested by configuring `CacheStrategy::Auto`, calling an adapter's `apply_cache_strategy()`, and verifying the correct provider-specific markers are injected into the request.
+
+**Acceptance Scenarios**:
+
+1. **Given** `CacheStrategy::None` (default), **When** an adapter builds a request, **Then** no cache markers are injected.
+2. **Given** `CacheStrategy::Auto`, **When** the Anthropic adapter builds a request, **Then** `cache_control: { type: "ephemeral" }` is injected on the system prompt and tool definitions.
+3. **Given** `CacheStrategy::Auto`, **When** an adapter that doesn't support caching builds a request, **Then** the strategy is silently ignored (graceful degradation).
+4. **Given** `CacheStrategy::Google { ttl }`, **When** the Google adapter builds a request, **Then** a `CachedContent` resource is referenced with the specified TTL.
+5. **Given** a `CacheStrategy`, **When** it is passed through `StreamOptions`, **Then** each adapter's streaming function receives it and applies it at request construction time.
+
+---
+
+### User Story 6 - Proxy Raw SSE Bytes Without Parsing (Priority: P3) — N3
+
+A gateway developer uses a `ProxyStreamFn` to relay raw SSE bytes from a provider to a consumer without parsing them into `AssistantMessageEvent`. This enables Swink to act as a thin proxy in gateway deployments where the consumer handles its own event parsing.
+
+**Why this priority**: Nice-to-have for gateway deployments. Most users use the full event-parsing pipeline.
+
+**Independent Test**: Can be tested by configuring a `ProxyStreamFn`, sending a request, and verifying the consumer receives raw SSE bytes matching what the provider sent.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `ProxyStreamFn` configured for an Anthropic endpoint, **When** a streaming request is made, **Then** the consumer receives raw `Bytes` chunks from the provider's SSE stream.
+2. **Given** a `ProxyStreamFn`, **When** the stream ends, **Then** the consumer receives no synthetic events — just the raw provider data.
+3. **Given** a `ProxyStreamFn`, **When** the provider returns an HTTP error, **Then** the error is propagated as-is to the consumer.
+
+---
+
+### User Story 7 - Observe Raw Provider Payloads (Priority: P3) — N4
+
+A developer configures an optional callback in `StreamOptions` that fires with each raw SSE data line before it enters the adapter's event parsing state machine. This is a low-level escape hatch for debugging, logging, or handling provider-specific extensions.
+
+**Why this priority**: Nice-to-have debugging tool. Most users don't need raw payload access.
+
+**Independent Test**: Can be tested by configuring an `on_raw_payload` callback, sending a request, and verifying the callback fires with each raw SSE data line.
+
+**Acceptance Scenarios**:
+
+1. **Given** an `on_raw_payload` callback configured in `StreamOptions`, **When** the adapter receives SSE data lines, **Then** the callback is called with each raw data line string before event parsing.
+2. **Given** no `on_raw_payload` callback (default), **When** the adapter receives SSE data lines, **Then** no overhead is added (the callback check is a simple `Option::is_some`).
+3. **Given** an `on_raw_payload` callback that panics, **When** it panics during invocation, **Then** the panic is caught and the streaming pipeline continues uninterrupted.
+4. **Given** an `on_raw_payload` callback, **When** it is invoked, **Then** it MUST NOT block the streaming pipeline (fire-and-forget semantics — the callback receives a `&str` reference and returns nothing).
+
+---
+
 ### Edge Cases
 
 - What happens when an HTTP response has no status code (connection reset) — the status code classifier only handles HTTP status codes. Connection-level errors (resets, timeouts) are mapped to `NetworkError` at the adapter level by reqwest error handling.
 - How does SSE parsing handle events with no data field — events without data are valid SSE (comment lines, event-type-only lines) and are parsed normally as their respective line types.
 - What happens when a preset references a provider not supported by any installed adapter — the connection factory returns None/error; the caller handles it (e.g., TUI shows available providers).
+- What happens when `CacheStrategy::Anthropic` is used with a non-Anthropic adapter — silently ignored. Each adapter only applies strategies it understands.
+- What happens when `CacheStrategy::Google { ttl }` is set but the Google adapter can't create a cached content resource — falls back to uncached request with a logged warning.
+- What happens when the `on_raw_payload` callback is slow — it executes synchronously on the streaming task. A slow callback delays event delivery. The callback contract requires it to return quickly (fire-and-forget). This is documented, not enforced at runtime.
+- What happens when `ProxyStreamFn` is used with a model that requires custom authentication (e.g., Bedrock SigV4) — `ProxyStreamFn` reuses `AdapterBase` for connection management, which handles auth. The proxy doesn't parse events but still authenticates correctly.
 
 ## Requirements *(mandatory)*
 
@@ -89,6 +144,11 @@ A developer selects a model from the catalog and the system constructs a fully c
 - **FR-006**: SSE parsing MUST handle the standard SSE protocol (event names, data fields, multi-line data, terminal events).
 - **FR-007**: System MUST provide catalog-driven remote connection construction that resolves presets to configured streaming functions.
 - **FR-008**: The adapters crate MUST re-export all public adapter types and the shared infrastructure from its root module.
+- **FR-009**: System MUST provide a `CacheStrategy` enum (`None`, `Auto`, `Anthropic`, `Google { ttl }`) that flows from `StreamOptions` to adapters for provider-specific cache marker injection.
+- **FR-010**: Adapters that support caching MUST implement `apply_cache_strategy()` to translate the `CacheStrategy` into provider-specific request modifications. Adapters that don't support caching MUST silently ignore the strategy.
+- **FR-011**: System MUST provide a `ProxyStreamFn` that relays raw SSE bytes from a provider without parsing them into `AssistantMessageEvent`.
+- **FR-012**: System MUST provide an optional `on_raw_payload: Option<OnRawPayload>` field in `StreamOptions` that receives raw SSE data line strings before event parsing.
+- **FR-013**: The `on_raw_payload` callback MUST NOT block the streaming pipeline. Panics in the callback MUST be caught and the stream MUST continue.
 
 ### Key Entities
 
@@ -96,6 +156,9 @@ A developer selects a model from the catalog and the system constructs a fully c
 - **HttpErrorClassifier**: Maps HTTP status codes and network errors to agent error types.
 - **SSE Parser**: Shared helpers for consuming Server-Sent Events streams.
 - **RemotePresets**: Catalog-driven factory for constructing configured remote connections.
+- **CacheStrategy**: Provider-agnostic caching configuration that adapters translate to provider-specific markers.
+- **ProxyStreamFn**: Raw SSE byte relay for gateway deployments — skips event parsing.
+- **OnRawPayload**: Optional callback for observing raw SSE data lines before event parsing.
 
 ## Success Criteria *(mandatory)*
 
@@ -105,6 +168,9 @@ A developer selects a model from the catalog and the system constructs a fully c
 - **SC-002**: HTTP error classification is consistent: same status code always maps to the same error type.
 - **SC-003**: SSE parsing correctly extracts event data from valid streams and reports errors for malformed streams.
 - **SC-004**: Catalog presets resolve to correctly configured remote connections with appropriate credentials and endpoints.
+- **SC-005**: `CacheStrategy::Auto` correctly injects Anthropic cache markers when used with the Anthropic adapter and is silently ignored by adapters without caching support.
+- **SC-006**: `ProxyStreamFn` delivers raw SSE bytes to the consumer without any `AssistantMessageEvent` conversion.
+- **SC-007**: `on_raw_payload` fires for each raw SSE data line and a panicking callback does not interrupt the stream.
 
 ## Clarifications
 
@@ -119,3 +185,7 @@ A developer selects a model from the catalog and the system constructs a fully c
 - SSE is the dominant streaming protocol (used by 7 of 9 adapters). NDJSON (Ollama) is handled separately.
 - The error classifier is a utility function, not a trait — all adapters use the same classification logic.
 - The adapters crate depends only on the core `swink-agent` crate, not on memory, eval, or TUI.
+- `CacheStrategy` is defined in the core crate (in `StreamOptions`) so it's provider-agnostic. Adapters translate it to provider-specific formats.
+- `CacheStrategy::Auto` is the recommended default for users who want caching — each adapter determines optimal cache points for its provider.
+- `ProxyStreamFn` reuses `AdapterBase` for HTTP/auth but returns `Stream<Item = Bytes>` instead of `Stream<Item = AssistantMessageEvent>`.
+- `on_raw_payload` is synchronous and runs on the streaming task. The contract requires it to return quickly — enforcement is by documentation, not runtime timeout.

--- a/specs/011-adapter-shared-infra/tasks.md
+++ b/specs/011-adapter-shared-infra/tasks.md
@@ -140,7 +140,73 @@
 
 ---
 
-## Phase 7: Polish & Cross-Cutting Concerns
+## Phase 7: User Story 5 — Prompt Caching Strategy (Priority: P2) — I6
+
+**Goal**: Provider-agnostic caching configuration via `CacheStrategy` enum flowing through `StreamOptions`
+
+**Independent Test**: Configure `CacheStrategy::Auto`, call adapter's `apply_cache_strategy()`, verify provider-specific markers injected
+
+### Tests for User Story 5
+
+- [ ] T041 [P] [US5] Unit test `cache_strategy_none_no_markers` in `adapters/tests/`: verify no cache markers when `CacheStrategy::None`
+- [ ] T042 [P] [US5] Unit test `cache_strategy_auto_anthropic_markers` in `adapters/tests/`: verify Anthropic adapter injects `cache_control` blocks on system prompt and tool definitions when `Auto`
+- [ ] T043 [P] [US5] Unit test `cache_strategy_ignored_by_unsupporting_adapter` in `adapters/tests/`: verify an adapter without caching support ignores the strategy silently
+
+### Implementation for User Story 5
+
+- [ ] T044 [US5] Add `CacheStrategy` enum (`None`, `Auto`, `Anthropic`, `Google { ttl }`) to `src/stream.rs` in core. Derive `Debug`, `Clone`, `Default` (default = `None`).
+- [ ] T045 [US5] Add `cache_strategy: CacheStrategy` field to `StreamOptions` in `src/stream.rs` with `#[serde(default)]`.
+- [ ] T046 [US5] Implement `apply_cache_strategy()` in the Anthropic adapter (`adapters/src/anthropic.rs`): inject `cache_control: { type: "ephemeral" }` on system prompt and tool definitions when `Auto` or `Anthropic`.
+- [ ] T047 [US5] Verify other adapters (OpenAI, Ollama, Mistral, xAI, Azure) silently ignore `CacheStrategy` (no-op — no code changes needed, just verify).
+- [ ] T048 [US5] Re-export `CacheStrategy` from `src/lib.rs` (core).
+
+**Checkpoint**: US5 complete — caching strategy flows from configuration to adapters
+
+---
+
+## Phase 8: User Story 6 — Proxy Streaming Mode (Priority: P3) — N3
+
+**Goal**: Raw SSE byte relay for gateway deployments via `ProxyStreamFn`
+
+**Independent Test**: Configure `ProxyStreamFn`, send request, verify consumer receives raw SSE bytes
+
+### Tests for User Story 6
+
+- [ ] T049 [P] [US6] Integration test `proxy_stream_raw_bytes` in `adapters/tests/`: configure `ProxyStreamFn` with a mock HTTP server, verify raw bytes are relayed
+- [ ] T050 [P] [US6] Integration test `proxy_stream_error_propagated` in `adapters/tests/`: mock HTTP server returns 500, verify error propagated to consumer
+
+### Implementation for User Story 6
+
+- [ ] T051 [US6] Implement `ProxyStreamFn` struct in `adapters/src/proxy.rs` (or new `proxy_raw.rs`): `new()` constructor, `stream_raw()` method returning `Stream<Item = Result<Bytes, Error>>`.
+- [ ] T052 [US6] Re-export `ProxyStreamFn` from `adapters/src/lib.rs`.
+
+**Checkpoint**: US6 complete — raw SSE relay available for gateway use cases
+
+---
+
+## Phase 9: User Story 7 — Raw Provider Payload Callback (Priority: P3) — N4
+
+**Goal**: Optional `on_raw_payload` callback in `StreamOptions` for observing raw SSE data lines
+
+**Independent Test**: Configure callback, send request, verify callback fires with raw data lines
+
+### Tests for User Story 7
+
+- [ ] T053 [P] [US7] Unit test `on_raw_payload_fires_for_each_line` in `adapters/tests/`: configure callback, feed SSE data, verify callback called for each data line
+- [ ] T054 [P] [US7] Unit test `on_raw_payload_none_no_overhead` in `adapters/tests/`: verify no overhead when callback is `None`
+- [ ] T055 [P] [US7] Unit test `on_raw_payload_panic_caught` in `adapters/tests/`: configure panicking callback, verify stream continues
+
+### Implementation for User Story 7
+
+- [ ] T056 [US7] Add `OnRawPayload` type alias and `on_raw_payload: Option<OnRawPayload>` field to `StreamOptions` in `src/stream.rs` (core).
+- [ ] T057 [US7] Integrate `on_raw_payload` invocation into `sse_data_lines()` in `adapters/src/sse.rs`: call callback with raw data line string before yielding `SseLine::Data`. Wrap in `catch_unwind`.
+- [ ] T058 [US7] Re-export `OnRawPayload` from `src/lib.rs` (core).
+
+**Checkpoint**: US7 complete — raw payload observation available for debugging
+
+---
+
+## Phase 10: Polish & Cross-Cutting Concerns
 
 **Purpose**: Final verification across all modules
 
@@ -149,6 +215,11 @@
 - [x] T038 Run `cargo clippy --workspace -- -D warnings` to verify zero clippy warnings
 - [x] T039 Run `cargo test --workspace` to verify no regressions in other crates
 - [x] T040 Run quickstart.md validation: execute all code examples from `specs/011-adapter-shared-infra/quickstart.md` usage section
+- [ ] T059 Verify `CacheStrategy`, `OnRawPayload`, and `ProxyStreamFn` are re-exported from their respective crate roots
+- [ ] T060 Run `cargo build --workspace` and verify zero compilation errors with new types
+- [ ] T061 Run `cargo test --workspace` and verify all new tests pass
+- [ ] T062 Run `cargo clippy --workspace -- -D warnings` and fix any warnings
+- [ ] T063 Validate new quickstart.md examples (caching, raw payload, proxy) match actual API
 
 ---
 
@@ -162,7 +233,10 @@
 - **US2 (Phase 4)**: Depends on Foundational (Phase 2) — independent of US1, US3, US4
 - **US3 (Phase 5)**: Depends on Foundational (Phase 2) — independent of US1, US2, US4
 - **US4 (Phase 6)**: Depends on Foundational (Phase 2) — may reference types from US1/US2/US3 but is independently testable
-- **Polish (Phase 7)**: Depends on all user stories being complete
+- **US5 Caching (Phase 7)**: Depends on Phase 2. Modifies core `StreamOptions` and Anthropic adapter.
+- **US6 Proxy (Phase 8)**: Depends on Phase 2. Adds new struct in adapters. Independent of US5/US7.
+- **US7 Raw Payload (Phase 9)**: Depends on Phase 2 and US3 (SSE parsing). Modifies `sse_data_lines()`.
+- **Polish (Phase 10)**: Depends on all user stories being complete
 
 ### User Story Dependencies
 
@@ -181,6 +255,8 @@
 ### Parallel Opportunities
 
 - US1, US2, US3 are fully independent and can all start in parallel after Phase 2
+- US5, US6 can proceed in parallel after Phase 2 (separate files, no cross-deps)
+- US7 depends on US3 (modifies sse_data_lines) but can proceed after US3 is complete
 - Within US2: T011, T012 (tests) in parallel; T013 (types) in parallel with tests
 - Within US3: T017, T018, T019 (tests) in parallel; T020 (types) in parallel with tests
 - Within US4: T026, T027, T028 (tests) in parallel; T029 (types) in parallel with tests
@@ -256,3 +332,6 @@ Task T025: "Re-exports in lib.rs"
 - Verify tests fail before implementing
 - Commit after each task or logical group
 - Stop at any checkpoint to validate story independently
+- US5 (Caching) adds `CacheStrategy` to core `StreamOptions` and modifies Anthropic adapter
+- US6 (Proxy) adds `ProxyStreamFn` — new struct in adapters crate
+- US7 (Raw Payload) adds `OnRawPayload` to core `StreamOptions` and modifies `sse_data_lines()`


### PR DESCRIPTION
## Summary
- Add 3 new features to 011-adapter-shared-infra: I6 (prompt caching strategy), N3 (proxy streaming mode), N4 (raw payload callback)
- All 8 spec artifacts updated: spec (US5–US7, FR-009–013, SC-005–007), data-model, research (D5–D7), plan, contracts, quickstart, tasks (T041–T063), checklist

## Test plan
- [ ] Verify spec consistency across all 8 artifacts
- [ ] Verify task coverage for all new FRs and acceptance scenarios
- [ ] Verify CacheStrategy defined in core (StreamOptions), not adapters

🤖 Generated with [Claude Code](https://claude.com/claude-code)