### PR TITLE
Add spec 036: Artifact Service with plan and tasks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,6 +198,8 @@ MSRV **1.88** (edition 2024). Workspace deps centralized in root `Cargo.toml`.
 - Rust 1.88 (edition 2024) + `swink-agent` (core), `swink-agent-adapters` (shared infra: `openai_compat`, `classify`, `sse`, `convert`, `base`) (017-adapter-xai)
 - N/A (stateless adapter) (017-adapter-xai)
 - Rust 1.88 (edition 2024) + `swink-agent` (core), `swink-agent-adapters` (shared infra), `sha2`/`hmac` (SigV4 signing), `chrono` (timestamps), `aws-smithy-eventstream` (NEW — event-stream frame decoding), `aws-smithy-types` (NEW — event-stream types) (019-adapter-bedrock)
+- Rust 1.88 (edition 2024) + `serde`, `serde_json`, `tokio` (fs + sync), `chrono` (timestamps), `tracing` (diagnostics), `thiserror` (errors), `futures` (streaming trait), `schemars` (tool schemas) — all workspace deps (036-artifact-service)
+- Local filesystem (versioned files + JSON metadata sidecar); in-memory (`HashMap`) for testing (036-artifact-service)
 
 ## Recent Changes
 - 001-workspace-scaffold: Added Rust 1.88 (edition 2024) + serde, serde_json, tokio, futures, thiserror, uuid, reqwest, jsonschema, schemars, rand, tracing, toml (all centralized in workspace `[workspace.dependencies]`)

