### PR TITLE
Add spec 019: AWS Bedrock adapter with plan and tasks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,7 @@ MSRV **1.88** (edition 2024). Workspace deps centralized in root `Cargo.toml`.
 - N/A (in-memory token cache only) (016-adapter-azure)
 - Rust 1.88 (edition 2024) + `swink-agent` (core), `swink-agent-adapters` (shared infra: `openai_compat`, `classify`, `sse`, `convert`, `base`) (017-adapter-xai)
 - N/A (stateless adapter) (017-adapter-xai)
+- Rust 1.88 (edition 2024) + `swink-agent` (core), `swink-agent-adapters` (shared infra), `sha2`/`hmac` (SigV4 signing), `chrono` (timestamps), `aws-smithy-eventstream` (NEW — event-stream frame decoding), `aws-smithy-types` (NEW — event-stream types) (019-adapter-bedrock)
 
 ## Recent Changes
 - 001-workspace-scaffold: Added Rust 1.88 (edition 2024) + serde, serde_json, tokio, futures, thiserror, uuid, reqwest, jsonschema, schemars, rand, tracing, toml (all centralized in workspace `[workspace.dependencies]`)

--- a/specs/019-adapter-bedrock/contracts/public-api.md
+++ b/specs/019-adapter-bedrock/contracts/public-api.md
@@ -1,0 +1,82 @@
+# Public API Contract: swink-agent-adapters (Bedrock)
+
+**Feature**: 019-adapter-bedrock | **Date**: 2026-04-02
+
+## Feature Gate
+
+```toml
+[dependencies]
+swink-agent-adapters = { features = ["bedrock"] }
+```
+
+Activates deps: `sha2`, `hmac`, `chrono`, `aws-smithy-eventstream`, `aws-smithy-types`
+
+## Public Type
+
+### `BedrockStreamFn`
+
+```rust
+pub struct BedrockStreamFn { /* private */ }
+
+impl BedrockStreamFn {
+    /// Create a new Bedrock stream function.
+    ///
+    /// # Arguments
+    /// * `region` - AWS region (e.g., `us-east-1`)
+    /// * `access_key_id` - AWS access key ID
+    /// * `secret_access_key` - AWS secret access key
+    /// * `session_token` - Optional session token for temporary credentials
+    pub fn new(
+        region: impl Into<String>,
+        access_key_id: impl Into<String>,
+        secret_access_key: impl Into<String>,
+        session_token: Option<String>,
+    ) -> Self;
+
+    /// Create with a custom base URL (for testing or custom endpoints).
+    pub fn new_with_base_url(
+        base_url: impl Into<String>,
+        region: impl Into<String>,
+        access_key_id: impl Into<String>,
+        secret_access_key: impl Into<String>,
+        session_token: Option<String>,
+    ) -> Self;
+}
+
+impl StreamFn for BedrockStreamFn { /* ... */ }
+impl Debug for BedrockStreamFn { /* redacted credentials */ }
+// Send + Sync enforced at compile time
+```
+
+## Usage Example
+
+```rust
+use swink_agent_adapters::BedrockStreamFn;
+
+let stream_fn = BedrockStreamFn::new(
+    "us-east-1",
+    std::env::var("AWS_ACCESS_KEY_ID").unwrap(),
+    std::env::var("AWS_SECRET_ACCESS_KEY").unwrap(),
+    std::env::var("AWS_SESSION_TOKEN").ok(),
+);
+// Use with Agent::new() or directly via stream_fn.stream()
+```
+
+## Wire Protocol
+
+- **Endpoint**: `POST {base_url}/model/{model_id}/converse-stream`
+- **Auth**: AWS SigV4 (`Authorization`, `x-amz-date`, `x-amz-content-sha256`, optional `x-amz-security-token`)
+- **Request**: `Content-Type: application/json` — Bedrock ConverseStream request body
+- **Response**: `Content-Type: application/vnd.amazon.eventstream` — binary event-stream frames
+- **Events**: `messageStart` → `contentBlockStart/Delta/Stop`* → `messageStop` → `metadata`
+
+## Behavioral Contract
+
+1. Text deltas arrive as individual `AssistantMessageEvent::TextDelta` events (true streaming)
+2. Tool calls emit `ToolCallStart` (with name/id), `ToolCallDelta` (partial JSON), then `ToolCallEnd`
+3. HTTP errors classified via shared classifier (429→throttled, 403→auth, 5xx→network)
+4. Network errors produce `AssistantMessageEvent::error_network()`
+5. `GUARDRAIL_INTERVENED` stop reason → `ContentFiltered` error event
+6. Cancellation token terminates the stream immediately
+7. Usage data surfaced from `metadata` event in terminal `Done` event
+8. All requests signed with AWS SigV4 (including session token if present)

