### PR TITLE
Add spec 017: xAI adapter with plan and tasks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,6 +195,8 @@ MSRV **1.88** (edition 2024). Workspace deps centralized in root `Cargo.toml`.
 - N/A (in-memory state only — connection handles and discovered tool lists) (038-mcp-integration)
 - Rust 1.88, edition 2024 + `reqwest` (HTTP + token acquisition), `tokio` (async runtime), `serde`/`serde_json` (serialization), `tracing` (diagnostics), `swink-agent` (core types). All workspace deps. (016-adapter-azure)
 - N/A (in-memory token cache only) (016-adapter-azure)
+- Rust 1.88 (edition 2024) + `swink-agent` (core), `swink-agent-adapters` (shared infra: `openai_compat`, `classify`, `sse`, `convert`, `base`) (017-adapter-xai)
+- N/A (stateless adapter) (017-adapter-xai)
 
 ## Recent Changes
 - 001-workspace-scaffold: Added Rust 1.88 (edition 2024) + serde, serde_json, tokio, futures, thiserror, uuid, reqwest, jsonschema, schemars, rand, tracing, toml (all centralized in workspace `[workspace.dependencies]`)

--- a/specs/017-adapter-xai/contracts/public-api.md
+++ b/specs/017-adapter-xai/contracts/public-api.md
@@ -1,0 +1,66 @@
+# Public API Contract: swink-agent-adapters (xAI)
+
+**Feature**: 017-adapter-xai | **Date**: 2026-04-02
+
+## Feature Gate
+
+```toml
+[dependencies]
+swink-agent-adapters = { features = ["xai"] }
+```
+
+## Public Type
+
+### `XAiStreamFn`
+
+```rust
+pub struct XAiStreamFn { /* private */ }
+
+impl XAiStreamFn {
+    /// Create a new xAI stream function.
+    ///
+    /// # Arguments
+    /// * `base_url` - xAI API base URL (e.g. `https://api.x.ai`)
+    /// * `api_key` - Bearer token for authentication
+    pub fn new(base_url: impl Into<String>, api_key: impl Into<String>) -> Self;
+}
+
+impl StreamFn for XAiStreamFn {
+    fn stream<'a>(
+        &'a self,
+        model: &'a ModelSpec,
+        context: &'a AgentContext,
+        options: &'a StreamOptions,
+        cancellation_token: CancellationToken,
+    ) -> Pin<Box<dyn Stream<Item = AssistantMessageEvent> + Send + 'a>>;
+}
+
+impl Debug for XAiStreamFn { /* redacted credentials */ }
+// Send + Sync enforced at compile time
+```
+
+## Usage Example
+
+```rust
+use swink_agent_adapters::XAiStreamFn;
+
+let stream_fn = XAiStreamFn::new("https://api.x.ai", "xai-api-key-here");
+// Use with Agent::new() or directly via stream_fn.stream()
+```
+
+## Wire Protocol
+
+- **Endpoint**: `POST {base_url}/v1/chat/completions`
+- **Auth**: `Authorization: Bearer {api_key}`
+- **Request body**: OpenAI chat completions format (`OaiChatRequest`)
+- **Response**: SSE stream of `chat.completion.chunk` objects
+- **Terminal**: `data: [DONE]`
+
+## Behavioral Contract
+
+1. Text deltas arrive as individual `AssistantMessageEvent::TextDelta` events
+2. Tool calls emit `ToolCallStart`, `ToolCallDelta`, then accumulated on `[DONE]`
+3. HTTP errors classified via shared classifier (429→throttled, 401/403→auth, 5xx→network)
+4. Network errors produce `AssistantMessageEvent::error_network()`
+5. Cancellation token terminates the stream immediately
+6. Usage data requested via `stream_options` and surfaced in terminal event

--- a/specs/017-adapter-xai/data-model.md
+++ b/specs/017-adapter-xai/data-model.md
@@ -1,0 +1,65 @@
+# Data Model: Adapter xAI
+
+**Feature**: 017-adapter-xai | **Date**: 2026-04-02
+
+## Entities
+
+### XAiStreamFn
+
+The sole public type. A thin wrapper that delegates to `OpenAiStreamFn` for all transport logic.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `inner` | `OpenAiStreamFn` | Wrapped OpenAI-compatible stream function |
+
+**Constructor**: `XAiStreamFn::new(base_url, api_key)` — creates inner `OpenAiStreamFn` with provided credentials.
+
+**Trait implementations**:
+- `StreamFn` — delegates to `inner.stream()`
+- `Debug` — shows struct name with redacted credentials
+- `Send + Sync` — enforced via compile-time assertion
+
+### Model Catalog Presets (TOML, not Rust types)
+
+Provider entry in `src/model_catalog.toml`:
+
+| Field | Value |
+|-------|-------|
+| `key` | `"xai"` |
+| `display_name` | `"xAI"` |
+| `kind` | `"remote"` |
+| `auth_mode` | `"bearer"` |
+| `credential_env_var` | `"XAI_API_KEY"` |
+| `base_url_env_var` | `"XAI_BASE_URL"` |
+| `default_base_url` | `"https://api.x.ai"` |
+
+Preset entries (5 models):
+
+| Preset ID | Model ID | Context | Max Output | Cost In/Out |
+|-----------|----------|---------|------------|-------------|
+| `grok_4_20_reasoning` | `grok-4.20-0309-reasoning` | 2M | 16384 | $2.00/$6.00 |
+| `grok_4_20_non_reasoning` | `grok-4.20-0309-non-reasoning` | 2M | 16384 | $2.00/$6.00 |
+| `grok_4_1_fast_reasoning` | `grok-4-1-fast-reasoning` | 2M | 16384 | $0.20/$0.50 |
+| `grok_4_1_fast_non_reasoning` | `grok-4-1-fast-non-reasoning` | 2M | 16384 | $0.20/$0.50 |
+| `grok_4_20_multi_agent` | `grok-4.20-multi-agent-0309` | 2M | 16384 | $2.00/$6.00 |
+
+All presets share: `capabilities = ["text", "tools", "images_in", "streaming", "structured_output"]`, `status = "ga"`, `api_version = "v1"`.
+
+## Relationships
+
+```
+XAiStreamFn --wraps--> OpenAiStreamFn --uses--> AdapterBase
+                                       --uses--> OaiConverter (message conversion)
+                                       --uses--> OaiChatRequest (request body)
+                                       --uses--> parse_oai_sse_stream() (response parsing)
+```
+
+## State Transitions
+
+None — `XAiStreamFn` is stateless. Each `stream()` call is independent.
+
+## Validation Rules
+
+- `base_url` must not be empty (enforced by `AdapterBase`)
+- `api_key` must not be empty (enforced by `AdapterBase`)
+- Model ID is passed through to the API (xAI validates server-side)

--- a/specs/017-adapter-xai/plan.md
+++ b/specs/017-adapter-xai/plan.md
@@ -1,0 +1,120 @@
+# Implementation Plan: Adapter xAI
+
+**Branch**: `017-adapter-xai` | **Date**: 2026-04-02 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/017-adapter-xai/spec.md`
+
+## Summary
+
+Implement the xAI (Grok) streaming chat adapter. The adapter code (`xai.rs`) already exists as a thin wrapper around `OpenAiStreamFn` — this is architecturally correct since xAI follows the OpenAI chat completions protocol exactly. Remaining work: update stale model catalog presets from grok-3 to current grok-4.x models, add comprehensive live tests, and wire up the `remote_presets` module for catalog-driven construction.
+
+## Technical Context
+
+**Language/Version**: Rust 1.88 (edition 2024)
+**Primary Dependencies**: `swink-agent` (core), `swink-agent-adapters` (shared infra: `openai_compat`, `classify`, `sse`, `convert`, `base`)
+**Storage**: N/A (stateless adapter)
+**Testing**: `cargo test` — unit tests (mocked SSE) + live tests (`#[ignore]`, requires `XAI_API_KEY`)
+**Target Platform**: Any (library crate)
+**Project Type**: Library
+**Performance Goals**: Streaming latency ≤ provider latency (zero buffering overhead)
+**Constraints**: No `unsafe`, no new dependencies, reuse shared infra exclusively
+**Scale/Scope**: ~50 lines adapter code (already written), ~100 lines catalog updates, ~200 lines live tests
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Library-First | PASS | Adapter is a library type in the adapters crate. No new crate needed. |
+| II. Test-Driven Development | PASS | Live tests planned before any behavioral changes. |
+| III. Efficiency & Performance | PASS | Zero-copy delegation to `OpenAiStreamFn`. No extra allocations. |
+| IV. Leverage the Ecosystem | PASS | Reuses all shared infra (`openai_compat`, `sse`, `classify`, `convert`). No hand-rolled protocol handling. |
+| V. Provider Agnosticism | PASS | `XAiStreamFn` implements `StreamFn`. Core crate untouched. |
+| VI. Safety & Correctness | PASS | `#[forbid(unsafe_code)]` inherited from crate root. Compile-time `Send + Sync` assertion present. |
+
+**Architectural Constraints**:
+- Crate count: unchanged (adapters crate absorbs this)
+- MSRV: 1.88 ✓
+- No new dependencies required
+
+**Post-Phase 1 Re-check**: All gates still pass. No design decisions required normalization or new crates.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/017-adapter-xai/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+│   └── public-api.md
+└── tasks.md             # Phase 2 output (created by /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+adapters/src/
+├── xai.rs               # XAiStreamFn (exists — ~50 lines, delegates to OpenAiStreamFn)
+├── lib.rs               # Feature-gated mod + pub use (exists)
+├── remote_presets.rs     # build_remote_connection match arm for "xai" (needs update)
+└── openai_compat.rs     # Shared types/parser (unchanged)
+
+src/
+└── model_catalog.toml   # xAI provider + presets (needs update: grok-3 → grok-4.x)
+
+adapters/tests/
+└── xai_live.rs          # Live integration tests (new)
+```
+
+**Structure Decision**: No new modules or crates. All changes fit within existing adapter crate structure following the established pattern from OpenAI, Mistral, and Gemini adapters.
+
+## Implementation Phases
+
+### Phase 1: Model Catalog Update
+
+Update `src/model_catalog.toml`:
+- Replace 2 stale `grok-3`/`grok-3-fast` presets with 5 current grok-4.x models
+- Update context windows from 131K to 2M tokens
+- Update pricing to current rates
+- Add `"structured_output"` capability to all presets
+
+### Phase 2: Remote Presets Wiring
+
+Update `adapters/src/remote_presets.rs`:
+- Verify the `"xai"` match arm in `build_remote_connection()` creates `XAiStreamFn`
+- Ensure it correctly resolves base URL and API key from preset/env
+
+### Phase 3: Live Tests
+
+Create `adapters/tests/xai_live.rs` following the OpenAI/Mistral live test pattern:
+- Text streaming test (simple prompt → verify incremental deltas + terminal event)
+- Tool call test (prompt with tool definitions → verify tool call events with valid JSON args)
+- Error handling test (invalid API key → verify auth error classification)
+- Cancellation test (cancel mid-stream → verify clean termination)
+- Multi-tool test (prompt likely to trigger multiple tool calls → verify separate indexed blocks)
+
+All tests `#[ignore]` (require `XAI_API_KEY`), 30s timeout, use cheapest model (`grok-4-1-fast-non-reasoning`).
+
+### Phase 4: Verification
+
+- `cargo build --workspace` passes
+- `cargo test --workspace` passes
+- `cargo clippy --workspace -- -D warnings` clean
+- `cargo test -p swink-agent-adapters --no-default-features --features xai` compiles and runs
+- Live tests pass with real xAI API key (manual verification)
+
+## Complexity Tracking
+
+No constitution violations. No complexity justifications needed.
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| xAI rejects `stream_options` field | Low | Lenient parsing handles gracefully; can add custom request type as follow-up |
+| Stale model IDs (grok-4.x renamed/deprecated) | Low | Catalog is data, easily updated without code changes |
+| Usage data format differs from OpenAI | Low | Shared parser already handles usage in any chunk position |