--- a/specs/036-artifact-service/contracts/public-api.md
+++ b/specs/036-artifact-service/contracts/public-api.md
@@ -1,0 +1,254 @@
+# Public API Contract: Artifact Service
+
+**Feature**: 036-artifact-service | **Date**: 2026-04-02
+
+## Core Trait (swink-agent crate, `artifact-store` feature)
+
+### ArtifactStore
+
+```rust
+/// Pluggable storage backend for session-attached versioned artifacts.
+///
+/// All methods are scoped by session ID. Implementations must be safe for
+/// concurrent use from multiple tools within the same agent.
+#[async_trait]
+pub trait ArtifactStore: Send + Sync {
+    /// Save content as a new version of the named artifact.
+    ///
+    /// Returns the version record on success. Version numbers are
+    /// monotonically increasing per artifact per session, starting at 1.
+    ///
+    /// # Errors
+    /// - `ArtifactError::InvalidName` if the name fails validation.
+    /// - `ArtifactError::Storage` on I/O failure.
+    async fn save(
+        &self,
+        session_id: &str,
+        name: &str,
+        data: ArtifactData,
+    ) -> Result<ArtifactVersion, ArtifactError>;
+
+    /// Load the latest version of the named artifact.
+    ///
+    /// Returns `None` if the artifact does not exist.
+    async fn load(
+        &self,
+        session_id: &str,
+        name: &str,
+    ) -> Result<Option<(ArtifactData, ArtifactVersion)>, ArtifactError>;
+
+    /// Load a specific version of the named artifact.
+    ///
+    /// Returns `None` if the artifact or version does not exist.
+    async fn load_version(
+        &self,
+        session_id: &str,
+        name: &str,
+        version: u32,
+    ) -> Result<Option<(ArtifactData, ArtifactVersion)>, ArtifactError>;
+
+    /// List metadata for all artifacts in a session.
+    ///
+    /// Returns an empty vec if the session has no artifacts.
+    async fn list(
+        &self,
+        session_id: &str,
+    ) -> Result<Vec<ArtifactMeta>, ArtifactError>;
+
+    /// Delete all versions of the named artifact.
+    ///
+    /// Succeeds silently if the artifact does not exist (idempotent).
+    async fn delete(
+        &self,
+        session_id: &str,
+        name: &str,
+    ) -> Result<(), ArtifactError>;
+}
+```
+
+### StreamingArtifactStore (extension trait)
+
+```rust
+/// Extension trait for artifact stores that support streaming I/O.
+///
+/// Implementing this trait is optional. The base `ArtifactStore` trait
+/// uses `Vec<u8>` for all content operations.
+#[async_trait]
+pub trait StreamingArtifactStore: ArtifactStore {
+    /// Save content from a byte stream as a new version.
+    async fn save_stream(
+        &self,
+        session_id: &str,
+        name: &str,
+        content_type: String,
+        metadata: HashMap<String, String>,
+        stream: Pin<Box<dyn Stream<Item = Result<Bytes, ArtifactError>> + Send>>,
+    ) -> Result<ArtifactVersion, ArtifactError>;
+
+    /// Load an artifact version as a byte stream.
+    ///
+    /// If `version` is `None`, loads the latest version.
+    /// Returns `None` if the artifact or version does not exist.
+    async fn load_stream(
+        &self,
+        session_id: &str,
+        name: &str,
+        version: Option<u32>,
+    ) -> Result<Option<Pin<Box<dyn Stream<Item = Result<Bytes, ArtifactError>> + Send>>>, ArtifactError>;
+}
+```
+
+### Types
+
+```rust
+/// Content payload for an artifact save operation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ArtifactData {
+    pub content: Vec<u8>,
+    pub content_type: String,
+    #[serde(default)]
+    pub metadata: HashMap<String, String>,
+}
+
+/// Record describing a specific saved version.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ArtifactVersion {
+    pub name: String,
+    pub version: u32,
+    pub created_at: DateTime<Utc>,
+    pub size: usize,
+    pub content_type: String,
+}
+
+/// Summary metadata for an artifact (used in list results).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ArtifactMeta {
+    pub name: String,
+    pub latest_version: u32,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub content_type: String,
+}
+
+/// Errors from artifact operations.
+#[derive(Debug, thiserror::Error)]
+pub enum ArtifactError {
+    #[error("invalid artifact name '{name}': {reason}")]
+    InvalidName { name: String, reason: String },
+
+    #[error("artifact storage error: {0}")]
+    Storage(#[from] Box<dyn std::error::Error + Send + Sync>),
+
+    #[error("artifact store not configured")]
+    NotConfigured,
+}
+```
+
+### AgentEvent Variant
+
+```rust
+// Added to the existing AgentEvent enum (behind #[cfg(feature = "artifact-store")])
+AgentEvent::ArtifactSaved {
+    session_id: String,
+    name: String,
+    version: u32,
+},
+```
+
+### Name Validation
+
+```rust
+/// Validate an artifact name. Returns `Ok(())` if valid.
+///
+/// Allowed characters: alphanumeric, hyphens, underscores, dots, forward slashes.
+/// Must not be empty, start/end with `/`, or contain `//`.
+pub fn validate_artifact_name(name: &str) -> Result<(), ArtifactError>;
+```
+
+## Artifacts Crate (swink-agent-artifacts)
+
+### FileArtifactStore
+
+```rust
+/// Filesystem-backed artifact store.
+///
+/// Organizes artifacts as versioned files under a configurable root directory.
+/// Thread-safe for concurrent access within a single process.
+impl FileArtifactStore {
+    /// Create a new store rooted at the given directory path.
+    pub fn new(root: impl Into<PathBuf>) -> Self;
+}
+
+// Implements: ArtifactStore + StreamingArtifactStore
+```
+
+### InMemoryArtifactStore
+
+```rust
+/// In-memory artifact store for testing and lightweight use.
+///
+/// All data lives in heap memory. Not persisted across process restarts.
+impl InMemoryArtifactStore {
+    /// Create a new empty in-memory store.
+    pub fn new() -> Self;
+}
+
+// Implements: ArtifactStore (not StreamingArtifactStore)
+```
+
+## Built-in Tools (swink-agent crate, `artifact-tools` feature)
+
+### SaveArtifactTool
+
+```rust
+impl SaveArtifactTool {
+    pub fn new(store: Arc<dyn ArtifactStore>) -> Self;
+}
+// Tool name: "save_artifact"
+// Parameters: { name: String, content: String, content_type?: String }
+// Returns: "Saved {name} version {version}" or error
+```
+
+### LoadArtifactTool
+
+```rust
+impl LoadArtifactTool {
+    pub fn new(store: Arc<dyn ArtifactStore>) -> Self;
+}
+// Tool name: "load_artifact"
+// Parameters: { name: String, version?: u32 }
+// Returns: text content or "[binary: {size} bytes, type: {type}]"
+```
+
+### ListArtifactsTool
+
+```rust
+impl ListArtifactsTool {
+    pub fn new(store: Arc<dyn ArtifactStore>) -> Self;
+}
+// Tool name: "list_artifacts"
+// Parameters: {} (none required)
+// Returns: formatted list or "No artifacts in this session."
+```
+
+### Convenience Constructor
+
+```rust
+/// Create all built-in artifact tools.
+pub fn artifact_tools(store: Arc<dyn ArtifactStore>) -> Vec<Box<dyn AgentTool>>;
+```
+
+## Re-exports (swink-agent lib.rs)
+
+```rust
+// Behind #[cfg(feature = "artifact-store")]
+pub use artifact::{
+    ArtifactData, ArtifactError, ArtifactMeta, ArtifactStore, ArtifactVersion,
+    StreamingArtifactStore, validate_artifact_name,
+};
+
+// Behind #[cfg(feature = "artifact-tools")]
+pub use tools::{
+    SaveArtifactTool, LoadArtifactTool, ListArtifactsTool, artifact_tools,
+};
+```

--- a/specs/036-artifact-service/data-model.md
+++ b/specs/036-artifact-service/data-model.md
@@ -1,0 +1,136 @@
+# Data Model: Artifact Service
+
+**Feature**: 036-artifact-service | **Date**: 2026-04-02
+
+## Entities
+
+### ArtifactData
+
+Content payload for a single artifact save operation.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `content` | `Vec<u8>` | Raw byte content of the artifact |
+| `content_type` | `String` | MIME type (e.g., `"text/plain"`, `"image/png"`) |
+| `metadata` | `HashMap<String, String>` | Consumer-defined key-value pairs |
+
+**Validation**: None on `ArtifactData` itself — name validation happens at the store level.
+
+### ArtifactVersion
+
+Record describing a specific saved version. Returned by `save` and used for version discovery.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | `String` | Artifact name (validated) |
+| `version` | `u32` | Monotonically increasing per artifact per session, starting at 1 |
+| `created_at` | `DateTime<Utc>` | Timestamp when this version was saved |
+| `size` | `usize` | Byte size of the content |
+| `content_type` | `String` | MIME type of this version's content |
+
+**Derives**: `Debug`, `Clone`, `Serialize`, `Deserialize`, `PartialEq`, `Eq`
+
+### ArtifactMeta
+
+Summary metadata for an artifact across all its versions. Used in list results.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | `String` | Artifact name |
+| `latest_version` | `u32` | Highest version number |
+| `created_at` | `DateTime<Utc>` | Timestamp of version 1 |
+| `updated_at` | `DateTime<Utc>` | Timestamp of the latest version |
+| `content_type` | `String` | Content type of the latest version |
+
+**Derives**: `Debug`, `Clone`, `Serialize`, `Deserialize`, `PartialEq`, `Eq`
+
+### ArtifactError
+
+Error type for artifact operations.
+
+| Variant | Fields | Description |
+|---------|--------|-------------|
+| `InvalidName` | `name: String`, `reason: String` | Name validation failure |
+| `Storage` | `source: Box<dyn Error + Send + Sync>` | Underlying storage I/O error |
+| `NotConfigured` | (none) | Artifact store not set on agent |
+
+**Derives**: `Debug`, `thiserror::Error`
+
+### AgentEvent::ArtifactSaved
+
+New variant on the existing `AgentEvent` enum (behind `artifact-store` feature gate).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `session_id` | `String` | Session the artifact belongs to |
+| `name` | `String` | Artifact name |
+| `version` | `u32` | Version number that was saved |
+
+## Relationships
+
+```text
+ArtifactStore (trait)
+  ├── save(session_id, name, data: ArtifactData) → Result<ArtifactVersion>
+  ├── load(session_id, name) → Result<Option<(ArtifactData, ArtifactVersion)>>
+  ├── load_version(session_id, name, version: u32) → Result<Option<(ArtifactData, ArtifactVersion)>>
+  ├── list(session_id) → Result<Vec<ArtifactMeta>>
+  └── delete(session_id, name) → Result<()>
+
+StreamingArtifactStore (extension trait)
+  ├── save_stream(session_id, name, content_type, metadata, stream) → Result<ArtifactVersion>
+  └── load_stream(session_id, name, version?) → Result<Option<impl Stream<Item = Result<Bytes>>>>
+
+FileArtifactStore ──implements──▶ ArtifactStore + StreamingArtifactStore
+InMemoryArtifactStore ──implements──▶ ArtifactStore (only)
+```
+
+## Filesystem Layout (FileArtifactStore)
+
+```text
+{root}/
+└── {session_id}/
+    └── {artifact_name}/
+        ├── meta.json       # Serialized: Vec<ArtifactVersion> + per-version metadata
+        ├── v1.bin          # Version 1 raw content
+        ├── v2.bin          # Version 2 raw content
+        └── ...
+```
+
+### meta.json Schema
+
+```json
+{
+  "versions": [
+    {
+      "name": "report.md",
+      "version": 1,
+      "created_at": "2026-04-02T10:30:00Z",
+      "size": 2048,
+      "content_type": "text/markdown",
+      "metadata": { "tool": "report-generator" }
+    }
+  ]
+}
+```
+
+## InMemoryArtifactStore Internal Structure
+
+```text
+Arc<tokio::sync::Mutex<
+  HashMap<String,                              // session_id
+    HashMap<String,                            // artifact_name
+      Vec<(ArtifactVersion, ArtifactData)>     // versions (index 0 = v1)
+    >
+  >
+>>
+```
+
+## State Transitions
+
+Artifacts have a simple lifecycle — no complex state machine:
+
+1. **Created**: First `save` creates version 1
+2. **Updated**: Subsequent `save` with same name creates version N+1
+3. **Deleted**: `delete` removes all versions (artifact ceases to exist)
+
+No intermediate states (draft, pending, etc.). Artifacts are immediately available after save completes.

--- a/specs/036-artifact-service/plan.md
+++ b/specs/036-artifact-service/plan.md
@@ -1,0 +1,153 @@
+# Implementation Plan: Artifact Service
+
+**Branch**: `036-artifact-service` | **Date**: 2026-04-02 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/036-artifact-service/spec.md`
+
+## Summary
+
+Session-attached versioned artifact storage for agent-produced outputs. Introduces an `ArtifactStore` trait in the core crate (feature-gated) with save/load/list/delete operations scoped by session ID. A new `swink-agent-artifacts` workspace crate provides `FileArtifactStore` and `InMemoryArtifactStore` implementations. Built-in LLM tools (save, load, list) are gated under a separate `artifact-tools` feature. An `AgentEvent::ArtifactSaved` variant integrates with the existing event system.
+
+## Technical Context
+
+**Language/Version**: Rust 1.88 (edition 2024)
+**Primary Dependencies**: `serde`, `serde_json`, `tokio` (fs + sync), `chrono` (timestamps), `tracing` (diagnostics), `thiserror` (errors), `futures` (streaming trait), `schemars` (tool schemas) — all workspace deps
+**Storage**: Local filesystem (versioned files + JSON metadata sidecar); in-memory (`HashMap`) for testing
+**Testing**: `cargo test --workspace` — unit tests in each module, integration tests in `tests/`
+**Target Platform**: Cross-platform (Linux, macOS, Windows)
+**Project Type**: Library crate (workspace member)
+**Performance Goals**: Streaming I/O for 10MB+ artifacts without proportional heap allocation
+**Constraints**: No `unsafe`, `#[forbid(unsafe_code)]` at crate root. `Send + Sync` on all traits. Zero overhead when feature disabled.
+**Scale/Scope**: Per-session artifact storage; no cross-session versioning; no size limits enforced by framework
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Library-First | ✅ PASS | New `swink-agent-artifacts` crate is independently compilable and testable. Core trait in `swink-agent` behind feature gate. |
+| II. Test-Driven Development | ✅ PASS | Plan requires tests before implementation. `InMemoryArtifactStore` enables fast unit tests. |
+| III. Efficiency & Performance | ✅ PASS | `StreamingArtifactStore` extension trait for large artifacts. Base API uses `Vec<u8>` — simple path first. |
+| IV. Leverage the Ecosystem | ✅ PASS | Uses `tokio::fs` for async I/O, `serde_json` for metadata, `chrono` for timestamps — all existing workspace deps. |
+| V. Provider Agnosticism | ✅ PASS | Artifact storage is provider-independent; trait abstraction allows any backend. |
+| VI. Safety & Correctness | ✅ PASS | `#[forbid(unsafe_code)]`, concurrent access via `tokio::sync::Mutex`, event-based observability. |
+
+**Crate count**: Constitution specifies 7 workspace members. Current workspace has 10 (core, adapters, auth, eval, local-llm, macros, memory, policies, tui, xtask). Adding `artifacts` brings it to 11. **Justified**: Artifacts involve large binary I/O with different performance characteristics than the JSONL-based memory crate. Merging into memory would violate single-responsibility and couple binary storage decisions to conversation persistence.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/036-artifact-service/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+│   └── public-api.md    # ArtifactStore trait contract
+└── tasks.md             # Phase 2 output (/speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+artifacts/
+├── Cargo.toml           # swink-agent-artifacts crate
+├── src/
+│   ├── lib.rs           # Re-exports, #[forbid(unsafe_code)]
+│   ├── error.rs         # ArtifactError enum
+│   ├── fs_store.rs      # FileArtifactStore implementation
+│   ├── memory_store.rs  # InMemoryArtifactStore implementation
+│   ├── streaming.rs     # StreamingArtifactStore trait + FileArtifactStore impl
+│   └── validate.rs      # Artifact name validation
+└── tests/
+    ├── fs_store.rs       # FileArtifactStore integration tests
+    ├── memory_store.rs   # InMemoryArtifactStore unit tests
+    └── streaming.rs      # StreamingArtifactStore tests
+
+# Core crate additions (behind `artifact-store` feature gate)
+src/
+├── artifact.rs          # ArtifactStore trait, ArtifactData, ArtifactVersion, ArtifactMeta types
+└── loop_/event.rs       # + AgentEvent::ArtifactSaved variant
+
+# Core crate additions (behind `artifact-tools` feature gate)
+src/tools/
+├── save_artifact.rs     # SaveArtifactTool
+├── load_artifact.rs     # LoadArtifactTool
+└── list_artifacts.rs    # ListArtifactsTool
+```
+
+**Structure Decision**: New `artifacts/` workspace member for implementations. Core trait and types live in `src/artifact.rs` behind `artifact-store` feature. Built-in tools in `src/tools/` behind `artifact-tools` feature. This follows the same pattern as `builtin-tools` gating `BashTool`/`ReadFileTool`/`WriteFileTool`.
+
+## Implementation Phases
+
+### Phase 1: Core Trait & Types (P1 — FR-001 through FR-009, FR-014, FR-017)
+
+Define the `ArtifactStore` trait and supporting types in `src/artifact.rs`:
+
+- `ArtifactData` struct: `content: Vec<u8>`, `content_type: String`, `metadata: HashMap<String, String>`
+- `ArtifactVersion` struct: `name: String`, `version: u32`, `created_at: DateTime<Utc>`, `size: usize`, `content_type: String`
+- `ArtifactMeta` struct: `name: String`, `latest_version: u32`, `created_at: DateTime<Utc>`, `updated_at: DateTime<Utc>`, `content_type: String`
+- `ArtifactStore` trait: `save`, `load`, `load_version`, `list`, `delete` — all async, `Send + Sync` bounds
+- `ArtifactError` enum: `InvalidName`, `StorageError`, `NotConfigured`
+- `AgentEvent::ArtifactSaved` variant: `session_id: String`, `name: String`, `version: u32`
+- Artifact name validation function (alphanumeric, hyphens, underscores, dots, forward slashes)
+- Feature gate: `artifact-store` on core crate
+
+### Phase 2: Artifacts Crate — InMemoryArtifactStore (P1 — FR-018, FR-019)
+
+New `artifacts/` workspace crate with `InMemoryArtifactStore`:
+
+- `HashMap<String, HashMap<String, Vec<(ArtifactVersion, ArtifactData)>>>` — session → artifact name → versions
+- `tokio::sync::Mutex` for interior mutability (concurrent-safe, matches `Send + Sync`)
+- `tracing::debug!` on save/load/list/delete operations
+- Full test coverage: save, load latest, load specific version, list, delete, concurrent saves, empty cases
+
+### Phase 3: Artifacts Crate — FileArtifactStore (P1 — FR-010, FR-011, FR-019)
+
+Filesystem implementation:
+
+```text
+{root}/{session_id}/{artifact_name}/
+├── meta.json            # ArtifactMeta + per-version records
+├── v1.bin               # Version 1 content
+├── v2.bin               # Version 2 content
+└── ...
+```
+
+- Artifact names with forward slashes create subdirectories (e.g., `tool/output` → `{root}/{session}/{tool/output}/`)
+- `meta.json` contains serialized version records + custom metadata per version
+- Concurrent access: `tokio::sync::Mutex` per session+artifact key for version numbering; file writes use atomic temp-file + rename
+- `tracing::info!` on save, `tracing::debug!` on load/list/delete
+- Integration tests using `tempfile::TempDir`
+
+### Phase 4: StreamingArtifactStore Extension Trait (P2 — FR-016)
+
+- `StreamingArtifactStore` trait: `save_stream` (accepts `impl Stream<Item = Bytes>`) and `load_stream` (returns `impl Stream<Item = Bytes>`)
+- `FileArtifactStore` implements it using `tokio::fs` read/write with buffered I/O
+- `InMemoryArtifactStore` does NOT implement it (uses base `Vec<u8>` API only)
+- Tests: 10MB artifact save/load via streaming
+
+### Phase 5: Built-in Artifact Tools (P2 — FR-013, FR-017)
+
+Three tools behind `artifact-tools` feature gate:
+
+- **SaveArtifactTool**: Takes `name`, `content` (string), `content_type` (optional, defaults to `text/plain`). Captures `Arc<dyn ArtifactStore>`. Returns version number on success.
+- **LoadArtifactTool**: Takes `name`, `version` (optional). Returns content as text for text types, size/type summary for binary.
+- **ListArtifactsTool**: No required args. Returns formatted table of artifact names, versions, content types.
+- All tools implement `AgentTool` with `JsonSchema`-derived parameter schemas
+- `artifact_tools(store: Arc<dyn ArtifactStore>) -> Vec<Box<dyn AgentTool>>` convenience constructor
+
+### Phase 6: Integration & Agent Configuration (P1 — FR-012, FR-015)
+
+- Add optional `artifact_store: Option<Arc<dyn ArtifactStore>>` to `AgentOptions` (behind feature gate)
+- Agent passes artifact store reference to event emission on artifact saves
+- No changes to `AgentLoopConfig` or `StreamFn` — artifact store is orthogonal
+- Verify agent operates normally when no artifact store configured
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| New workspace crate (`artifacts`) | Binary I/O with different perf characteristics than JSONL message store | Merging into `memory` crate couples binary storage to conversation persistence; different dependency needs (streaming I/O vs line-oriented JSON) |

--- a/specs/036-artifact-service/quickstart.md
+++ b/specs/036-artifact-service/quickstart.md
@@ -1,0 +1,147 @@
+# Quickstart: Artifact Service
+
+**Feature**: 036-artifact-service | **Date**: 2026-04-02
+
+## Enable the Feature
+
+```toml
+# In your Cargo.toml
+[dependencies]
+swink-agent = { version = "0.1", features = ["artifact-store"] }
+swink-agent-artifacts = "0.1"
+
+# If you also want built-in LLM tools:
+swink-agent = { version = "0.1", features = ["artifact-store", "artifact-tools"] }
+```
+
+## Basic Usage: Programmatic Artifact Storage
+
+```rust
+use swink_agent::{ArtifactStore, ArtifactData};
+use swink_agent_artifacts::FileArtifactStore;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Create a filesystem-backed store
+    let store = FileArtifactStore::new("./artifacts");
+
+    let session_id = "session-abc";
+
+    // Save an artifact
+    let version = store.save(session_id, "report.md", ArtifactData {
+        content: b"# My Report\nHello world".to_vec(),
+        content_type: "text/markdown".into(),
+        metadata: Default::default(),
+    }).await?;
+
+    println!("Saved version {}", version.version); // "Saved version 1"
+
+    // Save a second version
+    let v2 = store.save(session_id, "report.md", ArtifactData {
+        content: b"# My Report\nUpdated content".to_vec(),
+        content_type: "text/markdown".into(),
+        metadata: Default::default(),
+    }).await?;
+
+    println!("Saved version {}", v2.version); // "Saved version 2"
+
+    // Load latest version
+    if let Some((data, ver)) = store.load(session_id, "report.md").await? {
+        println!("Latest: v{}, {} bytes", ver.version, data.content.len());
+    }
+
+    // Load specific version
+    if let Some((data, _)) = store.load_version(session_id, "report.md", 1).await? {
+        println!("v1: {}", String::from_utf8_lossy(&data.content));
+    }
+
+    // List all artifacts
+    let artifacts = store.list(session_id).await?;
+    for meta in &artifacts {
+        println!("{}: v{} ({})", meta.name, meta.latest_version, meta.content_type);
+    }
+
+    // Delete an artifact
+    store.delete(session_id, "report.md").await?;
+
+    Ok(())
+}
+```
+
+## With an Agent: Built-in Tools
+
+```rust
+use std::sync::Arc;
+use swink_agent::{Agent, artifact_tools};
+use swink_agent_artifacts::InMemoryArtifactStore;
+
+let store = Arc::new(InMemoryArtifactStore::new());
+
+// Create artifact tools that the LLM can call
+let tools = artifact_tools(store.clone());
+
+let agent = Agent::new("You are a helpful assistant that can save and load files.")
+    .tools(tools)
+    // ... configure stream function, etc.
+    .build();
+
+// The LLM can now call:
+//   save_artifact(name: "notes.md", content: "...", content_type: "text/markdown")
+//   load_artifact(name: "notes.md")
+//   list_artifacts()
+```
+
+## Testing with InMemoryArtifactStore
+
+```rust
+use swink_agent_artifacts::InMemoryArtifactStore;
+use swink_agent::{ArtifactStore, ArtifactData};
+
+#[tokio::test]
+async fn artifact_round_trip() {
+    let store = InMemoryArtifactStore::new();
+
+    let v = store.save("test-session", "data.csv", ArtifactData {
+        content: b"col1,col2\na,b".to_vec(),
+        content_type: "text/csv".into(),
+        metadata: [("source".into(), "test".into())].into(),
+    }).await.unwrap();
+
+    assert_eq!(v.version, 1);
+    assert_eq!(v.size, 14);
+
+    let (loaded, _) = store.load("test-session", "data.csv").await.unwrap().unwrap();
+    assert_eq!(loaded.content, b"col1,col2\na,b");
+    assert_eq!(loaded.metadata["source"], "test");
+}
+```
+
+## Streaming Large Artifacts
+
+```rust
+use swink_agent::StreamingArtifactStore;
+use swink_agent_artifacts::FileArtifactStore;
+use futures::stream;
+use bytes::Bytes;
+
+let store = FileArtifactStore::new("./artifacts");
+
+// Save from a byte stream (e.g., from an HTTP response)
+let chunks = stream::iter(vec![
+    Ok(Bytes::from(vec![0u8; 1_000_000])),
+    Ok(Bytes::from(vec![1u8; 1_000_000])),
+]);
+
+let version = store.save_stream(
+    "session-1",
+    "large-export.bin",
+    "application/octet-stream".into(),
+    Default::default(),
+    Box::pin(chunks),
+).await?;
+
+// Load as a stream
+if let Some(stream) = store.load_stream("session-1", "large-export.bin", None).await? {
+    // Process chunks incrementally...
+}
+```

--- a/specs/036-artifact-service/research.md
+++ b/specs/036-artifact-service/research.md
@@ -1,0 +1,75 @@
+# Research: Artifact Service
+
+**Feature**: 036-artifact-service | **Date**: 2026-04-02
+
+## 1. Filesystem Layout for Versioned Artifacts
+
+**Decision**: Version-numbered files (`v1.bin`, `v2.bin`, ...) with a single `meta.json` sidecar per artifact directory.
+
+**Rationale**: Simple, human-inspectable layout. Each version is a standalone file — easy to debug, backup, or migrate. The sidecar JSON consolidates all version metadata in one read, avoiding per-version metadata files. Atomic version numbering is handled by reading `meta.json` under a lock, incrementing, and writing back.
+
+**Alternatives considered**:
+- Content-addressed storage (SHA-based filenames): Adds deduplication but complicates version ordering and requires hash computation on every save. Overkill for per-session artifacts.
+- SQLite per session: Provides strong concurrency guarantees but adds a heavy dependency (`rusqlite`) for a simple versioned blob store. Violates constitution principle IV (prefer existing workspace deps).
+- Append-only log file: Would require custom parsing and makes random-access to specific versions expensive.
+
+## 2. Concurrency Strategy for FileArtifactStore
+
+**Decision**: In-process `tokio::sync::Mutex` keyed by `(session_id, artifact_name)` for version numbering. File writes use temp-file + atomic rename.
+
+**Rationale**: The artifact store is used within a single Tokio runtime (agent process). Cross-process concurrency is not a requirement (spec assumption: per-session, single-agent access). `tokio::sync::Mutex` avoids blocking the runtime. Temp-file + rename ensures no partial writes are visible.
+
+**Alternatives considered**:
+- File locking (`flock`/`lockfile`): Adds cross-process safety but is platform-dependent and unnecessary given single-process assumption.
+- Lock-free CAS on version counter file: Complex, error-prone, and gains nothing when we already hold a Tokio mutex.
+- `std::sync::Mutex`: Would block the async runtime during I/O operations.
+
+## 3. Metadata Sidecar Format
+
+**Decision**: JSON (`meta.json`) using `serde_json`.
+
+**Rationale**: `serde_json` is already a workspace dependency. JSON is human-readable and easily inspectable. The metadata is small (version records with name, number, timestamp, size, content type, custom metadata map) — no performance concern from JSON parsing.
+
+**Alternatives considered**:
+- TOML: Less natural for arrays of version records. Would add complexity without benefit.
+- Bincode/MessagePack: Faster but not human-readable. Debugging artifact stores becomes harder. Not justified for small metadata files.
+
+## 4. Streaming Trait Design
+
+**Decision**: Separate `StreamingArtifactStore` trait with `save_stream` and `load_stream` methods using `futures::Stream<Item = Result<bytes::Bytes, ArtifactError>>`.
+
+**Rationale**: Keeps the base `ArtifactStore` trait simple (just `Vec<u8>`). Implementations opt into streaming by additionally implementing the extension trait. Uses `bytes::Bytes` (already in the dependency tree via `reqwest`) for zero-copy chunk passing. `Result` in the stream item allows implementations to surface I/O errors during streaming.
+
+**Alternatives considered**:
+- `AsyncRead`/`AsyncWrite` from `tokio::io`: Lower-level, requires callers to manage buffering. Less ergonomic for consumers who just want chunks.
+- Default trait methods on `ArtifactStore`: Would force all implementations to deal with stream types even if they only support `Vec<u8>`.
+
+## 5. Artifact Name Validation
+
+**Decision**: Regex-free validation function checking each character against the allowed set: `[a-zA-Z0-9\-_./]`. Names must not be empty, must not start or end with `/`, and must not contain `//` (consecutive slashes).
+
+**Rationale**: Simple character-by-character check is faster than regex compilation for a validation that runs on every save. Additional path-safety rules (no leading/trailing slash, no consecutive slashes) prevent filesystem edge cases.
+
+**Alternatives considered**:
+- Regex: Overhead of compilation for a simple character set check. Would need `regex` crate (not currently a core dependency).
+- No validation (consumer responsibility): Risks filesystem injection via `../` or OS-specific path issues. Validation at the framework level is safer.
+
+## 6. Built-in Tool Content Handling
+
+**Decision**: `SaveArtifactTool` accepts string content and encodes to UTF-8 bytes. `LoadArtifactTool` returns text content as-is for text MIME types, and a `"[binary: {size} bytes, type: {content_type}]"` summary for non-text types.
+
+**Rationale**: LLMs work with text. Providing binary content directly in tool results would produce garbled output. The size/type summary gives the LLM enough information to reference the artifact without attempting to render binary data. Consumers who need binary artifact access use the programmatic API, not the LLM tools.
+
+**Alternatives considered**:
+- Base64-encoding binary content: Would bloat tool results (33% overhead) and most LLMs can't meaningfully process base64 binary data.
+- Refusing to load binary artifacts: Too restrictive — the LLM should at least know the artifact exists and its type.
+
+## 7. Feature Gate Structure
+
+**Decision**: Two independent features on the core crate: `artifact-store` (trait + types + event variant) and `artifact-tools` (built-in tools, depends on `artifact-store`). The `artifacts` crate has no feature gates (both `FileArtifactStore` and `InMemoryArtifactStore` always available).
+
+**Rationale**: Follows the established pattern from spec 033 (workspace feature gates). Consumers who want custom artifact tools but not the built-in ones can enable only `artifact-store`. The artifacts crate is opt-in at the dependency level — no need for internal feature gates.
+
+**Alternatives considered**:
+- Single `artifacts` feature: Would force built-in tools on consumers who only want the storage trait.
+- Feature gates on the artifacts crate: Unnecessary complexity — if you depend on the crate, you want both implementations.

