### PR TITLE
Refactor loop internals into smaller focused modules

### DIFF
--- a/src/loop_/config.rs
+++ b/src/loop_/config.rs
@@ -1,0 +1,142 @@
+//! Configuration for the agent loop.
+
+use std::sync::Arc;
+
+use crate::agent_options::{ApproveToolFn, GetApiKeyFn};
+use crate::async_context_transformer::AsyncContextTransformer;
+use crate::fallback::ModelFallback;
+use crate::message_provider::MessageProvider;
+use crate::retry::RetryStrategy;
+use crate::stream::{StreamFn, StreamOptions};
+use crate::tool::{AgentTool, ApprovalMode};
+use crate::tool_execution_policy::ToolExecutionPolicy;
+use crate::types::ModelSpec;
+
+use super::ConvertToLlmFn;
+
+// ─── AgentLoopConfig ─────────────────────────────────────────────────────────
+
+/// Configuration for the agent loop.
+///
+/// Carries the model spec, stream options, retry strategy, stream function,
+/// tools, and all the hooks that the loop calls at various points.
+pub struct AgentLoopConfig {
+    /// Model specification passed through to `StreamFn`.
+    pub model: ModelSpec,
+
+    /// Stream options passed through to `StreamFn`.
+    pub stream_options: StreamOptions,
+
+    /// Retry strategy applied to model calls.
+    pub retry_strategy: Box<dyn RetryStrategy>,
+
+    /// The pluggable streaming function that calls the LLM provider.
+    pub stream_fn: Arc<dyn StreamFn>,
+
+    /// Available tools for the agent to call.
+    pub tools: Vec<Arc<dyn AgentTool>>,
+
+    /// Converts an `AgentMessage` to an `LlmMessage` for the provider.
+    /// Returns `None` to filter out custom or UI-only messages.
+    pub convert_to_llm: Box<ConvertToLlmFn>,
+
+    /// Optional hook called before `convert_to_llm`; used for context pruning,
+    /// token budget enforcement, or external context injection.
+    /// When the overflow signal is set, the transformer should prune more
+    /// aggressively.
+    pub transform_context: Option<Arc<dyn crate::context_transformer::ContextTransformer>>,
+
+    /// Optional async callback for dynamic API key resolution.
+    pub get_api_key: Option<Box<GetApiKeyFn>>,
+
+    /// Optional provider polled for steering and follow-up messages.
+    ///
+    /// [`MessageProvider::poll_steering`] is called after each tool execution batch.
+    /// [`MessageProvider::poll_follow_up`] is called when the agent would otherwise stop.
+    pub message_provider: Option<Arc<dyn MessageProvider>>,
+
+    /// Optional async callback for approving/rejecting tool calls before execution.
+    /// When `Some` and `approval_mode` is `Enabled`, each tool call is sent through
+    /// this callback before dispatch. Rejected tools return an error result to the LLM.
+    pub approve_tool: Option<Box<ApproveToolFn>>,
+
+    /// Controls whether the approval gate is active. Defaults to `Enabled`.
+    pub approval_mode: ApprovalMode,
+
+    /// Pre-turn policies evaluated before each LLM call.
+    pub pre_turn_policies: Vec<Arc<dyn crate::policy::PreTurnPolicy>>,
+
+    /// Pre-dispatch policies evaluated per tool call, before approval.
+    pub pre_dispatch_policies: Vec<Arc<dyn crate::policy::PreDispatchPolicy>>,
+
+    /// Post-turn policies evaluated after each completed turn.
+    pub post_turn_policies: Vec<Arc<dyn crate::policy::PostTurnPolicy>>,
+
+    /// Post-loop policies evaluated after the inner loop exits.
+    pub post_loop_policies: Vec<Arc<dyn crate::policy::PostLoopPolicy>>,
+
+    /// Optional async context transformer (runs before the sync transformer).
+    ///
+    /// Enables async operations like fetching summaries or RAG retrieval
+    /// before context compaction.
+    pub async_transform_context: Option<Arc<dyn AsyncContextTransformer>>,
+
+    /// Optional metrics collector invoked at the end of each turn with
+    /// per-turn timing, token usage, and cost data.
+    pub metrics_collector: Option<Arc<dyn crate::metrics::MetricsCollector>>,
+
+    /// Optional model fallback chain tried when the primary model exhausts
+    /// its retry budget on a retryable error.
+    pub fallback: Option<ModelFallback>,
+
+    /// Controls how tool calls within a turn are dispatched.
+    ///
+    /// Defaults to [`ToolExecutionPolicy::Concurrent`] for backward
+    /// compatibility.
+    pub tool_execution_policy: ToolExecutionPolicy,
+
+    /// Session key-value state store shared with tools and policies.
+    pub session_state: Arc<std::sync::RwLock<crate::SessionState>>,
+
+    /// Optional credential resolver for tool authentication.
+    pub credential_resolver: Option<Arc<dyn crate::credential::CredentialResolver>>,
+
+    /// Optional context caching configuration.
+    pub cache_config: Option<crate::context_cache::CacheConfig>,
+
+    /// Mutable cache state tracking turns since last write.
+    pub cache_state: std::sync::Mutex<crate::context_cache::CacheState>,
+
+    /// Optional dynamic system prompt closure (called fresh each turn).
+    ///
+    /// Its output is injected as a user-role message after the system prompt
+    /// to avoid invalidating provider-side caches.
+    pub dynamic_system_prompt: Option<Arc<dyn Fn() -> String + Send + Sync>>,
+}
+
+impl std::fmt::Debug for AgentLoopConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AgentLoopConfig")
+            .field("model", &self.model)
+            .field("stream_options", &self.stream_options)
+            .field("tools", &format_args!("[{} tool(s)]", self.tools.len()))
+            .field(
+                "pre_turn_policies",
+                &format_args!("[{} policy(ies)]", self.pre_turn_policies.len()),
+            )
+            .field(
+                "pre_dispatch_policies",
+                &format_args!("[{} policy(ies)]", self.pre_dispatch_policies.len()),
+            )
+            .field(
+                "post_turn_policies",
+                &format_args!("[{} policy(ies)]", self.post_turn_policies.len()),
+            )
+            .field(
+                "post_loop_policies",
+                &format_args!("[{} policy(ies)]", self.post_loop_policies.len()),
+            )
+            .field("tool_execution_policy", &self.tool_execution_policy)
+            .finish_non_exhaustive()
+    }
+}