--- a/specs/017-adapter-xai/quickstart.md
+++ b/specs/017-adapter-xai/quickstart.md
@@ -1,0 +1,65 @@
+# Quickstart: xAI Adapter
+
+**Feature**: 017-adapter-xai | **Date**: 2026-04-02
+
+## Prerequisites
+
+- Rust 1.88+ (edition 2024)
+- xAI API key (set `XAI_API_KEY` env var or pass directly)
+
+## Add Dependency
+
+```toml
+[dependencies]
+swink-agent-adapters = { path = "../adapters", features = ["xai"] }
+```
+
+## Basic Usage
+
+```rust
+use swink_agent_adapters::XAiStreamFn;
+use swink_agent::types::ModelSpec;
+
+// Create the adapter
+let stream_fn = XAiStreamFn::new(
+    "https://api.x.ai",
+    std::env::var("XAI_API_KEY").unwrap(),
+);
+
+// Use with an Agent
+let agent = Agent::builder()
+    .model(ModelSpec::new("grok-4-1-fast-non-reasoning"))
+    .stream_fn(stream_fn)
+    .build();
+```
+
+## Using Model Catalog Presets
+
+```rust
+use swink_agent::model_catalog::ModelCatalog;
+use swink_agent_adapters::build_remote_connection;
+
+let catalog = ModelCatalog::load();
+let preset = catalog.preset("grok_4_1_fast_non_reasoning").unwrap();
+let (stream_fn, model_spec) = build_remote_connection(&preset, None)?;
+```
+
+## Run Tests
+
+```bash
+# Unit tests (no API key needed)
+cargo test -p swink-agent-adapters --features xai
+
+# Live tests (requires XAI_API_KEY)
+cargo test -p swink-agent-adapters --test xai_live -- --ignored
+```
+
+## Available Models
+
+| Preset ID | Model | Best For |
+|-----------|-------|----------|
+| `grok_4_20_reasoning` | Grok 4.20 Reasoning | Complex reasoning tasks |
+| `grok_4_20_non_reasoning` | Grok 4.20 | General-purpose, high quality |
+| `grok_4_1_fast_reasoning` | Grok 4.1 Fast Reasoning | Fast agentic tool calling |
+| `grok_4_1_fast_non_reasoning` | Grok 4.1 Fast | Fast, cheap general use |
+| `grok_4_20_multi_agent` | Grok 4.20 Multi-Agent | Multi-agent workflows |