--- a/specs/036-artifact-service/spec.md
+++ b/specs/036-artifact-service/spec.md
@@ -113,6 +113,18 @@ A library consumer wants to remove artifacts that are no longer needed — eithe
 - What happens when artifact content is empty (zero bytes)? Empty artifacts are valid. A zero-byte artifact is saved and loaded correctly with size 0.
 - What happens when the artifact store is not configured on the agent? Tools that require artifact access receive no store reference and return an error indicating artifacts are not enabled. The agent loop itself is unaffected.
 
+## Clarifications
+
+### Session 2026-04-02
+
+- Q: How should `ArtifactSaved` integrate with the event system? → A: New `AgentEvent::ArtifactSaved` variant on the existing enum, behind the feature gate.
+- Q: How should streaming I/O be exposed for implementations that support it? → A: Separate `StreamingArtifactStore` extension trait; base `ArtifactStore` uses `Vec<u8>` only.
+- Q: How should artifact tool feature gating relate to existing gates? → A: New `artifact-tools` feature (depends on `artifact-store` feature); independent of `builtin-tools`.
+- Q: Should the `ArtifactStore` trait require `Send + Sync`? → A: Yes, `ArtifactStore: Send + Sync` required, matching existing trait patterns (`AgentTool`, policy traits).
+- Q: How do tools get access to the artifact store at execution time? → A: Tools capture `Arc<dyn ArtifactStore>` at construction time; no changes to the core tool execution context.
+- Q: Should the artifacts crate ship a built-in `InMemoryArtifactStore`? → A: Yes, always available (not feature-gated), matching project patterns like `InMemoryVersionStore`.
+- Q: Should artifact store operations emit tracing spans? → A: Implementations emit `tracing` spans/events; not a trait requirement.
+
 ## Requirements *(mandatory)*
 
 ### Functional Requirements