--- a/src/loop_/event.rs
+++ b/src/loop_/event.rs
@@ -1,0 +1,142 @@
+//! Public event types emitted by the agent loop.
+
+use std::sync::Arc;
+
+use crate::stream::AssistantMessageDelta;
+use crate::tool::AgentToolResult;
+use crate::types::{
+    AgentMessage, AssistantMessage, LlmMessage, ModelSpec, ToolResultMessage,
+};
+
+// ─── TurnEndReason ───────────────────────────────────────────────────────────
+
+/// Why a turn ended.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TurnEndReason {
+    /// Assistant completed without requesting tool calls.
+    Complete,
+    /// Tools were executed (loop continues).
+    ToolsExecuted,
+    /// Turn was interrupted by a steering message during tool execution.
+    SteeringInterrupt,
+    /// LLM returned an error stop reason.
+    Error,
+    /// External cancellation via `CancellationToken`.
+    Cancelled,
+    /// Stream was aborted mid-generation.
+    Aborted,
+}
+
+// ─── AgentEvent ──────────────────────────────────────────────────────────────
+
+/// Fine-grained lifecycle event emitted by the agent loop.
+///
+/// Consumers subscribe to these events for observability, UI updates, and
+/// logging. The harness never calls back into application logic for display
+/// concerns.
+#[non_exhaustive]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "event", rename_all = "snake_case")]
+#[allow(clippy::large_enum_variant)]
+pub enum AgentEvent {
+    /// Emitted once when the loop begins.
+    AgentStart,
+
+    /// Emitted once when the loop exits, carrying the final message context.
+    AgentEnd { messages: Arc<Vec<AgentMessage>> },
+
+    /// Emitted at the beginning of each assistant turn.
+    TurnStart,
+
+    /// Emitted at the end of each turn with the assistant message and tool results.
+    TurnEnd {
+        assistant_message: AssistantMessage,
+        tool_results: Vec<ToolResultMessage>,
+        reason: TurnEndReason,
+        /// Full context snapshot at the turn boundary for replay/auditing.
+        snapshot: crate::types::TurnSnapshot,
+    },
+
+    /// Emitted after context transform, before the LLM streaming call.
+    /// Allows plugins to observe/log the final prompt.
+    BeforeLlmCall {
+        system_prompt: String,
+        messages: Vec<LlmMessage>,
+        model: ModelSpec,
+    },
+
+    /// Emitted when a message begins streaming.
+    MessageStart,
+
+    /// Emitted for each incremental delta during assistant streaming.
+    MessageUpdate { delta: AssistantMessageDelta },
+
+    /// Emitted when a message is complete.
+    MessageEnd { message: AssistantMessage },
+
+    /// Emitted when a tool call begins execution.
+    ToolExecutionStart {
+        id: String,
+        name: String,
+        arguments: serde_json::Value,
+    },
+
+    /// Emitted for intermediate partial results from a streaming tool.
+    ToolExecutionUpdate { partial: AgentToolResult },
+
+    /// Emitted when a tool call is pending approval.
+    ToolApprovalRequested {
+        id: String,
+        name: String,
+        arguments: serde_json::Value,
+    },
+
+    /// Emitted when a tool call approval decision is made.
+    ToolApprovalResolved {
+        id: String,
+        name: String,
+        approved: bool,
+    },
+
+    /// Emitted when a tool call completes.
+    ToolExecutionEnd {
+        result: AgentToolResult,
+        is_error: bool,
+    },
+
+    /// Emitted when context compaction drops messages.
+    ContextCompacted {
+        report: crate::context_transformer::CompactionReport,
+    },
+
+    /// Emitted when the agent falls back to a different model after exhausting
+    /// retries on the current one.
+    ModelFallback {
+        from_model: ModelSpec,
+        to_model: ModelSpec,
+    },
+
+    /// Emitted when the agent switches to a different model during a retry cycle.
+    ModelCycled {
+        old: ModelSpec,
+        new: ModelSpec,
+        reason: String,
+    },
+
+    /// Emitted when session state delta is flushed (non-empty only).
+    /// Fired immediately before `TurnEnd`.
+    StateChanged {
+        delta: crate::StateDelta,
+    },
+
+    /// Emitted when context caching acts on a turn (write or read).
+    CacheAction {
+        hint: crate::context_cache::CacheHint,
+        prefix_tokens: usize,
+    },
+
+    /// A custom event emitted via [`Agent::emit`](crate::Agent::emit).
+    Custom(crate::emit::Emission),
+}

