### PR TITLE
impl(016): Add AzureAuth enum and text streaming (Phase 3 / US1)

### DIFF
--- a/adapters/src/azure.rs
+++ b/adapters/src/azure.rs
@@ -4,6 +4,8 @@
 //! It reuses the shared OAI-compatible SSE parsing from [`openai_compat`].
 
 use std::pin::Pin;
+use std::sync::{Arc, RwLock};
+use std::time::Instant;
 
 use futures::stream::{self, Stream, StreamExt as _};
 use tokio_util::sync::CancellationToken;
@@ -18,15 +20,58 @@ use crate::openai_compat::{
     OaiChatRequest, OaiConverter, OaiStreamOptions, build_oai_tools, parse_oai_sse_stream,
 };
 
+/// Authentication method for Azure `OpenAI` deployments.
+#[derive(Clone)]
+pub enum AzureAuth {
+    /// API key authentication via the `api-key` header.
+    ApiKey(String),
+    /// Azure AD / Entra ID `OAuth2` client credentials flow.
+    EntraId {
+        tenant_id: String,
+        client_id: String,
+        client_secret: String,
+    },
+}
+
+impl std::fmt::Debug for AzureAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ApiKey(_) => f.debug_tuple("ApiKey").field(&"[REDACTED]").finish(),
+            Self::EntraId { .. } => f
+                .debug_struct("EntraId")
+                .field("tenant_id", &"[REDACTED]")
+                .field("client_id", &"[REDACTED]")
+                .field("client_secret", &"[REDACTED]")
+                .finish(),
+        }
+    }
+}
+
+/// Cached `OAuth2` token for Entra ID authentication (used in Phase 5 / US3).
+#[allow(dead_code)]
+struct CachedToken {
+    access_token: String,
+    expires_at: Instant,
+}
+
 pub struct AzureStreamFn {
     base: AdapterBase,
+    auth: AzureAuth,
+    #[allow(dead_code)] // Used in Phase 5 (US3) for Entra ID token caching
+    token_cache: Arc<RwLock<Option<CachedToken>>>,
 }
 
 impl AzureStreamFn {
     #[must_use]
-    pub fn new(base_url: impl Into<String>, api_key: impl Into<String>) -> Self {
+    pub fn new(base_url: impl Into<String>, auth: AzureAuth) -> Self {
+        let api_key = match &auth {
+            AzureAuth::ApiKey(key) => key.clone(),
+            AzureAuth::EntraId { .. } => String::new(),
+        };
         Self {
             base: AdapterBase::new(base_url.into().trim_end_matches('/').to_string(), api_key),
+            auth,
+            token_cache: Arc::new(RwLock::new(None)),
         }
     }
 }
@@ -35,7 +80,7 @@ impl std::fmt::Debug for AzureStreamFn {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AzureStreamFn")
             .field("base_url", &self.base.base_url)
-            .field("api_key", &"[REDACTED]")
+            .field("auth", &self.auth)
             .finish_non_exhaustive()
     }
 }
@@ -117,14 +162,23 @@ async fn send_request(
         tool_choice,
     };
 
-    let api_key = options.api_key.as_deref().unwrap_or(&azure.base.api_key);
+    let mut request = azure.base.client.post(&url).json(&body);
 
-    azure
-        .base
-        .client
-        .post(&url)
-        .header("api-key", api_key)
-        .json(&body)
+    match &azure.auth {
+        AzureAuth::ApiKey(key) => {
+            let api_key = options.api_key.as_deref().unwrap_or(key);
+            request = request.header("api-key", api_key);
+        }
+        AzureAuth::EntraId { .. } => {
+            // Entra ID token acquisition will be implemented in Phase 5 (US3).
+            // For now, if a runtime api_key override is provided, use it as a Bearer token.
+            if let Some(token) = options.api_key.as_deref() {
+                request = request.header("Authorization", format!("Bearer {token}"));
+            }
+        }
+    }
+
+    request
         .send()
         .await
         .map_err(|e| AssistantMessageEvent::error_network(format!("Azure connection error: {e}")))