@@ -125,15 +137,17 @@ A library consumer wants to remove artifacts that are no longer needed — eithe
 - **FR-006**: Artifact data MUST include raw byte content, a MIME content type string, and an arbitrary string-to-string metadata map for consumer-defined key-value pairs.
 - **FR-007**: Each saved version MUST be described by a version record containing: artifact name, version number (monotonically increasing per artifact per session, starting at 1), creation timestamp, byte size, and content type.
 - **FR-008**: Artifact names MUST be validated: only alphanumeric characters, hyphens, underscores, dots, and forward slashes are allowed. Names MUST NOT be empty. Invalid names MUST return an error on save.
-- **FR-009**: The `ArtifactStore` trait methods MUST be asynchronous to support both local filesystem and remote storage implementations.
+- **FR-009**: The `ArtifactStore` trait methods MUST be asynchronous and the trait MUST require `Send + Sync` bounds to support concurrent tool execution and multi-agent scenarios.
 - **FR-010**: A built-in filesystem-backed implementation MUST be provided that stores artifacts as files organized by session ID and artifact name, with version-numbered filenames and a metadata sidecar file.
 - **FR-011**: The filesystem implementation MUST handle concurrent access safely — concurrent saves to the same artifact MUST produce sequential version numbers without data corruption.
 - **FR-012**: The artifact store MUST be injectable into the agent via configuration, similar to how session stores are configured. If no artifact store is configured, artifact functionality is unavailable but the agent operates normally.