--- a/src/loop_/mod.rs
+++ b/src/loop_/mod.rs
@@ -4,9 +4,17 @@
 //! injection, event emission, retry integration, error/abort handling, and max
 //! tokens recovery. Stateless — all state is passed in via [`AgentLoopConfig`].
 
+mod config;
+mod event;
+mod overflow;
 mod stream;
 mod tool_dispatch;
 mod turn;
+mod types;
+
+pub use types::*;
+pub use config::AgentLoopConfig;
+pub use event::{AgentEvent, TurnEndReason};
 
 use std::error::Error as _;
 use std::pin::Pin;
@@ -18,19 +26,8 @@ use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, info, info_span};
 
-use crate::agent_options::{ApproveToolFn, GetApiKeyFn};
-use crate::async_context_transformer::AsyncContextTransformer;
 use crate::error::AgentError;
-use crate::fallback::ModelFallback;
-use crate::message_provider::MessageProvider;
-use crate::retry::RetryStrategy;
-use crate::stream::{AssistantMessageDelta, StreamFn, StreamOptions};
-use crate::tool::AgentTool;
-use crate::tool::{AgentToolResult, ApprovalMode};
-use crate::tool_execution_policy::ToolExecutionPolicy;
-use crate::types::{
-    AgentMessage, AssistantMessage, LlmMessage, ModelSpec, StopReason, ToolResultMessage,
-};
+use crate::types::{AgentMessage, AssistantMessage, ModelSpec, StopReason};
 use crate::util::now_timestamp;
 
 // ─── Constants ───────────────────────────────────────────────────────────────
@@ -44,271 +41,6 @@ pub const CONTEXT_OVERFLOW_SENTINEL: &str = "__context_overflow__";
 /// Channel capacity for agent events. Sized to handle burst streaming
 /// without backpressure under normal operation.
 const EVENT_CHANNEL_CAPACITY: usize = 256;