--- a/specs/019-adapter-bedrock/data-model.md
+++ b/specs/019-adapter-bedrock/data-model.md
@@ -1,0 +1,103 @@
+# Data Model: Adapter AWS Bedrock
+
+**Feature**: 019-adapter-bedrock | **Date**: 2026-04-02
+
+## Entities
+
+### BedrockStreamFn (public)
+
+The streaming function that connects to AWS Bedrock's ConverseStream endpoint.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `base_url` | `String` | `https://bedrock-runtime.{region}.amazonaws.com` |
+| `region` | `String` | AWS region (e.g., `us-east-1`) |
+| `access_key_id` | `String` | AWS access key ID |
+| `secret_access_key` | `String` | AWS secret access key |
+| `session_token` | `Option<String>` | Optional session token for temporary credentials |
+| `client` | `reqwest::Client` | HTTP client for requests |
+
+**Constructors**:
+- `new(region, access_key_id, secret_access_key, session_token)` — derives `base_url` from region
+- `new_with_base_url(base_url, region, ...)` — for testing or custom endpoints
+
+**Trait implementations**: `StreamFn`, `Debug` (redacted credentials), `Send + Sync`
+
+### BedrockRequest (internal, serialized)
+
+Request body for ConverseStream endpoint.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `messages` | `Vec<BedrockMessage>` | Conversation messages |
+| `system` | `Option<Vec<BedrockSystemBlock>>` | System prompt (top-level, not synthetic user msg) |
+| `inferenceConfig` | `Option<BedrockInferenceConfig>` | Temperature, max_tokens |
+| `toolConfig` | `Option<BedrockToolConfig>` | Tool definitions |
+
+### BedrockMessage (internal, serialized)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `role` | `String` | `"user"` or `"assistant"` |
+| `content` | `Vec<BedrockContentBlock>` | Text, tool_use, or tool_result blocks |
+
+### Streaming Event Types (internal, deserialized from event-stream payloads)
+
+| Event Type | Key Fields | Maps To |
+|------------|------------|---------|
+| `MessageStartEvent` | `role: String` | `AssistantMessageEvent::Start` |
+| `ContentBlockStartEvent` | `contentBlockIndex: usize`, `start: StartBlock` | `TextStart` or `ToolCallStart` |
+| `ContentBlockDeltaEvent` | `contentBlockIndex: usize`, `delta: DeltaBlock` | `TextDelta` or `ToolCallDelta` |
+| `ContentBlockStopEvent` | `contentBlockIndex: usize` | `TextEnd` or `ToolCallEnd` |
+| `MessageStopEvent` | `stopReason: String` | (captured for Done event) |
+| `MetadataEvent` | `usage: BedrockUsage`, `metrics: Metrics` | `AssistantMessageEvent::Done` |
+
+### StartBlock (internal, deserialized)
+
+Tagged union for `contentBlockStart.start`:
+- Text variant: `{ "type": "text" }` (no additional fields at start)
+- ToolUse variant: `{ "type": "toolUse", "toolUseId": String, "name": String }`
+
+### DeltaBlock (internal, deserialized)
+
+Tagged union for `contentBlockDelta.delta`:
+- Text variant: `{ "type": "text", "text": String }`
+- ToolUse variant: `{ "type": "toolUse", "input": String }` (partial JSON fragment)
+
+## Relationships
+
+```
+BedrockStreamFn
+  --signs-with--> SigV4 (hmac/sha2 crypto helpers)
+  --sends-to--> POST /model/{modelId}/converse-stream
+  --receives--> application/vnd.amazon.eventstream binary frames
+  --parses-via--> aws-smithy-eventstream::MessageFrameDecoder
+  --deserializes--> Streaming Event Types (JSON payloads)
+  --emits--> AssistantMessageEvent stream
+```
+
+## State Machine (Streaming)
+
+```
+[Request Sent] → [messageStart] → [contentBlockStart]
+                                        ↓
+                                   [contentBlockDelta]* (repeats)
+                                        ↓
+                                   [contentBlockStop]
+                                        ↓
+                                   [contentBlockStart] (next block, if any)
+                                        ...
+                                   [messageStop] → [metadata] → DONE
+```
+
+State tracked during streaming:
+- `current_block_type: Option<BlockType>` — Text or ToolUse (set at contentBlockStart, cleared at contentBlockStop)
+- `stop_reason: Option<StopReason>` — captured from messageStop
+- `decoder: MessageFrameDecoder` — incremental binary frame decoder
+
+## Validation Rules
+
+- `region` must not be empty (Bedrock requires a valid AWS region)
+- `access_key_id` and `secret_access_key` must not be empty
+- `model_id` passed through to URL path (Bedrock validates server-side)
+- Event-stream frames validated by CRC (handled by aws-smithy-eventstream)