-- **FR-013**: Built-in artifact tools (save, load, list) MUST be provided that allow the LLM to manage artifacts during a conversation. These tools MUST be feature-gated independently from the core artifact store trait.
-- **FR-014**: An `ArtifactSaved` event MUST be emitted via the agent's event system whenever an artifact version is successfully saved, containing the session ID, artifact name, and version number.
+- **FR-013**: Built-in artifact tools (save, load, list) MUST be provided that allow the LLM to manage artifacts during a conversation. These tools MUST be feature-gated independently from the core artifact store trait. Tools MUST capture `Arc<dyn ArtifactStore>` at construction time rather than receiving it via the tool execution context.
+- **FR-018**: An `InMemoryArtifactStore` implementation MUST be provided in the artifacts crate, always available (not feature-gated), for use in tests and lightweight scenarios.
+- **FR-019**: Built-in artifact store implementations (`FileArtifactStore`, `InMemoryArtifactStore`) MUST emit `tracing` spans and events for diagnostic observability. Tracing is NOT a requirement of the `ArtifactStore` trait itself.
+- **FR-014**: An `ArtifactSaved` event MUST be emitted as a new variant on the existing `AgentEvent` enum (behind the `artifact-store` feature gate) whenever an artifact version is successfully saved, containing the session ID, artifact name, and version number.
 - **FR-015**: The artifact store MUST operate independently of the session message store. Artifacts MUST NOT be serialized into the conversation message stream.
-- **FR-016**: The `ArtifactStore` trait MUST support efficient handling of large artifacts. Implementations MAY provide streaming I/O as an optimization. The base trait MUST work with full byte vectors as the minimum API surface.
-- **FR-017**: The artifact service MUST be feature-gated so that projects not using artifacts incur no compile-time or runtime cost.
+- **FR-016**: The `ArtifactStore` trait MUST support efficient handling of large artifacts. The base trait MUST work with full byte vectors (`Vec<u8>`) as the minimum API surface. A separate `StreamingArtifactStore` extension trait MUST be defined for implementations that support incremental I/O; implementing it is optional.
+- **FR-017**: The artifact service MUST be feature-gated with an `artifact-store` feature for the core trait and storage. Built-in artifact tools MUST be gated under a separate `artifact-tools` feature that depends on `artifact-store` and is independent of the existing `builtin-tools` feature.
 
 ### Key Entities
 