-
-// ─── Type Aliases ────────────────────────────────────────────────────────────
-
-/// Converts an `AgentMessage` to an optional `LlmMessage` for the provider.
-type ConvertToLlmFn = dyn Fn(&AgentMessage) -> Option<LlmMessage> + Send + Sync;
-
-// ─── TurnEndReason ───────────────────────────────────────────────────────────
-
-/// Why a turn ended.
-#[non_exhaustive]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum TurnEndReason {
-    /// Assistant completed without requesting tool calls.
-    Complete,
-    /// Tools were executed (loop continues).
-    ToolsExecuted,
-    /// Turn was interrupted by a steering message during tool execution.
-    SteeringInterrupt,
-    /// LLM returned an error stop reason.
-    Error,
-    /// External cancellation via `CancellationToken`.
-    Cancelled,
-    /// Stream was aborted mid-generation.
-    Aborted,
-}
-
-// ─── AgentEvent ──────────────────────────────────────────────────────────────
-
-/// Fine-grained lifecycle event emitted by the agent loop.
-///
-/// Consumers subscribe to these events for observability, UI updates, and
-/// logging. The harness never calls back into application logic for display
-/// concerns.
-#[non_exhaustive]
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(tag = "event", rename_all = "snake_case")]
-#[allow(clippy::large_enum_variant)]
-pub enum AgentEvent {
-    /// Emitted once when the loop begins.
-    AgentStart,
-
-    /// Emitted once when the loop exits, carrying the final message context.
-    AgentEnd { messages: Arc<Vec<AgentMessage>> },
-
-    /// Emitted at the beginning of each assistant turn.
-    TurnStart,
-
-    /// Emitted at the end of each turn with the assistant message and tool results.
-    TurnEnd {
-        assistant_message: AssistantMessage,
-        tool_results: Vec<ToolResultMessage>,
-        reason: TurnEndReason,
-        /// Full context snapshot at the turn boundary for replay/auditing.
-        snapshot: crate::types::TurnSnapshot,
-    },
-
-    /// Emitted after context transform, before the LLM streaming call.
-    /// Allows plugins to observe/log the final prompt.
-    BeforeLlmCall {
-        system_prompt: String,
-        messages: Vec<LlmMessage>,
-        model: ModelSpec,
-    },
-
-    /// Emitted when a message begins streaming.
-    MessageStart,
-
-    /// Emitted for each incremental delta during assistant streaming.
-    MessageUpdate { delta: AssistantMessageDelta },
-
-    /// Emitted when a message is complete.
-    MessageEnd { message: AssistantMessage },
-
-    /// Emitted when a tool call begins execution.
-    ToolExecutionStart {
-        id: String,
-        name: String,
-        arguments: serde_json::Value,
-    },
-
-    /// Emitted for intermediate partial results from a streaming tool.
-    ToolExecutionUpdate { partial: AgentToolResult },
-
-    /// Emitted when a tool call is pending approval.
-    ToolApprovalRequested {
-        id: String,
-        name: String,
-        arguments: serde_json::Value,
-    },
-
-    /// Emitted when a tool call approval decision is made.
-    ToolApprovalResolved {
-        id: String,
-        name: String,
-        approved: bool,
-    },
-
-    /// Emitted when a tool call completes.
-    ToolExecutionEnd {
-        result: AgentToolResult,
-        is_error: bool,
-    },
-
-    /// Emitted when context compaction drops messages.
-    ContextCompacted {
-        report: crate::context_transformer::CompactionReport,
-    },
-
-    /// Emitted when the agent falls back to a different model after exhausting
-    /// retries on the current one.
-    ModelFallback {
-        from_model: ModelSpec,
-        to_model: ModelSpec,
-    },
-
-    /// Emitted when the agent switches to a different model during a retry cycle.
-    ModelCycled {
-        old: ModelSpec,
-        new: ModelSpec,
-        reason: String,
-    },
-
-    /// Emitted when session state delta is flushed (non-empty only).
-    /// Fired immediately before `TurnEnd`.
-    StateChanged {
-        delta: crate::StateDelta,
-    },
-
-    /// Emitted when context caching acts on a turn (write or read).
-    CacheAction {
-        hint: crate::context_cache::CacheHint,
-        prefix_tokens: usize,
-    },
-
-    /// A custom event emitted via [`Agent::emit`](crate::Agent::emit).
-    Custom(crate::emit::Emission),
-}
-
-// ─── AgentLoopConfig ─────────────────────────────────────────────────────────
-
-/// Configuration for the agent loop.
-///
-/// Carries the model spec, stream options, retry strategy, stream function,
-/// tools, and all the hooks that the loop calls at various points.
-pub struct AgentLoopConfig {
-    /// Model specification passed through to `StreamFn`.
-    pub model: ModelSpec,
-
-    /// Stream options passed through to `StreamFn`.
-    pub stream_options: StreamOptions,
-
-    /// Retry strategy applied to model calls.
-    pub retry_strategy: Box<dyn RetryStrategy>,
-
-    /// The pluggable streaming function that calls the LLM provider.
-    pub stream_fn: Arc<dyn StreamFn>,
-
-    /// Available tools for the agent to call.
-    pub tools: Vec<Arc<dyn AgentTool>>,
-
-    /// Converts an `AgentMessage` to an `LlmMessage` for the provider.
-    /// Returns `None` to filter out custom or UI-only messages.
-    pub convert_to_llm: Box<ConvertToLlmFn>,
-
-    /// Optional hook called before `convert_to_llm`; used for context pruning,
-    /// token budget enforcement, or external context injection.
-    /// When the overflow signal is set, the transformer should prune more
-    /// aggressively.
-    pub transform_context: Option<Arc<dyn crate::context_transformer::ContextTransformer>>,
-
-    /// Optional async callback for dynamic API key resolution.
-    pub get_api_key: Option<Box<GetApiKeyFn>>,
-
-    /// Optional provider polled for steering and follow-up messages.
-    ///
-    /// [`MessageProvider::poll_steering`] is called after each tool execution batch.
-    /// [`MessageProvider::poll_follow_up`] is called when the agent would otherwise stop.
-    pub message_provider: Option<Arc<dyn MessageProvider>>,
-
-    /// Optional async callback for approving/rejecting tool calls before execution.
-    /// When `Some` and `approval_mode` is `Enabled`, each tool call is sent through
-    /// this callback before dispatch. Rejected tools return an error result to the LLM.
-    pub approve_tool: Option<Box<ApproveToolFn>>,
-
-    /// Controls whether the approval gate is active. Defaults to `Enabled`.
-    pub approval_mode: ApprovalMode,
-
-    /// Pre-turn policies evaluated before each LLM call.
-    pub pre_turn_policies: Vec<Arc<dyn crate::policy::PreTurnPolicy>>,
-
-    /// Pre-dispatch policies evaluated per tool call, before approval.
-    pub pre_dispatch_policies: Vec<Arc<dyn crate::policy::PreDispatchPolicy>>,
-
-    /// Post-turn policies evaluated after each completed turn.
-    pub post_turn_policies: Vec<Arc<dyn crate::policy::PostTurnPolicy>>,
-
-    /// Post-loop policies evaluated after the inner loop exits.
-    pub post_loop_policies: Vec<Arc<dyn crate::policy::PostLoopPolicy>>,
-
-    /// Optional async context transformer (runs before the sync transformer).
-    ///
-    /// Enables async operations like fetching summaries or RAG retrieval
-    /// before context compaction.
-    pub async_transform_context: Option<Arc<dyn AsyncContextTransformer>>,
-
-    /// Optional metrics collector invoked at the end of each turn with
-    /// per-turn timing, token usage, and cost data.
-    pub metrics_collector: Option<Arc<dyn crate::metrics::MetricsCollector>>,
-
-    /// Optional model fallback chain tried when the primary model exhausts
-    /// its retry budget on a retryable error.
-    pub fallback: Option<ModelFallback>,
-
-    /// Controls how tool calls within a turn are dispatched.
-    ///
-    /// Defaults to [`ToolExecutionPolicy::Concurrent`] for backward
-    /// compatibility.
-    pub tool_execution_policy: ToolExecutionPolicy,
-
-    /// Session key-value state store shared with tools and policies.
-    pub session_state: Arc<std::sync::RwLock<crate::SessionState>>,
-
-    /// Optional credential resolver for tool authentication.
-    pub credential_resolver: Option<Arc<dyn crate::credential::CredentialResolver>>,
-
-    /// Optional context caching configuration.
-    pub cache_config: Option<crate::context_cache::CacheConfig>,
-
-    /// Mutable cache state tracking turns since last write.
-    pub cache_state: std::sync::Mutex<crate::context_cache::CacheState>,
-
-    /// Optional dynamic system prompt closure (called fresh each turn).
-    ///
-    /// Its output is injected as a user-role message after the system prompt
-    /// to avoid invalidating provider-side caches.
-    pub dynamic_system_prompt: Option<Arc<dyn Fn() -> String + Send + Sync>>,
-}
-
-impl std::fmt::Debug for AgentLoopConfig {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("AgentLoopConfig")
-            .field("model", &self.model)
-            .field("stream_options", &self.stream_options)
-            .field("tools", &format_args!("[{} tool(s)]", self.tools.len()))
-            .field(
-                "pre_turn_policies",
-                &format_args!("[{} policy(ies)]", self.pre_turn_policies.len()),
-            )
-            .field(
-                "pre_dispatch_policies",
-                &format_args!("[{} policy(ies)]", self.pre_dispatch_policies.len()),
-            )
-            .field(
-                "post_turn_policies",
-                &format_args!("[{} policy(ies)]", self.post_turn_policies.len()),
-            )
-            .field(
-                "post_loop_policies",
-                &format_args!("[{} policy(ies)]", self.post_loop_policies.len()),
-            )
-            .field("tool_execution_policy", &self.tool_execution_policy)
-            .finish_non_exhaustive()
-    }
-}
 
 // ─── Entry Points ────────────────────────────────────────────────────────────
 