--- a/specs/019-adapter-bedrock/plan.md
+++ b/specs/019-adapter-bedrock/plan.md
@@ -1,0 +1,151 @@
+# Implementation Plan: Adapter AWS Bedrock
+
+**Branch**: `019-adapter-bedrock` | **Date**: 2026-04-02 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/019-adapter-bedrock/spec.md`
+
+## Summary
+
+Implement the AWS Bedrock streaming adapter using the ConverseStream API with AWS event-stream binary encoding. The existing stub (`bedrock.rs`) has ~60% reusable code (SigV4 signing, request types, message conversion, crypto helpers). Main work: replace the non-streaming `converse()` with streaming `converse_stream()` using `aws-smithy-eventstream` for binary frame parsing, add `system` field to request body, update the comprehensive model catalog (~50 models across 10+ provider families), and add live tests.
+
+## Technical Context
+
+**Language/Version**: Rust 1.88 (edition 2024)
+**Primary Dependencies**: `swink-agent` (core), `swink-agent-adapters` (shared infra), `sha2`/`hmac` (SigV4 signing), `chrono` (timestamps), `aws-smithy-eventstream` (NEW — event-stream frame decoding), `aws-smithy-types` (NEW — event-stream types)
+**Storage**: N/A (stateless adapter)
+**Testing**: `cargo test` — unit tests (event-stream parsing, SigV4 signing) + live tests (`#[ignore]`, requires AWS credentials)
+**Target Platform**: Any (library crate)
+**Project Type**: Library
+**Performance Goals**: Streaming latency ≤ provider latency (zero buffering overhead)
+**Constraints**: No `unsafe`, reuse SigV4 signing from existing stub, new deps only for event-stream parsing
+**Scale/Scope**: ~600 lines adapter code (rewrite streaming path), ~200 lines catalog updates, ~200 lines live tests
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Library-First | PASS | Adapter is a library type in the adapters crate. No new crate needed. |
+| II. Test-Driven Development | PASS | Unit tests for event-stream parsing + live tests planned. |
+| III. Efficiency & Performance | PASS | True streaming via event-stream — no buffering. SigV4 crypto is one-time per request. |
+| IV. Leverage the Ecosystem | PASS | `aws-smithy-eventstream` is AWS's official parser. Constitution says "prefer well-maintained crates over hand-rolled." |
+| V. Provider Agnosticism | PASS | `BedrockStreamFn` implements `StreamFn`. Core crate untouched. |
+| VI. Safety & Correctness | PASS | `#[forbid(unsafe_code)]` inherited. CRC validation handled by aws-smithy-eventstream. |
+
+**Architectural Constraints**:
+- Crate count: unchanged (adapters crate absorbs this)
+- MSRV: 1.88 ✓
+- Two new workspace deps: `aws-smithy-eventstream`, `aws-smithy-types` (gated behind `bedrock` feature)
+
+**Post-Phase 1 Re-check**: All gates still pass. New deps are justified by Constitution IV (Leverage the Ecosystem).
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/019-adapter-bedrock/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+│   └── public-api.md
+└── tasks.md             # Phase 2 output (created by /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+adapters/src/
+├── bedrock.rs           # BedrockStreamFn (exists — rewrite streaming path)
+├── lib.rs               # Feature-gated mod + pub use (exists)
+├── remote_presets.rs     # build_remote_connection match arm for "bedrock" (exists, needs preset updates)
+└── classify.rs          # Shared error classifier (unchanged)
+
+src/
+└── model_catalog.toml   # Bedrock provider + presets (needs major expansion: 5 → ~50 models)
+
+Cargo.toml               # Add aws-smithy-eventstream, aws-smithy-types to workspace deps
+adapters/Cargo.toml      # Gate new deps behind bedrock feature
+
+adapters/tests/
+└── bedrock_live.rs      # Live integration tests (new)
+```
+
+**Structure Decision**: No new modules or crates. All changes fit within existing adapter crate structure.
+
+## Implementation Phases
+
+### Phase 1: Dependencies & Workspace Setup
+
+- Add `aws-smithy-eventstream` and `aws-smithy-types` to workspace `[workspace.dependencies]`
+- Gate them behind `bedrock` feature in `adapters/Cargo.toml`
+- Verify `cargo build --features bedrock` compiles
+
+### Phase 2: Streaming Implementation
+
+Replace the non-streaming `converse()` with streaming `converse_stream()`:
+
+1. **Request changes**:
+   - Add `system` field to `BedrockRequest` (top-level, not synthetic user message)
+   - Change URL path from `/model/{id}/converse` to `/model/{id}/converse-stream`
+
+2. **Event-stream parsing**:
+   - Read response body as byte stream (`response.bytes_stream()`)
+   - Feed bytes into `MessageFrameDecoder` incrementally
+   - For each complete frame: read `:event-type` header, deserialize JSON payload
+   - Map to `AssistantMessageEvent` (see research.md R3 for mapping)
+
+3. **Streaming state machine**:
+   - Track `current_block_type` (Text/ToolUse) across contentBlockStart/Stop
+   - Track `stop_reason` from messageStop
+   - Emit `Done` with usage from metadata event
+
+4. **Stop reason mapping**:
+   - `end_turn`/`stop_sequence` → `Stop`
+   - `tool_use` → `ToolUse`
+   - `max_tokens` → `Length`
+   - `guardrail_intervened` → `ContentFiltered` error event
+
+5. **Cancellation**: Check `cancellation_token` in the streaming loop via `tokio::select!`
+
+### Phase 3: Model Catalog Update
+
+Expand `src/model_catalog.toml` from 5 to ~50 Bedrock model presets:
+- Anthropic (9 models), Meta (10), Amazon (6), Mistral (9), DeepSeek (2), AI21 (3), Cohere (2), OpenAI (2), Qwen (4), Writer (2), Others (4)
+- Update `remote_presets.rs` preset key constants to match
+
+### Phase 4: Live Tests
+
+Create `adapters/tests/bedrock_live.rs`:
+- Text streaming test (simple prompt → verify incremental deltas)
+- Tool call test (prompt with tool definitions → verify tool call events)
+- Error handling test (invalid credentials → verify auth error)
+- Usage/metadata test (verify token counts in Done event)
+- Multi-turn context test (verify conversation continuity)
+
+All tests `#[ignore]`, 30s timeout, use cheapest available model.
+
+### Phase 5: Verification
+
+- `cargo build --workspace` passes
+- `cargo test --workspace` passes
+- `cargo clippy --workspace -- -D warnings` clean
+- `cargo test -p swink-agent-adapters --no-default-features --features bedrock` compiles and runs in isolation
+- Live tests pass with real AWS credentials (manual verification)
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| Two new workspace deps (`aws-smithy-eventstream`, `aws-smithy-types`) | Binary event-stream protocol requires specialized parsing with CRC validation | Hand-rolling is error-prone and violates Constitution IV |
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| `aws-smithy-eventstream` API changes | Low | Pin to compatible version range in workspace deps |
+| Event-stream frame format differences across Bedrock models | Low | ConverseStream API is model-agnostic (unified format) |
+| Model IDs stale or region-specific | Medium | Catalog is data, easily updated; IDs use cross-region inference profile format |
+| SigV4 signing incompatible with streaming endpoint | Very Low | Same signing process applies to all Bedrock endpoints |