@@ -142,6 +156,7 @@ A library consumer wants to remove artifacts that are no longer needed — eithe
 - **ArtifactVersion**: A record describing a specific saved version — name, version number, timestamp, size, content type. Returned on save as confirmation. Used for version discovery.
 - **ArtifactMeta**: Summary metadata for an artifact across all its versions — name, latest version number, creation and update timestamps. Used in list results without loading content.
 - **FileArtifactStore**: The built-in filesystem implementation. Organizes artifacts as versioned files under a configurable root directory.
+- **InMemoryArtifactStore**: A built-in in-memory implementation for testing and lightweight use. Always available (not feature-gated).
 
 ## Success Criteria *(mandatory)*
 

--- a/specs/036-artifact-service/tasks.md
+++ b/specs/036-artifact-service/tasks.md
@@ -1,0 +1,320 @@
+# Tasks: Artifact Service
+
+**Input**: Design documents from `/specs/036-artifact-service/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/
+
+**Tests**: Included — constitution mandates test-driven development (NON-NEGOTIABLE).
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create the `swink-agent-artifacts` workspace crate and add feature gates to the core crate.
+
+- [ ] T001 Create `artifacts/` directory and `artifacts/Cargo.toml` with workspace deps (`serde`, `serde_json`, `tokio`, `chrono`, `tracing`, `thiserror`, `futures`, `bytes`) and dependency on `swink-agent` with `artifact-store` feature
+- [ ] T002 Add `"artifacts"` to workspace members in root `Cargo.toml`
+- [ ] T003 Add `artifact-store` and `artifact-tools` features to core crate `Cargo.toml` (`artifact-tools` depends on `artifact-store`); add `chrono` dep (already workspace dep)
+- [ ] T004 Create `artifacts/src/lib.rs` with `#![forbid(unsafe_code)]` and placeholder module declarations
+- [ ] T005 Create `src/artifact.rs` with `#[cfg(feature = "artifact-store")]` module stub in `src/lib.rs`
+
+**Checkpoint**: Workspace compiles with `cargo build --workspace`. Feature gates are wired but empty.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core types, trait, error enum, and name validation that ALL user stories depend on.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [ ] T006 Define `ArtifactError` enum (`InvalidName`, `Storage`, `NotConfigured`) with `thiserror` derives in `src/artifact.rs`
+- [ ] T007 [P] Define `ArtifactData` struct (`content: Vec<u8>`, `content_type: String`, `metadata: HashMap<String, String>`) with serde derives in `src/artifact.rs`
+- [ ] T008 [P] Define `ArtifactVersion` struct (`name`, `version: u32`, `created_at: DateTime<Utc>`, `size: usize`, `content_type`) with serde derives in `src/artifact.rs`
+- [ ] T009 [P] Define `ArtifactMeta` struct (`name`, `latest_version: u32`, `created_at`, `updated_at`, `content_type`) with serde derives in `src/artifact.rs`
+- [ ] T010 Define `ArtifactStore` async trait (`save`, `load`, `load_version`, `list`, `delete`) with `Send + Sync` bounds in `src/artifact.rs` per contracts/public-api.md signatures
+- [ ] T011 Implement `validate_artifact_name` function in `artifacts/src/validate.rs` — allowed chars `[a-zA-Z0-9\-_./]`, no empty, no leading/trailing `/`, no `//`
+- [ ] T012 [P] Write unit tests for `validate_artifact_name` in `artifacts/src/validate.rs` — valid names, invalid chars, empty, leading/trailing slash, consecutive slashes, path traversal (`../`)
+- [ ] T013 Add `AgentEvent::ArtifactSaved { session_id, name, version }` variant to `src/loop_/event.rs` behind `#[cfg(feature = "artifact-store")]`
+- [ ] T014 Add re-exports of `ArtifactStore`, `ArtifactData`, `ArtifactVersion`, `ArtifactMeta`, `ArtifactError`, `validate_artifact_name` in `src/lib.rs` behind `#[cfg(feature = "artifact-store")]`
+- [ ] T015 Verify `cargo build --workspace` and `cargo test --workspace` pass with both features enabled and disabled
+
+**Checkpoint**: Foundation ready — core trait and types compile, validation tested, event variant wired.
+
+---
+
+## Phase 3: User Story 1 — Agent Tool Saves a Generated File as an Artifact (Priority: P1) 🎯 MVP
+
+**Goal**: Tools can save versioned artifacts attached to a session. Saving the same name creates a new version; all versions remain accessible.
+
+**Independent Test**: Create `InMemoryArtifactStore`, save two versions of "report.md", verify both are independently retrievable with correct content and version numbers.
+
+### Tests for User Story 1
+
+- [ ] T016 [P] [US1] Write test `save_creates_version_one` in `artifacts/tests/memory_store.rs` — save artifact, assert version 1, correct size/content_type
+- [ ] T017 [P] [US1] Write test `save_same_name_increments_version` in `artifacts/tests/memory_store.rs` — save twice, assert versions 1 and 2
+- [ ] T018 [P] [US1] Write test `load_returns_latest_version` in `artifacts/tests/memory_store.rs` — save 3 versions, `load` returns version 3
+- [ ] T019 [P] [US1] Write test `load_version_returns_specific` in `artifacts/tests/memory_store.rs` — save 3 versions, `load_version(1)` returns version 1 content
+- [ ] T020 [P] [US1] Write test `load_nonexistent_returns_none` in `artifacts/tests/memory_store.rs` — `load` unknown name returns `None`
+- [ ] T021 [P] [US1] Write test `load_version_nonexistent_returns_none` in `artifacts/tests/memory_store.rs` — `load_version(99)` returns `None`
+- [ ] T022 [P] [US1] Write test `save_validates_name` in `artifacts/tests/memory_store.rs` — invalid name returns `ArtifactError::InvalidName`
+- [ ] T023 [P] [US1] Write test `save_empty_content_succeeds` in `artifacts/tests/memory_store.rs` — zero-byte artifact saves correctly
+
+### Implementation for User Story 1
+
+- [ ] T024 [US1] Implement `InMemoryArtifactStore` struct in `artifacts/src/memory_store.rs` — `Arc<tokio::sync::Mutex<HashMap<String, HashMap<String, Vec<(ArtifactVersion, ArtifactData)>>>>>`, `new()` constructor
+- [ ] T025 [US1] Implement `ArtifactStore::save` for `InMemoryArtifactStore` in `artifacts/src/memory_store.rs` — validate name, increment version, store data, emit `tracing::debug!`
+- [ ] T026 [US1] Implement `ArtifactStore::load` and `ArtifactStore::load_version` for `InMemoryArtifactStore` in `artifacts/src/memory_store.rs`
+- [ ] T027 [US1] Re-export `InMemoryArtifactStore` from `artifacts/src/lib.rs`
+- [ ] T028 [US1] Run all US1 tests — verify they pass
+
+**Checkpoint**: `InMemoryArtifactStore` saves and loads versioned artifacts. All US1 tests pass.
+
+---
+
+## Phase 4: User Story 2 — Agent Lists and Loads Artifacts from a Session (Priority: P1)
+
+**Goal**: Consumers can list all artifacts in a session with metadata (name, version count, content type, timestamps) without loading content. Loading returns full content + metadata.
+
+**Independent Test**: Save three artifacts with different content types, call `list`, verify all three appear with correct metadata. Load each and verify content integrity.
+
+### Tests for User Story 2
+
+- [ ] T029 [P] [US2] Write test `list_returns_all_artifacts` in `artifacts/tests/memory_store.rs` — save 3 artifacts, list returns 3 entries with correct names/versions/types
+- [ ] T030 [P] [US2] Write test `list_empty_session_returns_empty` in `artifacts/tests/memory_store.rs` — list on unknown session returns empty vec
+- [ ] T031 [P] [US2] Write test `list_reflects_latest_version` in `artifacts/tests/memory_store.rs` — save 2 versions of same artifact, list shows `latest_version: 2`
+- [ ] T032 [P] [US2] Write test `load_includes_custom_metadata` in `artifacts/tests/memory_store.rs` — save with metadata map, load returns same metadata
+
+### Implementation for User Story 2
+
+- [ ] T033 [US2] Implement `ArtifactStore::list` for `InMemoryArtifactStore` in `artifacts/src/memory_store.rs` — iterate artifacts, build `ArtifactMeta` with timestamps from version records
+- [ ] T034 [US2] Run all US2 tests — verify they pass
+
+**Checkpoint**: List returns correct metadata for all artifacts. US1 + US2 tests pass.
+
+---
+
+## Phase 5: User Story 3 — Artifact Store Persists Across Session Boundaries (Priority: P1)
+
+**Goal**: Artifacts saved via `FileArtifactStore` persist on disk and survive session restore. A new agent with the same session ID and store can access all previously saved artifacts.
+
+**Independent Test**: Save artifacts to `FileArtifactStore` with a temp dir, drop the store, create a new one at the same path, verify all artifacts loadable with byte-for-byte content integrity.
+
+### Tests for User Story 3
+
+- [ ] T035 [P] [US3] Write test `fs_save_and_load_round_trip` in `artifacts/tests/fs_store.rs` — save artifact, load back, assert content matches byte-for-byte (use `tempfile::TempDir`)
+- [ ] T036 [P] [US3] Write test `fs_persistence_across_instances` in `artifacts/tests/fs_store.rs` — save with store A, drop A, create store B at same path, load succeeds
+- [ ] T037 [P] [US3] Write test `fs_versioning_persists` in `artifacts/tests/fs_store.rs` — save 3 versions, recreate store, all 3 versions accessible
+- [ ] T038 [P] [US3] Write test `fs_large_artifact_integrity` in `artifacts/tests/fs_store.rs` — save 1MB random bytes, load back, assert identical
+- [ ] T039 [P] [US3] Write test `fs_concurrent_saves_no_corruption` in `artifacts/tests/fs_store.rs` — spawn 10 concurrent saves to same artifact name, verify all 10 versions exist with no data corruption
+- [ ] T040 [P] [US3] Write test `fs_empty_session_returns_empty` in `artifacts/tests/fs_store.rs` — list/load on fresh store returns empty/None
+
+### Implementation for User Story 3
+
+- [ ] T041 [US3] Implement `FileArtifactStore` struct in `artifacts/src/fs_store.rs` — `root: PathBuf`, `locks: Arc<tokio::sync::Mutex<HashMap<(String, String), Arc<tokio::sync::Mutex<()>>>>>`, `new()` constructor
+- [ ] T042 [US3] Implement `ArtifactStore::save` for `FileArtifactStore` in `artifacts/src/fs_store.rs` — validate name, acquire per-artifact lock, read/create meta.json, write content to `v{N}.bin` via temp-file + atomic rename, update meta.json, `tracing::info!`
+- [ ] T043 [US3] Implement `ArtifactStore::load` and `ArtifactStore::load_version` for `FileArtifactStore` in `artifacts/src/fs_store.rs` — read meta.json for version lookup, read `v{N}.bin` content
+- [ ] T044 [US3] Implement `ArtifactStore::list` for `FileArtifactStore` in `artifacts/src/fs_store.rs` — scan session directory, read each artifact's meta.json, build `ArtifactMeta` entries
+- [ ] T045 [US3] Re-export `FileArtifactStore` from `artifacts/src/lib.rs`
+- [ ] T046 [US3] Run all US3 tests — verify they pass
+
+**Checkpoint**: `FileArtifactStore` persists artifacts to disk. Concurrent saves produce sequential versions. All P1 story tests pass.
+
+---
+
+## Phase 6: User Story 4 — LLM Agent Uses Built-in Tools to Manage Artifacts (Priority: P2)
+
+**Goal**: Built-in `save_artifact`, `load_artifact`, and `list_artifacts` tools let the LLM autonomously manage artifacts during a conversation.
+
+**Independent Test**: Configure agent with built-in artifact tools and `InMemoryArtifactStore`. Call save tool, then load tool, verify results. Verify tools absent when feature disabled.
+
+### Tests for User Story 4
+
+- [ ] T047 [P] [US4] Write test `save_artifact_tool_creates_version` in `src/tools/tests/artifact_tools.rs` — call tool with name/content, verify artifact saved in store
+- [ ] T048 [P] [US4] Write test `load_artifact_tool_returns_text_content` in `src/tools/tests/artifact_tools.rs` — save text artifact, call load tool, verify text content in result
+- [ ] T049 [P] [US4] Write test `load_artifact_tool_returns_binary_summary` in `src/tools/tests/artifact_tools.rs` — save binary artifact, call load tool, verify `"[binary: N bytes, type: ...]"` summary
+- [ ] T050 [P] [US4] Write test `list_artifacts_tool_returns_formatted_list` in `src/tools/tests/artifact_tools.rs` — save 2 artifacts, call list tool, verify formatted output
+- [ ] T051 [P] [US4] Write test `list_artifacts_tool_empty_session` in `src/tools/tests/artifact_tools.rs` — call list on empty session, verify "No artifacts" message
+- [ ] T052 [P] [US4] Write test `artifact_tools_convenience_constructor` in `src/tools/tests/artifact_tools.rs` — call `artifact_tools()`, verify returns 3 tools with correct names
+
+### Implementation for User Story 4
+
+- [ ] T053 [US4] Implement `SaveArtifactTool` in `src/tools/save_artifact.rs` — captures `Arc<dyn ArtifactStore>`, accepts `name`/`content`/`content_type` params, implements `AgentTool` with `JsonSchema`-derived params, returns version confirmation
+- [ ] T054 [US4] Implement `LoadArtifactTool` in `src/tools/load_artifact.rs` — captures `Arc<dyn ArtifactStore>`, accepts `name`/`version` params, returns text content or binary summary
+- [ ] T055 [US4] Implement `ListArtifactsTool` in `src/tools/list_artifacts.rs` — captures `Arc<dyn ArtifactStore>`, no required params, returns formatted artifact list
+- [ ] T056 [US4] Implement `artifact_tools(store) -> Vec<Box<dyn AgentTool>>` convenience constructor in `src/tools/mod.rs`
+- [ ] T057 [US4] Add `#[cfg(feature = "artifact-tools")]` module declarations for `save_artifact`, `load_artifact`, `list_artifacts` in `src/tools/mod.rs`
+- [ ] T058 [US4] Add re-exports of `SaveArtifactTool`, `LoadArtifactTool`, `ListArtifactsTool`, `artifact_tools` in `src/lib.rs` behind `#[cfg(feature = "artifact-tools")]`
+- [ ] T059 [US4] Run all US4 tests — verify they pass
+- [ ] T060 [US4] Verify `cargo build -p swink-agent --no-default-features` still compiles (tools not pulled in)
+
+**Checkpoint**: LLM can save, load, and list artifacts via built-in tools. Feature gate verified.
+
+---
+
+## Phase 7: User Story 5 — Streaming Large Artifacts (Priority: P2)
+
+**Goal**: `StreamingArtifactStore` extension trait enables memory-efficient I/O for large artifacts. `FileArtifactStore` implements it.
+
+**Independent Test**: Save 10MB artifact via `save_stream`, load via `load_stream`, verify byte-for-byte integrity.
+
+### Tests for User Story 5
+
+- [ ] T061 [P] [US5] Write test `streaming_save_round_trip` in `artifacts/tests/streaming.rs` — stream 10MB in chunks, load via `load_stream`, verify content matches
+- [ ] T062 [P] [US5] Write test `streaming_save_creates_version` in `artifacts/tests/streaming.rs` — save via stream, verify `ArtifactVersion` returned with correct size
+- [ ] T063 [P] [US5] Write test `streaming_load_nonexistent_returns_none` in `artifacts/tests/streaming.rs` — `load_stream` on unknown artifact returns `None`
+- [ ] T064 [P] [US5] Write test `non_streaming_api_still_works` in `artifacts/tests/streaming.rs` — save via base `Vec<u8>` API, load via streaming, verify compatible
+
+### Implementation for User Story 5
+
+- [ ] T065 [US5] Define `StreamingArtifactStore` extension trait in `src/artifact.rs` — `save_stream` and `load_stream` methods per contracts/public-api.md signatures, behind `artifact-store` feature
+- [ ] T066 [US5] Implement `StreamingArtifactStore` for `FileArtifactStore` in `artifacts/src/streaming.rs` — buffered `tokio::fs` read/write, chunk size 64KB
+- [ ] T067 [US5] Add re-export of `StreamingArtifactStore` in `src/lib.rs` behind `#[cfg(feature = "artifact-store")]`
+- [ ] T068 [US5] Run all US5 tests — verify they pass
+
+**Checkpoint**: Large artifacts stream through `FileArtifactStore` without full-content heap allocation.
+
+---
+
+## Phase 8: User Story 6 — Artifact Deletion (Priority: P3)
+
+**Goal**: Consumers can delete all versions of a named artifact. Deletion is idempotent.
+
+**Independent Test**: Save artifact with 3 versions, delete, verify list no longer includes it, load returns `None`.
+
+### Tests for User Story 6
+
+- [ ] T069 [P] [US6] Write test `delete_removes_all_versions` in `artifacts/tests/memory_store.rs` — save 3 versions, delete, load returns `None`, list excludes it
+- [ ] T070 [P] [US6] Write test `delete_nonexistent_succeeds` in `artifacts/tests/memory_store.rs` — delete unknown name succeeds silently
+- [ ] T071 [P] [US6] Write test `fs_delete_removes_files` in `artifacts/tests/fs_store.rs` — save artifact, delete, verify directory/files removed from disk
+- [ ] T072 [P] [US6] Write test `fs_delete_nonexistent_succeeds` in `artifacts/tests/fs_store.rs` — delete on empty store succeeds
+
+### Implementation for User Story 6
+
+- [ ] T073 [US6] Implement `ArtifactStore::delete` for `InMemoryArtifactStore` in `artifacts/src/memory_store.rs` — remove entry from hashmap
+- [ ] T074 [US6] Implement `ArtifactStore::delete` for `FileArtifactStore` in `artifacts/src/fs_store.rs` — remove artifact directory and all contents
+- [ ] T075 [US6] Run all US6 tests — verify they pass
+
+**Checkpoint**: Deletion works for both store implementations. All user story tests pass.
+
+---
+
+## Phase 9: Polish & Cross-Cutting Concerns
+
+**Purpose**: Integration, configuration hookup, and workspace-level validation.
+
+- [ ] T076 [P] Add optional `artifact_store: Option<Arc<dyn ArtifactStore>>` field to `AgentOptions` in `src/agent_options.rs` behind `#[cfg(feature = "artifact-store")]`
+- [ ] T077 [P] Verify `cargo clippy --workspace -- -D warnings` passes with zero warnings
+- [ ] T078 [P] Verify `cargo test --workspace` passes (all crates, all features)
+- [ ] T079 [P] Verify `cargo build -p swink-agent --no-default-features` compiles (no artifact deps pulled in)
+- [ ] T080 [P] Verify `cargo build -p swink-agent --features artifact-store` compiles without `artifact-tools`
+- [ ] T081 Run quickstart.md code examples validation — verify examples compile and demonstrate correct usage patterns
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion — BLOCKS all user stories
+- **User Stories (Phase 3–8)**: All depend on Foundational phase completion
+  - US1 (Save/Load): Can start after Phase 2
+  - US2 (List): Depends on US1 (needs `InMemoryArtifactStore` from US1)
+  - US3 (Persistence): Depends on US1 (needs trait + types; builds `FileArtifactStore`)
+  - US4 (Tools): Depends on US1 (needs `ArtifactStore` trait + `InMemoryArtifactStore` for testing)
+  - US5 (Streaming): Depends on US3 (needs `FileArtifactStore`)
+  - US6 (Deletion): Depends on US1 + US3 (adds `delete` to both stores)
+- **Polish (Phase 9)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: Phase 2 only — no other story dependencies
+- **US2 (P1)**: US1 (uses `InMemoryArtifactStore` and `save` to set up test data)
+- **US3 (P1)**: US1 (reuses trait types; `FileArtifactStore` implements same trait)
+- **US4 (P2)**: US1 (tools reference `ArtifactStore` trait)
+- **US5 (P2)**: US3 (implements streaming on `FileArtifactStore`)
+- **US6 (P3)**: US1 + US3 (adds `delete` method to both store implementations)
+
+### Within Each User Story
+
+- Tests MUST be written and FAIL before implementation
+- Types/models before trait implementations
+- Trait implementations before integration
+- Story complete before moving to next priority
+
+### Parallel Opportunities
+
+- T007, T008, T009 (type definitions) can run in parallel
+- All US1 tests (T016–T023) can run in parallel
+- All US2 tests (T029–T032) can run in parallel
+- US3 tests (T035–T040) and US4 tests (T047–T052) can run in parallel after their dependencies
+- US6 tests (T069–T072) can all run in parallel
+- Phase 9 tasks (T076–T080) can all run in parallel
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Write all US1 tests in parallel (different test functions, same file):
+T016: save_creates_version_one
+T017: save_same_name_increments_version
+T018: load_returns_latest_version
+T019: load_version_returns_specific
+T020: load_nonexistent_returns_none
+T021: load_version_nonexistent_returns_none
+T022: save_validates_name
+T023: save_empty_content_succeeds
+
+# Then implement sequentially:
+T024: InMemoryArtifactStore struct
+T025: save implementation
+T026: load + load_version implementation
+T027: Re-exports
+T028: Run all tests
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Stories 1–3 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational (CRITICAL — blocks all stories)
+3. Complete Phase 3: US1 (save/load/version)
+4. Complete Phase 4: US2 (list with metadata)
+5. Complete Phase 5: US3 (filesystem persistence)
+6. **STOP and VALIDATE**: All P1 stories functional, both store implementations working
+
+### Incremental Delivery
+
+1. Setup + Foundational → trait and types compile
+2. US1 → `InMemoryArtifactStore` saves/loads versioned artifacts (MVP!)
+3. US2 → List with metadata works
+4. US3 → `FileArtifactStore` persists to disk
+5. US4 → LLM can use artifact tools
+6. US5 → Streaming for large artifacts
+7. US6 → Cleanup/deletion
+8. Polish → Integration, clippy, feature gate validation
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Constitution requires TDD: write failing tests before implementation
+- `#[forbid(unsafe_code)]` on artifacts crate root
+- All store implementations must be `Send + Sync`
+- `InMemoryArtifactStore` is always available (not feature-gated in artifacts crate)
+- `FileArtifactStore` uses temp-file + rename for atomic writes
+- Commit after each task or logical group


### PR DESCRIPTION
## Summary
- Adds complete spec-driven design for session-attached versioned artifact storage
- `ArtifactStore` trait in core crate (feature-gated), `swink-agent-artifacts` crate with `FileArtifactStore` and `InMemoryArtifactStore`
- `StreamingArtifactStore` extension trait, built-in LLM tools (save/load/list), `AgentEvent::ArtifactSaved` variant
- 81 tasks across 6 user stories, 7 clarifications resolved

## Artifacts
- spec.md (updated with clarifications + new FRs)
- plan.md, research.md, data-model.md, quickstart.md
- contracts/public-api.md
- tasks.md (81 tasks, 6 user stories)

## Test plan
- [ ] Spec artifacts are complete and consistent
- [ ] No code changes — spec-only PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)