--- a/specs/017-adapter-xai/research.md
+++ b/specs/017-adapter-xai/research.md
@@ -1,0 +1,74 @@
+# Research: Adapter xAI
+
+**Feature**: 017-adapter-xai | **Date**: 2026-04-02
+
+## R1: xAI API Protocol Compatibility
+
+**Decision**: xAI follows the OpenAI chat completions protocol — reuse `OpenAiStreamFn` internals directly.
+
+**Rationale**: xAI explicitly documents OpenAI SDK compatibility (`base_url="https://api.x.ai/v1"`). The SSE streaming format is identical: `chat.completion.chunk` objects, `choices[].delta.content`, `data: [DONE]` sentinel. Message roles, tool call format, and tool definitions all match OpenAI.
+
+**Alternatives considered**:
+- Custom xAI-specific protocol implementation → rejected (unnecessary, xAI uses OpenAI protocol)
+- Proactive normalizer layer (Mistral pattern) → rejected (no known xAI-specific divergences unlike Mistral's ID format issues)
+
+## R2: Authentication
+
+**Decision**: Bearer token via `Authorization: Bearer <XAI_API_KEY>` header.
+
+**Rationale**: Matches xAI docs and all other OpenAI-compatible adapters (OpenAI, Mistral, Azure).
+
+**Alternatives considered**: None — Bearer is the only documented auth mechanism.
+
+## R3: stream_options Behavior
+
+**Decision**: Send `stream_options: { include_usage: true }` in request body (same as OpenAI adapter). If xAI rejects it, lenient parsing handles the error gracefully.
+
+**Rationale**: xAI may include usage data automatically in streaming chunks (some reports suggest usage appears in every chunk, not just the final one). The OpenAI-compatible shared parser already handles usage extraction from any chunk. Sending `stream_options` is harmless if ignored and beneficial if honored. If xAI rejects the field entirely, the HTTP error path handles it cleanly and we can add a custom request type (like Mistral did) as a follow-up.
+
+**Alternatives considered**:
+- Custom `XAiChatRequest` without `stream_options` (Mistral pattern) → deferred unless testing reveals rejection
+- Not requesting usage at all → rejected (budget policies need token counts)
+
+## R4: Model Catalog — Current Grok Models
+
+**Decision**: Update catalog from stale grok-3 entries to current grok-4.x lineup.
+
+**Rationale**: xAI's model page (as of April 2026) lists:
+
+| Model ID | Context | Cost (in/out per 1M) | Capabilities |
+|---|---|---|---|
+| `grok-4.20-0309-reasoning` | 2M | $2.00 / $6.00 | text, tools, vision, structured output, reasoning |
+| `grok-4.20-0309-non-reasoning` | 2M | $2.00 / $6.00 | text, tools, vision, structured output |
+| `grok-4-1-fast-reasoning` | 2M | $0.20 / $0.50 | text, tools, vision, structured output, reasoning |
+| `grok-4-1-fast-non-reasoning` | 2M | $0.20 / $0.50 | text, tools, vision, structured output |
+| `grok-4.20-multi-agent-0309` | 2M | $2.00 / $6.00 | text, tools, vision, structured output, reasoning |
+
+Cached input pricing: $0.20/M (grok-4.20), $0.05/M (grok-4-1-fast). All models support tool calling and vision.
+
+**Alternatives considered**:
+- Keep grok-3 entries → rejected (models no longer listed, likely deprecated)
+- Minimal catalog (1-2 models) → rejected (clarification decided comprehensive coverage)
+
+## R5: Existing Implementation State
+
+**Decision**: The adapter code (`adapters/src/xai.rs`) already exists as a thin wrapper delegating to `OpenAiStreamFn`. This is architecturally correct. The remaining work is:
+
+1. Update model catalog presets (stale grok-3 → current grok-4.x)
+2. Add live tests (text streaming, tool calls, error handling)
+3. Verify `stream_options` behavior with real xAI API
+
+**Rationale**: The existing 50-line wrapper is the correct architecture — xAI's protocol is identical to OpenAI's with no known quirks requiring normalization. The feature gate, `lib.rs` re-export, and `Cargo.toml` entry are already in place.
+
+## R6: Known xAI Quirks
+
+**Decision**: No dedicated quirk handling needed at this time.
+
+**Findings**:
+- Usage may appear in every streaming chunk (not just final) — shared parser already handles this
+- No tool call ID format restrictions (unlike Mistral's 9-char limit)
+- `finish_reason` values match OpenAI (`stop`, `tool_calls`, `length`)
+- Reasoning models (`*-reasoning`) may return reasoning content — not yet handled by the adapter but not blocking (content arrives as normal text deltas)
+- `presencePenalty`, `frequencyPenalty`, `stop` params unsupported by reasoning models — not currently passed by the adapter
+
+**Alternatives considered**: Proactive normalizer → rejected per clarification (lenient parsing only).

--- a/specs/017-adapter-xai/spec.md
+++ b/specs/017-adapter-xai/spec.md
@@ -74,10 +74,10 @@ A developer encounters various error conditions when communicating with the xAI 
 
 ### Edge Cases
 
-- What happens when xAI returns response fields that differ from standard OpenAI format?
-- How does the adapter handle xAI-specific rate limiting patterns?
+- When xAI returns response fields that differ from standard OpenAI format, they are handled via lenient parsing (tolerant deserialization, unknown fields ignored) — no dedicated normalizer layer.
+- xAI rate limiting (HTTP 429) is handled by the shared error classifier + core retry backoff strategy; no `Retry-After` header extraction (consistent with other adapters).
 - What happens when the xAI API returns an error format different from OpenAI's error schema?
-- How does the adapter handle model names that are xAI-specific (e.g., Grok variants)?
+- xAI-specific model names (Grok variants) are handled via comprehensive model catalog presets covering all currently available models (Grok-2, Grok-2-mini, Grok-3, vision variants).
 
 ## Requirements *(mandatory)*
 
@@ -89,6 +89,7 @@ A developer encounters various error conditions when communicating with the xAI 
 - **FR-004**: The adapter MUST convert agent messages to the chat completions message format using the shared conversion trait.
 - **FR-005**: The adapter MUST classify HTTP errors using the shared error classifier (429 → rate limit, 401/403 → auth, 5xx → network, timeout → network).
 - **FR-006**: The adapter MUST handle xAI-specific response quirks gracefully without panics or data loss.
+- **FR-007**: The adapter MUST request usage/token data via `stream_options: { include_usage: true }` to enable budget policies and cost tracking.
 
 ### Key Entities
 
@@ -102,6 +103,15 @@ A developer encounters various error conditions when communicating with the xAI 
 - **SC-002**: Tool calls produce valid, parseable JSON arguments upon completion.
 - **SC-003**: The adapter correctly targets the xAI endpoint and authenticates successfully.
 - **SC-004**: All xAI error codes map to the correct agent error types consistently.
+
+## Clarifications
+
+### Session 2026-04-02
+
+- Q: What quirk-handling strategy should the xAI adapter use? → A: Lenient parsing only (like OpenAI adapter) — no normalizer layer; handle minor quirks via tolerant deserialization.
+- Q: How many xAI models should be added to the model catalog? → A: Comprehensive — all currently available Grok models (Grok-2, Grok-2-mini, Grok-3, vision variants).
+- Q: Should the xAI adapter request usage tracking in streaming responses? → A: Yes, request usage via `stream_options: { include_usage: true }` — enables token/cost tracking; ignored via lenient parsing if unsupported.
+- Q: Should the adapter extract `Retry-After` from xAI 429 responses? → A: No — rely on shared error classifier + core retry backoff, consistent with other adapters.
 
 ## Assumptions
 

--- a/specs/017-adapter-xai/tasks.md
+++ b/specs/017-adapter-xai/tasks.md
@@ -1,0 +1,163 @@
+# Tasks: Adapter xAI
+
+**Input**: Design documents from `/specs/017-adapter-xai/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup (Model Catalog & Presets)
+
+**Purpose**: Update stale model catalog and remote preset constants to current Grok 4.x models
+
+- [ ] T001 Replace stale grok-3 and grok-3-fast presets with 5 current grok-4.x model entries in src/model_catalog.toml (grok-4.20-0309-reasoning, grok-4.20-0309-non-reasoning, grok-4-1-fast-reasoning, grok-4-1-fast-non-reasoning, grok-4.20-multi-agent-0309; all 2M context, capabilities: text/tools/images_in/streaming/structured_output)
+- [ ] T002 Update RemotePresetKey constants in adapters/src/remote_presets.rs: replace GROK_3/GROK_3_FAST with GROK_4_20_REASONING, GROK_4_20_NON_REASONING, GROK_4_1_FAST_REASONING, GROK_4_1_FAST_NON_REASONING, GROK_4_20_MULTI_AGENT
+- [ ] T003 Update the added_provider_presets_map_to_catalog_models test in adapters/src/remote_presets.rs to use new preset keys and verify correct model_id mapping
+
+**Checkpoint**: `cargo test -p swink-agent-adapters --features xai` passes with updated catalog and preset constants
+
+---
+
+## Phase 2: User Story 1 — Stream Text Responses from xAI (Priority: P1) MVP
+
+**Goal**: Verify that text content streams incrementally from the xAI endpoint via SSE
+
+**Independent Test**: Send a simple prompt to the xAI endpoint and verify text deltas arrive incrementally with a terminal Done event
+
+### Implementation for User Story 1
+
+- [ ] T004 [US1] Create adapters/tests/xai_live.rs with module-level cfg gate, imports, constants (TIMEOUT = 30s), and helper functions: xai_key() (reads XAI_API_KEY via dotenvy), cheap_model() (grok-4-1-fast-non-reasoning), simple_context(), collect_events(), event_name()
+- [ ] T005 [US1] Add live_text_stream test in adapters/tests/xai_live.rs: send simple prompt, assert Start/TextStart/TextDelta/TextEnd/Done events present and assembled text is non-empty
+- [ ] T006 [US1] Add live_usage_and_cost test in adapters/tests/xai_live.rs: send simple prompt, assert Done event contains non-zero input and output token counts
+- [ ] T007 [US1] Add live_stop_reason_mapping test in adapters/tests/xai_live.rs: send simple prompt, assert Done event has StopReason::Stop
+
+**Checkpoint**: `cargo test -p swink-agent-adapters --test xai_live -- --ignored` passes for text streaming tests (requires XAI_API_KEY)
+
+---
+
+## Phase 3: User Story 2 — Stream Tool Call Responses from xAI (Priority: P1)
+
+**Goal**: Verify that tool calls stream correctly with names, IDs, and parseable JSON arguments
+
+**Independent Test**: Send a prompt with tool definitions and verify ToolCallStart/ToolCallEnd events with correct tool name and valid JSON args
+
+### Implementation for User Story 2
+
+- [ ] T008 [US2] Add DummyTool struct (get_weather) in adapters/tests/xai_live.rs implementing AgentTool with JSON schema for city parameter
+- [ ] T009 [US2] Add live_tool_use_stream test in adapters/tests/xai_live.rs: send prompt with get_weather tool, assert ToolCallStart with name "get_weather", ToolCallEnd present, and StopReason::ToolUse
+- [ ] T010 [US2] Add live_multi_turn_context test in adapters/tests/xai_live.rs: send two-turn conversation (introduce name, then ask for recall), assert second reply contains the introduced name
+
+**Checkpoint**: `cargo test -p swink-agent-adapters --test xai_live -- --ignored` passes for all tool call tests
+
+---
+
+## Phase 4: User Story 3 — Connect to xAI-Specific Endpoint (Priority: P2)
+
+**Goal**: Verify that the adapter targets the correct xAI endpoint with proper Bearer authentication
+
+**Independent Test**: Verify correct URL construction and auth header by testing with invalid credentials
+
+### Implementation for User Story 3
+
+- [ ] T011 [US3] Add live_invalid_key_returns_auth_error test in adapters/tests/xai_live.rs: create XAiStreamFn with bogus key, assert Error event with auth-related message
+
+**Checkpoint**: Auth error test passes confirming correct endpoint targeting and error classification
+
+---
+
+## Phase 5: User Story 4 — Handle Errors from xAI (Priority: P2)
+
+**Goal**: Verify HTTP error codes are classified correctly via the shared error classifier
+
+**Independent Test**: Trigger auth error with invalid key and verify correct error classification
+
+### Implementation for User Story 4
+
+- [ ] T012 [US4] Verify error classification is handled by existing shared infra in adapters/src/classify.rs — no xAI-specific error handling code needed (covered by T011 auth error test and shared classifier unit tests)
+
+**Checkpoint**: All error classification verified through existing shared tests + live auth error test
+
+---
+
+## Phase 6: Polish & Verification
+
+**Purpose**: Build verification, clippy clean, feature-gate isolation
+
+- [ ] T013 Run cargo build --workspace and verify clean compilation
+- [ ] T014 Run cargo test --workspace and verify all tests pass
+- [ ] T015 Run cargo clippy --workspace -- -D warnings and verify zero warnings
+- [ ] T016 Run cargo test -p swink-agent-adapters --no-default-features --features xai and verify xai feature compiles and runs in isolation
+- [ ] T017 Update adapters/CLAUDE.md to change xai status from "Stub" to "Implemented" in the feature gates table
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies — start immediately
+- **Phase 2 (US1 Text Streaming)**: Depends on Phase 1 (needs correct model IDs for cheap_model())
+- **Phase 3 (US2 Tool Calls)**: Depends on Phase 2 (reuses test helpers from T004)
+- **Phase 4 (US3 Endpoint)**: Depends on Phase 2 (reuses test helpers from T004)
+- **Phase 5 (US4 Errors)**: Depends on Phase 4 (T011 covers the error case)
+- **Phase 6 (Polish)**: Depends on all previous phases
+
+### User Story Dependencies
+
+- **US1 (Text Streaming)**: Independent after Phase 1
+- **US2 (Tool Calls)**: Shares test file with US1 but independent test scenarios
+- **US3 (Endpoint)**: Independent test (invalid key)
+- **US4 (Error Handling)**: Covered by shared infra + US3 auth error test
+
+### Parallel Opportunities
+
+- T001, T002, T003 can run sequentially (same files/dependencies)
+- T005, T006, T007 are parallel (independent test functions, same file)
+- T009, T010 are parallel (independent test functions)
+- T013, T014, T015 are sequential (build → test → clippy)
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# After T004 creates test infrastructure, launch US1 tests in parallel:
+Task T005: "live_text_stream test in adapters/tests/xai_live.rs"
+Task T006: "live_usage_and_cost test in adapters/tests/xai_live.rs"
+Task T007: "live_stop_reason_mapping test in adapters/tests/xai_live.rs"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Update model catalog + preset constants
+2. Complete Phase 2: Text streaming live tests
+3. **STOP and VALIDATE**: Run live tests with XAI_API_KEY
+4. Adapter is usable for basic text generation
+
+### Incremental Delivery
+
+1. Phase 1 → Catalog current, presets wired
+2. Phase 2 → Text streaming verified (MVP!)
+3. Phase 3 → Tool calls verified
+4. Phase 4 + 5 → Error handling verified
+5. Phase 6 → Clean build, docs updated
+
+---
+
+## Notes
+
+- The adapter code (adapters/src/xai.rs) already exists and is complete — no code changes needed there
+- Feature gate, lib.rs re-export, and Cargo.toml entry are already in place
+- All live tests require XAI_API_KEY and use grok-4-1-fast-non-reasoning (cheapest model at $0.20/$0.50 per 1M tokens)
+- Tests follow the established pattern from openai_live.rs

--- a/specs/spec-status.md
+++ b/specs/spec-status.md
@@ -1,5 +1,5 @@
 # Spec-Driven Development Status
-<!-- spec-status: project=Swink-Agent commit=8bd7e1ce8c61d4cb13d2b21d72146488cfed25d6 updated=2026-04-01T23:47:13Z -->
+<!-- spec-status: project=Swink-Agent commit=445de8efb409d8e981f6c3db7f8025d86445f2ca updated=2026-04-02T14:51:14Z -->
 
 | Feature                         | Specify | Plan | Tasks | Implement |
 |---------------------------------|---------|------|-------|-----------|
@@ -18,7 +18,7 @@
 | 013-adapter-openai              | ✓     | ✓  | ✓   | ✓ Complete |
 | 014-adapter-ollama              | ✓     | ✓  | ✓   | ✓ Complete |
 | 015-adapter-gemini              | ✓     | ✓  | ✓   | ✓ Complete |
-| 016-adapter-azure               | ✓     | -    | -     | -         |
+| 016-adapter-azure               | ✓     | ✓  | ✓   | ● 0/54 (0%) |
 | 017-adapter-xai                 | ✓     | -    | -     | -         |
 | 018-adapter-mistral             | ✓     | ✓  | ✓   | ✓ Complete |
 | 019-adapter-bedrock             | ✓     | -    | -     | -         |
@@ -40,6 +40,7 @@
 | 035-credential-management       | ✓     | ✓  | ✓   | ● 0/73 (0%) |
 | 036-artifact-service            | ✓     | -    | -     | -         |
 | 037-plugin-system               | ✓     | -    | -     | -         |
+| 038-mcp-integration             | ✓     | ✓  | ✓   | ● 0/49 (0%) |
 
 <!-- feature: 001-workspace-scaffold has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=false has_checklists=true tasks_total=24 tasks_completed=24 checklist_files=requirements.md -->
 <!-- feature: 002-foundation-types-errors has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=63 tasks_completed=63 checklist_files=requirements.md -->
@@ -56,7 +57,7 @@
 <!-- feature: 013-adapter-openai has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=73 tasks_completed=73 checklist_files=requirements.md -->
 <!-- feature: 014-adapter-ollama has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=74 tasks_completed=74 checklist_files=requirements.md -->
 <!-- feature: 015-adapter-gemini has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=44 tasks_completed=44 checklist_files=requirements.md -->
-<!-- feature: 016-adapter-azure has_spec=true has_plan=false has_tasks=false has_research=false has_data_model=false has_quickstart=false has_contracts=false has_checklists=true tasks_total=0 tasks_completed=0 checklist_files=requirements.md -->
+<!-- feature: 016-adapter-azure has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=54 tasks_completed=0 checklist_files=requirements.md -->
 <!-- feature: 017-adapter-xai has_spec=true has_plan=false has_tasks=false has_research=false has_data_model=false has_quickstart=false has_contracts=false has_checklists=true tasks_total=0 tasks_completed=0 checklist_files=requirements.md -->
 <!-- feature: 018-adapter-mistral has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=42 tasks_completed=42 checklist_files=requirements.md -->
 <!-- feature: 019-adapter-bedrock has_spec=true has_plan=false has_tasks=false has_research=false has_data_model=false has_quickstart=false has_contracts=false has_checklists=true tasks_total=0 tasks_completed=0 checklist_files=requirements.md -->
@@ -78,3 +79,4 @@
 <!-- feature: 035-credential-management has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=73 tasks_completed=0 checklist_files=requirements.md -->
 <!-- feature: 036-artifact-service has_spec=true has_plan=false has_tasks=false has_research=false has_data_model=false has_quickstart=false has_contracts=false has_checklists=true tasks_total=0 tasks_completed=0 checklist_files=requirements.md -->
 <!-- feature: 037-plugin-system has_spec=true has_plan=false has_tasks=false has_research=false has_data_model=false has_quickstart=false has_contracts=false has_checklists=true tasks_total=0 tasks_completed=0 checklist_files=requirements.md -->
+<!-- feature: 038-mcp-integration has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=49 tasks_completed=0 checklist_files=requirements.md -->


### PR DESCRIPTION
## Summary
- Added clarifications to spec (lenient parsing, comprehensive model catalog, usage tracking, no Retry-After extraction)
- Generated implementation plan, research, data model, contracts, quickstart, and tasks
- 17 tasks across 6 phases: catalog update → text streaming → tool calls → endpoint → errors → polish

## Test plan
- [ ] Verify spec-status.md reflects updated 017 status
- [ ] Review task breakdown covers all 4 user stories from spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)