--- a/specs/019-adapter-bedrock/quickstart.md
+++ b/specs/019-adapter-bedrock/quickstart.md
@@ -1,0 +1,67 @@
+# Quickstart: AWS Bedrock Adapter
+
+**Feature**: 019-adapter-bedrock | **Date**: 2026-04-02
+
+## Prerequisites
+
+- Rust 1.88+ (edition 2024)
+- AWS credentials with Bedrock access (set `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, optionally `AWS_SESSION_TOKEN`)
+- AWS region with Bedrock models enabled (set `AWS_REGION`)
+
+## Add Dependency
+
+```toml
+[dependencies]
+swink-agent-adapters = { path = "../adapters", features = ["bedrock"] }
+```
+
+## Basic Usage
+
+```rust
+use swink_agent_adapters::BedrockStreamFn;
+use swink_agent::types::ModelSpec;
+
+let stream_fn = BedrockStreamFn::new(
+    std::env::var("AWS_REGION").unwrap_or_else(|_| "us-east-1".into()),
+    std::env::var("AWS_ACCESS_KEY_ID").unwrap(),
+    std::env::var("AWS_SECRET_ACCESS_KEY").unwrap(),
+    std::env::var("AWS_SESSION_TOKEN").ok(),
+);
+
+let agent = Agent::builder()
+    .model(ModelSpec::new("us.anthropic.claude-sonnet-4-6-v1:0"))
+    .stream_fn(stream_fn)
+    .build();
+```
+
+## Using Model Catalog Presets
+
+```rust
+use swink_agent::model_catalog::ModelCatalog;
+use swink_agent_adapters::build_remote_connection;
+
+let catalog = ModelCatalog::load();
+let preset = catalog.preset("anthropic_claude_sonnet_46").unwrap();
+let (stream_fn, model_spec) = build_remote_connection(&preset, None)?;
+```
+
+## Run Tests
+
+```bash
+# Unit tests (no AWS credentials needed)
+cargo test -p swink-agent-adapters --features bedrock
+
+# Live tests (requires AWS credentials + Bedrock access)
+cargo test -p swink-agent-adapters --test bedrock_live -- --ignored
+```
+
+## Available Models (selected)
+
+| Preset ID | Provider | Model | Best For |
+|-----------|----------|-------|----------|
+| `anthropic_claude_opus_46` | Anthropic | Claude Opus 4.6 | Complex reasoning, 1M context |
+| `anthropic_claude_sonnet_46` | Anthropic | Claude Sonnet 4.6 | Balanced quality/speed |
+| `meta_llama_4_scout` | Meta | Llama 4 Scout 17B | Long context (3.5M), vision |
+| `amazon_nova_2_lite` | Amazon | Nova 2 Lite | Fast, cheap reasoning |
+| `deepseek_v3_2` | DeepSeek | V3.2 | Tool calling, cost-effective |
+| `openai_gpt_oss_120b` | OpenAI | GPT-OSS 120B | Large open-weight model |

--- a/specs/019-adapter-bedrock/research.md
+++ b/specs/019-adapter-bedrock/research.md
@@ -1,0 +1,99 @@
+# Research: Adapter AWS Bedrock
+
+**Feature**: 019-adapter-bedrock | **Date**: 2026-04-02
+
+## R1: ConverseStream API Protocol
+
+**Decision**: Use the `ConverseStream` endpoint (`POST /model/{modelId}/converse-stream`) with AWS event-stream binary encoding.
+
+**Rationale**: Bedrock's ConverseStream API delivers true incremental streaming via `application/vnd.amazon.eventstream` binary framing. The request body is identical to the non-streaming `Converse` API (same JSON format). The response is a sequence of binary event-stream frames, each containing a JSON payload with one of 6 event types: `messageStart`, `contentBlockStart`, `contentBlockDelta`, `contentBlockStop`, `messageStop`, `metadata`.
+
+**Alternatives considered**:
+- Non-streaming `Converse` API (existing stub) → rejected (buffers entire response, violates SC-001)
+- `InvokeModelWithResponseStream` → rejected (model-specific request formats, ConverseStream is the unified API)
+
+## R2: AWS Event-Stream Binary Protocol
+
+**Decision**: Use `aws-smithy-eventstream` crate (v0.60.x) + `aws-smithy-types` for binary frame parsing.
+
+**Rationale**: AWS event-stream is a binary framed protocol (not SSE). Each frame has: `[total_length: u32][headers_length: u32][prelude_crc: u32][headers...][payload...][message_crc: u32]`. The `aws-smithy-eventstream::frame::MessageFrameDecoder` handles incremental decoding: feed bytes, get `DecodedFrame::Complete(Message)` or `DecodedFrame::Incomplete`. Key headers per frame: `:message-type` (event/exception), `:event-type` (messageStart, contentBlockDelta, etc.), `:content-type` (application/json).
+
+**Alternatives considered**:
+- Hand-rolled binary parser → rejected (complex protocol with CRC validation, error-prone)
+- Full AWS SDK (`aws-sdk-bedrockruntime`) → rejected (massive dependency tree for just event-stream parsing)
+
+## R3: ConverseStream Event Types
+
+**Decision**: Map Bedrock streaming events to `AssistantMessageEvent` as follows:
+
+| Bedrock Event | Harness Event | Notes |
+|---|---|---|
+| `messageStart` | `Start` | Contains `role: "assistant"` |
+| `contentBlockStart` (text) | `TextStart` | `contentBlockIndex` → `content_index` |
+| `contentBlockStart` (toolUse) | `ToolCallStart` | Contains `toolUseId`, `name` |
+| `contentBlockDelta` (text) | `TextDelta` | `delta.text` → `delta` |
+| `contentBlockDelta` (toolUse) | `ToolCallDelta` | `delta.input` → `delta` (partial JSON string) |
+| `contentBlockStop` | `TextEnd` or `ToolCallEnd` | Tracked by content block type |
+| `messageStop` | (internal) | Captures `stopReason` |
+| `metadata` | `Done` | Contains `usage`, triggers terminal event |
+
+**Rationale**: Direct 1:1 mapping from Bedrock streaming events to harness events. Tool call arguments arrive as incremental string fragments in `delta.input` and are emitted as `ToolCallDelta` events.
+
+## R4: Stop Reason Mapping
+
+**Decision**: Map Bedrock stop reasons as follows:
+
+| Bedrock `stopReason` | Harness `StopReason` |
+|---|---|
+| `end_turn` | `Stop` |
+| `stop_sequence` | `Stop` |
+| `tool_use` | `ToolUse` |
+| `max_tokens` | `Length` |
+| `guardrail_intervened` | → `ContentFiltered` error event |
+
+**Rationale**: Consistent with existing adapter patterns. `guardrail_intervened` is special-cased to emit an error event rather than a normal Done, matching the Azure adapter's `ContentFiltered` handling per clarification.
+
+## R5: System Prompt Handling
+
+**Decision**: Use Bedrock's native `system` field in the ConverseStream request body instead of prepending a synthetic user message.
+
+**Rationale**: The existing stub prepends the system prompt as a fake user message. However, the Converse/ConverseStream API supports a top-level `system` field: `"system": [{ "text": "..." }]`. This is the correct approach — it preserves model behavior (system messages have different attention patterns than user messages in most models).
+
+**Alternatives considered**:
+- Synthetic user message (existing stub) → rejected (incorrect semantics, may degrade model quality)
+
+## R6: New Dependencies
+
+**Decision**: Add `aws-smithy-eventstream` and `aws-smithy-types` as workspace dependencies, gated behind the `bedrock` feature.
+
+| Crate | Version | Purpose |
+|---|---|---|
+| `aws-smithy-eventstream` | 0.60.x | Binary frame decoding (`MessageFrameDecoder`) |
+| `aws-smithy-types` | 1.x | Event-stream types (`Message`, `Header`, `HeaderValue`) |
+
+**Rationale**: These are lightweight crates from the official AWS SDK that handle the binary event-stream protocol. They don't pull in the full AWS SDK dependency tree.
+
+## R7: Comprehensive Model Catalog
+
+**Decision**: Include all current Bedrock models across all provider families.
+
+The catalog will cover 9+ provider families with ~50 models total:
+- **Anthropic**: Claude Opus 4.6, Sonnet 4.6, Sonnet 4.5, Haiku 4.5, 3.7 Sonnet, 3.5 Sonnet v2, 3.5 Haiku, 3 Opus, 3 Haiku
+- **Meta**: Llama 4 Scout, 4 Maverick, 3.3 70B, 3.2 (90B/11B/3B/1B), 3.1 (405B/70B/8B)
+- **Amazon**: Nova 2 Pro, 2 Lite, Pro v1, Lite v1, Micro v1, Premier v1
+- **Mistral**: Large 3, Large 2407, Pixtral Large, Ministral 3 (14B/8B/3B), Small, Mixtral 8x7B, 7B
+- **DeepSeek**: R1, V3.2
+- **AI21**: Jamba 1.5 Large, 1.5 Mini, Instruct
+- **Cohere**: Command R+, Command R
+- **OpenAI**: GPT-OSS 120B, 20B
+- **Qwen**: Coder 480B, Coder 30B, 235B, 32B
+- **Writer**: Palmyra X5, X4
+- **Others**: Kimi K2.5, GLM 4.7, GLM 4.7 Flash, MiniMax M2.1
+
+Model IDs use cross-region inference profile format (`us.` prefix) where that is the recommended access pattern.
+
+## R8: Existing Stub Reuse
+
+**Decision**: Retain and extend the existing `bedrock.rs` stub. Keep: struct definition, constructors, SigV4 signing, message conversion types, crypto helpers, Debug impl, Send+Sync assertion. Replace: `converse()` method with streaming `converse_stream()`, add event-stream parsing, add `system` field to request, update response types for streaming events.
+
+**Rationale**: ~60% of the existing code is reusable (SigV4 signing, request types, message conversion, helpers). The main change is replacing the single-response `converse()` with a streaming `converse_stream()` that reads binary event-stream frames and maps them to `AssistantMessageEvent`s.

--- a/specs/019-adapter-bedrock/spec.md
+++ b/specs/019-adapter-bedrock/spec.md
@@ -3,13 +3,13 @@
 **Feature Branch**: `019-adapter-bedrock`
 **Created**: 2026-03-20
 **Status**: Draft
-**Input**: BedrockStreamFn for AWS Bedrock via SSE. AWS SigV4 request signing. References: PRD §15.1, HLD Adapters.
+**Input**: BedrockStreamFn for AWS Bedrock via ConverseStream (AWS event-stream encoding). AWS SigV4 request signing. References: PRD §15.1, HLD Adapters.
 
 ## User Scenarios & Testing *(mandatory)*
 
 ### User Story 1 - Stream Text Responses from AWS Bedrock (Priority: P1)
 
-A developer configures the Bedrock adapter with AWS credentials, a region, and a model ID and sends a conversation to the Bedrock streaming endpoint. The adapter streams back text content in real time as Server-Sent Events, delivering each text delta to the agent loop as it arrives. The developer sees assistant responses appear incrementally.
+A developer configures the Bedrock adapter with AWS credentials, a region, and a model ID and sends a conversation to the Bedrock streaming endpoint. The adapter streams back text content in real time via the ConverseStream API (AWS event-stream encoding), delivering each text delta to the agent loop as it arrives. The developer sees assistant responses appear incrementally.
 
 **Why this priority**: Streaming text is the fundamental capability — without it, the adapter has no value.
 
@@ -17,7 +17,7 @@ A developer configures the Bedrock adapter with AWS credentials, a region, and a
 
 **Acceptance Scenarios**:
 
-1. **Given** valid AWS credentials, a region, and a model ID, **When** a conversation is sent, **Then** text content streams back incrementally via SSE.
+1. **Given** valid AWS credentials, a region, and a model ID, **When** a conversation is sent, **Then** text content streams back incrementally via the ConverseStream API.
 2. **Given** a streaming response, **When** all deltas have arrived, **Then** the assembled message matches what the model produced.
 3. **Given** a streaming response, **When** the stream completes normally, **Then** a terminal event signals completion.
 
@@ -74,23 +74,24 @@ A developer encounters various error conditions when communicating with the Bedr
 
 ### Edge Cases
 
-- What happens when AWS credentials expire mid-stream — does the error surface clearly?
-- How does the adapter handle Bedrock-specific error codes that differ from standard HTTP error patterns?
-- What happens when the specified model ID is not available in the configured region?
-- How does the adapter handle Bedrock's content moderation responses that block output?
-- What happens when the SigV4 signing clock is skewed relative to the server?
+- AWS credentials expiring mid-stream: the ConverseStream connection is already authenticated at request time, so mid-stream expiry does not affect an in-flight response. Subsequent requests with expired creds surface as auth error (403).
+- Bedrock-specific error codes (e.g., `ModelNotReadyException`, `ModelTimeoutException`) are classified by HTTP status code via the shared classifier; the error body is included in the message for diagnostics.
+- Model ID not available in the configured region: Bedrock returns HTTP 400 or 404; classified as non-retryable error with descriptive message including region and model ID.
+- Bedrock content moderation (`GUARDRAIL_INTERVENED` stop reason) maps to `ContentFiltered` error type, consistent with Azure adapter. Not retryable; distinguishable from auth/network errors.
+- SigV4 clock skew (`RequestTimeTooSkewed`, HTTP 403) surfaces as auth error with descriptive message via shared classifier. No auto-retry with corrected timestamp — clock skew is a deployment-environment issue.
 
 ## Requirements *(mandatory)*
 
 ### Functional Requirements
 
-- **FR-001**: The adapter MUST stream text responses from the Bedrock streaming endpoint via SSE, emitting incremental text deltas.
+- **FR-001**: The adapter MUST stream text responses from the Bedrock ConverseStream endpoint (AWS event-stream binary encoding), emitting incremental text deltas.
 - **FR-002**: The adapter MUST stream tool call responses, emitting tool name, argument deltas, and completion events.
 - **FR-003**: The adapter MUST sign all requests using AWS Signature Version 4 with the provided credentials and region.
 - **FR-004**: The adapter MUST support temporary credentials (session tokens) in the SigV4 signing process.
 - **FR-005**: The adapter MUST convert agent messages to the Bedrock message format using the shared conversion trait.
 - **FR-006**: The adapter MUST classify errors using the shared error classifier (throttling → rate limit, access denied → auth, 5xx → network, timeout → network).
 - **FR-007**: The adapter MUST construct Bedrock-specific endpoint URLs from the region and model ID.
+- **FR-008**: The adapter MUST parse the AWS event-stream binary protocol using the `aws-smithy-eventstream` crate for response framing and CRC validation.
 
 ### Key Entities
 
@@ -106,9 +107,19 @@ A developer encounters various error conditions when communicating with the Bedr
 - **SC-003**: All requests include valid SigV4 authorization headers accepted by the Bedrock service.
 - **SC-004**: All Bedrock error codes map to the correct agent error types consistently.
 
+## Clarifications
+
+### Session 2026-04-02
+
+- Q: Which streaming approach should the adapter use? → A: Streaming `ConverseStream` API with AWS event-stream binary protocol parsing — true incremental delivery, not the non-streaming `Converse` API.
+- Q: How should the adapter parse the AWS event-stream binary protocol? → A: Use `aws-smithy-eventstream` crate (AWS's official parser) for binary framing + CRC validation.
+- Q: How should Bedrock content moderation blocks be surfaced? → A: Map `GUARDRAIL_INTERVENED` stop reason to `ContentFiltered` error type, consistent with Azure adapter.
+- Q: What scope of models should the catalog include? → A: Comprehensive — all available models across all providers on Bedrock (Anthropic, Meta, Mistral, Amazon, AI21, Cohere, etc.).
+- Q: How should the adapter handle SigV4 clock skew errors? → A: Surface as auth error with descriptive message — consistent with shared classifier's 403 handling; caller diagnoses.
+
 ## Assumptions
 
-- AWS Bedrock uses Server-Sent Events for streaming.
+- AWS Bedrock uses the ConverseStream API with AWS event-stream binary encoding (`application/vnd.amazon.eventstream`) for streaming — not standard SSE.
 - SigV4 signing is required for all Bedrock requests — there is no alternative authentication method.
 - The shared conversion trait and error classifier from the adapter shared infrastructure (spec 011) are available.
 - The adapter does not manage AWS credential lifecycle (rotation, refresh) — credentials are provided by the caller.

--- a/specs/019-adapter-bedrock/tasks.md
+++ b/specs/019-adapter-bedrock/tasks.md
@@ -1,0 +1,215 @@
+# Tasks: Adapter AWS Bedrock
+
+**Input**: Design documents from `/specs/019-adapter-bedrock/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup (Dependencies & Workspace)
+
+**Purpose**: Add new workspace dependencies and configure feature gates for event-stream parsing
+
+- [ ] T001 Add `aws-smithy-eventstream` (0.60.x) and `aws-smithy-types` (1.x) to workspace `[workspace.dependencies]` in Cargo.toml
+- [ ] T002 Add `aws-smithy-eventstream` and `aws-smithy-types` as optional deps gated behind `bedrock` feature in adapters/Cargo.toml (alongside existing `sha2`, `hmac`, `chrono`)
+- [ ] T003 Verify `cargo build -p swink-agent-adapters --no-default-features --features bedrock` compiles with new deps
+
+**Checkpoint**: Bedrock feature compiles with event-stream parsing crates available
+
+---
+
+## Phase 2: Foundational (Request & Type Updates)
+
+**Purpose**: Update request types and message conversion to support ConverseStream API — blocks all user stories
+
+**CRITICAL**: No user story work can begin until this phase is complete
+
+- [ ] T004 Add `BedrockSystemBlock` struct (`text: String`) and add `system: Option<Vec<BedrockSystemBlock>>` field to `BedrockRequest` in adapters/src/bedrock.rs
+- [ ] T005 Update `build_request()` in adapters/src/bedrock.rs to populate the `system` field from `context.system_prompt` instead of prepending a synthetic user message
+- [ ] T006 Add streaming event deserialization types in adapters/src/bedrock.rs: `MessageStartEvent`, `ContentBlockStartEvent` (with `StartBlock` enum for text/toolUse), `ContentBlockDeltaEvent` (with `DeltaBlock` enum for text/toolUse), `ContentBlockStopEvent`, `MessageStopEvent`, `MetadataEvent` (with `BedrockStreamUsage` and `BedrockMetrics`)
+- [ ] T007 Add `BedrockStreamState` struct in adapters/src/bedrock.rs to track streaming state: `current_block_type: Option<BlockType>` (Text/ToolUse), `stop_reason: Option<String>`, `usage: Option<Usage>`, `content_index: usize`
+- [ ] T008 Add `parse_event_frame()` function in adapters/src/bedrock.rs that takes an `aws_smithy_eventstream` `Message`, reads the `:event-type` header, deserializes the JSON payload into the appropriate event type, and returns `Option<Vec<AssistantMessageEvent>>`
+- [ ] T009 Add `map_stop_reason()` helper in adapters/src/bedrock.rs: `end_turn`/`stop_sequence` → `Stop`, `tool_use` → `ToolUse`, `max_tokens` → `Length`, `guardrail_intervened` → emit `ContentFiltered` error event
+
+**Checkpoint**: All streaming types defined, event parsing function compiles, `cargo test -p swink-agent-adapters --features bedrock` passes
+
+---
+
+## Phase 3: User Story 1 — Stream Text Responses from AWS Bedrock (Priority: P1) MVP
+
+**Goal**: Stream text content incrementally from the Bedrock ConverseStream endpoint
+
+**Independent Test**: Send a simple prompt to Bedrock and verify text deltas arrive incrementally with a terminal Done event
+
+### Implementation for User Story 1
+
+- [ ] T010 [US1] Replace the `converse()` method with `converse_stream()` in adapters/src/bedrock.rs: change URL path from `/model/{id}/converse` to `/model/{id}/converse-stream`, read response as `bytes_stream()`, feed into `MessageFrameDecoder`, yield `AssistantMessageEvent`s via `stream::unfold` with `BedrockStreamState`
+- [ ] T011 [US1] Update the `StreamFn::stream()` impl in adapters/src/bedrock.rs to call `converse_stream()` instead of `converse()`, integrating `tokio::select!` for cancellation_token support in the streaming loop
+- [ ] T012 [US1] Wire up `messageStart` → `Start`, `contentBlockStart(text)` → `TextStart`, `contentBlockDelta(text)` → `TextDelta`, `contentBlockStop` → `TextEnd`, `metadata` → `Done` event mapping in `parse_event_frame()` for text blocks
+- [ ] T013 [US1] Handle `messageStop` event in `parse_event_frame()`: capture `stopReason` into `BedrockStreamState`, emit `Done` event with usage from subsequent `metadata` event
+- [ ] T014 [US1] Add unit test `text_event_stream_parsing` in adapters/src/bedrock.rs that constructs mock event-stream frames for a text response and verifies correct `AssistantMessageEvent` sequence (Start, TextStart, TextDelta, TextEnd, Done)
+- [ ] T015 [US1] Create adapters/tests/bedrock_live.rs with module-level cfg gate, imports, constants (TIMEOUT = 30s), and helper functions: `aws_creds()` (reads AWS env vars via dotenvy), `cheap_model()` (cheapest available model), `simple_context()`, `collect_events()`, `event_name()`
+- [ ] T016 [US1] Add `live_text_stream` test in adapters/tests/bedrock_live.rs: send simple prompt, assert Start/TextStart/TextDelta/TextEnd/Done events present and assembled text is non-empty
+- [ ] T017 [US1] Add `live_usage_and_cost` test in adapters/tests/bedrock_live.rs: send simple prompt, assert Done event contains non-zero input and output token counts
+
+**Checkpoint**: `cargo test -p swink-agent-adapters --features bedrock` passes; live text streaming tests pass with AWS credentials
+
+---
+
+## Phase 4: User Story 2 — Stream Tool Call Responses from AWS Bedrock (Priority: P1)
+
+**Goal**: Stream tool calls with names, IDs, and incrementally-arriving JSON arguments
+
+**Independent Test**: Send a prompt with tool definitions and verify ToolCallStart/ToolCallDelta/ToolCallEnd events with correct tool name and valid JSON args
+
+### Implementation for User Story 2
+
+- [ ] T018 [US2] Wire up `contentBlockStart(toolUse)` → `ToolCallStart` (with `toolUseId`, `name`), `contentBlockDelta(toolUse)` → `ToolCallDelta` (with `input` partial JSON), `contentBlockStop` → `ToolCallEnd` event mapping in `parse_event_frame()`
+- [ ] T019 [US2] Add unit test `tool_call_event_stream_parsing` in adapters/src/bedrock.rs that constructs mock event-stream frames for a tool call response and verifies correct ToolCallStart/ToolCallDelta/ToolCallEnd sequence with valid accumulated JSON
+- [ ] T020 [US2] Add `DummyTool` struct (get_weather) in adapters/tests/bedrock_live.rs implementing `AgentTool` with JSON schema for city parameter
+- [ ] T021 [US2] Add `live_tool_use_stream` test in adapters/tests/bedrock_live.rs: send prompt with get_weather tool, assert ToolCallStart with name "get_weather", ToolCallEnd present, and StopReason::ToolUse
+- [ ] T022 [US2] Add `live_multi_turn_context` test in adapters/tests/bedrock_live.rs: send two-turn conversation (introduce name, then ask for recall), assert second reply contains the introduced name
+
+**Checkpoint**: Tool call streaming works; live tests pass for both text and tool call scenarios
+
+---
+
+## Phase 5: User Story 3 — Authenticate with AWS SigV4 Request Signing (Priority: P2)
+
+**Goal**: Verify SigV4 signing works correctly with the ConverseStream endpoint (signing logic already exists in stub)
+
+**Independent Test**: Verify correct SigV4 headers are generated and invalid credentials produce auth errors
+
+### Implementation for User Story 3
+
+- [ ] T023 [US3] Verify that the existing SigV4 signing in `converse_stream()` correctly signs the `/converse-stream` URL path (update path in signing if it was hardcoded to `/converse`)
+- [ ] T024 [US3] Add unit test `sigv4_signs_converse_stream_path` in adapters/src/bedrock.rs that verifies the canonical request uses the `/model/{id}/converse-stream` path
+- [ ] T025 [US3] Add `live_invalid_creds_returns_auth_error` test in adapters/tests/bedrock_live.rs: create BedrockStreamFn with bogus credentials, assert Error event with auth-related message
+
+**Checkpoint**: SigV4 signing verified for streaming endpoint; auth error test passes
+
+---
+
+## Phase 6: User Story 4 — Handle Errors from AWS Bedrock (Priority: P2)
+
+**Goal**: Verify HTTP error codes are classified correctly via the shared error classifier
+
+**Independent Test**: Trigger auth error with invalid credentials and verify correct error classification
+
+### Implementation for User Story 4
+
+- [ ] T026 [US4] Handle event-stream exception frames (`:message-type` = `"exception"`) in the streaming loop in adapters/src/bedrock.rs: extract `:exception-type` header and payload, emit appropriate error event
+- [ ] T027 [US4] Add `guardrail_intervened` handling in `map_stop_reason()` in adapters/src/bedrock.rs: when stopReason is `guardrail_intervened`, emit `ContentFiltered` error event instead of normal Done
+- [ ] T028 [US4] Add unit test `exception_frame_handling` in adapters/src/bedrock.rs that constructs a mock exception frame (`:message-type` = `"exception"`, `:exception-type` = `"throttlingException"`) and verifies it maps to a throttled error event
+- [ ] T029 [US4] Add unit test `guardrail_intervened_maps_to_content_filtered` in adapters/src/bedrock.rs that verifies `guardrail_intervened` stop reason produces a ContentFiltered error event
+
+**Checkpoint**: All error paths covered; exception frames and guardrail blocks handled correctly
+
+---
+
+## Phase 7: Model Catalog Update
+
+**Purpose**: Expand Bedrock model presets from 5 to ~50 models across all provider families
+
+- [ ] T030 [P] Update Bedrock provider presets in src/model_catalog.toml: add Anthropic models (Opus 4.6, Sonnet 4.6, Haiku 4.5, 3.7 Sonnet, 3.5 Sonnet v2, 3.5 Haiku, 3 Opus, 3 Haiku) — update existing Sonnet 4.5 entry if needed
+- [ ] T031 [P] Add Meta Llama models to Bedrock presets in src/model_catalog.toml: Llama 4 Scout, 3.3 70B, 3.2 (90B/11B/3B/1B), 3.1 (405B/70B/8B) — update existing Maverick entry
+- [ ] T032 [P] Add Amazon Nova models to Bedrock presets in src/model_catalog.toml: Nova 2 Pro, 2 Lite, Lite v1, Micro v1, Premier v1 — update existing Nova Pro entry
+- [ ] T033 [P] Add Mistral models to Bedrock presets in src/model_catalog.toml: Large 3 (2512), Large (2407), Ministral 3 (14B/8B/3B), Small, Mixtral 8x7B, 7B — update existing Pixtral Large entry
+- [ ] T034 [P] Add DeepSeek, AI21, Cohere, OpenAI, Qwen, Writer, and other provider models to Bedrock presets in src/model_catalog.toml
+- [ ] T035 Update `remote_presets.rs` preset key constants in `pub mod bedrock` to include all new model presets, and update the `added_provider_presets_map_to_catalog_models` test
+
+**Checkpoint**: `cargo test -p swink-agent-adapters --features bedrock` passes with expanded catalog; all preset keys map to valid catalog entries
+
+---
+
+## Phase 8: Polish & Verification
+
+**Purpose**: Build verification, clippy clean, feature-gate isolation, documentation
+
+- [ ] T036 Run `cargo build --workspace` and verify clean compilation
+- [ ] T037 Run `cargo test --workspace` and verify all tests pass
+- [ ] T038 Run `cargo clippy --workspace -- -D warnings` and verify zero warnings
+- [ ] T039 Run `cargo test -p swink-agent-adapters --no-default-features --features bedrock` and verify bedrock feature compiles and runs in isolation
+- [ ] T040 Update adapters/CLAUDE.md to change bedrock status from "Stub" to "Implemented" in the feature gates table, update extra deps to include `aws-smithy-eventstream`, `aws-smithy-types`
+- [ ] T041 Remove old non-streaming `BedrockResponse`, `BedrockOutput`, `BedrockOutputMessage`, `BedrockOutputContentBlock` types from adapters/src/bedrock.rs (replaced by streaming event types)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies — start immediately
+- **Phase 2 (Foundational)**: Depends on Phase 1 (needs new deps available)
+- **Phase 3 (US1 Text Streaming)**: Depends on Phase 2 (needs streaming types + event parser)
+- **Phase 4 (US2 Tool Calls)**: Depends on Phase 3 (extends event parser, reuses test infrastructure)
+- **Phase 5 (US3 SigV4 Auth)**: Depends on Phase 3 (needs streaming path to verify signing)
+- **Phase 6 (US4 Error Handling)**: Depends on Phase 3 (needs streaming loop for exception frames)
+- **Phase 7 (Model Catalog)**: Independent of Phases 3-6 (data-only changes to TOML)
+- **Phase 8 (Polish)**: Depends on all previous phases
+
+### User Story Dependencies
+
+- **US1 (Text Streaming)**: Foundation for all other stories
+- **US2 (Tool Calls)**: Extends US1 event parser with tool call mapping
+- **US3 (SigV4 Auth)**: Independent verification of existing signing with new endpoint
+- **US4 (Error Handling)**: Extends US1 streaming loop with exception frame handling
+
+### Parallel Opportunities
+
+- T004, T005, T006, T007 are independent struct/type additions (but same file)
+- T030, T031, T032, T033, T034 are parallel (different TOML sections, independent model families)
+- Phase 7 (Catalog) can run in parallel with Phases 4-6
+- T036, T037, T038 are sequential (build → test → clippy)
+
+---
+
+## Parallel Example: Model Catalog
+
+```bash
+# All catalog tasks can run in parallel (different TOML sections):
+Task T030: "Add Anthropic models to Bedrock presets in src/model_catalog.toml"
+Task T031: "Add Meta Llama models to Bedrock presets in src/model_catalog.toml"
+Task T032: "Add Amazon Nova models to Bedrock presets in src/model_catalog.toml"
+Task T033: "Add Mistral models to Bedrock presets in src/model_catalog.toml"
+Task T034: "Add DeepSeek/AI21/Cohere/OpenAI/Qwen/Writer models in src/model_catalog.toml"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Add deps
+2. Complete Phase 2: Streaming types + event parser
+3. Complete Phase 3: Text streaming with live tests
+4. **STOP and VALIDATE**: Run live tests with AWS credentials
+5. Adapter is usable for basic text generation
+
+### Incremental Delivery
+
+1. Phase 1 + 2 → Foundation ready (deps + types)
+2. Phase 3 → Text streaming verified (MVP!)
+3. Phase 4 → Tool calls verified
+4. Phase 5 → SigV4 signing verified for streaming
+5. Phase 6 → Error handling + guardrails
+6. Phase 7 → Comprehensive model catalog
+7. Phase 8 → Clean build, docs updated
+
+---
+
+## Notes
+
+- The existing `bedrock.rs` stub has ~600 lines of reusable code (SigV4 signing, request types, message conversion, crypto helpers)
+- The main rewrite is replacing `converse()` with streaming `converse_stream()` and adding event-stream frame parsing
+- Two new workspace deps: `aws-smithy-eventstream` (frame decoder) and `aws-smithy-types` (event-stream types)
+- Live tests require `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, and Bedrock model access
+- System prompt now uses native Bedrock `system` field instead of synthetic user message

--- a/specs/spec-status.md
+++ b/specs/spec-status.md
@@ -1,5 +1,5 @@
 # Spec-Driven Development Status
-<!-- spec-status: project=Swink-Agent commit=445de8efb409d8e981f6c3db7f8025d86445f2ca updated=2026-04-02T14:51:14Z -->
+<!-- spec-status: project=Swink-Agent commit=fa7fdc9830036e6ecc277fcb997eeb57770adc78 updated=2026-04-02T15:47:25Z -->
 
 | Feature                         | Specify | Plan | Tasks | Implement |
 |---------------------------------|---------|------|-------|-----------|


### PR DESCRIPTION
## Summary
- Clarified spec: ConverseStream API with AWS event-stream binary encoding (not SSE)
- Added `aws-smithy-eventstream` crate for binary frame parsing
- ContentFiltered error for guardrail blocks, consistent with Azure adapter
- Comprehensive model catalog (~50 models across Anthropic, Meta, Amazon, Mistral, DeepSeek, AI21, Cohere, OpenAI, Qwen, Writer, others)
- 41 tasks across 8 phases: deps → types → text streaming → tool calls → auth → errors → catalog → polish

## Test plan
- [ ] Verify spec-status.md reflects updated 019 status
- [ ] Review task breakdown covers all 4 user stories from spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)