--- a/adapters/src/lib.rs
+++ b/adapters/src/lib.rs
@@ -34,7 +34,12 @@ pub mod convert;
 )]
 mod finalize;
 #[cfg_attr(
-    not(any(feature = "openai", feature = "azure", feature = "mistral", feature = "xai")),
+    not(any(
+        feature = "openai",
+        feature = "azure",
+        feature = "mistral",
+        feature = "xai"
+    )),
     allow(dead_code)
 )]
 mod openai_compat;
@@ -82,7 +87,7 @@ pub use proxy::ProxyStreamFn;
 #[cfg(feature = "azure")]
 mod azure;
 #[cfg(feature = "azure")]
-pub use azure::AzureStreamFn;
+pub use azure::{AzureAuth, AzureStreamFn};
 
 #[cfg(feature = "bedrock")]
 mod bedrock;

--- a/adapters/src/remote_presets.rs
+++ b/adapters/src/remote_presets.rs
@@ -7,8 +7,6 @@ use thiserror::Error;
 
 #[cfg(feature = "anthropic")]
 use crate::AnthropicStreamFn;
-#[cfg(feature = "azure")]
-use crate::AzureStreamFn;
 #[cfg(feature = "bedrock")]
 use crate::BedrockStreamFn;
 #[cfg(feature = "gemini")]
@@ -19,6 +17,8 @@ use crate::MistralStreamFn;
 use crate::OpenAiStreamFn;
 #[cfg(feature = "xai")]
 use crate::XAiStreamFn;