@@ -369,25 +101,6 @@ fn run_loop(
 /// Send an event through the channel. Returns false if the receiver is dropped.
 pub async fn emit(tx: &mpsc::Sender<AgentEvent>, event: AgentEvent) -> bool {
     tx.send(event).await.is_ok()
-}
-
-// ─── Loop State ──────────────────────────────────────────────────────────────
-
-/// Mutable state threaded through the loop iterations.
-pub struct LoopState {
-    pub context_messages: Vec<AgentMessage>,
-    pub pending_messages: Vec<AgentMessage>,
-    pub overflow_signal: bool,
-    /// Whether emergency overflow recovery has already been attempted this turn.
-    /// Resets to `false` at the start of each turn.
-    pub overflow_recovery_attempted: bool,
-    pub turn_index: usize,
-    pub accumulated_usage: crate::types::Usage,
-    pub accumulated_cost: crate::types::Cost,
-    /// The last assistant message from a completed turn (for policy checks).
-    pub last_assistant_message: Option<AssistantMessage>,
-    /// Tool results from the last completed turn (for post-turn hook).
-    pub last_tool_results: Vec<ToolResultMessage>,
 }
 
 // ─── run_loop_inner ──────────────────────────────────────────────────────────
@@ -562,49 +275,7 @@ async fn run_loop_inner(
     .await;
 }
 
-/// Outcome of a single turn execution within the inner loop.
-pub enum TurnOutcome {
-    /// Continue to the next inner-loop iteration (tool results need processing).
-    ContinueInner,
-    /// Break out of the inner loop (no tool calls, check follow-ups).
-    BreakInner,
-    /// Return from the entire loop (channel closed, error, or abort).
-    Return,
-}
-
 // ─── Helpers ─────────────────────────────────────────────────────────────────
-
-/// Info about a tool call extracted from the assistant message.
-pub struct ToolCallInfo {
-    pub id: String,
-    pub name: String,
-    pub arguments: serde_json::Value,
-    pub is_incomplete: bool,
-}
-
-/// Result of streaming an assistant response.
-#[allow(clippy::large_enum_variant)]
-pub enum StreamResult {
-    Message(AssistantMessage),
-    ContextOverflow,
-    Aborted,
-    ChannelClosed,
-}
-
-/// Outcome of concurrent tool execution.
-pub enum ToolExecOutcome {
-    Completed {
-        results: Vec<ToolResultMessage>,
-        tool_metrics: Vec<crate::metrics::ToolExecMetrics>,
-    },
-    SteeringInterrupt {
-        completed: Vec<ToolResultMessage>,
-        cancelled: Vec<ToolResultMessage>,
-        steering_messages: Vec<AgentMessage>,
-        tool_metrics: Vec<crate::metrics::ToolExecMetrics>,
-    },
-    ChannelClosed,
-}
 
 /// Build a terminal `AssistantMessage` with the given stop reason and message.
 fn build_terminal_message(

--- a/src/loop_/overflow.rs
+++ b/src/loop_/overflow.rs
@@ -1,0 +1,161 @@
+//! Emergency context overflow detection and recovery.
+//!
+//! When the LLM rejects a request with a context-window overflow, this module
+//! re-runs context transformers with `overflow=true`, then retries the LLM call
+//! with the compacted context. If recovery is not possible (no transformers, no
+//! compaction, second overflow, or cancellation), it surfaces an error.
+
+use std::sync::Arc;
+
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use tracing::debug;
+
+use crate::types::{AgentMessage, LlmMessage, StopReason};
+
+use super::stream::stream_with_retry;
+use super::{
+    AgentEvent, AgentLoopConfig, LoopState, StreamResult, TurnEndReason, TurnOutcome,
+    build_error_message, emit,
+};
+use super::turn::{build_snapshot, emit_turn_end_and_agent_end, handle_cancellation};
+
+/// Outcome of an in-place overflow recovery attempt.
+pub(super) enum OverflowRecoveryResult {
+    /// Recovery succeeded — the retry produced a new `StreamResult`.
+    Recovered(Box<StreamResult>),
+    /// Recovery failed — the turn should exit with this outcome.
+    Failed(TurnOutcome),
+}
+
+/// Attempt emergency in-place overflow recovery.
+///
+/// When the LLM rejects a request with a context-window overflow, this function
+/// re-runs context transformers with `overflow=true`, then retries the LLM call
+/// with the compacted context. If recovery is not possible (no transformers, no
+/// compaction, second overflow, or cancellation), it surfaces an error.
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn attempt_overflow_recovery(
+    config: &Arc<AgentLoopConfig>,
+    state: &mut LoopState,
+    system_prompt: &str,
+    agent_context: &crate::types::AgentContext,
+    api_key: Option<String>,
+    cancellation_token: &CancellationToken,
+    tx: &mpsc::Sender<AgentEvent>,
+) -> OverflowRecoveryResult {
+    // Guard 1: Already attempted recovery this turn — surface error.
+    if state.overflow_recovery_attempted {
+        debug!("second overflow in same turn — surfacing error");
+        return overflow_error(config, state, tx).await;
+    }
+
+    // Guard 2: No transformer configured — cannot compact.
+    if config.async_transform_context.is_none() && config.transform_context.is_none() {
+        debug!("no context transformer configured — cannot recover from overflow");
+        return overflow_error(config, state, tx).await;
+    }
+
+    // Mark recovery as attempted for this turn.
+    state.overflow_recovery_attempted = true;
+    state.overflow_signal = true;
+
+    // Re-run async transformer with overflow=true
+    let mut any_compacted = false;
+    if let Some(ref async_transformer) = config.async_transform_context
+        && let Some(report) = async_transformer
+            .transform(&mut state.context_messages, true)
+            .await
+    {
+        any_compacted = true;
+        let _ = emit(tx, AgentEvent::ContextCompacted { report }).await;
+    }
+
+    // Re-run sync transformer with overflow=true
+    if let Some(ref transformer) = config.transform_context
+        && let Some(report) = transformer.transform(&mut state.context_messages, true)
+    {
+        any_compacted = true;
+        let _ = emit(tx, AgentEvent::ContextCompacted { report }).await;
+    }
+
+    // Reset overflow signal after transformers ran.
+    state.overflow_signal = false;
+
+    // Guard 3: Transformers ran but neither reported compaction — no point retrying.
+    if !any_compacted {
+        debug!("transformers ran but no compaction occurred — surfacing error");
+        return overflow_error(config, state, tx).await;
+    }
+
+    // Check cancellation before retrying.
+    if cancellation_token.is_cancelled() {
+        return OverflowRecoveryResult::Failed(
+            handle_cancellation(config, state, tx).await,
+        );
+    }
+
+    // Re-run convert-to-LLM pipeline with compacted context.
+    let llm_messages: Vec<LlmMessage> = state
+        .context_messages
+        .iter()
+        .filter_map(|m| (config.convert_to_llm)(m))
+        .collect();
+
+    // Retry the stream call with compacted context.
+    let retry_result = stream_with_retry(
+        config,
+        agent_context,
+        &llm_messages,
+        system_prompt,
+        api_key,
+        cancellation_token,
+        tx,
+    )
+    .await;
+
+    // If the retry also overflows, surface the error — no further recovery.
+    if matches!(retry_result, StreamResult::ContextOverflow) {
+        debug!("retry after compaction still overflowed — surfacing error");
+        return overflow_error(config, state, tx).await;
+    }
+
+    OverflowRecoveryResult::Recovered(Box::new(retry_result))
+}
+
+/// Build an overflow error message and emit `TurnEnd` + `AgentEnd`.
+pub(super) async fn overflow_error(
+    config: &Arc<AgentLoopConfig>,
+    state: &mut LoopState,
+    tx: &mpsc::Sender<AgentEvent>,
+) -> OverflowRecoveryResult {
+    let error = crate::error::AgentError::ContextWindowOverflow {
+        model: config.model.model_id.clone(),
+    };
+    let error_msg = build_error_message(&config.model, &error);
+    let msg_for_event = error_msg.clone();
+    state
+        .context_messages
+        .push(AgentMessage::Llm(LlmMessage::Assistant(error_msg)));
+
+    let _ = emit(
+        tx,
+        AgentEvent::MessageEnd {
+            message: msg_for_event.clone(),
+        },
+    )
+    .await;
+
+    let snapshot = build_snapshot(state, StopReason::Error, None);
+    OverflowRecoveryResult::Failed(
+        emit_turn_end_and_agent_end(
+            msg_for_event,
+            vec![],
+            TurnEndReason::Error,
+            snapshot,
+            state,
+            tx,
+        )
+        .await,
+    )
+}

--- a/src/loop_/tool_dispatch.rs
+++ b/src/loop_/tool_dispatch.rs
@@ -14,7 +14,9 @@ use crate::tool_execution_policy::{ToolCallSummary, ToolExecutionPolicy};
 use crate::types::{ContentBlock, ToolResultMessage};
 use crate::util::now_timestamp;
 
-use super::{AgentEvent, AgentLoopConfig, ApproveToolFn, ToolCallInfo, ToolExecOutcome, emit};
+use crate::agent_options::ApproveToolFn;
+
+use super::{AgentEvent, AgentLoopConfig, ToolCallInfo, ToolExecOutcome, emit};
 
 // ─── Pre-processed tool call ─────────────────────────────────────────────────
 

--- a/src/loop_/turn.rs
+++ b/src/loop_/turn.rs
@@ -11,11 +11,12 @@ use crate::types::{
 };
 use crate::util::now_timestamp;
 
+use super::overflow::{OverflowRecoveryResult, attempt_overflow_recovery};
 use super::stream::{capability_filter_tools, stream_with_retry};
 use super::tool_dispatch::execute_tools_concurrently;
 use super::{
     AgentEvent, AgentLoopConfig, LoopState, StreamResult, ToolCallInfo,
-    ToolExecOutcome, TurnEndReason, TurnOutcome, build_abort_message, build_error_message, emit,
+    ToolExecOutcome, TurnEndReason, TurnOutcome, build_abort_message, emit,
 };
 
 /// Run a single turn of the inner loop: inject pending messages, transform
@@ -313,148 +314,6 @@ pub async fn run_single_turn(
     .await
 }
 
-// ─── Emergency overflow recovery ────────────────────────────────────────
-
-/// Outcome of an in-place overflow recovery attempt.
-enum OverflowRecoveryResult {
-    /// Recovery succeeded — the retry produced a new `StreamResult`.
-    Recovered(Box<StreamResult>),
-    /// Recovery failed — the turn should exit with this outcome.
-    Failed(TurnOutcome),
-}
-
-/// Attempt emergency in-place overflow recovery.
-///
-/// When the LLM rejects a request with a context-window overflow, this function
-/// re-runs context transformers with `overflow=true`, then retries the LLM call
-/// with the compacted context. If recovery is not possible (no transformers, no
-/// compaction, second overflow, or cancellation), it surfaces an error.
-#[allow(clippy::too_many_arguments)]
-async fn attempt_overflow_recovery(
-    config: &Arc<AgentLoopConfig>,
-    state: &mut LoopState,
-    system_prompt: &str,
-    agent_context: &crate::types::AgentContext,
-    api_key: Option<String>,
-    cancellation_token: &CancellationToken,
-    tx: &mpsc::Sender<AgentEvent>,
-) -> OverflowRecoveryResult {
-    // Guard 1: Already attempted recovery this turn — surface error.
-    if state.overflow_recovery_attempted {
-        debug!("second overflow in same turn — surfacing error");
-        return overflow_error(config, state, tx).await;
-    }
-
-    // Guard 2: No transformer configured — cannot compact.
-    if config.async_transform_context.is_none() && config.transform_context.is_none() {
-        debug!("no context transformer configured — cannot recover from overflow");
-        return overflow_error(config, state, tx).await;
-    }
-
-    // Mark recovery as attempted for this turn.
-    state.overflow_recovery_attempted = true;
-    state.overflow_signal = true;
-
-    // Re-run async transformer with overflow=true
-    let mut any_compacted = false;
-    if let Some(ref async_transformer) = config.async_transform_context
-        && let Some(report) = async_transformer
-            .transform(&mut state.context_messages, true)
-            .await
-    {
-        any_compacted = true;
-        let _ = emit(tx, AgentEvent::ContextCompacted { report }).await;
-    }
-
-    // Re-run sync transformer with overflow=true
-    if let Some(ref transformer) = config.transform_context
-        && let Some(report) = transformer.transform(&mut state.context_messages, true)
-    {
-        any_compacted = true;
-        let _ = emit(tx, AgentEvent::ContextCompacted { report }).await;
-    }
-
-    // Reset overflow signal after transformers ran.
-    state.overflow_signal = false;
-
-    // Guard 3: Transformers ran but neither reported compaction — no point retrying.
-    if !any_compacted {
-        debug!("transformers ran but no compaction occurred — surfacing error");
-        return overflow_error(config, state, tx).await;
-    }
-
-    // Check cancellation before retrying.
-    if cancellation_token.is_cancelled() {
-        return OverflowRecoveryResult::Failed(
-            handle_cancellation(config, state, tx).await,
-        );
-    }
-
-    // Re-run convert-to-LLM pipeline with compacted context.
-    let llm_messages: Vec<LlmMessage> = state
-        .context_messages
-        .iter()
-        .filter_map(|m| (config.convert_to_llm)(m))
-        .collect();
-
-    // Retry the stream call with compacted context.
-    let retry_result = stream_with_retry(
-        config,
-        agent_context,
-        &llm_messages,
-        system_prompt,
-        api_key,
-        cancellation_token,
-        tx,
-    )
-    .await;
-
-    // If the retry also overflows, surface the error — no further recovery.
-    if matches!(retry_result, StreamResult::ContextOverflow) {
-        debug!("retry after compaction still overflowed — surfacing error");
-        return overflow_error(config, state, tx).await;
-    }
-
-    OverflowRecoveryResult::Recovered(Box::new(retry_result))
-}
-
-/// Build an overflow error message and emit `TurnEnd` + `AgentEnd`.
-async fn overflow_error(
-    config: &Arc<AgentLoopConfig>,
-    state: &mut LoopState,
-    tx: &mpsc::Sender<AgentEvent>,
-) -> OverflowRecoveryResult {
-    let error = crate::error::AgentError::ContextWindowOverflow {
-        model: config.model.model_id.clone(),
-    };
-    let error_msg = build_error_message(&config.model, &error);
-    let msg_for_event = error_msg.clone();
-    state
-        .context_messages
-        .push(AgentMessage::Llm(LlmMessage::Assistant(error_msg)));
-
-    let _ = emit(
-        tx,
-        AgentEvent::MessageEnd {
-            message: msg_for_event.clone(),
-        },
-    )
-    .await;
-
-    let snapshot = build_snapshot(state, StopReason::Error, None);
-    OverflowRecoveryResult::Failed(
-        emit_turn_end_and_agent_end(
-            msg_for_event,
-            vec![],
-            TurnEndReason::Error,
-            snapshot,
-            state,
-            tx,
-        )
-        .await,
-    )
-}
-
 // ─── Shared helpers ──────────────────────────────────────────────────────
 
 /// Update accumulated usage/cost and track the last assistant message.
@@ -490,7 +349,7 @@ async fn emit_turn_metrics(
 ///
 /// Consolidates the repeated pattern of emitting these two terminal events
 /// and draining `context_messages` into the `AgentEnd` payload.
-async fn emit_turn_end_and_agent_end(
+pub(super) async fn emit_turn_end_and_agent_end(
     assistant_message: AssistantMessage,
     tool_results: Vec<ToolResultMessage>,
     reason: TurnEndReason,
@@ -527,7 +386,7 @@ async fn emit_turn_end_and_agent_end(
 ///
 /// Extracts LLM messages from `context_messages`, using the accumulated
 /// usage/cost and the given stop reason.
-fn build_snapshot(state: &LoopState, stop_reason: StopReason, state_delta: Option<crate::StateDelta>) -> TurnSnapshot {
+pub(super) fn build_snapshot(state: &LoopState, stop_reason: StopReason, state_delta: Option<crate::StateDelta>) -> TurnSnapshot {
     let llm_messages: Vec<LlmMessage> = state
         .context_messages
         .iter()
@@ -566,7 +425,7 @@ async fn flush_state_delta(
 // ─── run_single_turn helpers ─────────────────────────────────────────────────
 
 /// Emit cancellation events and return from the loop.
-async fn handle_cancellation(
+pub(super) async fn handle_cancellation(
     config: &Arc<AgentLoopConfig>,
     state: &mut LoopState,
     tx: &mpsc::Sender<AgentEvent>,

--- a/src/loop_/types.rs
+++ b/src/loop_/types.rs
@@ -1,0 +1,77 @@
+//! Internal type definitions shared across loop submodules.
+
+use crate::types::{AgentMessage, AssistantMessage, LlmMessage, ToolResultMessage};
+
+// ─── Type Aliases ────────────────────────────────────────────────────────────
+
+/// Converts an `AgentMessage` to an optional `LlmMessage` for the provider.
+pub type ConvertToLlmFn = dyn Fn(&AgentMessage) -> Option<LlmMessage> + Send + Sync;
+
+// ─── LoopState ──────────────────────────────────────────────────────────────
+
+/// Mutable state threaded through the loop iterations.
+pub struct LoopState {
+    pub context_messages: Vec<AgentMessage>,
+    pub pending_messages: Vec<AgentMessage>,
+    pub overflow_signal: bool,
+    /// Whether emergency overflow recovery has already been attempted this turn.
+    /// Resets to `false` at the start of each turn.
+    pub overflow_recovery_attempted: bool,
+    pub turn_index: usize,
+    pub accumulated_usage: crate::types::Usage,
+    pub accumulated_cost: crate::types::Cost,
+    /// The last assistant message from a completed turn (for policy checks).
+    pub last_assistant_message: Option<AssistantMessage>,
+    /// Tool results from the last completed turn (for post-turn hook).
+    pub last_tool_results: Vec<ToolResultMessage>,
+}
+
+// ─── TurnOutcome ────────────────────────────────────────────────────────────
+
+/// Outcome of a single turn execution within the inner loop.
+pub enum TurnOutcome {
+    /// Continue to the next inner-loop iteration (tool results need processing).
+    ContinueInner,
+    /// Break out of the inner loop (no tool calls, check follow-ups).
+    BreakInner,
+    /// Return from the entire loop (channel closed, error, or abort).
+    Return,
+}
+
+// ─── ToolCallInfo ───────────────────────────────────────────────────────────
+
+/// Info about a tool call extracted from the assistant message.
+pub struct ToolCallInfo {
+    pub id: String,
+    pub name: String,
+    pub arguments: serde_json::Value,
+    pub is_incomplete: bool,
+}
+
+// ─── StreamResult ───────────────────────────────────────────────────────────
+
+/// Result of streaming an assistant response.
+#[allow(clippy::large_enum_variant)]
+pub enum StreamResult {
+    Message(AssistantMessage),
+    ContextOverflow,
+    Aborted,
+    ChannelClosed,
+}
+
+// ─── ToolExecOutcome ────────────────────────────────────────────────────────
+
+/// Outcome of concurrent tool execution.
+pub enum ToolExecOutcome {
+    Completed {
+        results: Vec<ToolResultMessage>,
+        tool_metrics: Vec<crate::metrics::ToolExecMetrics>,
+    },
+    SteeringInterrupt {
+        completed: Vec<ToolResultMessage>,
+        cancelled: Vec<ToolResultMessage>,
+        steering_messages: Vec<AgentMessage>,
+        tool_metrics: Vec<crate::metrics::ToolExecMetrics>,
+    },
+    ChannelClosed,
+}


### PR DESCRIPTION
## Summary
- Split `mod.rs` (702→373 lines) into `event.rs`, `config.rs`, and `types.rs`
- Extracted overflow recovery from `turn.rs` (894→753 lines) into `overflow.rs`
- Public API unchanged — same `lib.rs` re-exports, zero test modifications

## Test plan
- [x] `cargo build --workspace` — clean
- [x] `cargo clippy --workspace -- -D warnings` — zero warnings
- [x] `cargo test --workspace` — all tests pass
- [x] `cargo test -p swink-agent --no-default-features` — feature gate verified

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)