+#[cfg(feature = "azure")]
+use crate::{AzureAuth, AzureStreamFn};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct RemotePresetKey {
@@ -96,28 +96,21 @@ pub mod remote_preset_keys {
     pub mod mistral {
         use super::RemotePresetKey;
 
-        pub const MISTRAL_LARGE: RemotePresetKey =
-            RemotePresetKey::new("mistral", "mistral_large");
+        pub const MISTRAL_LARGE: RemotePresetKey = RemotePresetKey::new("mistral", "mistral_large");
         pub const MISTRAL_MEDIUM: RemotePresetKey =
             RemotePresetKey::new("mistral", "mistral_medium");
-        pub const MISTRAL_SMALL: RemotePresetKey =
-            RemotePresetKey::new("mistral", "mistral_small");
-        pub const MINISTRAL_3B: RemotePresetKey =
-            RemotePresetKey::new("mistral", "ministral_3b");
-        pub const MINISTRAL_8B: RemotePresetKey =
-            RemotePresetKey::new("mistral", "ministral_8b");
-        pub const MINISTRAL_14B: RemotePresetKey =
-            RemotePresetKey::new("mistral", "ministral_14b");
+        pub const MISTRAL_SMALL: RemotePresetKey = RemotePresetKey::new("mistral", "mistral_small");
+        pub const MINISTRAL_3B: RemotePresetKey = RemotePresetKey::new("mistral", "ministral_3b");
+        pub const MINISTRAL_8B: RemotePresetKey = RemotePresetKey::new("mistral", "ministral_8b");
+        pub const MINISTRAL_14B: RemotePresetKey = RemotePresetKey::new("mistral", "ministral_14b");
         pub const MAGISTRAL_MEDIUM: RemotePresetKey =
             RemotePresetKey::new("mistral", "magistral_medium");
         pub const MAGISTRAL_SMALL: RemotePresetKey =
             RemotePresetKey::new("mistral", "magistral_small");
         pub const CODESTRAL: RemotePresetKey = RemotePresetKey::new("mistral", "codestral");
         pub const DEVSTRAL: RemotePresetKey = RemotePresetKey::new("mistral", "devstral");
-        pub const PIXTRAL_LARGE: RemotePresetKey =
-            RemotePresetKey::new("mistral", "pixtral_large");
-        pub const PIXTRAL_12B: RemotePresetKey =
-            RemotePresetKey::new("mistral", "pixtral_12b");
+        pub const PIXTRAL_LARGE: RemotePresetKey = RemotePresetKey::new("mistral", "pixtral_large");
+        pub const PIXTRAL_12B: RemotePresetKey = RemotePresetKey::new("mistral", "pixtral_12b");
     }
 
     #[cfg(feature = "bedrock")]
@@ -261,7 +254,11 @@ fn build_remote_connection_from_values(
             preset.api_version.clone().unwrap_or(ApiVersion::V1beta),
         )),
         #[cfg(feature = "azure")]
-        "azure" => Arc::new(AzureStreamFn::new(resolved_base_url()?, &api_key)),
+        #[allow(clippy::redundant_clone)] // Clone needed when multiple adapter features enabled
+        "azure" => Arc::new(AzureStreamFn::new(
+            resolved_base_url()?,
+            AzureAuth::ApiKey(api_key.clone()),
+        )),
         #[cfg(feature = "xai")]
         "xai" => Arc::new(XAiStreamFn::new(resolved_base_url()?, &api_key)),
         #[cfg(feature = "mistral")]
@@ -450,7 +447,12 @@ mod tests {
         assert!(preset("nonexistent-model-xyz").is_none());
     }
 
-    #[cfg(all(feature = "azure", feature = "xai", feature = "mistral", feature = "bedrock"))]
+    #[cfg(all(
+        feature = "azure",
+        feature = "xai",
+        feature = "mistral",
+        feature = "bedrock"
+    ))]
     #[test]
     fn added_provider_presets_map_to_catalog_models() {
         assert_eq!(

--- a/adapters/tests/azure.rs
+++ b/adapters/tests/azure.rs
@@ -9,7 +9,7 @@ use wiremock::matchers::{header, method, path};
 use wiremock::{Mock, MockServer};
 
 use swink_agent::{AssistantMessageEvent, ModelSpec, StopReason, StreamFn, StreamOptions};
-use swink_agent_adapters::AzureStreamFn;
+use swink_agent_adapters::{AzureAuth, AzureStreamFn};
 
 use common::{sse_response, test_context};
 
@@ -30,10 +30,14 @@ async fn collect_events(stream_fn: &AzureStreamFn) -> Vec<AssistantMessageEvent>
         .await
 }
 
+// ── T019: Text streaming with API key auth ──────────────────────────────────
+
 #[tokio::test]
-async fn azure_text_stream() {
+async fn text_stream_with_api_key_auth() {
     let body = [
         r#"data: {"choices":[{"delta":{"content":"hello"}}]}"#,
+        "",
+        r#"data: {"choices":[{"delta":{"content":" world"}}]}"#,
         "",
         r#"data: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":4,"completion_tokens":2}}"#,
         "",
@@ -50,7 +54,8 @@ async fn azure_text_stream() {
         .mount(&server)
         .await;
 
-    let stream_fn = AzureStreamFn::new(format!("{}/openai/v1", server.uri()), "test-key");
+    let auth = AzureAuth::ApiKey("test-key".into());
+    let stream_fn = AzureStreamFn::new(format!("{}/openai/v1", server.uri()), auth);
     let events = collect_events(&stream_fn).await;
 
     assert!(
@@ -58,11 +63,17 @@ async fn azure_text_stream() {
             .iter()
             .any(|e| matches!(e, AssistantMessageEvent::Start))
     );
-    assert!(
-        events.iter().any(
-            |e| matches!(e, AssistantMessageEvent::TextDelta { delta, .. } if delta == "hello")
-        )
-    );
+
+    // Verify text deltas arrive incrementally
+    let deltas: Vec<&str> = events
+        .iter()
+        .filter_map(|e| match e {
+            AssistantMessageEvent::TextDelta { delta, .. } => Some(delta.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(deltas, vec!["hello", " world"]);
+
     assert!(events.iter().any(|e| matches!(
         e,
         AssistantMessageEvent::Done {
@@ -70,4 +81,162 @@ async fn azure_text_stream() {
             ..
         }
     )));
+}
+
+// ── T020: Verify api-key header is set correctly ────────────────────────────
+
+#[tokio::test]
+async fn api_key_header_set_correctly() {
+    let body = [
+        r#"data: {"choices":[{"delta":{"content":"ok"}}]}"#,
+        "",
+        r#"data: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}"#,
+        "",
+        "data: [DONE]",
+        "",
+    ]
+    .join("\n");
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .and(header("api-key", "my-secret-key"))
+        .respond_with(sse_response(&body))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let auth = AzureAuth::ApiKey("my-secret-key".into());
+    let stream_fn = AzureStreamFn::new(server.uri(), auth);
+    let events = collect_events(&stream_fn).await;
+
+    // If the header didn't match, wiremock would return 404 and we'd get an error event.
+    assert!(events.iter().any(|e| matches!(
+        e,
+        AssistantMessageEvent::Done {
+            stop_reason: StopReason::Stop,
+            ..
+        }
+    )));
+}
+
+// ── T021: Trailing slash in base URL is stripped ────────────────────────────
+
+#[tokio::test]
+async fn trailing_slash_stripped_from_base_url() {
+    let body = [
+        r#"data: {"choices":[{"delta":{"content":"ok"}}]}"#,
+        "",
+        r#"data: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}"#,
+        "",
+        "data: [DONE]",
+        "",
+    ]
+    .join("\n");
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .and(header("api-key", "test-key"))
+        .respond_with(sse_response(&body))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // Pass URL with trailing slash — should still work
+    let auth = AzureAuth::ApiKey("test-key".into());
+    let stream_fn = AzureStreamFn::new(format!("{}/", server.uri()), auth);
+    let events = collect_events(&stream_fn).await;
+
+    assert!(events.iter().any(|e| matches!(
+        e,
+        AssistantMessageEvent::Done {
+            stop_reason: StopReason::Stop,
+            ..
+        }
+    )));
+}
+
+// ── T022: [DONE] sentinel produces terminal Done event ──────────────────────
+
+#[tokio::test]
+async fn done_sentinel_produces_terminal_event() {
+    let body = [
+        r#"data: {"choices":[{"delta":{"content":"hi"}}]}"#,
+        "",
+        r#"data: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":2,"completion_tokens":1}}"#,
+        "",
+        "data: [DONE]",
+        "",
+    ]
+    .join("\n");
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(sse_response(&body))
+        .mount(&server)
+        .await;
+
+    let auth = AzureAuth::ApiKey("test-key".into());
+    let stream_fn = AzureStreamFn::new(server.uri(), auth);
+    let events = collect_events(&stream_fn).await;
+
+    // The last meaningful event should be Done
+    let last_event = events.last().expect("should have events");
+    assert!(
+        matches!(
+            last_event,
+            AssistantMessageEvent::Done {
+                stop_reason: StopReason::Stop,
+                ..
+            }
+        ),
+        "expected Done as terminal event, got: {last_event:?}"
+    );
+}
+
+// ── T012: AzureAuth Debug redacts secrets ───────────────────────────────────
+
+#[test]
+fn azure_auth_debug_redacts_secrets() {
+    let api_key = AzureAuth::ApiKey("super-secret".into());
+    let debug_str = format!("{api_key:?}");
+    assert!(
+        !debug_str.contains("super-secret"),
+        "API key should be redacted"
+    );
+    assert!(debug_str.contains("[REDACTED]"));
+
+    let entra = AzureAuth::EntraId {
+        tenant_id: "tid".into(),
+        client_id: "cid".into(),
+        client_secret: "csecret".into(),
+    };
+    let debug_str = format!("{entra:?}");
+    assert!(!debug_str.contains("tid"), "tenant_id should be redacted");
+    assert!(!debug_str.contains("cid"), "client_id should be redacted");
+    assert!(
+        !debug_str.contains("csecret"),
+        "client_secret should be redacted"
+    );
+}
+
+// ── T016: AzureStreamFn Debug redacts credentials ───────────────────────────
+
+#[test]
+fn azure_stream_fn_debug_redacts_credentials() {
+    let stream_fn = AzureStreamFn::new(
+        "https://myresource.openai.azure.com/openai/deployments/gpt-4",
+        AzureAuth::ApiKey("my-key".into()),
+    );
+    let debug_str = format!("{stream_fn:?}");
+    assert!(
+        !debug_str.contains("my-key"),
+        "API key should be redacted in Debug"
+    );
+    assert!(
+        debug_str.contains("myresource"),
+        "base_url should be visible"
+    );
 }

--- a/adapters/tests/azure_live.rs
+++ b/adapters/tests/azure_live.rs
@@ -8,7 +8,7 @@ use tokio::time::timeout;
 use tokio_util::sync::CancellationToken;
 
 use swink_agent::{AgentContext, AssistantMessageEvent, ModelSpec, StreamFn, StreamOptions};
-use swink_agent_adapters::AzureStreamFn;
+use swink_agent_adapters::{AzureAuth, AzureStreamFn};
 
 const TIMEOUT: Duration = Duration::from_secs(30);
 
@@ -16,7 +16,7 @@ fn stream_fn() -> AzureStreamFn {
     dotenvy::dotenv().ok();
     AzureStreamFn::new(
         std::env::var("AZURE_BASE_URL").expect("AZURE_BASE_URL must be set"),
-        std::env::var("AZURE_API_KEY").expect("AZURE_API_KEY must be set"),
+        AzureAuth::ApiKey(std::env::var("AZURE_API_KEY").expect("AZURE_API_KEY must be set")),
     )
 }
 

--- a/specs/016-adapter-azure/tasks.md
+++ b/specs/016-adapter-azure/tasks.md
@@ -49,19 +49,19 @@
 
 ### Implementation for User Story 1
 
-- [ ] T011 [US1] Define `AzureAuth` enum with `ApiKey(String)` and `EntraId { tenant_id, client_id, client_secret }` variants in `adapters/src/azure.rs`
-- [ ] T012 [US1] Implement `Clone` for `AzureAuth` and `Debug` that redacts secrets in `adapters/src/azure.rs`
-- [ ] T013 [US1] Update `AzureStreamFn` struct to hold `auth: AzureAuth` and `token_cache: Arc<RwLock<Option<CachedToken>>>` in `adapters/src/azure.rs`
-- [ ] T014 [US1] Define internal `CachedToken` struct with `access_token: String` and `expires_at: Instant` in `adapters/src/azure.rs`
-- [ ] T015 [US1] Update `AzureStreamFn::new()` constructor to accept `(base_url, AzureAuth)` instead of `(base_url, api_key)` in `adapters/src/azure.rs`
-- [ ] T016 [US1] Update `Debug` impl for `AzureStreamFn` to redact all credential fields in `adapters/src/azure.rs`
-- [ ] T017 [US1] Update `send_request` to select auth header based on `AzureAuth` variant — `api-key` header for `ApiKey`, `Authorization: Bearer` for `EntraId` in `adapters/src/azure.rs`
-- [ ] T018 [US1] Re-export `AzureAuth` from `adapters/src/lib.rs` under `#[cfg(feature = "azure")]`
-- [ ] T019 [US1] Add wiremock test: text streaming with API key auth — verify SSE text deltas arrive incrementally in `adapters/tests/azure.rs`
-- [ ] T020 [US1] Add wiremock test: verify `api-key` header is set correctly on requests in `adapters/tests/azure.rs`
-- [ ] T021 [US1] Add wiremock test: verify trailing slash in base URL is stripped in `adapters/tests/azure.rs`
-- [ ] T022 [US1] Add wiremock test: verify `[DONE]` sentinel produces terminal Done event in `adapters/tests/azure.rs`
-- [ ] T023 [US1] Run `cargo test -p swink-agent-adapters --features azure` to verify all US1 tests pass
+- [x] T011 [US1] Define `AzureAuth` enum with `ApiKey(String)` and `EntraId { tenant_id, client_id, client_secret }` variants in `adapters/src/azure.rs`
+- [x] T012 [US1] Implement `Clone` for `AzureAuth` and `Debug` that redacts secrets in `adapters/src/azure.rs`
+- [x] T013 [US1] Update `AzureStreamFn` struct to hold `auth: AzureAuth` and `token_cache: Arc<RwLock<Option<CachedToken>>>` in `adapters/src/azure.rs`
+- [x] T014 [US1] Define internal `CachedToken` struct with `access_token: String` and `expires_at: Instant` in `adapters/src/azure.rs`
+- [x] T015 [US1] Update `AzureStreamFn::new()` constructor to accept `(base_url, AzureAuth)` instead of `(base_url, api_key)` in `adapters/src/azure.rs`
+- [x] T016 [US1] Update `Debug` impl for `AzureStreamFn` to redact all credential fields in `adapters/src/azure.rs`
+- [x] T017 [US1] Update `send_request` to select auth header based on `AzureAuth` variant — `api-key` header for `ApiKey`, `Authorization: Bearer` for `EntraId` in `adapters/src/azure.rs`
+- [x] T018 [US1] Re-export `AzureAuth` from `adapters/src/lib.rs` under `#[cfg(feature = "azure")]`
+- [x] T019 [US1] Add wiremock test: text streaming with API key auth — verify SSE text deltas arrive incrementally in `adapters/tests/azure.rs`
+- [x] T020 [US1] Add wiremock test: verify `api-key` header is set correctly on requests in `adapters/tests/azure.rs`
+- [x] T021 [US1] Add wiremock test: verify trailing slash in base URL is stripped in `adapters/tests/azure.rs`
+- [x] T022 [US1] Add wiremock test: verify `[DONE]` sentinel produces terminal Done event in `adapters/tests/azure.rs`
+- [x] T023 [US1] Run `cargo test -p swink-agent-adapters --features azure` to verify all US1 tests pass
 
 **Checkpoint**: Text streaming with API key auth works end-to-end. MVP complete.
 


### PR DESCRIPTION
## Summary
- Adds `AzureAuth` enum with `ApiKey` and `EntraId` variants for flexible Azure OpenAI authentication
- Updates `AzureStreamFn` constructor to accept `AzureAuth` instead of raw API key string
- Adds `CachedToken` struct (placeholder for Phase 5 Entra ID token caching)
- Updates `send_request` to select auth header based on `AzureAuth` variant
- Re-exports `AzureAuth` from adapter crate root
- Updates `remote_presets` and `azure_live` to use new constructor signature

## Tasks completed
- T011: Define `AzureAuth` enum
- T012: Implement `Clone` and secret-redacting `Debug` for `AzureAuth`
- T013: Update `AzureStreamFn` struct with `auth` and `token_cache` fields
- T014: Define internal `CachedToken` struct
- T015: Update constructor to accept `AzureAuth`
- T016: Update `Debug` impl for `AzureStreamFn`
- T017: Update `send_request` auth header selection
- T018: Re-export `AzureAuth` from `lib.rs`
- T019: Wiremock test — text streaming with API key auth (incremental deltas)
- T020: Wiremock test — `api-key` header verification
- T021: Wiremock test — trailing slash stripped from base URL
- T022: Wiremock test — `[DONE]` sentinel produces terminal Done event
- T023: All US1 tests pass (6/6)

## Test plan
- [x] `cargo test -p swink-agent-adapters --test azure` — 6 tests pass
- [x] `cargo clippy -p swink-agent-adapters -- -D warnings` — clean (with default features)
- [x] `cargo test -p swink-agent --no-default-features` — passes
- [ ] Pre-existing clippy warnings in `tui/src/main.rs` (not introduced by this PR)

Part of #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)