### PR TITLE
impl(017): Update xAI model catalog to Grok 4.x lineup

### DIFF
--- a/adapters/src/anthropic.rs
+++ b/adapters/src/anthropic.rs
@@ -252,13 +252,17 @@ async fn send_request(
     // Apply cache strategy: inject cache_control on system prompt and last tool def
     let system = if use_caching {
         if let Some(last) = tools.last_mut() {
-            last.cache_control = Some(CacheControl { r#type: "ephemeral" });
+            last.cache_control = Some(CacheControl {
+                r#type: "ephemeral",
+            });
         }
         system_text.map(|text| {
             serde_json::to_value(vec![SystemBlock {
                 r#type: "text",
                 text,
-                cache_control: Some(CacheControl { r#type: "ephemeral" }),
+                cache_control: Some(CacheControl {
+                    r#type: "ephemeral",
+                }),
             }])
             .unwrap_or(Value::Null)
         })

--- a/adapters/src/bedrock.rs
+++ b/adapters/src/bedrock.rs
@@ -564,8 +564,7 @@ fn hex_encode(bytes: &[u8]) -> String {
 type HmacSha256 = Hmac<Sha256>;
 
 fn hmac_sha256(key: &[u8], data: &[u8]) -> [u8; 32] {
-    let mut mac =
-        HmacSha256::new_from_slice(key).expect("HMAC accepts any key size");
+    let mut mac = HmacSha256::new_from_slice(key).expect("HMAC accepts any key size");
     mac.update(data);
     mac.finalize().into_bytes().into()
 }
@@ -585,8 +584,7 @@ mod tests {
         let key = b"Jefe";
         let data = b"what do ya want for nothing?";
         let result = hmac_sha256(key, data);
-        let expected =
-            "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843";
+        let expected = "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843";
         assert_eq!(hex_encode(&result), expected);
     }
 

--- a/adapters/src/classify.rs
+++ b/adapters/src/classify.rs
@@ -177,10 +177,7 @@ mod tests {
                 assert!(error_message.contains("TestProvider"));
                 assert!(error_message.contains("401"));
                 assert!(error_message.contains("bad key"));
-                assert_eq!(
-                    error_kind,
-                    Some(swink_agent::stream::StreamErrorKind::Auth)
-                );
+                assert_eq!(error_kind, Some(swink_agent::stream::StreamErrorKind::Auth));
             }
             other => panic!("expected Error, got {other:?}"),
         }

--- a/adapters/src/lib.rs
+++ b/adapters/src/lib.rs
@@ -34,7 +34,12 @@ pub mod convert;
 )]
 mod finalize;
 #[cfg_attr(
-    not(any(feature = "openai", feature = "azure", feature = "mistral", feature = "xai")),
+    not(any(
+        feature = "openai",
+        feature = "azure",
+        feature = "mistral",
+        feature = "xai"
+    )),
     allow(dead_code)
 )]
 mod openai_compat;

--- a/adapters/src/mistral.rs
+++ b/adapters/src/mistral.rs
@@ -28,9 +28,7 @@ use swink_agent::types::{AgentContext, AgentMessage, ModelSpec};
 
 use crate::base::AdapterBase;
 use crate::convert;
-use crate::openai_compat::{
-    OaiConverter, OaiMessage, build_oai_tools, parse_oai_sse_stream,
-};
+use crate::openai_compat::{OaiConverter, OaiMessage, build_oai_tools, parse_oai_sse_stream};
 
 /// Charset for generating Mistral-compatible 9-char tool call IDs.
 const MISTRAL_ID_CHARSET: &[u8] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
@@ -248,9 +246,7 @@ async fn send_request(
         .json(&body)
         .send()
         .await
-        .map_err(|e| {
-            AssistantMessageEvent::error_network(format!("Mistral connection error: {e}"))
-        })
+        .map_err(|e| AssistantMessageEvent::error_network(format!("Mistral connection error: {e}")))
 }
 
 // ─── Message conversion ────────────────────────────────────────────────────

--- a/adapters/src/remote_presets.rs
+++ b/adapters/src/remote_presets.rs
@@ -88,36 +88,37 @@ pub mod remote_preset_keys {
     pub mod xai {
         use super::RemotePresetKey;
 
-        pub const GROK_3: RemotePresetKey = RemotePresetKey::new("xai", "grok_3");
-        pub const GROK_3_FAST: RemotePresetKey = RemotePresetKey::new("xai", "grok_3_fast");
+        pub const GROK_4_20_REASONING: RemotePresetKey =
+            RemotePresetKey::new("xai", "grok_4_20_reasoning");
+        pub const GROK_4_20_NON_REASONING: RemotePresetKey =
+            RemotePresetKey::new("xai", "grok_4_20_non_reasoning");
+        pub const GROK_4_1_FAST_REASONING: RemotePresetKey =
+            RemotePresetKey::new("xai", "grok_4_1_fast_reasoning");
+        pub const GROK_4_1_FAST_NON_REASONING: RemotePresetKey =
+            RemotePresetKey::new("xai", "grok_4_1_fast_non_reasoning");
+        pub const GROK_4_20_MULTI_AGENT: RemotePresetKey =
+            RemotePresetKey::new("xai", "grok_4_20_multi_agent");
     }
 
     #[cfg(feature = "mistral")]
     pub mod mistral {
         use super::RemotePresetKey;
 
-        pub const MISTRAL_LARGE: RemotePresetKey =
-            RemotePresetKey::new("mistral", "mistral_large");
+        pub const MISTRAL_LARGE: RemotePresetKey = RemotePresetKey::new("mistral", "mistral_large");
         pub const MISTRAL_MEDIUM: RemotePresetKey =
             RemotePresetKey::new("mistral", "mistral_medium");
-        pub const MISTRAL_SMALL: RemotePresetKey =
-            RemotePresetKey::new("mistral", "mistral_small");
-        pub const MINISTRAL_3B: RemotePresetKey =
-            RemotePresetKey::new("mistral", "ministral_3b");
-        pub const MINISTRAL_8B: RemotePresetKey =
-            RemotePresetKey::new("mistral", "ministral_8b");
-        pub const MINISTRAL_14B: RemotePresetKey =
-            RemotePresetKey::new("mistral", "ministral_14b");
+        pub const MISTRAL_SMALL: RemotePresetKey = RemotePresetKey::new("mistral", "mistral_small");
+        pub const MINISTRAL_3B: RemotePresetKey = RemotePresetKey::new("mistral", "ministral_3b");
+        pub const MINISTRAL_8B: RemotePresetKey = RemotePresetKey::new("mistral", "ministral_8b");
+        pub const MINISTRAL_14B: RemotePresetKey = RemotePresetKey::new("mistral", "ministral_14b");
         pub const MAGISTRAL_MEDIUM: RemotePresetKey =
             RemotePresetKey::new("mistral", "magistral_medium");
         pub const MAGISTRAL_SMALL: RemotePresetKey =
             RemotePresetKey::new("mistral", "magistral_small");
         pub const CODESTRAL: RemotePresetKey = RemotePresetKey::new("mistral", "codestral");
         pub const DEVSTRAL: RemotePresetKey = RemotePresetKey::new("mistral", "devstral");
-        pub const PIXTRAL_LARGE: RemotePresetKey =
-            RemotePresetKey::new("mistral", "pixtral_large");
-        pub const PIXTRAL_12B: RemotePresetKey =
-            RemotePresetKey::new("mistral", "pixtral_12b");
+        pub const PIXTRAL_LARGE: RemotePresetKey = RemotePresetKey::new("mistral", "pixtral_large");
+        pub const PIXTRAL_12B: RemotePresetKey = RemotePresetKey::new("mistral", "pixtral_12b");
     }
 
     #[cfg(feature = "bedrock")]
@@ -450,7 +451,12 @@ mod tests {
         assert!(preset("nonexistent-model-xyz").is_none());
     }
 
-    #[cfg(all(feature = "azure", feature = "xai", feature = "mistral", feature = "bedrock"))]
+    #[cfg(all(
+        feature = "azure",
+        feature = "xai",
+        feature = "mistral",
+        feature = "bedrock"
+    ))]
     #[test]
     fn added_provider_presets_map_to_catalog_models() {
         assert_eq!(
@@ -460,10 +466,34 @@ mod tests {
             "gpt-4o"
         );
         assert_eq!(
-            required_catalog_preset(remote_preset_keys::xai::GROK_3)
+            required_catalog_preset(remote_preset_keys::xai::GROK_4_20_REASONING)
                 .unwrap()
                 .model_id,
-            "grok-3"
+            "grok-4.20-0309-reasoning"
+        );
+        assert_eq!(
+            required_catalog_preset(remote_preset_keys::xai::GROK_4_20_NON_REASONING)
+                .unwrap()
+                .model_id,
+            "grok-4.20-0309-non-reasoning"
+        );
+        assert_eq!(
+            required_catalog_preset(remote_preset_keys::xai::GROK_4_1_FAST_REASONING)
+                .unwrap()
+                .model_id,
+            "grok-4-1-fast-reasoning"
+        );
+        assert_eq!(
+            required_catalog_preset(remote_preset_keys::xai::GROK_4_1_FAST_NON_REASONING)
+                .unwrap()
+                .model_id,
+            "grok-4-1-fast-non-reasoning"
+        );
+        assert_eq!(
+            required_catalog_preset(remote_preset_keys::xai::GROK_4_20_MULTI_AGENT)
+                .unwrap()
+                .model_id,
+            "grok-4.20-multi-agent-0309"
         );
         assert_eq!(
             required_catalog_preset(remote_preset_keys::mistral::MISTRAL_LARGE)

--- a/adapters/src/sse.rs
+++ b/adapters/src/sse.rs
@@ -8,9 +8,9 @@
 //! on `swink_agent` (core) types. Breaking changes to this module's API
 //! may occur without a major version bump.
 
+use std::collections::VecDeque;
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::pin::Pin;
-use std::collections::VecDeque;
 
 use futures::stream::{self, Stream, StreamExt as _};
 
@@ -209,10 +209,7 @@ pub fn sse_data_lines_with_callback(
     on_raw_payload: Option<swink_agent::OnRawPayload>,
 ) -> Pin<Box<dyn Stream<Item = SseLine> + Send + 'static>> {
     Box::pin(stream::unfold(
-        (
-            Box::pin(sse_lines(byte_stream)),
-            on_raw_payload,
-        ),
+        (Box::pin(sse_lines(byte_stream)), on_raw_payload),
         |(mut stream, callback)| async move {
             loop {
                 if let Some(line) = stream.next().await {
@@ -394,9 +391,7 @@ mod tests {
             captured_clone.lock().unwrap().push(data.to_owned());
         });
 
-        let chunks = vec![
-            Ok(bytes::Bytes::from("data: line1\n\ndata: line2\n\n")),
-        ];
+        let chunks = vec![Ok(bytes::Bytes::from("data: line1\n\ndata: line2\n\n"))];
         let byte_stream = futures::stream::iter(chunks);
         let mut data_stream = sse_data_lines_with_callback(byte_stream, Some(callback));
 
@@ -414,9 +409,7 @@ mod tests {
 
     #[tokio::test]
     async fn on_raw_payload_none_no_overhead() {
-        let chunks = vec![
-            Ok(bytes::Bytes::from("data: hello\n\n")),
-        ];
+        let chunks = vec![Ok(bytes::Bytes::from("data: hello\n\n"))];
         let byte_stream = futures::stream::iter(chunks);
         let mut data_stream = sse_data_lines_with_callback(byte_stream, None);
 
@@ -433,9 +426,7 @@ mod tests {
             panic!("callback panic!");
         });
 
-        let chunks = vec![
-            Ok(bytes::Bytes::from("data: safe\n\ndata: also_safe\n\n")),
-        ];
+        let chunks = vec![Ok(bytes::Bytes::from("data: safe\n\ndata: also_safe\n\n"))];
         let byte_stream = futures::stream::iter(chunks);
         let mut data_stream = sse_data_lines_with_callback(byte_stream, Some(callback));
 
@@ -448,9 +439,9 @@ mod tests {
 
     #[tokio::test]
     async fn sse_lines_preserves_events_and_separators() {
-        let chunks = vec![
-            Ok(bytes::Bytes::from("event: start\ndata: hello\n\ndata: [DONE]\n")),
-        ];
+        let chunks = vec![Ok(bytes::Bytes::from(
+            "event: start\ndata: hello\n\ndata: [DONE]\n",
+        ))];
         let byte_stream = futures::stream::iter(chunks);
         let lines: Vec<_> = sse_lines(byte_stream).collect().await;
 

--- a/adapters/tests/anthropic.rs
+++ b/adapters/tests/anthropic.rs
@@ -304,10 +304,7 @@ async fn anthropic_http_401() {
         err.contains("auth error"),
         "expected 'auth error', got: {err}"
     );
-    assert!(
-        err.contains("401"),
-        "expected '401' mention, got: {err}"
-    );
+    assert!(err.contains("401"), "expected '401' mention, got: {err}");
 }
 
 #[tokio::test]
@@ -343,10 +340,7 @@ async fn anthropic_http_529() {
 
     let err = find_error_message(&events).expect("expected error event");
     // 529 is mapped to a network/server error via the Anthropic-specific override
-    assert!(
-        err.contains("529"),
-        "expected '529' mention, got: {err}"
-    );
+    assert!(err.contains("529"), "expected '529' mention, got: {err}");
     assert!(
         err.contains("Overloaded"),
         "expected body content, got: {err}"

--- a/adapters/tests/google.rs
+++ b/adapters/tests/google.rs
@@ -264,7 +264,11 @@ async fn google_multiple_tool_calls() {
         })
         .collect();
 
-    assert_eq!(tool_starts.len(), 2, "expected 2 tool calls: {tool_starts:?}");
+    assert_eq!(
+        tool_starts.len(),
+        2,
+        "expected 2 tool calls: {tool_starts:?}"
+    );
     assert_eq!(tool_starts[0].1, "c1");
     assert_eq!(tool_starts[0].2, "get_weather");
     assert_eq!(tool_starts[1].1, "c2");
@@ -294,8 +298,10 @@ async fn google_http_429_maps_to_throttled() {
     let events = collect_events(&stream_fn).await;
 
     let msg = find_error_message(&events).expect("expected error event");
-    assert!(msg.contains("throttled") || msg.contains("rate") || msg.contains("429"),
-        "expected throttled error, got: {msg}");
+    assert!(
+        msg.contains("throttled") || msg.contains("rate") || msg.contains("429"),
+        "expected throttled error, got: {msg}"
+    );
 }
 
 // T030: HTTP 401 → auth
@@ -311,8 +317,10 @@ async fn google_http_401_maps_to_auth() {
     let events = collect_events(&stream_fn).await;
 
     let msg = find_error_message(&events).expect("expected error event");
-    assert!(msg.contains("auth") || msg.contains("401"),
-        "expected auth error, got: {msg}");
+    assert!(
+        msg.contains("auth") || msg.contains("401"),
+        "expected auth error, got: {msg}"
+    );
 }
 
 // T031: HTTP 403 → auth
@@ -328,8 +336,10 @@ async fn google_http_403_maps_to_auth() {
     let events = collect_events(&stream_fn).await;
 
     let msg = find_error_message(&events).expect("expected error event");
-    assert!(msg.contains("auth") || msg.contains("403"),
-        "expected auth error, got: {msg}");
+    assert!(
+        msg.contains("auth") || msg.contains("403"),
+        "expected auth error, got: {msg}"
+    );
 }
 
 // T032: HTTP 500 → network
@@ -345,8 +355,10 @@ async fn google_http_500_maps_to_network() {
     let events = collect_events(&stream_fn).await;
 
     let msg = find_error_message(&events).expect("expected error event");
-    assert!(msg.contains("500") || msg.contains("Google"),
-        "expected network error, got: {msg}");
+    assert!(
+        msg.contains("500") || msg.contains("Google"),
+        "expected network error, got: {msg}"
+    );
 }
 
 // T033: Connection error → network
@@ -357,8 +369,10 @@ async fn google_connection_error_maps_to_network() {
     let events = collect_events(&stream_fn).await;
 
     let msg = find_error_message(&events).expect("expected error event");
-    assert!(msg.contains("connection") || msg.contains("Google connection"),
-        "expected network error, got: {msg}");
+    assert!(
+        msg.contains("connection") || msg.contains("Google connection"),
+        "expected network error, got: {msg}"
+    );
 }
 
 // T034: SAFETY finish reason → error event
@@ -386,8 +400,14 @@ async fn google_safety_finish_reason_emits_error() {
     let events = collect_events(&stream_fn).await;
 
     let types: Vec<_> = events.iter().map(event_name).collect();
-    assert!(types.contains(&"Error"), "expected Error event for SAFETY finish reason: {types:?}");
+    assert!(
+        types.contains(&"Error"),
+        "expected Error event for SAFETY finish reason: {types:?}"
+    );
 
     let msg = find_error_message(&events).expect("expected error message");
-    assert!(msg.contains("safety"), "error message should mention safety: {msg}");
+    assert!(
+        msg.contains("safety"),
+        "error message should mention safety: {msg}"
+    );
 }

--- a/adapters/tests/mistral.rs
+++ b/adapters/tests/mistral.rs
@@ -14,9 +14,7 @@ use tokio_util::sync::CancellationToken;
 use wiremock::matchers::{header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-use swink_agent::types::{
-    AssistantMessage, ContentBlock, ToolResultMessage, UserMessage,
-};
+use swink_agent::types::{AssistantMessage, ContentBlock, ToolResultMessage, UserMessage};
 use swink_agent::{
     AgentContext, AgentMessage, AgentTool, AgentToolResult, AssistantMessageEvent, LlmMessage,
     ModelSpec, StopReason, StreamFn, StreamOptions,
@@ -467,9 +465,10 @@ async fn tool_call_id_format_in_request() {
     let context = AgentContext {
         system_prompt: String::new(),
         messages: vec![
-            AgentMessage::Llm(LlmMessage::Assistant(
-                make_assistant_with_tool_call("call_abc123xyz456", "bash"),
-            )),
+            AgentMessage::Llm(LlmMessage::Assistant(make_assistant_with_tool_call(
+                "call_abc123xyz456",
+                "bash",
+            ))),
             AgentMessage::Llm(LlmMessage::ToolResult(make_tool_result(
                 "call_abc123xyz456",
                 "result",
@@ -502,7 +501,10 @@ async fn tool_call_id_format_in_request() {
         .find(|m| m["role"] == "tool")
         .expect("missing tool message");
     let tool_call_id = tool_msg["tool_call_id"].as_str().unwrap();
-    assert_eq!(tool_call_id, tc_id, "tool result ID must match assistant ID");
+    assert_eq!(
+        tool_call_id, tc_id,
+        "tool result ID must match assistant ID"
+    );
 }
 
 #[tokio::test]
@@ -610,9 +612,11 @@ async fn endpoint_url_trailing_slash() {
 
     let sf = MistralStreamFn::new(format!("{}/", server.uri()), "test-key");
     let events = collect_events(&sf).await;
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, AssistantMessageEvent::Start)));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, AssistantMessageEvent::Start))
+    );
 }
 
 #[tokio::test]
@@ -639,9 +643,11 @@ async fn bearer_auth_header() {
 
     let sf = MistralStreamFn::new(server.uri(), "my-secret-key");
     let events = collect_events(&sf).await;
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, AssistantMessageEvent::Start)));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, AssistantMessageEvent::Start))
+    );
 }
 
 #[tokio::test]
@@ -825,7 +831,10 @@ async fn text_then_tool() {
     let events = collect_events(&sf).await;
 
     let types: Vec<&str> = events.iter().map(|e| event_name(e)).collect();
-    let text_end_pos = types.iter().position(|&t| t == "TextEnd").expect("missing TextEnd");
+    let text_end_pos = types
+        .iter()
+        .position(|&t| t == "TextEnd")
+        .expect("missing TextEnd");
     let tool_start_pos = types
         .iter()
         .position(|&t| t == "ToolCallStart")
@@ -873,9 +882,11 @@ async fn api_key_override_in_options() {
     let token = CancellationToken::new();
     let events: Vec<_> = sf.stream(&model, &context, &options, token).collect().await;
 
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, AssistantMessageEvent::Start)));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, AssistantMessageEvent::Start))
+    );
 }
 
 #[tokio::test]

--- a/adapters/tests/xai.rs
+++ b/adapters/tests/xai.rs
@@ -36,7 +36,7 @@ async fn xai_wrapper_streams_chat_completions() {
     let stream_fn = XAiStreamFn::new(server.uri(), "test-key");
     let events = stream_fn
         .stream(
-            &ModelSpec::new("xai", "grok-3"),
+            &ModelSpec::new("xai", "grok-4-1-fast-non-reasoning"),
             &AgentContext {
                 system_prompt: String::new(),
                 messages: Vec::new(),

--- a/auth/src/in_memory.rs
+++ b/auth/src/in_memory.rs
@@ -54,10 +54,7 @@ impl std::fmt::Debug for InMemoryCredentialStore {
 }
 
 impl CredentialStore for InMemoryCredentialStore {
-    fn get(
-        &self,
-        key: &str,
-    ) -> CredentialFuture<'_, Option<Credential>> {
+    fn get(&self, key: &str) -> CredentialFuture<'_, Option<Credential>> {
         let result = self
             .store
             .read()
@@ -67,11 +64,7 @@ impl CredentialStore for InMemoryCredentialStore {
         Box::pin(std::future::ready(Ok(result)))
     }
 
-    fn set(
-        &self,
-        key: &str,
-        credential: Credential,
-    ) -> CredentialFuture<'_, ()> {
+    fn set(&self, key: &str, credential: Credential) -> CredentialFuture<'_, ()> {
         self.store
             .write()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -79,10 +72,7 @@ impl CredentialStore for InMemoryCredentialStore {
         Box::pin(std::future::ready(Ok(())))
     }
 
-    fn delete(
-        &self,
-        key: &str,
-    ) -> CredentialFuture<'_, ()> {
+    fn delete(&self, key: &str) -> CredentialFuture<'_, ()> {
         self.store
             .write()
             .unwrap_or_else(std::sync::PoisonError::into_inner)

--- a/auth/src/resolver.rs
+++ b/auth/src/resolver.rs
@@ -6,8 +6,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use chrono::Utc;
-use futures::future::{BoxFuture, Shared};
 use futures::FutureExt;
+use futures::future::{BoxFuture, Shared};
 use tokio::sync::Mutex;
 use tracing::{debug, info};
 
@@ -93,7 +93,6 @@ impl DefaultCredentialResolver {
             None => false, // No expiry = never expires (FR-022)
         }
     }
-
 }
 
 impl CredentialResolver for DefaultCredentialResolver {
@@ -110,7 +109,10 @@ impl CredentialResolver for DefaultCredentialResolver {
                 debug!(credential_key = %key, "joining existing credential resolution");
                 return shared_future
                     .await
-                    .map_err(|reason| CredentialError::RefreshFailed { key: key.clone(), reason });
+                    .map_err(|reason| CredentialError::RefreshFailed {
+                        key: key.clone(),
+                        reason,
+                    });
             }
 
             // First, do a quick check — if the credential is valid (no refresh needed),
@@ -125,7 +127,11 @@ impl CredentialResolver for DefaultCredentialResolver {
                     debug!(credential_key = %key, "resolved bearer token credential (fast path)");
                     return Ok(ResolvedCredential::Bearer(token.clone()));
                 }
-                Some(Credential::OAuth2 { access_token, expires_at, .. }) if !self.is_expired(*expires_at) => {
+                Some(Credential::OAuth2 {
+                    access_token,
+                    expires_at,
+                    ..
+                }) if !self.is_expired(*expires_at) => {
                     debug!(credential_key = %key, "resolved OAuth2 credential (fast path)");
                     return Ok(ResolvedCredential::OAuth2AccessToken(access_token.clone()));
                 }
@@ -157,16 +163,20 @@ impl CredentialResolver for DefaultCredentialResolver {
                     let authorization_handler = self.authorization_handler.clone();
                     let key_clone = key.clone();
 
-                    let fut: BoxFuture<'static, Result<ResolvedCredential, String>> = Box::pin(async move {
-                        // Re-create a temporary resolver-like context for the inner resolve
-                        let resolver = InnerResolver {
-                            store: &store,
-                            client: &client,
-                            expiry_buffer,
-                            authorization_handler: authorization_handler.as_deref(),
-                        };
-                        resolver.resolve_inner(&key_clone).await.map_err(|e| e.to_string())
-                    });
+                    let fut: BoxFuture<'static, Result<ResolvedCredential, String>> =
+                        Box::pin(async move {
+                            // Re-create a temporary resolver-like context for the inner resolve
+                            let resolver = InnerResolver {
+                                store: &store,
+                                client: &client,
+                                expiry_buffer,
+                                authorization_handler: authorization_handler.as_deref(),
+                            };
+                            resolver
+                                .resolve_inner(&key_clone)
+                                .await
+                                .map_err(|e| e.to_string())
+                        });
 
                     let shared = fut.shared();
                     guard.insert(key.clone(), shared.clone());
@@ -211,13 +221,13 @@ impl InnerResolver<'_> {
         let credential = self.store.get(key).await?;
 
         match credential {
-            Some(Credential::ApiKey { key: api_key }) => {
-                Ok(ResolvedCredential::ApiKey(api_key))
-            }
+            Some(Credential::ApiKey { key: api_key }) => Ok(ResolvedCredential::ApiKey(api_key)),
 
             Some(Credential::Bearer { token, expires_at }) => {
                 if self.is_expired(expires_at) {
-                    return Err(CredentialError::Expired { key: key.to_string() });
+                    return Err(CredentialError::Expired {
+                        key: key.to_string(),
+                    });
                 }
                 Ok(ResolvedCredential::Bearer(token))
             }
@@ -247,14 +257,17 @@ impl InnerResolver<'_> {
                     .await
                     .map_err(|e| match e {
                         CredentialError::RefreshFailed { reason, .. } => {
-                            CredentialError::RefreshFailed { key: key.to_string(), reason }
+                            CredentialError::RefreshFailed {
+                                key: key.to_string(),
+                                reason,
+                            }
                         }
                         other => other,
                     })?;
 
-                    let new_expires_at = response.expires_in.map(|secs| {
-                        Utc::now() + chrono::Duration::seconds(secs)
-                    });
+                    let new_expires_at = response
+                        .expires_in
+                        .map(|secs| Utc::now() + chrono::Duration::seconds(secs));
                     let new_refresh_token = response.refresh_token.take().or(Some(rt.clone()));
 
                     let new_credential = Credential::OAuth2 {
@@ -272,18 +285,26 @@ impl InnerResolver<'_> {
                 } else if self.authorization_handler.is_some() {
                     // Expired OAuth2 with no refresh token and handler available
                     // but we don't have enough context for the auth flow here
-                    Err(CredentialError::Expired { key: key.to_string() })
+                    Err(CredentialError::Expired {
+                        key: key.to_string(),
+                    })
                 } else {
-                    Err(CredentialError::Expired { key: key.to_string() })
+                    Err(CredentialError::Expired {
+                        key: key.to_string(),
+                    })
                 }
             }
 
             None => {
                 if self.authorization_handler.is_some() {
                     // Handler available but no credential and no OAuth2 context
-                    Err(CredentialError::NotFound { key: key.to_string() })
+                    Err(CredentialError::NotFound {
+                        key: key.to_string(),
+                    })
                 } else {
-                    Err(CredentialError::NotFound { key: key.to_string() })
+                    Err(CredentialError::NotFound {
+                        key: key.to_string(),
+                    })
                 }
             }
         }

--- a/auth/tests/common/mod.rs
+++ b/auth/tests/common/mod.rs
@@ -18,16 +18,14 @@ impl MockAuthHandler {
     }
 
     pub fn failing(reason: impl Into<String>) -> Arc<FailingAuthHandler> {
-        Arc::new(FailingAuthHandler { reason: reason.into() })
+        Arc::new(FailingAuthHandler {
+            reason: reason.into(),
+        })
     }
 }
 
 impl AuthorizationHandler for MockAuthHandler {
-    fn authorize(
-        &self,
-        _auth_url: &str,
-        _state: &str,
-    ) -> CredentialFuture<'_, String> {
+    fn authorize(&self, _auth_url: &str, _state: &str) -> CredentialFuture<'_, String> {
         let code = self.code.clone();
         Box::pin(async move { Ok(code) })
     }
@@ -39,11 +37,7 @@ pub struct FailingAuthHandler {
 }
 
 impl AuthorizationHandler for FailingAuthHandler {
-    fn authorize(
-        &self,
-        _auth_url: &str,
-        _state: &str,
-    ) -> CredentialFuture<'_, String> {
+    fn authorize(&self, _auth_url: &str, _state: &str) -> CredentialFuture<'_, String> {
         let reason = self.reason.clone();
         Box::pin(async move {
             Err(CredentialError::AuthorizationFailed {

--- a/auth/tests/in_memory_tests.rs
+++ b/auth/tests/in_memory_tests.rs
@@ -12,7 +12,9 @@ async fn get_returns_seeded_credential() {
     let mut creds = HashMap::new();
     creds.insert(
         "github".to_string(),
-        Credential::ApiKey { key: "ghp_abc123".into() },
+        Credential::ApiKey {
+            key: "ghp_abc123".into(),
+        },
     );
     let store = InMemoryCredentialStore::new(creds);
 
@@ -38,7 +40,12 @@ async fn set_and_delete_roundtrip() {
 
     // Set
     store
-        .set("test-key", Credential::ApiKey { key: "secret".into() })
+        .set(
+            "test-key",
+            Credential::ApiKey {
+                key: "secret".into(),
+            },
+        )
         .await
         .unwrap();
 
@@ -68,10 +75,12 @@ async fn with_credential_builder() {
 // T029: thread safety — concurrent reads and writes
 #[tokio::test]
 async fn thread_safety_concurrent_access() {
-    let store = Arc::new(
-        InMemoryCredentialStore::empty()
-            .with_credential("shared", Credential::ApiKey { key: "initial".into() }),
-    );
+    let store = Arc::new(InMemoryCredentialStore::empty().with_credential(
+        "shared",
+        Credential::ApiKey {
+            key: "initial".into(),
+        },
+    ));
 
     let mut handles = Vec::new();
 
@@ -91,7 +100,9 @@ async fn thread_safety_concurrent_access() {
             store
                 .set(
                     &format!("key-{i}"),
-                    Credential::ApiKey { key: format!("val-{i}") },
+                    Credential::ApiKey {
+                        key: format!("val-{i}"),
+                    },
                 )
                 .await
                 .unwrap();
@@ -113,8 +124,18 @@ async fn thread_safety_concurrent_access() {
 #[test]
 fn debug_impl_shows_count_not_values() {
     let store = InMemoryCredentialStore::empty()
-        .with_credential("k1", Credential::ApiKey { key: "secret-value".into() })
-        .with_credential("k2", Credential::ApiKey { key: "another-secret".into() });
+        .with_credential(
+            "k1",
+            Credential::ApiKey {
+                key: "secret-value".into(),
+            },
+        )
+        .with_credential(
+            "k2",
+            Credential::ApiKey {
+                key: "another-secret".into(),
+            },
+        );
 
     let debug = format!("{store:?}");
     assert!(debug.contains("credential_count"));

--- a/auth/tests/oauth2_tests.rs
+++ b/auth/tests/oauth2_tests.rs
@@ -48,8 +48,7 @@ async fn expired_oauth2_triggers_refresh() {
 
     let token_url = format!("{}/token", mock_server.uri());
     let store = store(
-        InMemoryCredentialStore::empty()
-            .with_credential("oauth-key", expired_oauth2(&token_url)),
+        InMemoryCredentialStore::empty().with_credential("oauth-key", expired_oauth2(&token_url)),
     );
     let resolver = DefaultCredentialResolver::new(Arc::clone(&store));
 
@@ -64,7 +63,11 @@ async fn expired_oauth2_triggers_refresh() {
     // Verify the store was updated
     let updated = store.get("oauth-key").await.unwrap().unwrap();
     match updated {
-        Credential::OAuth2 { access_token, refresh_token, .. } => {
+        Credential::OAuth2 {
+            access_token,
+            refresh_token,
+            ..
+        } => {
             assert_eq!(access_token, "new-access-token");
             assert_eq!(refresh_token.as_deref(), Some("new-refresh-token"));
         }
@@ -87,8 +90,7 @@ async fn refresh_failure_returns_error() {
 
     let token_url = format!("{}/token", mock_server.uri());
     let store = Arc::new(
-        InMemoryCredentialStore::empty()
-            .with_credential("oauth-key", expired_oauth2(&token_url)),
+        InMemoryCredentialStore::empty().with_credential("oauth-key", expired_oauth2(&token_url)),
     );
     let resolver = DefaultCredentialResolver::new(store);
 
@@ -123,8 +125,7 @@ async fn concurrent_refresh_deduplication() {
 
     let token_url = format!("{}/token", mock_server.uri());
     let store = store(
-        InMemoryCredentialStore::empty()
-            .with_credential("shared", expired_oauth2(&token_url)),
+        InMemoryCredentialStore::empty().with_credential("shared", expired_oauth2(&token_url)),
     );
     let resolver = Arc::new(DefaultCredentialResolver::new(store));
 
@@ -197,10 +198,8 @@ async fn pre_provisioned_expired_auto_refreshes() {
         .await;
 
     let token_url = format!("{}/token", mock_server.uri());
-    let store = store(
-        InMemoryCredentialStore::empty()
-            .with_credential("svc", expired_oauth2(&token_url)),
-    );
+    let store =
+        store(InMemoryCredentialStore::empty().with_credential("svc", expired_oauth2(&token_url)));
     // No authorization handler — headless mode
     let resolver = DefaultCredentialResolver::new(store);
 

--- a/auth/tests/resolver_tests.rs
+++ b/auth/tests/resolver_tests.rs
@@ -12,10 +12,13 @@ use swink_agent_auth::{DefaultCredentialResolver, InMemoryCredentialStore};
 // T030: Resolve API key
 #[tokio::test]
 async fn resolve_api_key() {
-    let store: Arc<dyn swink_agent::CredentialStore> = Arc::new(
-        InMemoryCredentialStore::empty()
-            .with_credential("github", Credential::ApiKey { key: "ghp_test".into() }),
-    );
+    let store: Arc<dyn swink_agent::CredentialStore> =
+        Arc::new(InMemoryCredentialStore::empty().with_credential(
+            "github",
+            Credential::ApiKey {
+                key: "ghp_test".into(),
+            },
+        ));
     let resolver = DefaultCredentialResolver::new(store);
 
     let result = resolver.resolve("github").await.unwrap();
@@ -44,16 +47,14 @@ async fn resolve_missing_key_returns_not_found() {
 #[tokio::test]
 async fn bearer_future_expiry_resolves() {
     let future_time = Utc::now() + chrono::Duration::hours(1);
-    let store: Arc<dyn swink_agent::CredentialStore> = Arc::new(
-        InMemoryCredentialStore::empty()
-            .with_credential(
-                "api",
-                Credential::Bearer {
-                    token: "tok-valid".into(),
-                    expires_at: Some(future_time),
-                },
-            ),
-    );
+    let store: Arc<dyn swink_agent::CredentialStore> =
+        Arc::new(InMemoryCredentialStore::empty().with_credential(
+            "api",
+            Credential::Bearer {
+                token: "tok-valid".into(),
+                expires_at: Some(future_time),
+            },
+        ));
     let resolver = DefaultCredentialResolver::new(store);
 
     let result = resolver.resolve("api").await.unwrap();
@@ -67,16 +68,14 @@ async fn bearer_future_expiry_resolves() {
 #[tokio::test]
 async fn bearer_past_expiry_returns_expired() {
     let past_time = Utc::now() - chrono::Duration::hours(1);
-    let store: Arc<dyn swink_agent::CredentialStore> = Arc::new(
-        InMemoryCredentialStore::empty()
-            .with_credential(
-                "api",
-                Credential::Bearer {
-                    token: "tok-old".into(),
-                    expires_at: Some(past_time),
-                },
-            ),
-    );
+    let store: Arc<dyn swink_agent::CredentialStore> =
+        Arc::new(InMemoryCredentialStore::empty().with_credential(
+            "api",
+            Credential::Bearer {
+                token: "tok-old".into(),
+                expires_at: Some(past_time),
+            },
+        ));
     let resolver = DefaultCredentialResolver::new(store);
 
     let err = resolver.resolve("api").await.unwrap_err();
@@ -91,16 +90,14 @@ async fn bearer_past_expiry_returns_expired() {
 // T039: Bearer with no expiry resolves (FR-022)
 #[tokio::test]
 async fn bearer_no_expiry_resolves() {
-    let store: Arc<dyn swink_agent::CredentialStore> = Arc::new(
-        InMemoryCredentialStore::empty()
-            .with_credential(
-                "api",
-                Credential::Bearer {
-                    token: "tok-forever".into(),
-                    expires_at: None,
-                },
-            ),
-    );
+    let store: Arc<dyn swink_agent::CredentialStore> =
+        Arc::new(InMemoryCredentialStore::empty().with_credential(
+            "api",
+            Credential::Bearer {
+                token: "tok-forever".into(),
+                expires_at: None,
+            },
+        ));
     let resolver = DefaultCredentialResolver::new(store);
 
     let result = resolver.resolve("api").await.unwrap();
@@ -115,16 +112,14 @@ async fn bearer_no_expiry_resolves() {
 async fn bearer_within_buffer_treated_as_expired() {
     // Default buffer is 60s — token expires in 30s (within buffer)
     let soon = Utc::now() + chrono::Duration::seconds(30);
-    let store: Arc<dyn swink_agent::CredentialStore> = Arc::new(
-        InMemoryCredentialStore::empty()
-            .with_credential(
-                "api",
-                Credential::Bearer {
-                    token: "tok-soon".into(),
-                    expires_at: Some(soon),
-                },
-            ),
-    );
+    let store: Arc<dyn swink_agent::CredentialStore> =
+        Arc::new(InMemoryCredentialStore::empty().with_credential(
+            "api",
+            Credential::Bearer {
+                token: "tok-soon".into(),
+                expires_at: Some(soon),
+            },
+        ));
     let resolver = DefaultCredentialResolver::new(store);
 
     let err = resolver.resolve("api").await.unwrap_err();
@@ -140,18 +135,16 @@ async fn bearer_within_buffer_treated_as_expired() {
 async fn custom_expiry_buffer_respected() {
     // Token expires in 90s, custom buffer is 120s — should be treated as expired
     let time = Utc::now() + chrono::Duration::seconds(90);
-    let store: Arc<dyn swink_agent::CredentialStore> = Arc::new(
-        InMemoryCredentialStore::empty()
-            .with_credential(
-                "api",
-                Credential::Bearer {
-                    token: "tok".into(),
-                    expires_at: Some(time),
-                },
-            ),
-    );
-    let resolver = DefaultCredentialResolver::new(store)
-        .with_expiry_buffer(Duration::from_secs(120));
+    let store: Arc<dyn swink_agent::CredentialStore> =
+        Arc::new(InMemoryCredentialStore::empty().with_credential(
+            "api",
+            Credential::Bearer {
+                token: "tok".into(),
+                expires_at: Some(time),
+            },
+        ));
+    let resolver =
+        DefaultCredentialResolver::new(store).with_expiry_buffer(Duration::from_secs(120));
 
     let err = resolver.resolve("api").await.unwrap_err();
     let err_str = format!("{err}");
@@ -167,21 +160,19 @@ async fn custom_expiry_buffer_respected() {
 #[tokio::test]
 async fn valid_oauth2_resolves() {
     let future_time = Utc::now() + chrono::Duration::hours(1);
-    let store: Arc<dyn swink_agent::CredentialStore> = Arc::new(
-        InMemoryCredentialStore::empty()
-            .with_credential(
-                "oauth",
-                Credential::OAuth2 {
-                    access_token: "access-good".into(),
-                    refresh_token: Some("refresh".into()),
-                    expires_at: Some(future_time),
-                    token_url: "https://auth.example.com/token".into(),
-                    client_id: "client-1".into(),
-                    client_secret: None,
-                    scopes: vec![],
-                },
-            ),
-    );
+    let store: Arc<dyn swink_agent::CredentialStore> =
+        Arc::new(InMemoryCredentialStore::empty().with_credential(
+            "oauth",
+            Credential::OAuth2 {
+                access_token: "access-good".into(),
+                refresh_token: Some("refresh".into()),
+                expires_at: Some(future_time),
+                token_url: "https://auth.example.com/token".into(),
+                client_id: "client-1".into(),
+                client_secret: None,
+                scopes: vec![],
+            },
+        ));
     let resolver = DefaultCredentialResolver::new(store);
 
     let result = resolver.resolve("oauth").await.unwrap();
@@ -195,21 +186,19 @@ async fn valid_oauth2_resolves() {
 #[tokio::test]
 async fn expired_oauth2_no_refresh_returns_expired() {
     let past = Utc::now() - chrono::Duration::hours(1);
-    let store: Arc<dyn swink_agent::CredentialStore> = Arc::new(
-        InMemoryCredentialStore::empty()
-            .with_credential(
-                "oauth",
-                Credential::OAuth2 {
-                    access_token: "old".into(),
-                    refresh_token: None,
-                    expires_at: Some(past),
-                    token_url: "https://auth.example.com/token".into(),
-                    client_id: "client-1".into(),
-                    client_secret: None,
-                    scopes: vec![],
-                },
-            ),
-    );
+    let store: Arc<dyn swink_agent::CredentialStore> =
+        Arc::new(InMemoryCredentialStore::empty().with_credential(
+            "oauth",
+            Credential::OAuth2 {
+                access_token: "old".into(),
+                refresh_token: None,
+                expires_at: Some(past),
+                token_url: "https://auth.example.com/token".into(),
+                client_id: "client-1".into(),
+                client_secret: None,
+                scopes: vec![],
+            },
+        ));
     let resolver = DefaultCredentialResolver::new(store);
 
     let err = resolver.resolve("oauth").await.unwrap_err();
@@ -239,21 +228,19 @@ async fn missing_credential_no_handler_returns_not_found() {
 #[tokio::test]
 async fn pre_provisioned_oauth2_resolves_without_handler() {
     let future_time = Utc::now() + chrono::Duration::hours(1);
-    let store: Arc<dyn swink_agent::CredentialStore> = Arc::new(
-        InMemoryCredentialStore::empty()
-            .with_credential(
-                "service",
-                Credential::OAuth2 {
-                    access_token: "svc-token".into(),
-                    refresh_token: Some("svc-refresh".into()),
-                    expires_at: Some(future_time),
-                    token_url: "https://auth.example.com/token".into(),
-                    client_id: "svc-client".into(),
-                    client_secret: Some("svc-secret".into()),
-                    scopes: vec![],
-                },
-            ),
-    );
+    let store: Arc<dyn swink_agent::CredentialStore> =
+        Arc::new(InMemoryCredentialStore::empty().with_credential(
+            "service",
+            Credential::OAuth2 {
+                access_token: "svc-token".into(),
+                refresh_token: Some("svc-refresh".into()),
+                expires_at: Some(future_time),
+                token_url: "https://auth.example.com/token".into(),
+                client_id: "svc-client".into(),
+                client_secret: Some("svc-secret".into()),
+                scopes: vec![],
+            },
+        ));
     // No authorization handler
     let resolver = DefaultCredentialResolver::new(store);
 
@@ -268,21 +255,19 @@ async fn pre_provisioned_oauth2_resolves_without_handler() {
 #[tokio::test]
 async fn expired_no_refresh_no_handler_returns_expired() {
     let past = Utc::now() - chrono::Duration::hours(1);
-    let store: Arc<dyn swink_agent::CredentialStore> = Arc::new(
-        InMemoryCredentialStore::empty()
-            .with_credential(
-                "service",
-                Credential::OAuth2 {
-                    access_token: "old".into(),
-                    refresh_token: None,
-                    expires_at: Some(past),
-                    token_url: "https://auth.example.com/token".into(),
-                    client_id: "svc".into(),
-                    client_secret: None,
-                    scopes: vec![],
-                },
-            ),
-    );
+    let store: Arc<dyn swink_agent::CredentialStore> =
+        Arc::new(InMemoryCredentialStore::empty().with_credential(
+            "service",
+            Credential::OAuth2 {
+                access_token: "old".into(),
+                refresh_token: None,
+                expires_at: Some(past),
+                token_url: "https://auth.example.com/token".into(),
+                client_id: "svc".into(),
+                client_secret: None,
+                scopes: vec![],
+            },
+        ));
     let resolver = DefaultCredentialResolver::new(store);
 
     let err = resolver.resolve("service").await.unwrap_err();

--- a/eval/src/response.rs
+++ b/eval/src/response.rs
@@ -62,25 +62,20 @@ impl Evaluator for ResponseMatcher {
                 }
                 Err(e) => (Score::fail(), format!("invalid regex: {e}")),
             },
-            ResponseCriteria::Custom(f) => {
-                match catch_unwind(AssertUnwindSafe(|| f(actual))) {
-                    Ok(score) => {
-                        let details = format!("custom score: {:.2}", score.value);
-                        (score, details)
-                    }
-                    Err(payload) => {
-                        let msg = payload
-                            .downcast_ref::<&str>()
-                            .copied()
-                            .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
-                            .unwrap_or("unknown panic");
-                        (
-                            Score::fail(),
-                            format!("custom matcher panicked: {msg}"),
-                        )
-                    }
+            ResponseCriteria::Custom(f) => match catch_unwind(AssertUnwindSafe(|| f(actual))) {
+                Ok(score) => {
+                    let details = format!("custom score: {:.2}", score.value);
+                    (score, details)
                 }
-            }
+                Err(payload) => {
+                    let msg = payload
+                        .downcast_ref::<&str>()
+                        .copied()
+                        .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
+                        .unwrap_or("unknown panic");
+                    (Score::fail(), format!("custom matcher panicked: {msg}"))
+                }
+            },
         };
 
         Some(EvalMetricResult {

--- a/eval/src/runner.rs
+++ b/eval/src/runner.rs
@@ -6,7 +6,9 @@
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
-use swink_agent::{Agent, AssistantMessage, ContentBlock, Cost, ModelSpec, StopReason, Usage, UserMessage};
+use swink_agent::{
+    Agent, AssistantMessage, ContentBlock, Cost, ModelSpec, StopReason, Usage, UserMessage,
+};
 
 use crate::error::EvalError;
 use crate::evaluator::EvaluatorRegistry;

--- a/eval/tests/evaluator.rs
+++ b/eval/tests/evaluator.rs
@@ -3,7 +3,7 @@
 mod common;
 
 use swink_agent_eval::{
-    Evaluator, EvaluatorRegistry, EvalCase, EvalMetricResult, Invocation, Score,
+    EvalCase, EvalMetricResult, Evaluator, EvaluatorRegistry, Invocation, Score,
 };
 
 fn minimal_case() -> EvalCase {
@@ -69,17 +69,19 @@ impl Evaluator for ReturnsNone {
 fn registry_with_defaults_has_four_evaluators() {
     let registry = EvaluatorRegistry::with_defaults();
     let invocation = common::mock_invocation(&["read", "write"], Some("hello"), 0.01, 500);
-    let case = common::case_with_trajectory(vec![
-        swink_agent_eval::ExpectedToolCall {
-            tool_name: "read".to_string(),
-            arguments: None,
-        },
-    ]);
+    let case = common::case_with_trajectory(vec![swink_agent_eval::ExpectedToolCall {
+        tool_name: "read".to_string(),
+        arguments: None,
+    }]);
     let results = registry.evaluate(&case, &invocation);
     // with_defaults registers: trajectory, budget, response, efficiency
     // trajectory applies (has expected_trajectory), efficiency applies (has tool calls)
     // budget does not apply (no budget constraints), response does not apply (no expected_response)
-    assert_eq!(results.len(), 2, "trajectory + efficiency should produce results");
+    assert_eq!(
+        results.len(),
+        2,
+        "trajectory + efficiency should produce results"
+    );
     let names: Vec<_> = results.iter().map(|r| r.evaluator_name.as_str()).collect();
     assert!(names.contains(&"trajectory"));
     assert!(names.contains(&"efficiency"));

--- a/eval/tests/match_.rs
+++ b/eval/tests/match_.rs
@@ -103,9 +103,18 @@ fn returns_none_when_no_trajectory_expected() {
 fn us2_exact_match_all_steps() {
     let matcher = TrajectoryMatcher::exact();
     let case = case_with_trajectory(vec![
-        ExpectedToolCall { tool_name: "read".into(), arguments: None },
-        ExpectedToolCall { tool_name: "write".into(), arguments: None },
-        ExpectedToolCall { tool_name: "deploy".into(), arguments: None },
+        ExpectedToolCall {
+            tool_name: "read".into(),
+            arguments: None,
+        },
+        ExpectedToolCall {
+            tool_name: "write".into(),
+            arguments: None,
+        },
+        ExpectedToolCall {
+            tool_name: "deploy".into(),
+            arguments: None,
+        },
     ]);
     let invocation = mock_invocation(&["read", "write", "deploy"], None, 0.0, 0);
     let result = matcher.evaluate(&case, &invocation).unwrap();
@@ -118,51 +127,92 @@ fn us2_exact_match_all_steps() {
 fn us2_missing_steps_identified() {
     let matcher = TrajectoryMatcher::in_order();
     let case = case_with_trajectory(vec![
-        ExpectedToolCall { tool_name: "read".into(), arguments: None },
-        ExpectedToolCall { tool_name: "write".into(), arguments: None },
-        ExpectedToolCall { tool_name: "deploy".into(), arguments: None },
+        ExpectedToolCall {
+            tool_name: "read".into(),
+            arguments: None,
+        },
+        ExpectedToolCall {
+            tool_name: "write".into(),
+            arguments: None,
+        },
+        ExpectedToolCall {
+            tool_name: "deploy".into(),
+            arguments: None,
+        },
     ]);
     // Only "read" and "deploy" present, "write" missing — but InOrder requires order,
     // so only "read" matches (deploy can't match before write in order)
     let invocation = mock_invocation(&["read", "deploy"], None, 0.0, 0);
     let result = matcher.evaluate(&case, &invocation).unwrap();
-    assert!(result.score.value < 1.0, "expected partial match, got {}", result.score.value);
+    assert!(
+        result.score.value < 1.0,
+        "expected partial match, got {}",
+        result.score.value
+    );
 }
 
 /// AS-2.3: Extra (unexpected) steps — `Exact` fails, `InOrder` passes.
 #[test]
 fn us2_extra_steps_exact_fails_inorder_passes() {
     let case = case_with_trajectory(vec![
-        ExpectedToolCall { tool_name: "read".into(), arguments: None },
-        ExpectedToolCall { tool_name: "write".into(), arguments: None },
+        ExpectedToolCall {
+            tool_name: "read".into(),
+            arguments: None,
+        },
+        ExpectedToolCall {
+            tool_name: "write".into(),
+            arguments: None,
+        },
     ]);
     let invocation = mock_invocation(&["search", "read", "think", "write"], None, 0.0, 0);
 
     let exact = TrajectoryMatcher::exact();
     let result = exact.evaluate(&case, &invocation).unwrap();
-    assert_eq!(result.score.verdict(), Verdict::Fail, "Exact should fail with extras");
+    assert_eq!(
+        result.score.verdict(),
+        Verdict::Fail,
+        "Exact should fail with extras"
+    );
 
     let in_order = TrajectoryMatcher::in_order();
     let result = in_order.evaluate(&case, &invocation).unwrap();
-    assert_eq!(result.score.verdict(), Verdict::Pass, "InOrder should pass with extras");
+    assert_eq!(
+        result.score.verdict(),
+        Verdict::Pass,
+        "InOrder should pass with extras"
+    );
 }
 
 /// AS-2.4: Ordering deviation — `Exact` fails (wrong order), `AnyOrder` passes.
 #[test]
 fn us2_ordering_deviation_exact_fails_anyorder_passes() {
     let case = case_with_trajectory(vec![
-        ExpectedToolCall { tool_name: "read".into(), arguments: None },
-        ExpectedToolCall { tool_name: "write".into(), arguments: None },
+        ExpectedToolCall {
+            tool_name: "read".into(),
+            arguments: None,
+        },
+        ExpectedToolCall {
+            tool_name: "write".into(),
+            arguments: None,
+        },
     ]);
     let invocation = mock_invocation(&["write", "read"], None, 0.0, 0);
 
     let exact = TrajectoryMatcher::exact();
     let result = exact.evaluate(&case, &invocation).unwrap();
-    assert_eq!(result.score.verdict(), Verdict::Fail, "Exact should fail on wrong order");
+    assert_eq!(
+        result.score.verdict(),
+        Verdict::Fail,
+        "Exact should fail on wrong order"
+    );
 
     let any = TrajectoryMatcher::any_order();
     let result = any.evaluate(&case, &invocation).unwrap();
-    assert_eq!(result.score.verdict(), Verdict::Pass, "AnyOrder should pass regardless of order");
+    assert_eq!(
+        result.score.verdict(),
+        Verdict::Pass,
+        "AnyOrder should pass regardless of order"
+    );
 }
 
 /// Edge case: Empty golden path — `InOrder`/`AnyOrder` return pass (vacuous truth).
@@ -203,16 +253,14 @@ fn us2_arguments_matching_exact_json() {
     }]);
 
     // Matching arguments
-    let invocation = mock_invocation_multi_turn(&[
-        &[("read", serde_json::json!({"file": "a.txt"}))],
-    ]);
+    let invocation =
+        mock_invocation_multi_turn(&[&[("read", serde_json::json!({"file": "a.txt"}))]]);
     let result = matcher.evaluate(&case, &invocation).unwrap();
     assert_eq!(result.score.verdict(), Verdict::Pass);
 
     // Non-matching arguments
-    let invocation = mock_invocation_multi_turn(&[
-        &[("read", serde_json::json!({"file": "b.txt"}))],
-    ]);
+    let invocation =
+        mock_invocation_multi_turn(&[&[("read", serde_json::json!({"file": "b.txt"}))]]);
     let result = matcher.evaluate(&case, &invocation).unwrap();
     assert_eq!(result.score.verdict(), Verdict::Fail);
 }
@@ -225,9 +273,8 @@ fn us2_arguments_none_matches_by_name_only() {
         tool_name: "read".into(),
         arguments: None,
     }]);
-    let invocation = mock_invocation_multi_turn(&[
-        &[("read", serde_json::json!({"file": "anything.txt"}))],
-    ]);
+    let invocation =
+        mock_invocation_multi_turn(&[&[("read", serde_json::json!({"file": "anything.txt"}))]]);
     let result = matcher.evaluate(&case, &invocation).unwrap();
     assert_eq!(result.score.verdict(), Verdict::Pass);
 }

--- a/eval/tests/response.rs
+++ b/eval/tests/response.rs
@@ -72,10 +72,24 @@ fn us4_exact_match_pass_and_fail() {
     });
 
     let pass = mock_invocation_with_response(&[], "42");
-    assert_eq!(ResponseMatcher.evaluate(&case, &pass).unwrap().score.verdict(), Verdict::Pass);
+    assert_eq!(
+        ResponseMatcher
+            .evaluate(&case, &pass)
+            .unwrap()
+            .score
+            .verdict(),
+        Verdict::Pass
+    );
 
     let fail = mock_invocation_with_response(&[], "43");
-    assert_eq!(ResponseMatcher.evaluate(&case, &fail).unwrap().score.verdict(), Verdict::Fail);
+    assert_eq!(
+        ResponseMatcher
+            .evaluate(&case, &fail)
+            .unwrap()
+            .score
+            .verdict(),
+        Verdict::Fail
+    );
 }
 
 /// AS-4.2: Contains match pass and fail.
@@ -86,10 +100,24 @@ fn us4_contains_match_pass_and_fail() {
     });
 
     let pass = mock_invocation_with_response(&[], "operation success!");
-    assert_eq!(ResponseMatcher.evaluate(&case, &pass).unwrap().score.verdict(), Verdict::Pass);
+    assert_eq!(
+        ResponseMatcher
+            .evaluate(&case, &pass)
+            .unwrap()
+            .score
+            .verdict(),
+        Verdict::Pass
+    );
 
     let fail = mock_invocation_with_response(&[], "operation failed");
-    assert_eq!(ResponseMatcher.evaluate(&case, &fail).unwrap().score.verdict(), Verdict::Fail);
+    assert_eq!(
+        ResponseMatcher
+            .evaluate(&case, &fail)
+            .unwrap()
+            .score
+            .verdict(),
+        Verdict::Fail
+    );
 }
 
 /// AS-4.3: Regex match pass and fail.
@@ -100,10 +128,24 @@ fn us4_regex_match_pass_and_fail() {
     });
 
     let pass = mock_invocation_with_response(&[], "42 files processed");
-    assert_eq!(ResponseMatcher.evaluate(&case, &pass).unwrap().score.verdict(), Verdict::Pass);
+    assert_eq!(
+        ResponseMatcher
+            .evaluate(&case, &pass)
+            .unwrap()
+            .score
+            .verdict(),
+        Verdict::Pass
+    );
 
     let fail = mock_invocation_with_response(&[], "no files");
-    assert_eq!(ResponseMatcher.evaluate(&case, &fail).unwrap().score.verdict(), Verdict::Fail);
+    assert_eq!(
+        ResponseMatcher
+            .evaluate(&case, &fail)
+            .unwrap()
+            .score
+            .verdict(),
+        Verdict::Fail
+    );
 }
 
 /// AS-4.4: Custom function match pass and fail.
@@ -118,10 +160,24 @@ fn us4_custom_fn_pass_and_fail() {
     })));
 
     let pass = mock_invocation_with_response(&[], "task done");
-    assert_eq!(ResponseMatcher.evaluate(&case, &pass).unwrap().score.verdict(), Verdict::Pass);
+    assert_eq!(
+        ResponseMatcher
+            .evaluate(&case, &pass)
+            .unwrap()
+            .score
+            .verdict(),
+        Verdict::Pass
+    );
 
     let fail = mock_invocation_with_response(&[], "task in progress");
-    assert_eq!(ResponseMatcher.evaluate(&case, &fail).unwrap().score.verdict(), Verdict::Fail);
+    assert_eq!(
+        ResponseMatcher
+            .evaluate(&case, &fail)
+            .unwrap()
+            .score
+            .verdict(),
+        Verdict::Fail
+    );
 }
 
 /// AS-4.5: Custom criterion combining multiple sub-checks.
@@ -138,10 +194,24 @@ fn us4_custom_composite_criterion() {
     })));
 
     let pass = mock_invocation_with_response(&[], "Summary: done. total: 5");
-    assert_eq!(ResponseMatcher.evaluate(&case, &pass).unwrap().score.verdict(), Verdict::Pass);
+    assert_eq!(
+        ResponseMatcher
+            .evaluate(&case, &pass)
+            .unwrap()
+            .score
+            .verdict(),
+        Verdict::Pass
+    );
 
     let fail = mock_invocation_with_response(&[], "Summary: done.");
-    assert_eq!(ResponseMatcher.evaluate(&case, &fail).unwrap().score.verdict(), Verdict::Fail);
+    assert_eq!(
+        ResponseMatcher
+            .evaluate(&case, &fail)
+            .unwrap()
+            .score
+            .verdict(),
+        Verdict::Fail
+    );
 }
 
 /// Edge case: Invalid regex returns `Score::fail` with compilation error.
@@ -154,7 +224,10 @@ fn us4_invalid_regex_fails_with_diagnostic() {
     let result = ResponseMatcher.evaluate(&case, &invocation).unwrap();
     assert_eq!(result.score.verdict(), Verdict::Fail);
     let details = result.details.unwrap();
-    assert!(details.contains("invalid regex"), "expected regex error, got: {details}");
+    assert!(
+        details.contains("invalid regex"),
+        "expected regex error, got: {details}"
+    );
 }
 
 /// Edge case: Custom function panic caught and reported as failure.
@@ -167,8 +240,14 @@ fn us4_custom_fn_panic_caught() {
     let result = ResponseMatcher.evaluate(&case, &invocation).unwrap();
     assert_eq!(result.score.verdict(), Verdict::Fail);
     let details = result.details.unwrap();
-    assert!(details.contains("panicked"), "expected panic in details, got: {details}");
-    assert!(details.contains("oops"), "expected panic message, got: {details}");
+    assert!(
+        details.contains("panicked"),
+        "expected panic in details, got: {details}"
+    );
+    assert!(
+        details.contains("oops"),
+        "expected panic message, got: {details}"
+    );
 }
 
 /// Edge case: `None` `final_response` falls back to empty string.
@@ -179,5 +258,9 @@ fn us4_none_response_falls_back_to_empty() {
     });
     let invocation = mock_invocation(&[], None, 0.0, 0);
     let result = ResponseMatcher.evaluate(&case, &invocation).unwrap();
-    assert_eq!(result.score.verdict(), Verdict::Pass, "empty expected should match None response");
+    assert_eq!(
+        result.score.verdict(),
+        Verdict::Pass,
+        "empty expected should match None response"
+    );
 }

--- a/eval/tests/runner.rs
+++ b/eval/tests/runner.rs
@@ -7,9 +7,7 @@ use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 
 use swink_agent::{Agent, AgentOptions, ModelSpec, testing::SimpleMockStreamFn};
-use swink_agent_eval::{
-    AgentFactory, EvalCase, EvalError, EvalRunner, EvalSet, Verdict,
-};
+use swink_agent_eval::{AgentFactory, EvalCase, EvalError, EvalRunner, EvalSet, Verdict};
 
 /// Factory that creates agents with a deterministic mock stream returning the
 /// given tokens as a text-only response.
@@ -26,10 +24,7 @@ impl MockFactory {
 }
 
 impl AgentFactory for MockFactory {
-    fn create_agent(
-        &self,
-        case: &EvalCase,
-    ) -> Result<(Agent, CancellationToken), EvalError> {
+    fn create_agent(&self, case: &EvalCase) -> Result<(Agent, CancellationToken), EvalError> {
         let cancel = CancellationToken::new();
         let stream_fn = Arc::new(SimpleMockStreamFn::new(self.tokens.clone()));
         let model = ModelSpec::new("test", "test-model");
@@ -43,10 +38,7 @@ impl AgentFactory for MockFactory {
 struct FailingFactory;
 
 impl AgentFactory for FailingFactory {
-    fn create_agent(
-        &self,
-        _case: &EvalCase,
-    ) -> Result<(Agent, CancellationToken), EvalError> {
+    fn create_agent(&self, _case: &EvalCase) -> Result<(Agent, CancellationToken), EvalError> {
         Err(EvalError::invalid_case("factory forced failure"))
     }
 }
@@ -86,7 +78,11 @@ async fn run_set_multi_case_produces_per_case_scores() {
         "all cases should be accounted for"
     );
     // Each case should have its ID preserved.
-    let ids: Vec<_> = result.case_results.iter().map(|r| r.case_id.as_str()).collect();
+    let ids: Vec<_> = result
+        .case_results
+        .iter()
+        .map(|r| r.case_id.as_str())
+        .collect();
     assert_eq!(ids, vec!["a", "b", "c"]);
 }
 
@@ -123,7 +119,11 @@ async fn case_failure_recorded_and_suite_continues() {
     let result = runner.run_set(&eval_set, &FailingFactory).await.unwrap();
 
     // All three cases should be present as failed results.
-    assert_eq!(result.case_results.len(), 3, "all cases should have results");
+    assert_eq!(
+        result.case_results.len(),
+        3,
+        "all cases should have results"
+    );
     assert_eq!(result.summary.total_cases, 3);
     assert_eq!(result.summary.failed, 3);
     assert_eq!(result.summary.passed, 0);
@@ -137,7 +137,13 @@ async fn case_failure_recorded_and_suite_continues() {
             .iter()
             .find(|m| m.evaluator_name == "error")
             .expect("should have error metric");
-        assert!(error_metric.details.as_ref().unwrap().contains("factory forced failure"));
+        assert!(
+            error_metric
+                .details
+                .as_ref()
+                .unwrap()
+                .contains("factory forced failure")
+        );
     }
 }
 

--- a/examples/custom_agent.rs
+++ b/examples/custom_agent.rs
@@ -19,8 +19,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // 1. Choose named helpers instead of hand-typing provider/model/base-url strings.
     let connections = ModelConnections::builder()
-        .primary(build_remote_connection(remote_preset_keys::anthropic::SONNET_46)?)
-        .fallback(build_remote_connection(remote_preset_keys::openai::GPT_4_1)?)
+        .primary(build_remote_connection(
+            remote_preset_keys::anthropic::SONNET_46,
+        )?)
+        .fallback(build_remote_connection(
+            remote_preset_keys::openai::GPT_4_1,
+        )?)
         .fallback(default_local_connection()?)
         .build();
 

--- a/examples/minimal_agent.rs
+++ b/examples/minimal_agent.rs
@@ -7,9 +7,7 @@
 //! Run: `cargo run --example minimal_agent`
 //! Requires: `ANTHROPIC_API_KEY` (or swap the preset for OpenAI/Ollama).
 
-use swink_agent::{
-    Agent, AgentMessage, AgentOptions, ContentBlock, LlmMessage, ModelConnections,
-};
+use swink_agent::{Agent, AgentMessage, AgentOptions, ContentBlock, LlmMessage, ModelConnections};
 use swink_agent_adapters::{build_remote_connection, remote_preset_keys};
 
 #[tokio::main]

--- a/local-llm/tests/common/mod.rs
+++ b/local-llm/tests/common/mod.rs
@@ -18,7 +18,6 @@ impl ProgressCollector {
     pub fn events(&self) -> Vec<ProgressEvent> {
         self.events.lock().unwrap().clone()
     }
-
 }
 
 /// Create a [`ProgressCallbackFn`] and its paired [`ProgressCollector`].
@@ -31,4 +30,3 @@ pub fn progress_collector() -> (ProgressCallbackFn, ProgressCollector) {
     let collector = ProgressCollector { events };
     (cb, collector)
 }
-

--- a/macros/src/tool_attr.rs
+++ b/macros/src/tool_attr.rs
@@ -188,10 +188,7 @@ fn is_cancellation_token(ty: &Type) -> bool {
 
 fn is_option_type(ty: &Type) -> bool {
     if let Type::Path(tp) = ty {
-        tp.path
-            .segments
-            .last()
-            .is_some_and(|s| s.ident == "Option")
+        tp.path.segments.last().is_some_and(|s| s.ident == "Option")
     } else {
         false
     }
@@ -206,8 +203,8 @@ fn rust_type_to_json_type(ty: &Type) -> &'static str {
     };
     match last.ident.to_string().as_str() {
         "bool" => "boolean",
-        "u8" | "u16" | "u32" | "u64" | "u128" | "usize" | "i8" | "i16" | "i32" | "i64"
-        | "i128" | "isize" => "integer",
+        "u8" | "u16" | "u32" | "u64" | "u128" | "usize" | "i8" | "i16" | "i32" | "i64" | "i128"
+        | "isize" => "integer",
         "f32" | "f64" => "number",
         "Vec" => "array",
         // String, str, Option, and any unknown types default to "string"

--- a/macros/src/tool_schema.rs
+++ b/macros/src/tool_schema.rs
@@ -140,7 +140,11 @@ fn get_doc_comment(field: &syn::Field) -> Option<String> {
         })
         .collect();
 
-    if lines.is_empty() { None } else { Some(lines.join(" ")) }
+    if lines.is_empty() {
+        None
+    } else {
+        Some(lines.join(" "))
+    }
 }
 
 /// Map a Rust type to `(json_schema_type, is_option)`. Returns `None` for unsupported types.
@@ -154,8 +158,8 @@ fn map_type(ty: &Type) -> Option<(&'static str, bool)> {
     match ident.as_str() {
         "String" | "str" => Some(("string", false)),
         "bool" => Some(("boolean", false)),
-        "u8" | "u16" | "u32" | "u64" | "u128" | "usize" | "i8" | "i16" | "i32" | "i64"
-        | "i128" | "isize" => Some(("integer", false)),
+        "u8" | "u16" | "u32" | "u64" | "u128" | "usize" | "i8" | "i16" | "i32" | "i64" | "i128"
+        | "isize" => Some(("integer", false)),
         "f32" | "f64" => Some(("number", false)),
         "Option" => {
             if let syn::PathArguments::AngleBracketed(args) = &last.arguments

--- a/memory/src/jsonl.rs
+++ b/memory/src/jsonl.rs
@@ -69,7 +69,10 @@ impl SessionRecord {
         let value: serde_json::Value = serde_json::from_str(line).map_err(io::Error::other)?;
         if value.get("_state").and_then(serde_json::Value::as_bool) == Some(true) {
             return Ok(Self::State(
-                value.get("data").cloned().unwrap_or(serde_json::Value::Null),
+                value
+                    .get("data")
+                    .cloned()
+                    .unwrap_or(serde_json::Value::Null),
             ));
         }
         if value.get("_custom").and_then(serde_json::Value::as_bool) == Some(true) {
@@ -221,8 +224,8 @@ fn parse_message_record(
 ) -> Option<AgentMessage> {
     match SessionRecord::parse(line) {
         Ok(SessionRecord::Llm(message)) => Some(AgentMessage::Llm(*message)),
-        Ok(SessionRecord::Custom(envelope)) => registry.and_then(|reg| {
-            match deserialize_custom_message(reg, &envelope) {
+        Ok(SessionRecord::Custom(envelope)) => {
+            registry.and_then(|reg| match deserialize_custom_message(reg, &envelope) {
                 Ok(custom) => Some(AgentMessage::Custom(custom)),
                 Err(error) => {
                     tracing::warn!(
@@ -232,8 +235,8 @@ fn parse_message_record(
                     );
                     None
                 }
-            }
-        }),
+            })
+        }
         Ok(SessionRecord::State(_)) => None,
         Err(error) => {
             tracing::warn!(
@@ -363,9 +366,9 @@ impl SessionStore for JsonlSessionStore {
             .into_iter()
             .enumerate()
             .filter_map(|(line_num, line)| {
-                (!line.trim().is_empty()).then_some(line).and_then(|line| {
-                    parse_llm_message(&line, line_num + 2, id)
-                })
+                (!line.trim().is_empty())
+                    .then_some(line)
+                    .and_then(|line| parse_llm_message(&line, line_num + 2, id))
             })
             .collect();
 
@@ -411,12 +414,7 @@ impl SessionStore for JsonlSessionStore {
         std::fs::remove_file(path)
     }
 
-    fn save_full(
-        &self,
-        id: &str,
-        meta: &SessionMeta,
-        messages: &[AgentMessage],
-    ) -> io::Result<()> {
+    fn save_full(&self, id: &str, meta: &SessionMeta, messages: &[AgentMessage]) -> io::Result<()> {
         validate_session_id(id)?;
 
         let path = session_path(&self.sessions_dir, id);
@@ -624,8 +622,7 @@ mod tests {
             }),
         );
 
-        let (loaded_meta, loaded_messages) =
-            store.load_full("test-full", Some(&registry)).unwrap();
+        let (loaded_meta, loaded_messages) = store.load_full("test-full", Some(&registry)).unwrap();
         assert_eq!(loaded_meta.id, "test-full");
         assert_eq!(loaded_messages.len(), 3);
         assert!(matches!(
@@ -639,9 +636,7 @@ mod tests {
         ));
 
         // Verify custom message content via downcast
-        let custom = loaded_messages[1]
-            .downcast_ref::<TestCustomMsg>()
-            .unwrap();
+        let custom = loaded_messages[1].downcast_ref::<TestCustomMsg>().unwrap();
         assert_eq!(custom.data, "custom-payload");
 
         // Load without registry — custom messages skipped

--- a/memory/src/store.rs
+++ b/memory/src/store.rs
@@ -32,12 +32,7 @@ pub trait SessionStore: Send + Sync {
     ///
     /// The default implementation filters to `LlmMessage` only and delegates
     /// to [`save`](Self::save).
-    fn save_full(
-        &self,
-        id: &str,
-        meta: &SessionMeta,
-        messages: &[AgentMessage],
-    ) -> io::Result<()> {
+    fn save_full(&self, id: &str, meta: &SessionMeta, messages: &[AgentMessage]) -> io::Result<()> {
         let llm_messages: Vec<LlmMessage> = messages
             .iter()
             .filter_map(|m| match m {

--- a/memory/src/store_async.rs
+++ b/memory/src/store_async.rs
@@ -15,7 +15,11 @@ pub type SessionStoreFuture<'a, T> = Pin<Box<dyn Future<Output = io::Result<T>> 
 fn spawn_store_call<T: Send + 'static>(
     f: impl FnOnce() -> io::Result<T> + Send + 'static,
 ) -> SessionStoreFuture<'static, T> {
-    Box::pin(async move { tokio::task::spawn_blocking(f).await.map_err(io::Error::other)? })
+    Box::pin(async move {
+        tokio::task::spawn_blocking(f)
+            .await
+            .map_err(io::Error::other)?
+    })
 }
 
 /// Async session persistence for non-blocking backends (Redis, S3, cloud storage).

--- a/memory/tests/stress_append.rs
+++ b/memory/tests/stress_append.rs
@@ -72,7 +72,10 @@ fn slow_path_triggered_by_title_change() {
     // Append a few messages with the original (short) title — fast path
     for i in 0..5 {
         store
-            .append("slow_path", &[user_message(&format!("before title change {i}"))])
+            .append(
+                "slow_path",
+                &[user_message(&format!("before title change {i}"))],
+            )
             .unwrap();
     }
 
@@ -90,7 +93,10 @@ fn slow_path_triggered_by_title_change() {
     // appends will hit fast path again since meta byte length stabilizes).
     for i in 0..5 {
         store
-            .append("slow_path", &[assistant_message(&format!("after title change {i}"))])
+            .append(
+                "slow_path",
+                &[assistant_message(&format!("after title change {i}"))],
+            )
             .unwrap();
     }
 

--- a/policies/examples/with_policies.rs
+++ b/policies/examples/with_policies.rs
@@ -91,10 +91,7 @@ async fn main() {
 
     // ── Run the agent with follow-ups to demonstrate turn limiting ──
 
-    let result = agent
-        .prompt_text("Hello!")
-        .await
-        .expect("prompt failed");
+    let result = agent.prompt_text("Hello!").await.expect("prompt failed");
     println!("Turn 1: {}", result.assistant_text());
 
     let result = agent.continue_async().await.expect("continue failed");

--- a/policies/src/audit_logger.rs
+++ b/policies/src/audit_logger.rs
@@ -8,9 +8,7 @@ use chrono::Utc;
 use serde::Serialize;
 use unicode_truncate::UnicodeTruncateStr;
 
-use swink_agent::{
-    ContentBlock, PolicyContext, PolicyVerdict, PostTurnPolicy, TurnPolicyContext,
-};
+use swink_agent::{ContentBlock, PolicyContext, PolicyVerdict, PostTurnPolicy, TurnPolicyContext};
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -98,11 +96,7 @@ impl PostTurnPolicy for AuditLogger {
         "audit-logger"
     }
 
-    fn evaluate(
-        &self,
-        ctx: &PolicyContext<'_>,
-        turn: &TurnPolicyContext<'_>,
-    ) -> PolicyVerdict {
+    fn evaluate(&self, ctx: &PolicyContext<'_>, turn: &TurnPolicyContext<'_>) -> PolicyVerdict {
         let full_text = ContentBlock::extract_text(&turn.assistant_message.content);
         let content_summary = truncate_to_chars(&full_text, 200);
 
@@ -163,8 +157,7 @@ impl AuditSink for JsonlAuditSink {
                 .create(true)
                 .append(true)
                 .open(&self.path)?;
-            let json = serde_json::to_string(record)
-                .map_err(std::io::Error::other)?;
+            let json = serde_json::to_string(record).map_err(std::io::Error::other)?;
             writeln!(file, "{json}")?;
             Ok(())
         })();
@@ -236,7 +229,11 @@ mod tests {
         }
     }
 
-    fn make_ctx<'a>(usage: &'a Usage, cost: &'a Cost, state: &'a swink_agent::SessionState) -> PolicyContext<'a> {
+    fn make_ctx<'a>(
+        usage: &'a Usage,
+        cost: &'a Cost,
+        state: &'a swink_agent::SessionState,
+    ) -> PolicyContext<'a> {
         PolicyContext {
             turn_index: 3,
             accumulated_usage: usage,

--- a/policies/src/budget.rs
+++ b/policies/src/budget.rs
@@ -102,7 +102,11 @@ mod tests {
     use super::*;
     use swink_agent::{Cost, Usage};
 
-    fn make_ctx<'a>(usage: &'a Usage, cost: &'a Cost, state: &'a swink_agent::SessionState) -> PolicyContext<'a> {
+    fn make_ctx<'a>(
+        usage: &'a Usage,
+        cost: &'a Cost,
+        state: &'a swink_agent::SessionState,
+    ) -> PolicyContext<'a> {
         PolicyContext {
             turn_index: 0,
             accumulated_usage: usage,
@@ -122,8 +126,15 @@ mod tests {
     #[test]
     fn no_limits_returns_continue() {
         let policy = BudgetPolicy::new();
-        let usage = Usage { input: 1000, output: 500, ..Default::default() };
-        let cost = Cost { total: 10.0, ..Default::default() };
+        let usage = Usage {
+            input: 1000,
+            output: 500,
+            ..Default::default()
+        };
+        let cost = Cost {
+            total: 10.0,
+            ..Default::default()
+        };
         let state = swink_agent::SessionState::new();
         let ctx = make_ctx(&usage, &cost, &state);
         assert!(matches!(policy.evaluate(&ctx), PolicyVerdict::Continue));
@@ -133,7 +144,10 @@ mod tests {
     fn cost_exceeded_returns_stop() {
         let policy = BudgetPolicy::new().max_cost(1.0);
         let usage = Usage::default();
-        let cost = Cost { total: 1.5, ..Default::default() };
+        let cost = Cost {
+            total: 1.5,
+            ..Default::default()
+        };
         let state = swink_agent::SessionState::new();
         let ctx = make_ctx(&usage, &cost, &state);
         assert!(matches!(policy.evaluate(&ctx), PolicyVerdict::Stop(_)));
@@ -143,7 +157,10 @@ mod tests {
     fn cost_not_exceeded_returns_continue() {
         let policy = BudgetPolicy::new().max_cost(5.0);
         let usage = Usage::default();
-        let cost = Cost { total: 4.99, ..Default::default() };
+        let cost = Cost {
+            total: 4.99,
+            ..Default::default()
+        };
         let state = swink_agent::SessionState::new();
         let ctx = make_ctx(&usage, &cost, &state);
         assert!(matches!(policy.evaluate(&ctx), PolicyVerdict::Continue));
@@ -152,7 +169,10 @@ mod tests {
     #[test]
     fn token_exceeded_returns_stop() {
         let policy = BudgetPolicy::new().max_input(100);
-        let usage = Usage { input: 150, ..Default::default() };
+        let usage = Usage {
+            input: 150,
+            ..Default::default()
+        };
         let cost = Cost::default();
         let state = swink_agent::SessionState::new();
         let ctx = make_ctx(&usage, &cost, &state);
@@ -163,7 +183,10 @@ mod tests {
     fn boundary_value_at_limit() {
         let policy = BudgetPolicy::new().max_cost(1.0);
         let usage = Usage::default();
-        let cost = Cost { total: 1.0, ..Default::default() };
+        let cost = Cost {
+            total: 1.0,
+            ..Default::default()
+        };
         let state = swink_agent::SessionState::new();
         let ctx = make_ctx(&usage, &cost, &state);
         // At exactly the limit, should stop (>= comparison)

--- a/policies/src/checkpoint.rs
+++ b/policies/src/checkpoint.rs
@@ -62,11 +62,7 @@ impl PostTurnPolicy for CheckpointPolicy {
         "checkpoint"
     }
 
-    fn evaluate(
-        &self,
-        ctx: &PolicyContext<'_>,
-        _turn: &TurnPolicyContext<'_>,
-    ) -> PolicyVerdict {
+    fn evaluate(&self, ctx: &PolicyContext<'_>, _turn: &TurnPolicyContext<'_>) -> PolicyVerdict {
         let checkpoint = Checkpoint::new(
             format!("turn-{}", ctx.turn_index),
             String::new(), // system_prompt not available in PolicyContext
@@ -128,9 +124,7 @@ mod tests {
         }
 
         fn list_checkpoints(&self) -> CheckpointFuture<'_, Vec<String>> {
-            Box::pin(async move {
-                Ok(self.data.lock().unwrap().keys().cloned().collect())
-            })
+            Box::pin(async move { Ok(self.data.lock().unwrap().keys().cloned().collect()) })
         }
 
         fn delete_checkpoint(&self, id: &str) -> CheckpointFuture<'_, ()> {

--- a/policies/src/content_filter.rs
+++ b/policies/src/content_filter.rs
@@ -252,11 +252,7 @@ impl PostTurnPolicy for ContentFilter {
         "ContentFilter"
     }
 
-    fn evaluate(
-        &self,
-        _ctx: &PolicyContext<'_>,
-        turn: &TurnPolicyContext<'_>,
-    ) -> PolicyVerdict {
+    fn evaluate(&self, _ctx: &PolicyContext<'_>, turn: &TurnPolicyContext<'_>) -> PolicyVerdict {
         let text = ContentBlock::extract_text(&turn.assistant_message.content);
         let mut lowercase_text = None;
 
@@ -299,7 +295,11 @@ mod tests {
 
     use super::*;
 
-    fn make_policy_ctx<'a>(usage: &'a Usage, cost: &'a Cost, state: &'a swink_agent::SessionState) -> PolicyContext<'a> {
+    fn make_policy_ctx<'a>(
+        usage: &'a Usage,
+        cost: &'a Cost,
+        state: &'a swink_agent::SessionState,
+    ) -> PolicyContext<'a> {
         PolicyContext {
             turn_index: 0,
             accumulated_usage: usage,
@@ -427,9 +427,7 @@ mod tests {
         let turn = make_turn_ctx(&msg);
 
         let verdict = filter.evaluate(&ctx, &turn);
-        assert!(
-            matches!(verdict, PolicyVerdict::Stop(reason) if reason.contains("restricted"))
-        );
+        assert!(matches!(verdict, PolicyVerdict::Stop(reason) if reason.contains("restricted")));
     }
 
     #[test]

--- a/policies/src/deny_list.rs
+++ b/policies/src/deny_list.rs
@@ -40,10 +40,7 @@ impl PreDispatchPolicy for ToolDenyListPolicy {
         tool: &mut ToolPolicyContext<'_>,
     ) -> PreDispatchVerdict {
         if self.denied.contains(tool.tool_name) {
-            PreDispatchVerdict::Skip(format!(
-                "tool '{}' is denied by policy",
-                tool.tool_name
-            ))
+            PreDispatchVerdict::Skip(format!("tool '{}' is denied by policy", tool.tool_name))
         } else {
             PreDispatchVerdict::Continue
         }
@@ -55,7 +52,11 @@ mod tests {
     use super::*;
     use swink_agent::{Cost, Usage};
 
-    fn make_ctx<'a>(usage: &'a Usage, cost: &'a Cost, state: &'a swink_agent::SessionState) -> PolicyContext<'a> {
+    fn make_ctx<'a>(
+        usage: &'a Usage,
+        cost: &'a Cost,
+        state: &'a swink_agent::SessionState,
+    ) -> PolicyContext<'a> {
         PolicyContext {
             turn_index: 0,
             accumulated_usage: usage,

--- a/policies/src/lib.rs
+++ b/policies/src/lib.rs
@@ -75,4 +75,6 @@ pub use content_filter::{ContentFilter, ContentFilterError, FilterRule};
 #[cfg(feature = "audit")]
 mod audit_logger;
 #[cfg(feature = "audit")]
-pub use audit_logger::{AuditCost, AuditLogger, AuditRecord, AuditSink, AuditUsage, JsonlAuditSink};
+pub use audit_logger::{
+    AuditCost, AuditLogger, AuditRecord, AuditSink, AuditUsage, JsonlAuditSink,
+};

--- a/policies/src/loop_detection.rs
+++ b/policies/src/loop_detection.rs
@@ -73,7 +73,10 @@ impl LoopDetectionPolicy {
 
     /// Check if the last `lookback` turns all have the same fingerprint.
     fn is_stuck(&self) -> bool {
-        let history = self.history.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let history = self
+            .history
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         if history.len() < self.lookback {
             return false;
         }
@@ -109,14 +112,13 @@ impl PostTurnPolicy for LoopDetectionPolicy {
         "loop_detection"
     }
 
-    fn evaluate(
-        &self,
-        _ctx: &PolicyContext<'_>,
-        turn: &TurnPolicyContext<'_>,
-    ) -> PolicyVerdict {
+    fn evaluate(&self, _ctx: &PolicyContext<'_>, turn: &TurnPolicyContext<'_>) -> PolicyVerdict {
         let fingerprint = Self::extract_fingerprint(turn);
 
-        let mut history = self.history.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut history = self
+            .history
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         history.push_back(fingerprint);
         // Keep only lookback + 1 entries (we need lookback for comparison)
         while history.len() > self.lookback + 1 {
@@ -130,15 +132,13 @@ impl PostTurnPolicy for LoopDetectionPolicy {
                     PolicyVerdict::Stop("loop detected: repeated tool call pattern".to_string())
                 }
                 LoopDetectionAction::Inject(message) => {
-                    let steering_msg = AgentMessage::Llm(
-                        LlmMessage::User(UserMessage {
-                            content: vec![ContentBlock::Text {
-                                text: message.clone(),
-                            }],
-                            timestamp: now_timestamp(),
-                            cache_hint: None,
-                        }),
-                    );
+                    let steering_msg = AgentMessage::Llm(LlmMessage::User(UserMessage {
+                        content: vec![ContentBlock::Text {
+                            text: message.clone(),
+                        }],
+                        timestamp: now_timestamp(),
+                        cache_hint: None,
+                    }));
                     PolicyVerdict::Inject(vec![steering_msg])
                 }
             }
@@ -153,7 +153,11 @@ mod tests {
     use super::*;
     use swink_agent::{AssistantMessage, ContentBlock, Cost, StopReason, Usage};
 
-    fn make_ctx<'a>(usage: &'a Usage, cost: &'a Cost, state: &'a swink_agent::SessionState) -> PolicyContext<'a> {
+    fn make_ctx<'a>(
+        usage: &'a Usage,
+        cost: &'a Cost,
+        state: &'a swink_agent::SessionState,
+    ) -> PolicyContext<'a> {
         PolicyContext {
             turn_index: 0,
             accumulated_usage: usage,
@@ -193,7 +197,9 @@ mod tests {
     fn tool_result(id: &str, text: &str) -> swink_agent::ToolResultMessage {
         swink_agent::ToolResultMessage {
             tool_call_id: id.to_string(),
-            content: vec![ContentBlock::Text { text: text.to_string() }],
+            content: vec![ContentBlock::Text {
+                text: text.to_string(),
+            }],
             is_error: false,
             timestamp: 0,
             details: serde_json::Value::Null,
@@ -212,15 +218,24 @@ mod tests {
 
         let results1 = vec![tool_result("bash_1", "output1")];
         let turn1 = make_turn_ctx(&msg, &results1);
-        assert!(matches!(policy.evaluate(&ctx, &turn1), PolicyVerdict::Continue));
+        assert!(matches!(
+            policy.evaluate(&ctx, &turn1),
+            PolicyVerdict::Continue
+        ));
 
         let results2 = vec![tool_result("bash_2", "output2")];
         let turn2 = make_turn_ctx(&msg, &results2);
-        assert!(matches!(policy.evaluate(&ctx, &turn2), PolicyVerdict::Continue));
+        assert!(matches!(
+            policy.evaluate(&ctx, &turn2),
+            PolicyVerdict::Continue
+        ));
 
         let results3 = vec![tool_result("bash_3", "output3")];
         let turn3 = make_turn_ctx(&msg, &results3);
-        assert!(matches!(policy.evaluate(&ctx, &turn3), PolicyVerdict::Continue));
+        assert!(matches!(
+            policy.evaluate(&ctx, &turn3),
+            PolicyVerdict::Continue
+        ));
     }
 
     #[test]
@@ -249,8 +264,7 @@ mod tests {
 
     #[test]
     fn repeat_with_steering_returns_inject() {
-        let policy = LoopDetectionPolicy::new(2)
-            .with_steering("Try something different");
+        let policy = LoopDetectionPolicy::new(2).with_steering("Try something different");
         let usage = Usage::default();
         let cost = Cost::default();
         let state = swink_agent::SessionState::new();

--- a/policies/src/max_turns.rs
+++ b/policies/src/max_turns.rs
@@ -68,7 +68,12 @@ mod tests {
     use super::*;
     use swink_agent::{Cost, Usage};
 
-    fn make_ctx_at_turn<'a>(turn: usize, usage: &'a Usage, cost: &'a Cost, state: &'a swink_agent::SessionState) -> PolicyContext<'a> {
+    fn make_ctx_at_turn<'a>(
+        turn: usize,
+        usage: &'a Usage,
+        cost: &'a Cost,
+        state: &'a swink_agent::SessionState,
+    ) -> PolicyContext<'a> {
         PolicyContext {
             turn_index: turn,
             accumulated_usage: usage,
@@ -87,7 +92,10 @@ mod tests {
         let cost = Cost::default();
         let state = swink_agent::SessionState::new();
         let ctx = make_ctx_at_turn(5, &usage, &cost, &state);
-        assert!(matches!(PreTurnPolicy::evaluate(&policy, &ctx), PolicyVerdict::Stop(_)));
+        assert!(matches!(
+            PreTurnPolicy::evaluate(&policy, &ctx),
+            PolicyVerdict::Stop(_)
+        ));
     }
 
     #[test]
@@ -97,7 +105,10 @@ mod tests {
         let cost = Cost::default();
         let state = swink_agent::SessionState::new();
         let ctx = make_ctx_at_turn(4, &usage, &cost, &state);
-        assert!(matches!(PreTurnPolicy::evaluate(&policy, &ctx), PolicyVerdict::Continue));
+        assert!(matches!(
+            PreTurnPolicy::evaluate(&policy, &ctx),
+            PolicyVerdict::Continue
+        ));
     }
 
     #[test]

--- a/policies/src/pii_redactor.rs
+++ b/policies/src/pii_redactor.rs
@@ -55,8 +55,9 @@ impl PiiRedactor {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            patterns: compile_named_regexes(default_patterns(), |name, regex| {
-                PiiPattern { name, regex }
+            patterns: compile_named_regexes(default_patterns(), |name, regex| PiiPattern {
+                name,
+                regex,
             })
             .expect("default PII pattern must compile"),
             mode: PiiMode::default(),
@@ -111,10 +112,7 @@ const fn default_patterns() -> &'static [(&'static str, &'static str)] {
             r"(\+1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}",
         ),
         ("ssn", r"\d{3}-\d{2}-\d{4}"),
-        (
-            "credit_card",
-            r"\d{4}[-\s]?\d{4}[-\s]?\d{4}[-\s]?\d{4}",
-        ),
+        ("credit_card", r"\d{4}[-\s]?\d{4}[-\s]?\d{4}[-\s]?\d{4}"),
         ("ipv4", r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}"),
     ]
 }
@@ -125,14 +123,13 @@ impl PostTurnPolicy for PiiRedactor {
         "pii-redactor"
     }
 
-    fn evaluate(
-        &self,
-        _ctx: &PolicyContext<'_>,
-        turn: &TurnPolicyContext<'_>,
-    ) -> PolicyVerdict {
+    fn evaluate(&self, _ctx: &PolicyContext<'_>, turn: &TurnPolicyContext<'_>) -> PolicyVerdict {
         let text = ContentBlock::extract_text(&turn.assistant_message.content);
 
-        let first_match = self.patterns.iter().find(|pattern| pattern.regex.is_match(&text));
+        let first_match = self
+            .patterns
+            .iter()
+            .find(|pattern| pattern.regex.is_match(&text));
         let Some(first_match) = first_match else {
             return PolicyVerdict::Continue;
         };
@@ -150,9 +147,7 @@ impl PostTurnPolicy for PiiRedactor {
 
                 let orig = &turn.assistant_message;
                 let msg = AssistantMessage {
-                    content: vec![ContentBlock::Text {
-                        text: redacted,
-                    }],
+                    content: vec![ContentBlock::Text { text: redacted }],
                     provider: orig.provider.clone(),
                     model_id: orig.model_id.clone(),
                     usage: orig.usage.clone(),
@@ -180,9 +175,7 @@ mod tests {
 
     fn make_turn_ctx(text: &str) -> (AssistantMessage, Vec<ToolResultMessage>) {
         let msg = AssistantMessage {
-            content: vec![ContentBlock::Text {
-                text: text.into(),
-            }],
+            content: vec![ContentBlock::Text { text: text.into() }],
             provider: "test".into(),
             model_id: "test-model".into(),
             usage: Usage::default(),
@@ -273,8 +266,7 @@ mod tests {
     #[test]
     fn redacts_multiple_pii_types() {
         let policy = PiiRedactor::new();
-        let verdict =
-            evaluate_text(&policy, "Email alice@test.org and call 555-123-4567 please");
+        let verdict = evaluate_text(&policy, "Email alice@test.org and call 555-123-4567 please");
         assert_redacted(verdict, "Email [REDACTED] and call [REDACTED] please");
     }
 
@@ -287,10 +279,7 @@ mod tests {
             &policy,
             "user@mail.com called from 555-111-2222 and 555-333-4444",
         );
-        assert_redacted(
-            verdict,
-            "[REDACTED] called from [REDACTED] and [REDACTED]",
-        );
+        assert_redacted(verdict, "[REDACTED] called from [REDACTED] and [REDACTED]");
     }
 
     #[test]

--- a/policies/src/prompt_guard.rs
+++ b/policies/src/prompt_guard.rs
@@ -62,7 +62,9 @@ impl PromptInjectionGuard {
     /// to add custom patterns.
     #[must_use]
     pub const fn without_defaults() -> Self {
-        Self { patterns: Vec::new() }
+        Self {
+            patterns: Vec::new(),
+        }
     }
 
     /// Adds a custom case-insensitive pattern to the guard.
@@ -151,10 +153,7 @@ const fn default_patterns() -> &'static [(&'static str, &'static str)] {
             r"disregard\s+your\s+system\s+prompt",
         ),
         ("you_are_now_a", r"you\s+are\s+now\s+a\b"),
-        (
-            "forget_your_instructions",
-            r"forget\s+your\s+instructions",
-        ),
+        ("forget_your_instructions", r"forget\s+your\s+instructions"),
         (
             "override_your_programming",
             r"override\s+your\s+programming",
@@ -278,7 +277,10 @@ mod tests {
         let ctx = make_policy_ctx(&messages, &usage, &cost, &state);
 
         assert!(
-            matches!(PreTurnPolicy::evaluate(&guard, &ctx), PolicyVerdict::Continue),
+            matches!(
+                PreTurnPolicy::evaluate(&guard, &ctx),
+                PolicyVerdict::Continue
+            ),
             "benign message should not be blocked"
         );
     }
@@ -286,13 +288,15 @@ mod tests {
     #[test]
     fn default_patterns_allow_partial_match() {
         let guard = PromptInjectionGuard::new();
-        let (messages, usage, cost) =
-            user_ctx("please ignore the previous error and try again");
+        let (messages, usage, cost) = user_ctx("please ignore the previous error and try again");
         let state = swink_agent::SessionState::new();
         let ctx = make_policy_ctx(&messages, &usage, &cost, &state);
 
         assert!(
-            matches!(PreTurnPolicy::evaluate(&guard, &ctx), PolicyVerdict::Continue),
+            matches!(
+                PreTurnPolicy::evaluate(&guard, &ctx),
+                PolicyVerdict::Continue
+            ),
             "partial match on benign phrase should not be blocked"
         );
     }
@@ -326,7 +330,10 @@ mod tests {
         let ctx = make_policy_ctx(&messages, &usage, &cost, &state);
 
         assert!(
-            matches!(PreTurnPolicy::evaluate(&guard, &ctx), PolicyVerdict::Continue),
+            matches!(
+                PreTurnPolicy::evaluate(&guard, &ctx),
+                PolicyVerdict::Continue
+            ),
             "empty message should not be blocked"
         );
     }
@@ -341,7 +348,10 @@ mod tests {
         let state = swink_agent::SessionState::new();
         let ctx = make_policy_ctx(&messages, &usage, &cost, &state);
         assert!(
-            matches!(PreTurnPolicy::evaluate(&guard, &ctx), PolicyVerdict::Continue),
+            matches!(
+                PreTurnPolicy::evaluate(&guard, &ctx),
+                PolicyVerdict::Continue
+            ),
             "without_defaults should not have default patterns"
         );
 

--- a/policies/src/sandbox.rs
+++ b/policies/src/sandbox.rs
@@ -41,10 +41,7 @@ impl SandboxPolicy {
 
     /// Override the argument field names to check for file paths.
     #[must_use]
-    pub fn with_path_fields(
-        mut self,
-        fields: impl IntoIterator<Item = impl Into<String>>,
-    ) -> Self {
+    pub fn with_path_fields(mut self, fields: impl IntoIterator<Item = impl Into<String>>) -> Self {
         self.path_fields = fields.into_iter().map(Into::into).collect();
         self
     }
@@ -87,14 +84,15 @@ impl PreDispatchPolicy for SandboxPolicy {
 
         for field_name in &self.path_fields {
             if let Some(serde_json::Value::String(path_str)) = obj.get(field_name.as_str())
-                && !self.is_path_allowed(path_str) {
-                    return PreDispatchVerdict::Skip(format!(
-                        "path '{}' in field '{}' is outside allowed root '{}'",
-                        path_str,
-                        field_name,
-                        self.allowed_root.display()
-                    ));
-                }
+                && !self.is_path_allowed(path_str)
+            {
+                return PreDispatchVerdict::Skip(format!(
+                    "path '{}' in field '{}' is outside allowed root '{}'",
+                    path_str,
+                    field_name,
+                    self.allowed_root.display()
+                ));
+            }
         }
 
         PreDispatchVerdict::Continue
@@ -106,7 +104,11 @@ mod tests {
     use super::*;
     use swink_agent::{Cost, Usage};
 
-    fn make_ctx<'a>(usage: &'a Usage, cost: &'a Cost, state: &'a swink_agent::SessionState) -> PolicyContext<'a> {
+    fn make_ctx<'a>(
+        usage: &'a Usage,
+        cost: &'a Cost,
+        state: &'a swink_agent::SessionState,
+    ) -> PolicyContext<'a> {
         PolicyContext {
             turn_index: 0,
             accumulated_usage: usage,
@@ -189,8 +191,8 @@ mod tests {
 
     #[test]
     fn custom_path_fields() {
-        let policy = SandboxPolicy::new("/tmp/workspace")
-            .with_path_fields(["target_dir", "output"]);
+        let policy =
+            SandboxPolicy::new("/tmp/workspace").with_path_fields(["target_dir", "output"]);
         let usage = Usage::default();
         let cost = Cost::default();
         let state = swink_agent::SessionState::new();

--- a/policies/tests/policy_integration.rs
+++ b/policies/tests/policy_integration.rs
@@ -5,8 +5,7 @@ mod common;
 use std::sync::Arc;
 
 use swink_agent::{
-    AgentOptions, AssistantMessageEvent, Cost, StopReason, SubAgent, Usage,
-    stream::StreamFn,
+    AgentOptions, AssistantMessageEvent, Cost, StopReason, SubAgent, Usage, stream::StreamFn,
 };
 use swink_agent_policies::{BudgetPolicy, MaxTurnsPolicy};
 

--- a/specs/017-adapter-xai/tasks.md
+++ b/specs/017-adapter-xai/tasks.md
@@ -17,9 +17,9 @@
 
 **Purpose**: Update stale model catalog and remote preset constants to current Grok 4.x models
 
-- [ ] T001 Replace stale grok-3 and grok-3-fast presets with 5 current grok-4.x model entries in src/model_catalog.toml (grok-4.20-0309-reasoning, grok-4.20-0309-non-reasoning, grok-4-1-fast-reasoning, grok-4-1-fast-non-reasoning, grok-4.20-multi-agent-0309; all 2M context, capabilities: text/tools/images_in/streaming/structured_output)
-- [ ] T002 Update RemotePresetKey constants in adapters/src/remote_presets.rs: replace GROK_3/GROK_3_FAST with GROK_4_20_REASONING, GROK_4_20_NON_REASONING, GROK_4_1_FAST_REASONING, GROK_4_1_FAST_NON_REASONING, GROK_4_20_MULTI_AGENT
-- [ ] T003 Update the added_provider_presets_map_to_catalog_models test in adapters/src/remote_presets.rs to use new preset keys and verify correct model_id mapping
+- [x] T001 Replace stale grok-3 and grok-3-fast presets with 5 current grok-4.x model entries in src/model_catalog.toml (grok-4.20-0309-reasoning, grok-4.20-0309-non-reasoning, grok-4-1-fast-reasoning, grok-4-1-fast-non-reasoning, grok-4.20-multi-agent-0309; all 2M context, capabilities: text/tools/images_in/streaming/structured_output)
+- [x] T002 Update RemotePresetKey constants in adapters/src/remote_presets.rs: replace GROK_3/GROK_3_FAST with GROK_4_20_REASONING, GROK_4_20_NON_REASONING, GROK_4_1_FAST_REASONING, GROK_4_1_FAST_NON_REASONING, GROK_4_20_MULTI_AGENT
+- [x] T003 Update the added_provider_presets_map_to_catalog_models test in adapters/src/remote_presets.rs to use new preset keys and verify correct model_id mapping
 
 **Checkpoint**: `cargo test -p swink-agent-adapters --features xai` passes with updated catalog and preset constants
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -31,6 +31,7 @@ use std::sync::{Arc, Mutex};
 use tokio::sync::Notify;
 use tokio_util::sync::CancellationToken;
 
+use crate::agent_id::AgentId;
 use crate::agent_options::{
     ApproveToolArc, AsyncTransformContextArc, CheckpointStoreArc, ConvertToLlmFn, GetApiKeyArc,
     TransformContextArc,
@@ -38,7 +39,6 @@ use crate::agent_options::{
 use crate::agent_subscriptions::ListenerRegistry;
 use crate::error::AgentError;
 use crate::message_provider::MessageProvider;
-use crate::agent_id::AgentId;
 use crate::retry::RetryStrategy;
 use crate::stream::{StreamFn, StreamOptions};
 use crate::tool::{AgentTool, ApprovalMode};
@@ -292,7 +292,6 @@ impl Agent {
     pub const fn session_state(&self) -> &Arc<std::sync::RwLock<crate::SessionState>> {
         &self.session_state
     }
-
 }
 
 impl std::fmt::Debug for Agent {

--- a/src/agent/checkpointing.rs
+++ b/src/agent/checkpointing.rs
@@ -5,8 +5,8 @@ use crate::checkpoint::{Checkpoint, CheckpointStore};
 use crate::error::AgentError;
 use crate::loop_::AgentEvent;
 
-use super::queueing::llm_messages_from_queue;
 use super::Agent;
+use super::queueing::llm_messages_from_queue;
 
 impl Agent {
     // ── Checkpointing ────────────────────────────────────────────────────
@@ -52,7 +52,9 @@ impl Agent {
     /// full restoration including custom messages.
     pub fn restore_from_checkpoint(&mut self, checkpoint: &Checkpoint) {
         self.state.messages = checkpoint.restore_messages(None);
-        self.state.system_prompt.clone_from(&checkpoint.system_prompt);
+        self.state
+            .system_prompt
+            .clone_from(&checkpoint.system_prompt);
         self.state.model.provider.clone_from(&checkpoint.provider);
         self.state.model.model_id.clone_from(&checkpoint.model_id);
 
@@ -159,7 +161,9 @@ impl Agent {
         checkpoint: &crate::checkpoint::LoopCheckpoint,
     ) -> Result<(), AgentError> {
         self.state.messages = checkpoint.restore_messages(None);
-        self.state.system_prompt.clone_from(&checkpoint.system_prompt);
+        self.state
+            .system_prompt
+            .clone_from(&checkpoint.system_prompt);
         self.state.model.provider.clone_from(&checkpoint.provider);
         self.state.model.model_id.clone_from(&checkpoint.model_id);
 

--- a/src/agent/queueing.rs
+++ b/src/agent/queueing.rs
@@ -94,7 +94,8 @@ impl MessageProvider for QueueMessageProvider {
 pub(super) fn llm_messages_from_queue(
     queue: &Arc<Mutex<VecDeque<AgentMessage>>>,
 ) -> Vec<LlmMessage> {
-    queue.lock()
+    queue
+        .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
         .iter()
         .filter_map(|msg| match msg {
@@ -104,10 +105,7 @@ pub(super) fn llm_messages_from_queue(
         .collect()
 }
 
-fn drain_queue(
-    queue: &Mutex<VecDeque<AgentMessage>>,
-    one_at_a_time: bool,
-) -> Vec<AgentMessage> {
+fn drain_queue(queue: &Mutex<VecDeque<AgentMessage>>, one_at_a_time: bool) -> Vec<AgentMessage> {
     let mut guard = queue
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);

--- a/src/agent/structured_output.rs
+++ b/src/agent/structured_output.rs
@@ -162,7 +162,10 @@ impl crate::tool::AgentTool for StructuredOutputTool {
     }
 }
 
-fn extract_structured_output(result: &crate::types::AgentResult, schema: &Value) -> Result<Value, String> {
+fn extract_structured_output(
+    result: &crate::types::AgentResult,
+    schema: &Value,
+) -> Result<Value, String> {
     for msg in &result.messages {
         if let AgentMessage::Llm(LlmMessage::Assistant(assistant)) = msg {
             for block in &assistant.content {

--- a/src/agent_options.rs
+++ b/src/agent_options.rs
@@ -499,8 +499,14 @@ impl AgentOptions {
 
     /// Add a single key-value pair to initial state.
     #[must_use]
-    pub fn with_state_entry(mut self, key: impl Into<String>, value: impl serde::Serialize) -> Self {
-        let state = self.session_state.get_or_insert_with(crate::SessionState::new);
+    pub fn with_state_entry(
+        mut self,
+        key: impl Into<String>,
+        value: impl serde::Serialize,
+    ) -> Self {
+        let state = self
+            .session_state
+            .get_or_insert_with(crate::SessionState::new);
         state.set(&key.into(), value);
         // Flush delta so pre-seeded entries don't appear as mutations (baseline semantics).
         state.flush_delta();

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -121,9 +121,7 @@ fn restore_messages(
             match deserialize_custom_message(reg, envelope) {
                 Ok(custom) => result.push(AgentMessage::Custom(custom)),
                 Err(error) => {
-                    tracing::warn!(
-                        "failed to deserialize custom message from {kind}: {error}"
-                    );
+                    tracing::warn!("failed to deserialize custom message from {kind}: {error}");
                 }
             }
         }
@@ -527,8 +525,14 @@ mod tests {
 
         let restored = restored_cp.restore_messages(Some(&registry));
         assert_eq!(restored.len(), 3);
-        assert!(matches!(restored[0], AgentMessage::Llm(LlmMessage::User(_))));
-        assert!(matches!(restored[1], AgentMessage::Llm(LlmMessage::Assistant(_))));
+        assert!(matches!(
+            restored[0],
+            AgentMessage::Llm(LlmMessage::User(_))
+        ));
+        assert!(matches!(
+            restored[1],
+            AgentMessage::Llm(LlmMessage::Assistant(_))
+        ));
         let custom = restored[2].downcast_ref::<SerializableCustom>().unwrap();
         assert_eq!(custom.value, "hello");
 
@@ -905,10 +909,7 @@ mod tests {
         // message_order field to simulate a legacy checkpoint.
         let (registry, factory) = make_registry_and_custom("test");
 
-        let messages = vec![
-            user_msg("hi"),
-            AgentMessage::Custom(factory("legacy")),
-        ];
+        let messages = vec![user_msg("hi"), AgentMessage::Custom(factory("legacy"))];
 
         let checkpoint = Checkpoint::new("cp-legacy", "hello", "p", "m", &messages);
         // Serialize, strip message_order, deserialize — simulates old format
@@ -922,7 +923,10 @@ mod tests {
         let restored = legacy_cp.restore_messages(Some(&registry));
         // Legacy fallback: LLM first, then custom appended
         assert_eq!(restored.len(), 2);
-        assert!(matches!(restored[0], AgentMessage::Llm(LlmMessage::User(_))));
+        assert!(matches!(
+            restored[0],
+            AgentMessage::Llm(LlmMessage::User(_))
+        ));
         let order: Vec<String> = restored.iter().map(message_text).collect();
         assert_eq!(order, vec!["user:hi", "custom:legacy"]);
     }

--- a/src/checkpoint/store.rs
+++ b/src/checkpoint/store.rs
@@ -85,8 +85,8 @@ mod tests {
     #[tokio::test]
     async fn in_memory_checkpoint_store_roundtrip() {
         let store = InMemoryCheckpointStore::new();
-        let checkpoint = Checkpoint::new("cp-store-test", "prompt", "provider", "model", &[])
-            .with_turn_count(2);
+        let checkpoint =
+            Checkpoint::new("cp-store-test", "prompt", "provider", "model", &[]).with_turn_count(2);
 
         store.save_checkpoint(&checkpoint).await.unwrap();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -571,17 +571,37 @@ mod tests {
 
         let stream_fn: std::sync::Arc<dyn crate::stream::StreamFn> =
             std::sync::Arc::new(crate::testing::MockStreamFn::new(vec![]));
-        let opts = config.clone().into_agent_options(stream_fn, crate::agent::default_convert);
+        let opts = config
+            .clone()
+            .into_agent_options(stream_fn, crate::agent::default_convert);
 
         assert_eq!(opts.system_prompt, config.system_prompt);
         assert_eq!(opts.model.provider, config.model.provider);
         assert_eq!(opts.model.model_id, config.model.model_id);
-        assert_eq!(opts.stream_options.temperature, config.stream_options.temperature);
-        assert_eq!(opts.stream_options.max_tokens, config.stream_options.max_tokens);
-        assert_eq!(opts.structured_output_max_retries, config.structured_output_max_retries);
-        assert!(matches!(opts.steering_mode, crate::agent::SteeringMode::All));
-        assert!(matches!(opts.follow_up_mode, crate::agent::FollowUpMode::All));
-        assert!(matches!(opts.approval_mode, crate::tool::ApprovalMode::Bypassed));
+        assert_eq!(
+            opts.stream_options.temperature,
+            config.stream_options.temperature
+        );
+        assert_eq!(
+            opts.stream_options.max_tokens,
+            config.stream_options.max_tokens
+        );
+        assert_eq!(
+            opts.structured_output_max_retries,
+            config.structured_output_max_retries
+        );
+        assert!(matches!(
+            opts.steering_mode,
+            crate::agent::SteeringMode::All
+        ));
+        assert!(matches!(
+            opts.follow_up_mode,
+            crate::agent::FollowUpMode::All
+        ));
+        assert!(matches!(
+            opts.approval_mode,
+            crate::tool::ApprovalMode::Bypassed
+        ));
     }
 
     #[test]

--- a/src/context.rs
+++ b/src/context.rs
@@ -649,7 +649,11 @@ mod tests {
     #[test]
     fn overflow_within_budget_returns_false() {
         let messages = vec![text_message(&"x".repeat(400))]; // 100 tokens
-        assert!(!is_context_overflow(&messages, &model_with_window(1000), None));
+        assert!(!is_context_overflow(
+            &messages,
+            &model_with_window(1000),
+            None
+        ));
     }
 
     #[test]
@@ -658,7 +662,11 @@ mod tests {
             text_message(&"x".repeat(400)), // 100 tokens
             text_message(&"x".repeat(400)), // 100 tokens
         ];
-        assert!(is_context_overflow(&messages, &model_with_window(150), None));
+        assert!(is_context_overflow(
+            &messages,
+            &model_with_window(150),
+            None
+        ));
     }
 
     #[test]
@@ -677,12 +685,20 @@ mod tests {
             Some(&CharCounter)
         ));
         // With default counter: 400/4 = 100 tokens < 300
-        assert!(!is_context_overflow(&messages, &model_with_window(300), None));
+        assert!(!is_context_overflow(
+            &messages,
+            &model_with_window(300),
+            None
+        ));
     }
 
     #[test]
     fn overflow_empty_messages_returns_false() {
         let messages: Vec<AgentMessage> = vec![];
-        assert!(!is_context_overflow(&messages, &model_with_window(100), None));
+        assert!(!is_context_overflow(
+            &messages,
+            &model_with_window(100),
+            None
+        ));
     }
 }

--- a/src/context_cache.rs
+++ b/src/context_cache.rs
@@ -144,7 +144,12 @@ mod tests {
         let mut state = CacheState::new();
         let config = test_config(3);
         let hint = state.advance_turn(&config);
-        assert_eq!(hint, CacheHint::Write { ttl: Duration::from_secs(600) });
+        assert_eq!(
+            hint,
+            CacheHint::Write {
+                ttl: Duration::from_secs(600)
+            }
+        );
     }
 
     #[test]
@@ -165,7 +170,12 @@ mod tests {
         state.advance_turn(&config); // turn 3: Read
         // turn 4: should refresh (turns_since_write == 3 == cache_intervals)
         let hint = state.advance_turn(&config);
-        assert_eq!(hint, CacheHint::Write { ttl: Duration::from_secs(600) });
+        assert_eq!(
+            hint,
+            CacheHint::Write {
+                ttl: Duration::from_secs(600)
+            }
+        );
     }
 
     #[test]
@@ -176,7 +186,12 @@ mod tests {
         state.advance_turn(&config); // Read
         state.reset(); // adapter-reported cache miss
         let hint = state.advance_turn(&config);
-        assert_eq!(hint, CacheHint::Write { ttl: Duration::from_secs(600) });
+        assert_eq!(
+            hint,
+            CacheHint::Write {
+                ttl: Duration::from_secs(600)
+            }
+        );
     }
 
     #[test]
@@ -199,7 +214,9 @@ mod tests {
 
     #[test]
     fn serde_round_trip_write_hint() {
-        let hint = CacheHint::Write { ttl: Duration::from_secs(600) };
+        let hint = CacheHint::Write {
+            ttl: Duration::from_secs(600),
+        };
         let json = serde_json::to_string(&hint).unwrap();
         let back: CacheHint = serde_json::from_str(&json).unwrap();
         assert_eq!(hint, back);

--- a/src/context_transformer.rs
+++ b/src/context_transformer.rs
@@ -116,7 +116,8 @@ impl ContextTransformer for SlidingWindowTransformer {
 
         let effective_anchor = self.anchor.max(self.cached_prefix_len);
         let counter_ref = self.token_counter.as_deref();
-        let mut report = compact_sliding_window_with(messages, budget, effective_anchor, counter_ref)?;
+        let mut report =
+            compact_sliding_window_with(messages, budget, effective_anchor, counter_ref)?;
         report.overflow = overflow;
         Some(report)
     }

--- a/src/credential.rs
+++ b/src/credential.rs
@@ -51,22 +51,31 @@ pub enum Credential {
 impl std::fmt::Debug for Credential {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::ApiKey { .. } => f.debug_struct("Credential::ApiKey").field("key", &"[REDACTED]").finish(),
-            Self::Bearer { expires_at, .. } => f.debug_struct("Credential::Bearer")
+            Self::ApiKey { .. } => f
+                .debug_struct("Credential::ApiKey")
+                .field("key", &"[REDACTED]")
+                .finish(),
+            Self::Bearer { expires_at, .. } => f
+                .debug_struct("Credential::Bearer")
                 .field("token", &"[REDACTED]")
                 .field("expires_at", expires_at)
                 .finish(),
-            Self::OAuth2 { expires_at, token_url, client_id, scopes, .. } => {
-                f.debug_struct("Credential::OAuth2")
-                    .field("access_token", &"[REDACTED]")
-                    .field("refresh_token", &"[REDACTED]")
-                    .field("expires_at", expires_at)
-                    .field("token_url", token_url)
-                    .field("client_id", client_id)
-                    .field("client_secret", &"[REDACTED]")
-                    .field("scopes", scopes)
-                    .finish()
-            }
+            Self::OAuth2 {
+                expires_at,
+                token_url,
+                client_id,
+                scopes,
+                ..
+            } => f
+                .debug_struct("Credential::OAuth2")
+                .field("access_token", &"[REDACTED]")
+                .field("refresh_token", &"[REDACTED]")
+                .field("expires_at", expires_at)
+                .field("token_url", token_url)
+                .field("client_id", client_id)
+                .field("client_secret", &"[REDACTED]")
+                .field("scopes", scopes)
+                .finish(),
         }
     }
 }
@@ -102,9 +111,18 @@ pub enum ResolvedCredential {
 impl std::fmt::Debug for ResolvedCredential {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::ApiKey(_) => f.debug_tuple("ResolvedCredential::ApiKey").field(&"[REDACTED]").finish(),
-            Self::Bearer(_) => f.debug_tuple("ResolvedCredential::Bearer").field(&"[REDACTED]").finish(),
-            Self::OAuth2AccessToken(_) => f.debug_tuple("ResolvedCredential::OAuth2AccessToken").field(&"[REDACTED]").finish(),
+            Self::ApiKey(_) => f
+                .debug_tuple("ResolvedCredential::ApiKey")
+                .field(&"[REDACTED]")
+                .finish(),
+            Self::Bearer(_) => f
+                .debug_tuple("ResolvedCredential::Bearer")
+                .field(&"[REDACTED]")
+                .finish(),
+            Self::OAuth2AccessToken(_) => f
+                .debug_tuple("ResolvedCredential::OAuth2AccessToken")
+                .field(&"[REDACTED]")
+                .finish(),
         }
     }
 }
@@ -233,23 +251,13 @@ pub type CredentialFuture<'a, T> =
 /// `Send + Sync` to allow sharing across `tokio::spawn` boundaries.
 pub trait CredentialStore: Send + Sync {
     /// Retrieve a credential by key.
-    fn get(
-        &self,
-        key: &str,
-    ) -> CredentialFuture<'_, Option<Credential>>;
+    fn get(&self, key: &str) -> CredentialFuture<'_, Option<Credential>>;
 
     /// Store or update a credential by key.
-    fn set(
-        &self,
-        key: &str,
-        credential: Credential,
-    ) -> CredentialFuture<'_, ()>;
+    fn set(&self, key: &str, credential: Credential) -> CredentialFuture<'_, ()>;
 
     /// Delete a credential by key.
-    fn delete(
-        &self,
-        key: &str,
-    ) -> CredentialFuture<'_, ()>;
+    fn delete(&self, key: &str) -> CredentialFuture<'_, ()>;
 }
 
 // ─── CredentialResolver trait ───────────────────────────────────────────────
@@ -259,10 +267,7 @@ pub trait CredentialStore: Send + Sync {
 pub trait CredentialResolver: Send + Sync {
     /// Resolve a credential by key. Returns the minimal secret value
     /// needed for the authenticated request.
-    fn resolve(
-        &self,
-        key: &str,
-    ) -> CredentialFuture<'_, ResolvedCredential>;
+    fn resolve(&self, key: &str) -> CredentialFuture<'_, ResolvedCredential>;
 }
 
 // ─── AuthorizationHandler trait ─────────────────────────────────────────────
@@ -276,11 +281,7 @@ pub trait AuthorizationHandler: Send + Sync {
     ///
     /// `state` is the CSRF token that the caller generated and appended to
     /// the authorization URL; implementations should verify it matches.
-    fn authorize(
-        &self,
-        auth_url: &str,
-        state: &str,
-    ) -> CredentialFuture<'_, String>;
+    fn authorize(&self, auth_url: &str, state: &str) -> CredentialFuture<'_, String>;
 }
 
 // ─── Tests ──────────────────────────────────────────────────────────────────
@@ -292,7 +293,9 @@ mod tests {
     // T023: Credential serde roundtrip
     #[test]
     fn credential_serde_roundtrip_api_key() {
-        let cred = Credential::ApiKey { key: "sk-test-123".into() };
+        let cred = Credential::ApiKey {
+            key: "sk-test-123".into(),
+        };
         let json = serde_json::to_string(&cred).unwrap();
         let decoded: Credential = serde_json::from_str(&json).unwrap();
         match decoded {
@@ -332,7 +335,13 @@ mod tests {
         let json = serde_json::to_string(&cred).unwrap();
         let decoded: Credential = serde_json::from_str(&json).unwrap();
         match decoded {
-            Credential::OAuth2 { access_token, refresh_token, client_id, scopes, .. } => {
+            Credential::OAuth2 {
+                access_token,
+                refresh_token,
+                client_id,
+                scopes,
+                ..
+            } => {
                 assert_eq!(access_token, "access-123");
                 assert_eq!(refresh_token.as_deref(), Some("refresh-456"));
                 assert_eq!(client_id, "client-1");
@@ -346,27 +355,53 @@ mod tests {
     #[test]
     fn credential_error_display_no_secrets() {
         let errors = vec![
-            CredentialError::NotFound { key: "my-key".into() },
-            CredentialError::Expired { key: "my-key".into() },
-            CredentialError::RefreshFailed { key: "my-key".into(), reason: "bad response".into() },
+            CredentialError::NotFound {
+                key: "my-key".into(),
+            },
+            CredentialError::Expired {
+                key: "my-key".into(),
+            },
+            CredentialError::RefreshFailed {
+                key: "my-key".into(),
+                reason: "bad response".into(),
+            },
             CredentialError::TypeMismatch {
                 key: "my-key".into(),
                 expected: CredentialType::Bearer,
                 actual: CredentialType::ApiKey,
             },
-            CredentialError::AuthorizationFailed { key: "my-key".into(), reason: "denied".into() },
-            CredentialError::AuthorizationTimeout { key: "my-key".into() },
-            CredentialError::Timeout { key: "my-key".into() },
+            CredentialError::AuthorizationFailed {
+                key: "my-key".into(),
+                reason: "denied".into(),
+            },
+            CredentialError::AuthorizationTimeout {
+                key: "my-key".into(),
+            },
+            CredentialError::Timeout {
+                key: "my-key".into(),
+            },
         ];
 
-        let secret_values = ["sk-test-123", "tok-abc", "access-123", "refresh-456", "secret"];
+        let secret_values = [
+            "sk-test-123",
+            "tok-abc",
+            "access-123",
+            "refresh-456",
+            "secret",
+        ];
         for err in &errors {
             let display = format!("{err}");
             for secret in &secret_values {
-                assert!(!display.contains(secret), "Display of {err:?} leaks secret {secret}");
+                assert!(
+                    !display.contains(secret),
+                    "Display of {err:?} leaks secret {secret}"
+                );
             }
             // Should contain the key name for diagnostics
-            assert!(display.contains("my-key"), "Display of {err:?} should contain key name");
+            assert!(
+                display.contains("my-key"),
+                "Display of {err:?} should contain key name"
+            );
         }
     }
 
@@ -376,7 +411,10 @@ mod tests {
         let api_key = Credential::ApiKey { key: "k".into() };
         assert_eq!(api_key.credential_type(), CredentialType::ApiKey);
 
-        let bearer = Credential::Bearer { token: "t".into(), expires_at: None };
+        let bearer = Credential::Bearer {
+            token: "t".into(),
+            expires_at: None,
+        };
         assert_eq!(bearer.credential_type(), CredentialType::Bearer);
 
         let oauth2 = Credential::OAuth2 {
@@ -394,7 +432,9 @@ mod tests {
     // T023 additional: Debug impl redacts secrets
     #[test]
     fn debug_impl_redacts_secrets() {
-        let cred = Credential::ApiKey { key: "super-secret".into() };
+        let cred = Credential::ApiKey {
+            key: "super-secret".into(),
+        };
         let debug = format!("{cred:?}");
         assert!(!debug.contains("super-secret"), "Debug leaks secret");
         assert!(debug.contains("[REDACTED]"));

--- a/src/fn_tool.rs
+++ b/src/fn_tool.rs
@@ -35,7 +35,7 @@ use crate::tool::{
 // ─── Type aliases for stored closures ───────────────────────────────────────
 
 type ExecuteFn = Arc<
-        dyn Fn(
+    dyn Fn(
             String,
             Value,
             CancellationToken,
@@ -250,7 +250,14 @@ mod tests {
     async fn default_execute_returns_error() {
         let tool = sample_tool();
         let result = tool
-            .execute("{}", json!({}), CancellationToken::new(), None, std::sync::Arc::new(std::sync::RwLock::new(crate::SessionState::new())), None)
+            .execute(
+                "{}",
+                json!({}),
+                CancellationToken::new(),
+                None,
+                std::sync::Arc::new(std::sync::RwLock::new(crate::SessionState::new())),
+                None,
+            )
             .await;
         assert!(result.is_error);
     }
@@ -313,7 +320,14 @@ mod tests {
             );
 
         let result = tool
-            .execute("call_42", json!({}), CancellationToken::new(), None, std::sync::Arc::new(std::sync::RwLock::new(crate::SessionState::new())), None)
+            .execute(
+                "call_42",
+                json!({}),
+                CancellationToken::new(),
+                None,
+                std::sync::Arc::new(std::sync::RwLock::new(crate::SessionState::new())),
+                None,
+            )
             .await;
         assert!(!result.is_error);
     }

--- a/src/hot_reload.rs
+++ b/src/hot_reload.rs
@@ -20,7 +20,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use notify::{RecommendedWatcher, RecursiveMode, Watcher, Event, EventKind};
+use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use serde::Deserialize;
 use serde_json::Value;
 use tokio::sync::mpsc;
@@ -430,14 +430,12 @@ command = "echo hello"
     #[test]
     fn duplicate_tool_names_last_write_wins() {
         // Simulate two ScriptTools with the same name
-        let tool1 = ScriptTool::from_toml(
-            r#"name = "dup" description = "First" command = "echo 1""#,
-        )
-        .unwrap();
-        let tool2 = ScriptTool::from_toml(
-            r#"name = "dup" description = "Second" command = "echo 2""#,
-        )
-        .unwrap();
+        let tool1 =
+            ScriptTool::from_toml(r#"name = "dup" description = "First" command = "echo 1""#)
+                .unwrap();
+        let tool2 =
+            ScriptTool::from_toml(r#"name = "dup" description = "Second" command = "echo 2""#)
+                .unwrap();
 
         let mut map: HashMap<PathBuf, ScriptTool> = HashMap::new();
         map.insert(PathBuf::from("/a.toml"), tool1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,9 +9,9 @@ mod config;
 mod context;
 pub mod context_cache;
 mod context_transformer;
-pub mod credential;
 mod context_version;
 pub mod convert;
+pub mod credential;
 pub mod display;
 mod emit;
 mod error;
@@ -19,13 +19,18 @@ mod event_forwarder;
 mod fallback;
 mod fn_tool;
 mod handle;
+#[cfg(feature = "hot-reload")]
+pub mod hot_reload;
 mod loop_;
 pub mod message_provider;
 mod messaging;
 pub mod metrics;
 mod model_catalog;
 mod model_presets;
+mod noop_tool;
 mod orchestrator;
+#[cfg(feature = "otel")]
+pub mod otel;
 pub mod policy;
 mod registry;
 mod retry;
@@ -38,11 +43,6 @@ pub mod tool;
 mod tool_execution_policy;
 pub mod tool_filter;
 mod tool_middleware;
-mod noop_tool;
-#[cfg(feature = "hot-reload")]
-pub mod hot_reload;
-#[cfg(feature = "otel")]
-pub mod otel;
 pub mod tools;
 pub mod types;
 mod util;
@@ -56,28 +56,37 @@ pub use agent::{
     Agent, AgentOptions, AgentState, DEFAULT_PLAN_MODE_ADDENDUM, FollowUpMode, SteeringMode,
     SubscriptionId, default_convert,
 };
+pub use agent_id::AgentId;
 pub use async_context_transformer::{AsyncContextTransformer, AsyncTransformFuture};
 pub use checkpoint::{Checkpoint, CheckpointFuture, CheckpointStore, LoopCheckpoint};
 pub use config::{
     AgentConfig, ApprovalModeConfig, FollowUpModeConfig, RetryConfig, SteeringModeConfig,
     StreamOptionsConfig,
 };
-#[allow(deprecated)]
-pub use context::{DefaultTokenCounter, TokenCounter, estimate_tokens, is_context_overflow, sliding_window};
-pub use context_cache::{CacheConfig, CacheHint, CacheState};
 pub use context::CompactionReport;
+#[allow(deprecated)]
+pub use context::{
+    DefaultTokenCounter, TokenCounter, estimate_tokens, is_context_overflow, sliding_window,
+};
+pub use context_cache::{CacheConfig, CacheHint, CacheState};
 pub use context_transformer::{ContextTransformer, SlidingWindowTransformer};
 pub use context_version::{
     ContextSummarizer, ContextVersion, ContextVersionMeta, ContextVersionStore,
     InMemoryVersionStore, VersioningTransformer,
 };
 pub use convert::{MessageConverter, ToolSchema, convert_messages, extract_tool_schemas};
+pub use credential::{
+    AuthConfig, AuthScheme, AuthorizationHandler, Credential, CredentialError, CredentialResolver,
+    CredentialStore, CredentialType, ResolvedCredential,
+};
 pub use emit::Emission;
 pub use error::{AgentError, DowncastError};
 pub use event_forwarder::EventForwarderFn;
 pub use fallback::ModelFallback;
 pub use fn_tool::FnTool;
 pub use handle::{AgentHandle, AgentStatus};
+#[cfg(feature = "hot-reload")]
+pub use hot_reload::{ScriptTool, ToolWatcher};
 pub use loop_::{AgentEvent, AgentLoopConfig, TurnEndReason, agent_loop, agent_loop_continue};
 pub use message_provider::{
     ChannelMessageProvider, ComposedMessageProvider, MessageProvider, MessageSender, from_fns,
@@ -90,15 +99,18 @@ pub use model_catalog::{
     PresetStatus, ProviderCatalog, ProviderKind, calculate_cost, model_catalog,
 };
 pub use model_presets::{ModelConnection, ModelConnections, ModelConnectionsBuilder};
+pub use noop_tool::NoopTool;
 pub use orchestrator::{
     AgentOrchestrator, AgentRequest, DefaultSupervisor, OrchestratedHandle, SupervisorAction,
     SupervisorPolicy,
 };
-pub use agent_id::AgentId;
+#[cfg(feature = "otel")]
+pub use otel::{OtelInitConfig, init_otel_layer};
 pub use registry::{AgentRef, AgentRegistry};
 pub use retry::{DefaultRetryStrategy, RetryStrategy};
 pub use schema::schema_for;
 pub use schemars::JsonSchema;
+pub use state::{SessionState, StateDelta};
 pub use stream::{
     AssistantMessageDelta, AssistantMessageEvent, CacheStrategy, OnRawPayload, StreamErrorKind,
     StreamFn, StreamOptions, StreamTransport, accumulate_message,
@@ -107,8 +119,8 @@ pub use stream_middleware::StreamMiddleware;
 pub use sub_agent::SubAgent;
 pub use tool::{
     AgentTool, AgentToolResult, ApprovalMode, IntoTool, ToolApproval, ToolApprovalRequest,
-    ToolFuture, ToolMetadata, ToolParameters, redact_sensitive_values, selective_approve, unknown_tool_result,
-    validate_schema, validate_tool_arguments, validation_error_result,
+    ToolFuture, ToolMetadata, ToolParameters, redact_sensitive_values, selective_approve,
+    unknown_tool_result, validate_schema, validate_tool_arguments, validation_error_result,
 };
 pub use tool_execution_policy::{
     PriorityFn, ToolCallSummary, ToolExecutionPolicy, ToolExecutionStrategy,
@@ -116,23 +128,13 @@ pub use tool_execution_policy::{
 };
 pub use tool_filter::{ToolFilter, ToolPattern};
 pub use tool_middleware::ToolMiddleware;
-pub use noop_tool::NoopTool;
 #[cfg(feature = "builtin-tools")]
 pub use tools::{BashTool, ReadFileTool, WriteFileTool, builtin_tools};
-#[cfg(feature = "hot-reload")]
-pub use hot_reload::{ScriptTool, ToolWatcher};
-#[cfg(feature = "otel")]
-pub use otel::{OtelInitConfig, init_otel_layer};
 pub use types::{
     AgentContext, AgentMessage, AgentResult, AssistantMessage, ContentBlock, Cost, CustomMessage,
     CustomMessageRegistry, ImageSource, LlmMessage, ModelCapabilities, ModelSpec, StopReason,
     ThinkingBudgets, ThinkingLevel, ToolResultMessage, TurnSnapshot, Usage, UserMessage,
     deserialize_custom_message, serialize_custom_message,
-};
-pub use state::{SessionState, StateDelta};
-pub use credential::{
-    AuthConfig, AuthScheme, AuthorizationHandler, Credential, CredentialError, CredentialResolver,
-    CredentialStore, CredentialType, ResolvedCredential,
 };
 pub use util::now_timestamp;
 

--- a/src/loop_/event.rs
+++ b/src/loop_/event.rs
@@ -4,9 +4,7 @@ use std::sync::Arc;
 
 use crate::stream::AssistantMessageDelta;
 use crate::tool::AgentToolResult;
-use crate::types::{
-    AgentMessage, AssistantMessage, LlmMessage, ModelSpec, ToolResultMessage,
-};
+use crate::types::{AgentMessage, AssistantMessage, LlmMessage, ModelSpec, ToolResultMessage};
 
 // ─── TurnEndReason ───────────────────────────────────────────────────────────
 
@@ -127,9 +125,7 @@ pub enum AgentEvent {
 
     /// Emitted when session state delta is flushed (non-empty only).
     /// Fired immediately before `TurnEnd`.
-    StateChanged {
-        delta: crate::StateDelta,
-    },
+    StateChanged { delta: crate::StateDelta },
 
     /// Emitted when context caching acts on a turn (write or read).
     CacheAction {

--- a/src/loop_/overflow.rs
+++ b/src/loop_/overflow.rs
@@ -14,11 +14,13 @@ use tracing::debug;
 use crate::types::{AgentMessage, LlmMessage, StopReason};
 
 use super::stream::stream_with_retry;
+use super::turn::{
+    build_snapshot, emit_turn_end_and_agent_end, handle_cancellation, run_context_transformers,
+};
 use super::{
     AgentEvent, AgentLoopConfig, LoopState, StreamResult, TurnEndReason, TurnOutcome,
     build_error_message, emit,
 };
-use super::turn::{build_snapshot, emit_turn_end_and_agent_end, handle_cancellation, run_context_transformers};
 
 /// Outcome of an in-place overflow recovery attempt.
 pub(super) enum OverflowRecoveryResult {
@@ -61,7 +63,8 @@ pub(super) async fn attempt_overflow_recovery(
     state.overflow_signal = true;
 
     // Re-run transformers with overflow=true
-    let any_compacted = run_context_transformers(config, &mut state.context_messages, true, tx).await;
+    let any_compacted =
+        run_context_transformers(config, &mut state.context_messages, true, tx).await;
     state.overflow_signal = false;
 
     // Guard 3: Transformers ran but neither reported compaction — no point retrying.
@@ -72,9 +75,7 @@ pub(super) async fn attempt_overflow_recovery(
 
     // Check cancellation before retrying.
     if cancellation_token.is_cancelled() {
-        return OverflowRecoveryResult::Failed(
-            handle_cancellation(config, state, tx).await,
-        );
+        return OverflowRecoveryResult::Failed(handle_cancellation(config, state, tx).await);
     }
 
     // Re-run convert-to-LLM pipeline with compacted context.

--- a/src/loop_/tool_dispatch.rs
+++ b/src/loop_/tool_dispatch.rs
@@ -144,7 +144,10 @@ pub async fn execute_tools_concurrently(
             };
 
             let state_snapshot = {
-                let guard = config.session_state.read().unwrap_or_else(std::sync::PoisonError::into_inner);
+                let guard = config
+                    .session_state
+                    .read()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
                 guard.clone()
             };
             let policy_ctx = PolicyContext {
@@ -204,7 +207,17 @@ pub async fn execute_tools_concurrently(
             let requires_approval = tool_map
                 .get(tc.name.as_str())
                 .is_some_and(|t| t.requires_approval());
-            match check_approval(approve_fn, tc, idx, requires_approval, &tool_map, &results, tx).await {
+            match check_approval(
+                approve_fn,
+                tc,
+                idx,
+                requires_approval,
+                &tool_map,
+                &results,
+                tx,
+            )
+            .await
+            {
                 ApprovalOutcome::Approved => {}
                 ApprovalOutcome::ApprovedWith(new_params) => {
                     effective_arguments = new_params;
@@ -512,17 +525,15 @@ async fn check_approval(
     }
 
     // Resolve approval context with panic safety.
-    let approval_context = tool_map
-        .get(tc.name.as_str())
-        .and_then(|tool| {
-            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                tool.approval_context(&tc.arguments)
-            }))
-            .unwrap_or_else(|_| {
-                tracing::warn!(tool_name = %tc.name, "approval_context() panicked — using None");
-                None
-            })
-        });
+    let approval_context = tool_map.get(tc.name.as_str()).and_then(|tool| {
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            tool.approval_context(&tc.arguments)
+        }))
+        .unwrap_or_else(|_| {
+            tracing::warn!(tool_name = %tc.name, "approval_context() panicked — using None");
+            None
+        })
+    });
 
     let request = ToolApprovalRequest {
         tool_call_id: tc.id.clone(),
@@ -620,16 +631,22 @@ async fn dispatch_single_tool(
             } else {
                 // ── Credential resolution (zero overhead when no auth_config) ──
                 match resolve_credential(&tool, &config_clone, &tool_call_id).await {
-                    Err(cred_error) => {
-                        (AgentToolResult::error(format!("{cred_error}")), true)
-                    }
+                    Err(cred_error) => (AgentToolResult::error(format!("{cred_error}")), true),
                     Ok(credential) => {
                         let on_update_tx = tx_clone.clone();
                         let on_update = Box::new(move |partial: AgentToolResult| {
-                            let _ = on_update_tx.try_send(AgentEvent::ToolExecutionUpdate { partial });
+                            let _ =
+                                on_update_tx.try_send(AgentEvent::ToolExecutionUpdate { partial });
                         });
                         let result = tool
-                            .execute(&tool_call_id, arguments, child_token, Some(on_update), config_clone.session_state.clone(), credential)
+                            .execute(
+                                &tool_call_id,
+                                arguments,
+                                child_token,
+                                Some(on_update),
+                                config_clone.session_state.clone(),
+                                credential,
+                            )
                             .await;
                         let is_error = result.is_error;
                         (result, is_error)
@@ -713,9 +730,15 @@ async fn resolve_credential(
 
     // Type mismatch check (FR-018)
     let actual_type = match &credential {
-        crate::credential::ResolvedCredential::ApiKey(_) => crate::credential::CredentialType::ApiKey,
-        crate::credential::ResolvedCredential::Bearer(_) => crate::credential::CredentialType::Bearer,
-        crate::credential::ResolvedCredential::OAuth2AccessToken(_) => crate::credential::CredentialType::OAuth2,
+        crate::credential::ResolvedCredential::ApiKey(_) => {
+            crate::credential::CredentialType::ApiKey
+        }
+        crate::credential::ResolvedCredential::Bearer(_) => {
+            crate::credential::CredentialType::Bearer
+        }
+        crate::credential::ResolvedCredential::OAuth2AccessToken(_) => {
+            crate::credential::CredentialType::OAuth2
+        }
     };
     if actual_type != auth_config.credential_type {
         return Err(crate::credential::CredentialError::TypeMismatch {

--- a/src/loop_/turn.rs
+++ b/src/loop_/turn.rs
@@ -15,8 +15,8 @@ use super::overflow::{OverflowRecoveryResult, attempt_overflow_recovery};
 use super::stream::{capability_filter_tools, stream_with_retry};
 use super::tool_dispatch::execute_tools_concurrently;
 use super::{
-    AgentEvent, AgentLoopConfig, LoopState, StreamResult, ToolCallInfo,
-    ToolExecOutcome, TurnEndReason, TurnOutcome, build_abort_message, emit,
+    AgentEvent, AgentLoopConfig, LoopState, StreamResult, ToolCallInfo, ToolExecOutcome,
+    TurnEndReason, TurnOutcome, build_abort_message, emit,
 };
 
 /// Run a single turn of the inner loop: inject pending messages, transform
@@ -58,7 +58,10 @@ pub async fn run_single_turn(
         use tracing::info;
 
         let state_snapshot = {
-            let guard = config.session_state.read().unwrap_or_else(std::sync::PoisonError::into_inner);
+            let guard = config
+                .session_state
+                .read()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             guard.clone()
         };
         let policy_ctx = PolicyContext {
@@ -103,7 +106,13 @@ pub async fn run_single_turn(
     let _turn_guard = turn_span.enter();
 
     // ii. Run context transformers (async first, then sync)
-    run_context_transformers(config, &mut state.context_messages, state.overflow_signal, tx).await;
+    run_context_transformers(
+        config,
+        &mut state.context_messages,
+        state.overflow_signal,
+        tx,
+    )
+    .await;
     state.overflow_signal = false;
 
     // ii-c. Annotate context messages with cache hints if caching is configured
@@ -145,23 +154,33 @@ pub async fn run_single_turn(
 
         // Emit CacheAction event (after guard is dropped)
         if let Some((hint, prefix_tokens)) = cache_event {
-            let _ = emit(tx, AgentEvent::CacheAction { hint, prefix_tokens }).await;
+            let _ = emit(
+                tx,
+                AgentEvent::CacheAction {
+                    hint,
+                    prefix_tokens,
+                },
+            )
+            .await;
         }
     }
 
     // ii-d. Inject dynamic system prompt as a user-role message (non-cacheable)
-    let dynamic_prompt_injected = config.dynamic_system_prompt.as_ref().and_then(|dynamic_fn| {
-        let dynamic_text = dynamic_fn();
-        if dynamic_text.is_empty() {
-            None
-        } else {
-            Some(LlmMessage::User(crate::types::UserMessage {
-                content: vec![ContentBlock::Text { text: dynamic_text }],
-                timestamp: crate::util::now_timestamp(),
-                cache_hint: None,
-            }))
-        }
-    });
+    let dynamic_prompt_injected = config
+        .dynamic_system_prompt
+        .as_ref()
+        .and_then(|dynamic_fn| {
+            let dynamic_text = dynamic_fn();
+            if dynamic_text.is_empty() {
+                None
+            } else {
+                Some(LlmMessage::User(crate::types::UserMessage {
+                    content: vec![ContentBlock::Text { text: dynamic_text }],
+                    timestamp: crate::util::now_timestamp(),
+                    cache_hint: None,
+                }))
+            }
+        });
 
     // iii. Apply convert_to_llm to filter messages for the provider
     let mut llm_messages: Vec<LlmMessage> = state
@@ -246,7 +265,10 @@ pub async fn run_single_turn(
     };
 
     // Record OTel-compatible attributes on the turn span.
-    turn_span.record("agent.stop_reason", tracing::field::debug(&assistant_message.stop_reason));
+    turn_span.record(
+        "agent.stop_reason",
+        tracing::field::debug(&assistant_message.stop_reason),
+    );
 
     // vii. Check stop_reason for error/aborted
     if matches!(
@@ -389,7 +411,11 @@ pub(super) async fn emit_turn_end_and_agent_end(
 ///
 /// Extracts LLM messages from `context_messages`, using the accumulated
 /// usage/cost and the given stop reason.
-pub(super) fn build_snapshot(state: &LoopState, stop_reason: StopReason, state_delta: Option<crate::StateDelta>) -> TurnSnapshot {
+pub(super) fn build_snapshot(
+    state: &LoopState,
+    stop_reason: StopReason,
+    state_delta: Option<crate::StateDelta>,
+) -> TurnSnapshot {
     let llm_messages: Vec<LlmMessage> = state
         .context_messages
         .iter()
@@ -414,13 +440,22 @@ async fn flush_state_delta(
     tx: &mpsc::Sender<AgentEvent>,
 ) -> Option<crate::StateDelta> {
     let delta = {
-        let mut s = config.session_state.write().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut s = config
+            .session_state
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         s.flush_delta()
     };
     if delta.is_empty() {
         None
     } else {
-        let _ = emit(tx, AgentEvent::StateChanged { delta: delta.clone() }).await;
+        let _ = emit(
+            tx,
+            AgentEvent::StateChanged {
+                delta: delta.clone(),
+            },
+        )
+        .await;
         Some(delta)
     }
 }
@@ -712,9 +747,7 @@ async fn handle_tool_calls(
     }
 
     // Poll steering if not already interrupted
-    if !steering_interrupted
-        && let Some(ref provider) = config.message_provider
-    {
+    if !steering_interrupted && let Some(ref provider) = config.message_provider {
         let msgs = provider.poll_steering();
         if !msgs.is_empty() {
             state.pending_messages.extend(msgs);

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -73,10 +73,7 @@ pub type MetricsFuture<'a> = Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
 /// ```
 pub trait MetricsCollector: Send + Sync {
     /// Called at the end of each turn with the collected metrics.
-    fn on_metrics<'a>(
-        &'a self,
-        metrics: &'a TurnMetrics,
-    ) -> MetricsFuture<'a>;
+    fn on_metrics<'a>(&'a self, metrics: &'a TurnMetrics) -> MetricsFuture<'a>;
 }
 
 // ─── Compile-time Send + Sync assertions ────────────────────────────────────
@@ -98,10 +95,7 @@ mod tests {
     }
 
     impl MetricsCollector for CountingCollector {
-        fn on_metrics<'a>(
-            &'a self,
-            _metrics: &'a TurnMetrics,
-        ) -> MetricsFuture<'a> {
+        fn on_metrics<'a>(&'a self, _metrics: &'a TurnMetrics) -> MetricsFuture<'a> {
             Box::pin(async move {
                 self.count.fetch_add(1, Ordering::SeqCst);
             })

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -492,8 +492,10 @@ mod tests {
 
     #[test]
     fn find_preset_by_model_id_unknown_returns_none() {
-        assert!(model_catalog()
-            .find_preset_by_model_id("nonexistent")
-            .is_none());
+        assert!(
+            model_catalog()
+                .find_preset_by_model_id("nonexistent")
+                .is_none()
+        );
     }
 }

--- a/src/model_catalog.toml
+++ b/src/model_catalog.toml
@@ -269,30 +269,69 @@ base_url_env_var = "XAI_BASE_URL"
 default_base_url = "https://api.x.ai"
 
 [[providers.presets]]
-id = "grok_3"
-display_name = "xAI Grok 3"
+id = "grok_4_20_reasoning"
+display_name = "xAI Grok 4.20 Reasoning"
 group = "grok"
-model_id = "grok-3"
+model_id = "grok-4.20-0309-reasoning"
 api_version = "v1"
-capabilities = ["text", "tools", "images_in", "streaming"]
+capabilities = ["text", "tools", "images_in", "streaming", "structured_output"]
 status = "ga"
-context_window_tokens = 131072
+context_window_tokens = 2000000
 max_output_tokens = 16384
-cost_per_million_input = 3.0
-cost_per_million_output = 15.0
+cost_per_million_input = 2.0
+cost_per_million_output = 6.0
 
 [[providers.presets]]
-id = "grok_3_fast"
-display_name = "xAI Grok 3 Fast"
+id = "grok_4_20_non_reasoning"
+display_name = "xAI Grok 4.20 Non-Reasoning"
 group = "grok"
-model_id = "grok-3-fast"
+model_id = "grok-4.20-0309-non-reasoning"
 api_version = "v1"
-capabilities = ["text", "tools", "images_in", "streaming"]
+capabilities = ["text", "tools", "images_in", "streaming", "structured_output"]
 status = "ga"
-context_window_tokens = 131072
+context_window_tokens = 2000000
 max_output_tokens = 16384
-cost_per_million_input = 5.0
-cost_per_million_output = 25.0
+cost_per_million_input = 2.0
+cost_per_million_output = 6.0
+
+[[providers.presets]]
+id = "grok_4_1_fast_reasoning"
+display_name = "xAI Grok 4.1 Fast Reasoning"
+group = "grok"
+model_id = "grok-4-1-fast-reasoning"
+api_version = "v1"
+capabilities = ["text", "tools", "images_in", "streaming", "structured_output"]
+status = "ga"
+context_window_tokens = 2000000
+max_output_tokens = 16384
+cost_per_million_input = 0.2
+cost_per_million_output = 0.5
+
+[[providers.presets]]
+id = "grok_4_1_fast_non_reasoning"
+display_name = "xAI Grok 4.1 Fast Non-Reasoning"
+group = "grok"
+model_id = "grok-4-1-fast-non-reasoning"
+api_version = "v1"
+capabilities = ["text", "tools", "images_in", "streaming", "structured_output"]
+status = "ga"
+context_window_tokens = 2000000
+max_output_tokens = 16384
+cost_per_million_input = 0.2
+cost_per_million_output = 0.5
+
+[[providers.presets]]
+id = "grok_4_20_multi_agent"
+display_name = "xAI Grok 4.20 Multi-Agent"
+group = "grok"
+model_id = "grok-4.20-multi-agent-0309"
+api_version = "v1"
+capabilities = ["text", "tools", "images_in", "streaming", "structured_output"]
+status = "ga"
+context_window_tokens = 2000000
+max_output_tokens = 16384
+cost_per_million_input = 2.0
+cost_per_million_output = 6.0
 
 [[providers]]
 key = "mistral"

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 
 use tracing::{debug, warn};
 
-use crate::types::{AgentMessage, AssistantMessage, StopReason, ToolResultMessage, Usage, Cost};
+use crate::types::{AgentMessage, AssistantMessage, Cost, StopReason, ToolResultMessage, Usage};
 
 // ─── Verdict Enums ──────────────────────────────────────────────────────────
 
@@ -155,11 +155,7 @@ pub trait PostTurnPolicy: Send + Sync {
     /// Policy identifier for tracing and debugging.
     fn name(&self) -> &str;
     /// Evaluate the policy. Returns [`PolicyVerdict`].
-    fn evaluate(
-        &self,
-        ctx: &PolicyContext<'_>,
-        turn: &TurnPolicyContext<'_>,
-    ) -> PolicyVerdict;
+    fn evaluate(&self, ctx: &PolicyContext<'_>, turn: &TurnPolicyContext<'_>) -> PolicyVerdict;
 }
 
 /// Slot 4: Evaluated after the inner loop exits, before follow-up polling.
@@ -179,10 +175,7 @@ pub trait PostLoopPolicy: Send + Sync {
 /// - **Stop** short-circuits: first Stop wins, remaining policies don't run.
 /// - **Inject** accumulates: all non-short-circuited policies contribute messages.
 /// - **Panics** are caught via `catch_unwind` and treated as Continue.
-pub fn run_policies(
-    policies: &[Arc<dyn PreTurnPolicy>],
-    ctx: &PolicyContext<'_>,
-) -> PolicyVerdict {
+pub fn run_policies(policies: &[Arc<dyn PreTurnPolicy>], ctx: &PolicyContext<'_>) -> PolicyVerdict {
     run_policies_inner(policies.iter().map(std::convert::AsRef::as_ref), ctx)
 }
 
@@ -196,9 +189,7 @@ pub fn run_post_turn_policies(
 
     for policy in policies {
         let policy_name = policy.name().to_string();
-        let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
-            policy.evaluate(ctx, turn)
-        }));
+        let result = std::panic::catch_unwind(AssertUnwindSafe(|| policy.evaluate(ctx, turn)));
 
         match result {
             Ok(PolicyVerdict::Continue) => {}
@@ -231,9 +222,7 @@ pub fn run_post_loop_policies(
 
     for policy in policies {
         let policy_name = policy.name().to_string();
-        let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
-            policy.evaluate(ctx)
-        }));
+        let result = std::panic::catch_unwind(AssertUnwindSafe(|| policy.evaluate(ctx)));
 
         match result {
             Ok(PolicyVerdict::Continue) => {}
@@ -266,9 +255,7 @@ fn run_policies_inner<'a>(
 
     for policy in policies {
         let policy_name = policy.name().to_string();
-        let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
-            policy.evaluate(ctx)
-        }));
+        let result = std::panic::catch_unwind(AssertUnwindSafe(|| policy.evaluate(ctx)));
 
         match result {
             Ok(PolicyVerdict::Continue) => {}
@@ -307,9 +294,7 @@ pub fn run_pre_dispatch_policies(
 
     for policy in policies {
         let policy_name = policy.name().to_string();
-        let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
-            policy.evaluate(ctx, tool)
-        }));
+        let result = std::panic::catch_unwind(AssertUnwindSafe(|| policy.evaluate(ctx, tool)));
 
         match result {
             Ok(PreDispatchVerdict::Continue) => {}
@@ -367,7 +352,9 @@ mod tests {
     }
 
     impl PreTurnPolicy for TestPolicy {
-        fn name(&self) -> &str { &self.policy_name }
+        fn name(&self) -> &str {
+            &self.policy_name
+        }
         fn evaluate(&self, _ctx: &PolicyContext<'_>) -> PolicyVerdict {
             self.call_count.fetch_add(1, Ordering::SeqCst);
             (self.make_verdict)()
@@ -376,7 +363,9 @@ mod tests {
 
     struct PanickingPolicy;
     impl PreTurnPolicy for PanickingPolicy {
-        fn name(&self) -> &'static str { "panicker" }
+        fn name(&self) -> &'static str {
+            "panicker"
+        }
         fn evaluate(&self, _ctx: &PolicyContext<'_>) -> PolicyVerdict {
             panic!("policy intentionally panicked");
         }
@@ -403,8 +392,14 @@ mod tests {
     }
 
     impl PreDispatchPolicy for TestPreDispatchPolicy {
-        fn name(&self) -> &str { &self.policy_name }
-        fn evaluate(&self, _ctx: &PolicyContext<'_>, _tool: &mut ToolPolicyContext<'_>) -> PreDispatchVerdict {
+        fn name(&self) -> &str {
+            &self.policy_name
+        }
+        fn evaluate(
+            &self,
+            _ctx: &PolicyContext<'_>,
+            _tool: &mut ToolPolicyContext<'_>,
+        ) -> PreDispatchVerdict {
             self.call_count.fetch_add(1, Ordering::SeqCst);
             (self.make_verdict)()
         }
@@ -412,16 +407,28 @@ mod tests {
 
     struct PanickingPreDispatchPolicy;
     impl PreDispatchPolicy for PanickingPreDispatchPolicy {
-        fn name(&self) -> &'static str { "panicker" }
-        fn evaluate(&self, _ctx: &PolicyContext<'_>, _tool: &mut ToolPolicyContext<'_>) -> PreDispatchVerdict {
+        fn name(&self) -> &'static str {
+            "panicker"
+        }
+        fn evaluate(
+            &self,
+            _ctx: &PolicyContext<'_>,
+            _tool: &mut ToolPolicyContext<'_>,
+        ) -> PreDispatchVerdict {
             panic!("pre-dispatch policy panicked");
         }
     }
 
     struct MutatingPreDispatchPolicy;
     impl PreDispatchPolicy for MutatingPreDispatchPolicy {
-        fn name(&self) -> &'static str { "mutator" }
-        fn evaluate(&self, _ctx: &PolicyContext<'_>, tool: &mut ToolPolicyContext<'_>) -> PreDispatchVerdict {
+        fn name(&self) -> &'static str {
+            "mutator"
+        }
+        fn evaluate(
+            &self,
+            _ctx: &PolicyContext<'_>,
+            tool: &mut ToolPolicyContext<'_>,
+        ) -> PreDispatchVerdict {
             if let Some(obj) = tool.arguments.as_object_mut() {
                 obj.insert("injected".to_string(), serde_json::json!("by_policy"));
             }
@@ -433,8 +440,14 @@ mod tests {
         expected_key: String,
     }
     impl PreDispatchPolicy for VerifyingPreDispatchPolicy {
-        fn name(&self) -> &'static str { "verifier" }
-        fn evaluate(&self, _ctx: &PolicyContext<'_>, tool: &mut ToolPolicyContext<'_>) -> PreDispatchVerdict {
+        fn name(&self) -> &'static str {
+            "verifier"
+        }
+        fn evaluate(
+            &self,
+            _ctx: &PolicyContext<'_>,
+            tool: &mut ToolPolicyContext<'_>,
+        ) -> PreDispatchVerdict {
             if tool.arguments.get(&self.expected_key).is_some() {
                 PreDispatchVerdict::Continue
             } else {
@@ -455,7 +468,11 @@ mod tests {
         (Usage::default(), Cost::default())
     }
 
-    fn make_ctx<'a>(usage: &'a Usage, cost: &'a Cost, state: &'a crate::SessionState) -> PolicyContext<'a> {
+    fn make_ctx<'a>(
+        usage: &'a Usage,
+        cost: &'a Cost,
+        state: &'a crate::SessionState,
+    ) -> PolicyContext<'a> {
         PolicyContext {
             turn_index: 0,
             accumulated_usage: usage,
@@ -526,7 +543,9 @@ mod tests {
 
     #[test]
     fn single_stop_short_circuits() {
-        let p1 = Arc::new(TestPolicy::new("stopper", || PolicyVerdict::Stop("done".into())));
+        let p1 = Arc::new(TestPolicy::new("stopper", || {
+            PolicyVerdict::Stop("done".into())
+        }));
         let p2 = Arc::new(TestPolicy::new("never_called", || PolicyVerdict::Continue));
         let policies: Vec<Arc<dyn PreTurnPolicy>> = vec![p1.clone(), p2.clone()];
         let (usage, cost) = test_context();
@@ -562,7 +581,9 @@ mod tests {
         let p1 = Arc::new(TestPolicy::new("injector", || {
             PolicyVerdict::Inject(vec![test_message()])
         }));
-        let p2 = Arc::new(TestPolicy::new("stopper", || PolicyVerdict::Stop("halt".into())));
+        let p2 = Arc::new(TestPolicy::new("stopper", || {
+            PolicyVerdict::Stop("halt".into())
+        }));
         let policies: Vec<Arc<dyn PreTurnPolicy>> = vec![p1, p2];
         let (usage, cost) = test_context();
         let state = crate::SessionState::new();
@@ -604,8 +625,12 @@ mod tests {
 
     #[test]
     fn pre_dispatch_skip_short_circuits() {
-        let p1 = Arc::new(TestPreDispatchPolicy::new("skipper", || PreDispatchVerdict::Skip("denied".into())));
-        let p2 = Arc::new(TestPreDispatchPolicy::new("never", || PreDispatchVerdict::Continue));
+        let p1 = Arc::new(TestPreDispatchPolicy::new("skipper", || {
+            PreDispatchVerdict::Skip("denied".into())
+        }));
+        let p2 = Arc::new(TestPreDispatchPolicy::new("never", || {
+            PreDispatchVerdict::Continue
+        }));
         let policies: Vec<Arc<dyn PreDispatchPolicy>> = vec![p1.clone(), p2.clone()];
         let (usage, cost) = test_context();
         let state = crate::SessionState::new();
@@ -624,8 +649,12 @@ mod tests {
 
     #[test]
     fn pre_dispatch_stop_short_circuits() {
-        let p1 = Arc::new(TestPreDispatchPolicy::new("stopper", || PreDispatchVerdict::Stop("halt".into())));
-        let p2 = Arc::new(TestPreDispatchPolicy::new("never", || PreDispatchVerdict::Continue));
+        let p1 = Arc::new(TestPreDispatchPolicy::new("stopper", || {
+            PreDispatchVerdict::Stop("halt".into())
+        }));
+        let p2 = Arc::new(TestPreDispatchPolicy::new("never", || {
+            PreDispatchVerdict::Continue
+        }));
         let policies: Vec<Arc<dyn PreDispatchPolicy>> = vec![p1, p2.clone()];
         let (usage, cost) = test_context();
         let state = crate::SessionState::new();
@@ -669,7 +698,9 @@ mod tests {
     #[test]
     fn pre_dispatch_panic_caught_returns_continue() {
         let p1: Arc<dyn PreDispatchPolicy> = Arc::new(PanickingPreDispatchPolicy);
-        let p2 = Arc::new(TestPreDispatchPolicy::new("after", || PreDispatchVerdict::Continue));
+        let p2 = Arc::new(TestPreDispatchPolicy::new("after", || {
+            PreDispatchVerdict::Continue
+        }));
         let policies: Vec<Arc<dyn PreDispatchPolicy>> = vec![p1, p2.clone()];
         let (usage, cost) = test_context();
         let state = crate::SessionState::new();

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -12,9 +12,8 @@ pub use crate::{
     ContextVersionMeta, ContextVersionStore, Cost, DefaultTokenCounter, Emission, EventForwarderFn,
     FnTool, InMemoryVersionStore, IntoTool, LlmMessage, LoopCheckpoint, MetricsCollector,
     ModelConnection, ModelConnections, ModelConnectionsBuilder, ModelFallback, ModelSpec,
-    StopReason, StreamErrorKind,
-    StreamFn, StreamMiddleware, StreamOptions, SubAgent, TokenCounter, Usage, UserMessage,
-    VersioningTransformer,
+    StopReason, StreamErrorKind, StreamFn, StreamMiddleware, StreamOptions, SubAgent, TokenCounter,
+    Usage, UserMessage, VersioningTransformer,
 };
 
 #[cfg(feature = "builtin-tools")]

--- a/src/state.rs
+++ b/src/state.rs
@@ -81,9 +81,7 @@ impl SessionState {
     pub fn set<T: Serialize>(&mut self, key: &str, value: T) {
         let val = serde_json::to_value(value).expect("value must be serializable");
         self.data.insert(key.to_string(), val.clone());
-        self.delta
-            .changes
-            .insert(key.to_string(), Some(val));
+        self.delta.changes.insert(key.to_string(), Some(val));
     }
 
     /// Remove a key. Records removal in delta. No-op if key absent.
@@ -139,8 +137,7 @@ impl SessionState {
     /// Restore from a JSON Value snapshot. Returns a new `SessionState` with
     /// empty delta.
     pub fn restore_from_snapshot(snapshot: Value) -> Self {
-        let data: HashMap<String, Value> =
-            serde_json::from_value(snapshot).unwrap_or_default();
+        let data: HashMap<String, Value> = serde_json::from_value(snapshot).unwrap_or_default();
         Self {
             data,
             delta: StateDelta::default(),
@@ -282,9 +279,7 @@ mod tests {
 
     #[test]
     fn delta_remove_set_is_some() {
-        let mut s = SessionState::with_data(
-            std::iter::once(("k".to_string(), json!(1))).collect(),
-        );
+        let mut s = SessionState::with_data(std::iter::once(("k".to_string(), json!(1))).collect());
         s.remove("k");
         s.set("k", 99);
         assert_eq!(s.delta().changes["k"], Some(json!(99)));
@@ -312,8 +307,7 @@ mod tests {
 
     #[test]
     fn with_data_pre_seeds_without_delta() {
-        let data: HashMap<String, Value> =
-            std::iter::once(("x".into(), json!(42))).collect();
+        let data: HashMap<String, Value> = std::iter::once(("x".into(), json!(42))).collect();
         let s = SessionState::with_data(data);
         assert_eq!(s.get::<i64>("x"), Some(42));
         assert!(s.delta().is_empty());

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -6,8 +6,8 @@
 
 use crate::loop_::AgentEvent;
 use crate::stream::{AssistantMessageEvent, StreamErrorKind, StreamFn, StreamOptions};
-use crate::tool::{AgentTool, AgentToolResult, ToolFuture};
 use crate::tool::permissive_object_schema;
+use crate::tool::{AgentTool, AgentToolResult, ToolFuture};
 use crate::types::{AgentContext, ModelSpec};
 use crate::types::{
     AgentMessage, AssistantMessage, ContentBlock, Cost, LlmMessage, StopReason, ToolResultMessage,

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -279,7 +279,9 @@ fn compiled_validator(schema: &Value) -> Result<Arc<jsonschema::Validator>, Stri
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
     Ok(Arc::clone(
-        cache.entry(cache_key).or_insert_with(|| Arc::clone(&compiled)),
+        cache
+            .entry(cache_key)
+            .or_insert_with(|| Arc::clone(&compiled)),
     ))
 }
 
@@ -359,9 +361,7 @@ pub enum ApprovalMode {
 /// Wraps an approval callback so that only tools with `requires_approval == true`
 /// go through the inner callback. All other tools are auto-approved.
 #[allow(clippy::type_complexity)]
-pub fn selective_approve<F>(
-    inner: F,
-) -> Box<ApproveToolFn>
+pub fn selective_approve<F>(inner: F) -> Box<ApproveToolFn>
 where
     F: Fn(ToolApprovalRequest) -> ApproveToolFuture + Send + Sync + 'static,
 {
@@ -751,10 +751,18 @@ mod tests {
         struct NoAuthTool;
 
         impl AgentTool for NoAuthTool {
-            fn name(&self) -> &'static str { "no-auth" }
-            fn label(&self) -> &'static str { "No Auth" }
-            fn description(&self) -> &'static str { "Tool with no auth" }
-            fn parameters_schema(&self) -> &Value { &Value::Null }
+            fn name(&self) -> &'static str {
+                "no-auth"
+            }
+            fn label(&self) -> &'static str {
+                "No Auth"
+            }
+            fn description(&self) -> &'static str {
+                "Tool with no auth"
+            }
+            fn parameters_schema(&self) -> &Value {
+                &Value::Null
+            }
             fn execute(
                 &self,
                 _tool_call_id: &str,
@@ -781,10 +789,18 @@ mod tests {
         struct PlainTool;
 
         impl AgentTool for PlainTool {
-            fn name(&self) -> &'static str { "plain" }
-            fn label(&self) -> &'static str { "Plain" }
-            fn description(&self) -> &'static str { "No context" }
-            fn parameters_schema(&self) -> &Value { &Value::Null }
+            fn name(&self) -> &'static str {
+                "plain"
+            }
+            fn label(&self) -> &'static str {
+                "Plain"
+            }
+            fn description(&self) -> &'static str {
+                "No context"
+            }
+            fn parameters_schema(&self) -> &Value {
+                &Value::Null
+            }
             fn execute(
                 &self,
                 _tool_call_id: &str,
@@ -809,10 +825,18 @@ mod tests {
         struct ContextTool;
 
         impl AgentTool for ContextTool {
-            fn name(&self) -> &'static str { "ctx" }
-            fn label(&self) -> &'static str { "Ctx" }
-            fn description(&self) -> &'static str { "With context" }
-            fn parameters_schema(&self) -> &Value { &Value::Null }
+            fn name(&self) -> &'static str {
+                "ctx"
+            }
+            fn label(&self) -> &'static str {
+                "Ctx"
+            }
+            fn description(&self) -> &'static str {
+                "With context"
+            }
+            fn parameters_schema(&self) -> &Value {
+                &Value::Null
+            }
             fn approval_context(&self, params: &Value) -> Option<Value> {
                 Some(json!({"preview": format!("Will process: {}", params)}))
             }
@@ -832,7 +856,12 @@ mod tests {
         let tool = ContextTool;
         let ctx = tool.approval_context(&json!({"file": "test.txt"}));
         assert!(ctx.is_some());
-        assert!(ctx.unwrap()["preview"].as_str().unwrap().contains("test.txt"));
+        assert!(
+            ctx.unwrap()["preview"]
+                .as_str()
+                .unwrap()
+                .contains("test.txt")
+        );
     }
 
     #[test]
@@ -842,10 +871,18 @@ mod tests {
         struct PanickingTool;
 
         impl AgentTool for PanickingTool {
-            fn name(&self) -> &'static str { "panicker" }
-            fn label(&self) -> &'static str { "Panicker" }
-            fn description(&self) -> &'static str { "Panics in context" }
-            fn parameters_schema(&self) -> &Value { &Value::Null }
+            fn name(&self) -> &'static str {
+                "panicker"
+            }
+            fn label(&self) -> &'static str {
+                "Panicker"
+            }
+            fn description(&self) -> &'static str {
+                "Panics in context"
+            }
+            fn parameters_schema(&self) -> &Value {
+                &Value::Null
+            }
             fn approval_context(&self, _params: &Value) -> Option<Value> {
                 panic!("oops");
             }

--- a/src/tool_execution_policy.rs
+++ b/src/tool_execution_policy.rs
@@ -55,10 +55,7 @@ pub trait ToolExecutionStrategy: Send + Sync {
     /// Each inner `Vec<usize>` contains indices (into the original tool call
     /// slice) that should execute concurrently. The outer `Vec` is processed
     /// sequentially — group 0 completes before group 1 starts, etc.
-    fn partition(
-        &self,
-        tool_calls: &[ToolCallSummary<'_>],
-    ) -> ToolExecutionStrategyFuture<'_>;
+    fn partition(&self, tool_calls: &[ToolCallSummary<'_>]) -> ToolExecutionStrategyFuture<'_>;
 }
 
 // ─── ToolExecutionPolicy ─────────────────────────────────────────────────────

--- a/src/tool_filter.rs
+++ b/src/tool_filter.rs
@@ -47,10 +47,7 @@ impl ToolPattern {
     #[must_use]
     pub fn parse(pattern: &str) -> Self {
         if pattern.starts_with('^') || pattern.ends_with('$') {
-            Regex::new(pattern).map_or_else(
-                |_| Self::Exact(pattern.to_string()),
-                Self::Regex,
-            )
+            Regex::new(pattern).map_or_else(|_| Self::Exact(pattern.to_string()), Self::Regex)
         } else if pattern.contains('*') || pattern.contains('?') {
             Self::Glob(pattern.to_string())
         } else {
@@ -247,16 +244,14 @@ mod tests {
 
     #[test]
     fn allowed_only_restricts_to_matching() {
-        let filter = ToolFilter::new()
-            .with_allowed(vec![ToolPattern::parse("bash")]);
+        let filter = ToolFilter::new().with_allowed(vec![ToolPattern::parse("bash")]);
         assert!(filter.is_allowed("bash"));
         assert!(!filter.is_allowed("read_file"));
     }
 
     #[test]
     fn rejected_only_excludes_matching() {
-        let filter = ToolFilter::new()
-            .with_rejected(vec![ToolPattern::parse("bash")]);
+        let filter = ToolFilter::new().with_rejected(vec![ToolPattern::parse("bash")]);
         assert!(!filter.is_allowed("bash"));
         assert!(filter.is_allowed("read_file"));
     }
@@ -272,6 +267,9 @@ mod tests {
     fn parse_detects_pattern_type() {
         assert!(matches!(ToolPattern::parse("exact"), ToolPattern::Exact(_)));
         assert!(matches!(ToolPattern::parse("glob_*"), ToolPattern::Glob(_)));
-        assert!(matches!(ToolPattern::parse("^regex$"), ToolPattern::Regex(_)));
+        assert!(matches!(
+            ToolPattern::parse("^regex$"),
+            ToolPattern::Regex(_)
+        ));
     }
 }

--- a/src/tool_middleware.rs
+++ b/src/tool_middleware.rs
@@ -31,7 +31,7 @@ use crate::tool::{AgentTool, AgentToolResult, ToolFuture};
 // ─── Type alias for the middleware closure ──────────────────────────────────
 
 type MiddlewareFn = Arc<
-        dyn Fn(
+    dyn Fn(
             Arc<dyn AgentTool>,
             String,
             Value,
@@ -86,20 +86,23 @@ impl ToolMiddleware {
     /// If the inner tool does not complete within `timeout`, an error result
     /// is returned.
     pub fn with_timeout(inner: Arc<dyn AgentTool>, timeout: Duration) -> Self {
-        Self::new(inner, move |tool, id, params, cancel, on_update, state, credential| {
-            Box::pin(async move {
-                tokio::select! {
-                    result = tool.execute(&id, params, cancel.clone(), on_update, state, credential) => result,
-                    () = tokio::time::sleep(timeout) => {
-                        cancel.cancel();
-                        AgentToolResult::error(format!(
-                            "tool timed out after {}ms",
-                            timeout.as_millis()
-                        ))
+        Self::new(
+            inner,
+            move |tool, id, params, cancel, on_update, state, credential| {
+                Box::pin(async move {
+                    tokio::select! {
+                        result = tool.execute(&id, params, cancel.clone(), on_update, state, credential) => result,
+                        () = tokio::time::sleep(timeout) => {
+                            cancel.cancel();
+                            AgentToolResult::error(format!(
+                                "tool timed out after {}ms",
+                                timeout.as_millis()
+                            ))
+                        }
                     }
-                }
-            })
-        })
+                })
+            },
+        )
     }
 
     /// Create a middleware that calls a logging callback before and after
@@ -112,16 +115,21 @@ impl ToolMiddleware {
         F: Fn(&str, &str, bool) + Send + Sync + 'static,
     {
         let callback = Arc::new(callback);
-        Self::new(inner, move |tool, id, params, cancel, on_update, state, credential| {
-            let cb = callback.clone();
-            let name = tool.name().to_owned();
-            Box::pin(async move {
-                cb(&name, &id, true);
-                let result = tool.execute(&id, params, cancel, on_update, state, credential).await;
-                cb(&name, &id, false);
-                result
-            })
-        })
+        Self::new(
+            inner,
+            move |tool, id, params, cancel, on_update, state, credential| {
+                let cb = callback.clone();
+                let name = tool.name().to_owned();
+                Box::pin(async move {
+                    cb(&name, &id, true);
+                    let result = tool
+                        .execute(&id, params, cancel, on_update, state, credential)
+                        .await;
+                    cb(&name, &id, false);
+                    result
+                })
+            },
+        )
     }
 }
 
@@ -161,7 +169,15 @@ impl AgentTool for ToolMiddleware {
     ) -> ToolFuture<'_> {
         let inner = self.inner.clone();
         let id = tool_call_id.to_owned();
-        let fut = (self.middleware_fn)(inner, id, params, cancellation_token, on_update, state, credential);
+        let fut = (self.middleware_fn)(
+            inner,
+            id,
+            params,
+            cancellation_token,
+            on_update,
+            state,
+            credential,
+        );
         Box::pin(fut)
     }
 }
@@ -225,9 +241,15 @@ mod tests {
     #[test]
     fn metadata_delegates_to_inner() {
         let inner: Arc<dyn AgentTool> = Arc::new(DummyTool);
-        let mw = ToolMiddleware::new(inner, |tool, id, params, cancel, on_update, state, credential| {
-            Box::pin(async move { tool.execute(&id, params, cancel, on_update, state, credential).await })
-        });
+        let mw = ToolMiddleware::new(
+            inner,
+            |tool, id, params, cancel, on_update, state, credential| {
+                Box::pin(async move {
+                    tool.execute(&id, params, cancel, on_update, state, credential)
+                        .await
+                })
+            },
+        );
 
         assert_eq!(mw.name(), "dummy");
         assert_eq!(mw.label(), "Dummy");
@@ -245,16 +267,27 @@ mod tests {
         let counter_clone = counter.clone();
 
         let inner: Arc<dyn AgentTool> = Arc::new(DummyTool);
-        let mw = ToolMiddleware::new(inner, move |tool, id, params, cancel, on_update, state, credential| {
-            let c = counter_clone.clone();
-            Box::pin(async move {
-                c.fetch_add(1, Ordering::SeqCst);
-                tool.execute(&id, params, cancel, on_update, state, credential).await
-            })
-        });
+        let mw = ToolMiddleware::new(
+            inner,
+            move |tool, id, params, cancel, on_update, state, credential| {
+                let c = counter_clone.clone();
+                Box::pin(async move {
+                    c.fetch_add(1, Ordering::SeqCst);
+                    tool.execute(&id, params, cancel, on_update, state, credential)
+                        .await
+                })
+            },
+        );
 
         let result = mw
-            .execute("id", json!({}), CancellationToken::new(), None, test_state(), None)
+            .execute(
+                "id",
+                json!({}),
+                CancellationToken::new(),
+                None,
+                test_state(),
+                None,
+            )
             .await;
         assert!(!result.is_error);
         assert_eq!(counter.load(Ordering::SeqCst), 1);
@@ -263,12 +296,25 @@ mod tests {
     #[tokio::test]
     async fn call_through_returns_inner_result() {
         let inner: Arc<dyn AgentTool> = Arc::new(DummyTool);
-        let mw = ToolMiddleware::new(inner, |tool, id, params, cancel, on_update, state, credential| {
-            Box::pin(async move { tool.execute(&id, params, cancel, on_update, state, credential).await })
-        });
+        let mw = ToolMiddleware::new(
+            inner,
+            |tool, id, params, cancel, on_update, state, credential| {
+                Box::pin(async move {
+                    tool.execute(&id, params, cancel, on_update, state, credential)
+                        .await
+                })
+            },
+        );
 
         let result = mw
-            .execute("id", json!({}), CancellationToken::new(), None, test_state(), None)
+            .execute(
+                "id",
+                json!({}),
+                CancellationToken::new(),
+                None,
+                test_state(),
+                None,
+            )
             .await;
         assert!(!result.is_error);
     }
@@ -310,7 +356,14 @@ mod tests {
         let mw = ToolMiddleware::with_timeout(inner, Duration::from_millis(10));
 
         let result = mw
-            .execute("id", json!({}), CancellationToken::new(), None, test_state(), None)
+            .execute(
+                "id",
+                json!({}),
+                CancellationToken::new(),
+                None,
+                test_state(),
+                None,
+            )
             .await;
         assert!(result.is_error);
     }
@@ -325,8 +378,15 @@ mod tests {
             calls_clone.fetch_add(1, Ordering::SeqCst);
         });
 
-        mw.execute("id", json!({}), CancellationToken::new(), None, test_state(), None)
-            .await;
+        mw.execute(
+            "id",
+            json!({}),
+            CancellationToken::new(),
+            None,
+            test_state(),
+            None,
+        )
+        .await;
 
         // Should be called twice — once before, once after.
         assert_eq!(calls.load(Ordering::SeqCst), 2);

--- a/src/types/custom_message.rs
+++ b/src/types/custom_message.rs
@@ -298,10 +298,7 @@ impl<'de> Deserialize<'de> for AgentMessage {
             "custom" => Err(serde::de::Error::custom(
                 "cannot deserialize AgentMessage::Custom (requires runtime type info)",
             )),
-            other => Err(serde::de::Error::unknown_variant(
-                other,
-                &["llm", "custom"],
-            )),
+            other => Err(serde::de::Error::unknown_variant(other, &["llm", "custom"])),
         }
     }
 }

--- a/tests/ac_context.rs
+++ b/tests/ac_context.rs
@@ -194,13 +194,15 @@ async fn context_overflow_triggers_retry() {
     let padding = "x".repeat(400); // 400 chars = ~100 tokens
     let mut messages = Vec::new();
     for i in 0..5 {
-        messages.push(AgentMessage::Llm(LlmMessage::User(swink_agent::UserMessage {
-            content: vec![ContentBlock::Text {
-                text: format!("msg{i}:{padding}"),
-            }],
-            timestamp: 0,
-            cache_hint: None,
-        })));
+        messages.push(AgentMessage::Llm(LlmMessage::User(
+            swink_agent::UserMessage {
+                content: vec![ContentBlock::Text {
+                    text: format!("msg{i}:{padding}"),
+                }],
+                timestamp: 0,
+                cache_hint: None,
+            },
+        )));
     }
 
     let result = agent.prompt_async(messages).await.unwrap();

--- a/tests/ac_resilience.rs
+++ b/tests/ac_resilience.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use common::{
-    MockContextCapturingStreamFn, EventCollector, MockStreamFn, MockTool, default_convert,
+    EventCollector, MockContextCapturingStreamFn, MockStreamFn, MockTool, default_convert,
     default_model, error_events, text_only_events, tool_call_events, user_msg,
 };
 use futures::stream::StreamExt;

--- a/tests/ac_tools.rs
+++ b/tests/ac_tools.rs
@@ -192,11 +192,7 @@ async fn tool_execution_with_valid_args() {
     // Verify tool result content appears in messages
     let tool_result_content = result.messages.iter().find_map(|msg| {
         if let AgentMessage::Llm(LlmMessage::ToolResult(tr)) = msg {
-            if tr.is_error {
-                None
-            } else {
-                Some(&tr.content)
-            }
+            if tr.is_error { None } else { Some(&tr.content) }
         } else {
             None
         }

--- a/tests/agent_continuation.rs
+++ b/tests/agent_continuation.rs
@@ -299,7 +299,9 @@ async fn session_id_forwarding() {
 
 #[tokio::test]
 async fn get_api_key_forwarding() {
-    let capturing = Arc::new(MockApiKeyCapturingStreamFn::new(vec![text_only_events("ok")]));
+    let capturing = Arc::new(MockApiKeyCapturingStreamFn::new(vec![text_only_events(
+        "ok",
+    )]));
 
     let stream_fn: Arc<dyn StreamFn> = Arc::clone(&capturing) as Arc<dyn StreamFn>;
 

--- a/tests/agent_event_serde.rs
+++ b/tests/agent_event_serde.rs
@@ -36,9 +36,7 @@ fn minimal_snapshot() -> TurnSnapshot {
     TurnSnapshot {
         turn_index: 0,
         messages: Arc::new(vec![LlmMessage::User(UserMessage {
-            content: vec![ContentBlock::Text {
-                text: "hi".into(),
-            }],
+            content: vec![ContentBlock::Text { text: "hi".into() }],
             timestamp: 0,
             cache_hint: None,
         })]),
@@ -69,9 +67,7 @@ fn all_agent_event_variants_serialize_to_json() {
                 assistant_message: minimal_assistant_message(),
                 tool_results: vec![ToolResultMessage {
                     tool_call_id: "tc1".into(),
-                    content: vec![ContentBlock::Text {
-                        text: "ok".into(),
-                    }],
+                    content: vec![ContentBlock::Text { text: "ok".into() }],
                     is_error: false,
                     timestamp: 0,
                     details: json!(null),
@@ -86,9 +82,7 @@ fn all_agent_event_variants_serialize_to_json() {
             AgentEvent::BeforeLlmCall {
                 system_prompt: "You are helpful.".into(),
                 messages: vec![LlmMessage::User(UserMessage {
-                    content: vec![ContentBlock::Text {
-                        text: "hi".into(),
-                    }],
+                    content: vec![ContentBlock::Text { text: "hi".into() }],
                     timestamp: 0,
                     cache_hint: None,
                 })],
@@ -355,9 +349,7 @@ fn agent_event_roundtrip_all_variants() {
                 assistant_message: minimal_assistant_message(),
                 tool_results: vec![ToolResultMessage {
                     tool_call_id: "tc1".into(),
-                    content: vec![ContentBlock::Text {
-                        text: "ok".into(),
-                    }],
+                    content: vec![ContentBlock::Text { text: "ok".into() }],
                     is_error: false,
                     timestamp: 0,
                     details: json!(null),
@@ -372,9 +364,7 @@ fn agent_event_roundtrip_all_variants() {
             AgentEvent::BeforeLlmCall {
                 system_prompt: "You are helpful.".into(),
                 messages: vec![LlmMessage::User(UserMessage {
-                    content: vec![ContentBlock::Text {
-                        text: "hi".into(),
-                    }],
+                    content: vec![ContentBlock::Text { text: "hi".into() }],
                     timestamp: 0,
                     cache_hint: None,
                 })],
@@ -486,9 +476,8 @@ fn agent_event_roundtrip_all_variants() {
 
     for (label, event) in &events {
         let json = serde_json::to_value(event).unwrap();
-        let deserialized: AgentEvent = serde_json::from_value(json.clone()).unwrap_or_else(|e| {
-            panic!("Failed to deserialize AgentEvent variant '{label}': {e}")
-        });
+        let deserialized: AgentEvent = serde_json::from_value(json.clone())
+            .unwrap_or_else(|e| panic!("Failed to deserialize AgentEvent variant '{label}': {e}"));
         // Compare by re-serializing — exact equality may not hold for all types.
         let reserialized = serde_json::to_value(&deserialized).unwrap();
         assert_eq!(

--- a/tests/agent_loop.rs
+++ b/tests/agent_loop.rs
@@ -7,8 +7,8 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use common::{
-    MockApiKeyCapturingStreamFn, MockContextCapturingStreamFn, MockStreamFn, MockTool, default_model,
-    text_only_events, tool_call_events,
+    MockApiKeyCapturingStreamFn, MockContextCapturingStreamFn, MockStreamFn, MockTool,
+    default_model, text_only_events, tool_call_events,
 };
 use futures::Stream;
 use futures::stream::StreamExt;
@@ -147,7 +147,9 @@ fn default_config(stream_fn: Arc<dyn StreamFn>) -> AgentLoopConfig {
         metrics_collector: None,
         fallback: None,
         tool_execution_policy: swink_agent::ToolExecutionPolicy::default(),
-        session_state: std::sync::Arc::new(std::sync::RwLock::new(swink_agent::SessionState::new())),
+        session_state: std::sync::Arc::new(
+            std::sync::RwLock::new(swink_agent::SessionState::new()),
+        ),
         credential_resolver: None,
         cache_config: None,
         cache_state: std::sync::Mutex::new(swink_agent::CacheState::default()),
@@ -842,7 +844,9 @@ async fn convert_to_llm_filter() {
         }
     }
 
-    let capturing_fn = Arc::new(MockContextCapturingStreamFn::new(vec![text_only_events("ok")]));
+    let capturing_fn = Arc::new(MockContextCapturingStreamFn::new(vec![text_only_events(
+        "ok",
+    )]));
 
     let stream_fn: Arc<dyn StreamFn> = Arc::clone(&capturing_fn) as Arc<dyn StreamFn>;
 

--- a/tests/agent_models.rs
+++ b/tests/agent_models.rs
@@ -310,7 +310,10 @@ async fn set_model_swaps_stream_fn() {
             primary_sfn as Arc<dyn StreamFn>,
             default_convert,
         )
-        .with_available_models(vec![(extra.clone(), extra_sfn.clone() as Arc<dyn StreamFn>)]),
+        .with_available_models(vec![(
+            extra.clone(),
+            extra_sfn.clone() as Arc<dyn StreamFn>,
+        )]),
     );
 
     agent.set_model(extra.clone());
@@ -365,7 +368,10 @@ async fn set_model_with_stream_bypasses_available() {
     ));
 
     // set_model_with_stream bypasses available_models.
-    agent.set_model_with_stream(explicit_model.clone(), explicit_sfn.clone() as Arc<dyn StreamFn>);
+    agent.set_model_with_stream(
+        explicit_model.clone(),
+        explicit_sfn.clone() as Arc<dyn StreamFn>,
+    );
     assert_eq!(agent.state().model, explicit_model);
 
     let _result = agent.prompt_async(vec![user_msg("hello")]).await.unwrap();
@@ -415,7 +421,10 @@ fn set_model_emits_model_cycled_event() {
     agent.set_model(extra.clone());
 
     let received_len = events.lock().unwrap().len();
-    assert_eq!(received_len, 1, "should receive exactly one ModelCycled event");
+    assert_eq!(
+        received_len, 1,
+        "should receive exactly one ModelCycled event"
+    );
 
     let old = captured_old.lock().unwrap().clone().unwrap();
     let new = captured_new.lock().unwrap().clone().unwrap();

--- a/tests/agent_structured.rs
+++ b/tests/agent_structured.rs
@@ -12,9 +12,7 @@ use common::{
 use futures::stream::StreamExt;
 use serde_json::json;
 
-use swink_agent::{
-    Agent, AgentError, AgentOptions, DefaultRetryStrategy, StopReason, StreamFn,
-};
+use swink_agent::{Agent, AgentError, AgentOptions, DefaultRetryStrategy, StopReason, StreamFn};
 
 // ─── Helpers ─────────────────────────────────────────────────────────────
 
@@ -245,7 +243,11 @@ async fn structured_output_fails_after_max_retries() {
     );
 
     assert!(
-        agent.state().tools.iter().all(|tool| tool.name() != "__structured_output"),
+        agent
+            .state()
+            .tools
+            .iter()
+            .all(|tool| tool.name() != "__structured_output"),
         "synthetic structured output tool should always be removed after failure"
     );
 }

--- a/tests/context_compaction.rs
+++ b/tests/context_compaction.rs
@@ -97,7 +97,9 @@ fn default_config(stream_fn: Arc<dyn StreamFn>) -> AgentLoopConfig {
         metrics_collector: None,
         fallback: None,
         tool_execution_policy: swink_agent::ToolExecutionPolicy::default(),
-        session_state: std::sync::Arc::new(std::sync::RwLock::new(swink_agent::SessionState::new())),
+        session_state: std::sync::Arc::new(
+            std::sync::RwLock::new(swink_agent::SessionState::new()),
+        ),
         credential_resolver: None,
         cache_config: None,
         cache_state: std::sync::Mutex::new(swink_agent::CacheState::default()),
@@ -124,9 +126,7 @@ async fn collect_events(stream: Pin<Box<dyn Stream<Item = AgentEvent> + Send>>) 
 
 /// Check if events contain a specific variant by name.
 fn has_event(events: &[AgentEvent], name: &str) -> bool {
-    events
-        .iter()
-        .any(|e| common::event_variant_name(e) == name)
+    events.iter().any(|e| common::event_variant_name(e) == name)
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/tests/fallback.rs
+++ b/tests/fallback.rs
@@ -71,7 +71,9 @@ fn default_config(
         metrics_collector: None,
         fallback,
         tool_execution_policy: swink_agent::ToolExecutionPolicy::default(),
-        session_state: std::sync::Arc::new(std::sync::RwLock::new(swink_agent::SessionState::new())),
+        session_state: std::sync::Arc::new(
+            std::sync::RwLock::new(swink_agent::SessionState::new()),
+        ),
         credential_resolver: None,
         cache_config: None,
         cache_state: std::sync::Mutex::new(swink_agent::CacheState::default()),

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4,8 +4,8 @@
 
 mod common;
 
-use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::time::{Duration, Instant};
 
 use common::{

--- a/tests/loop_overflow.rs
+++ b/tests/loop_overflow.rs
@@ -20,8 +20,7 @@ use tokio_util::sync::CancellationToken;
 
 use swink_agent::{
     AgentContext, AgentEvent, AgentLoopConfig, AgentMessage, AssistantMessageEvent, ContentBlock,
-    DefaultRetryStrategy, LlmMessage, ModelSpec, StreamFn, StreamOptions, UserMessage,
-    agent_loop,
+    DefaultRetryStrategy, LlmMessage, ModelSpec, StreamFn, StreamOptions, UserMessage, agent_loop,
 };
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
@@ -84,16 +83,12 @@ fn large_user_msg(label: &str, token_count: usize) -> AgentMessage {
     }))
 }
 
-async fn collect_events(
-    stream: Pin<Box<dyn Stream<Item = AgentEvent> + Send>>,
-) -> Vec<AgentEvent> {
+async fn collect_events(stream: Pin<Box<dyn Stream<Item = AgentEvent> + Send>>) -> Vec<AgentEvent> {
     stream.collect().await
 }
 
 fn has_event(events: &[AgentEvent], name: &str) -> bool {
-    events
-        .iter()
-        .any(|e| common::event_variant_name(e) == name)
+    events.iter().any(|e| common::event_variant_name(e) == name)
 }
 
 fn count_events(events: &[AgentEvent], name: &str) -> usize {
@@ -116,11 +111,7 @@ impl swink_agent::AsyncContextTransformer for MockAsyncTransformer {
         &'a self,
         messages: &'a mut Vec<AgentMessage>,
         overflow: bool,
-    ) -> Pin<
-        Box<
-            dyn Future<Output = Option<swink_agent::CompactionReport>> + Send + 'a,
-        >,
-    > {
+    ) -> Pin<Box<dyn Future<Output = Option<swink_agent::CompactionReport>> + Send + 'a>> {
         self.overflow_flags.lock().unwrap().push(overflow);
         let compact = self.compact;
         Box::pin(async move {
@@ -233,13 +224,11 @@ async fn double_overflow_surfaces_error() {
     let mut config = default_config(stream_fn as Arc<dyn StreamFn>);
 
     // Compacting transformer that always removes some messages.
-    config.transform_context = Some(Arc::new(
-        |msgs: &mut Vec<AgentMessage>, overflow: bool| {
-            if overflow && msgs.len() > 1 {
-                msgs.truncate(1);
-            }
-        },
-    ));
+    config.transform_context = Some(Arc::new(|msgs: &mut Vec<AgentMessage>, overflow: bool| {
+        if overflow && msgs.len() > 1 {
+            msgs.truncate(1);
+        }
+    }));
 
     let mut initial_messages = Vec::new();
     for i in 0..5 {
@@ -335,13 +324,11 @@ async fn overflow_recovery_resets_per_turn() {
 
     let mut config = default_config(stream_fn as Arc<dyn StreamFn>);
     config.tools = vec![tool];
-    config.transform_context = Some(Arc::new(
-        |msgs: &mut Vec<AgentMessage>, overflow: bool| {
-            if overflow && msgs.len() > 1 {
-                msgs.truncate(1);
-            }
-        },
-    ));
+    config.transform_context = Some(Arc::new(|msgs: &mut Vec<AgentMessage>, overflow: bool| {
+        if overflow && msgs.len() > 1 {
+            msgs.truncate(1);
+        }
+    }));
 
     let mut initial_messages = Vec::new();
     for i in 0..5 {
@@ -493,13 +480,11 @@ async fn cancellation_during_recovery_aborts() {
     let mut config = default_config(stream_fn as Arc<dyn StreamFn>);
 
     // Compacting transformer so recovery tries.
-    config.transform_context = Some(Arc::new(
-        |msgs: &mut Vec<AgentMessage>, overflow: bool| {
-            if overflow && msgs.len() > 1 {
-                msgs.truncate(1);
-            }
-        },
-    ));
+    config.transform_context = Some(Arc::new(|msgs: &mut Vec<AgentMessage>, overflow: bool| {
+        if overflow && msgs.len() > 1 {
+            msgs.truncate(1);
+        }
+    }));
 
     let events = collect_events(agent_loop(
         vec![user_msg("msg1"), user_msg("msg2"), user_msg("msg3")],

--- a/tests/otel_spans.rs
+++ b/tests/otel_spans.rs
@@ -20,8 +20,8 @@ use common::{MockStreamFn, MockTool, default_model, text_only_events, tool_call_
 use opentelemetry::trace::Status as OtelStatus;
 use swink_agent::{
     AgentEvent, AgentLoopConfig, AgentMessage, AssistantMessageEvent, ContentBlock,
-    DefaultRetryStrategy, LlmMessage, ModelFallback, ModelSpec, StopReason, StreamFn, StreamOptions,
-    UserMessage, agent_loop,
+    DefaultRetryStrategy, LlmMessage, ModelFallback, ModelSpec, StopReason, StreamFn,
+    StreamOptions, UserMessage, agent_loop,
 };
 
 type ConvertToLlmBoxed = Box<dyn Fn(&AgentMessage) -> Option<LlmMessage> + Send + Sync>;
@@ -94,8 +94,7 @@ fn setup_otel_tracing() -> (
 async fn otel_span_hierarchy() {
     let (exporter, _guard) = setup_otel_tracing();
 
-    let stream_fn: Arc<dyn StreamFn> =
-        Arc::new(MockStreamFn::new(vec![text_only_events("hello")]));
+    let stream_fn: Arc<dyn StreamFn> = Arc::new(MockStreamFn::new(vec![text_only_events("hello")]));
     let config = default_config(stream_fn);
 
     let stream = agent_loop(
@@ -131,11 +130,13 @@ async fn otel_span_hierarchy() {
     let llm_span = spans.iter().find(|s| s.name == "agent.llm_call").unwrap();
 
     assert_eq!(
-        turn_span.parent_span_id, run_span.span_context.span_id(),
+        turn_span.parent_span_id,
+        run_span.span_context.span_id(),
         "agent.turn should be child of agent.run"
     );
     assert_eq!(
-        llm_span.parent_span_id, turn_span.span_context.span_id(),
+        llm_span.parent_span_id,
+        turn_span.span_context.span_id(),
         "agent.llm_call should be child of agent.turn"
     );
 }
@@ -144,8 +145,7 @@ async fn otel_span_hierarchy() {
 async fn otel_span_attributes() {
     let (exporter, _guard) = setup_otel_tracing();
 
-    let stream_fn: Arc<dyn StreamFn> =
-        Arc::new(MockStreamFn::new(vec![text_only_events("hello")]));
+    let stream_fn: Arc<dyn StreamFn> = Arc::new(MockStreamFn::new(vec![text_only_events("hello")]));
     let config = default_config(stream_fn);
 
     let stream = agent_loop(
@@ -162,17 +162,25 @@ async fn otel_span_attributes() {
 
     // Check agent.turn has turn_index attribute
     let turn_span = spans.iter().find(|s| s.name == "agent.turn").unwrap();
-    let turn_attrs: Vec<(&opentelemetry::Key, &opentelemetry::Value)> =
-        turn_span.attributes.iter().map(|kv| (&kv.key, &kv.value)).collect();
+    let turn_attrs: Vec<(&opentelemetry::Key, &opentelemetry::Value)> = turn_span
+        .attributes
+        .iter()
+        .map(|kv| (&kv.key, &kv.value))
+        .collect();
     assert!(
-        turn_attrs.iter().any(|(k, _)| k.as_str() == "agent.turn_index"),
+        turn_attrs
+            .iter()
+            .any(|(k, _)| k.as_str() == "agent.turn_index"),
         "agent.turn should have agent.turn_index attribute, got: {turn_attrs:?}"
     );
 
     // Check agent.llm_call has model attribute
     let llm_span = spans.iter().find(|s| s.name == "agent.llm_call").unwrap();
-    let llm_attrs: Vec<(&opentelemetry::Key, &opentelemetry::Value)> =
-        llm_span.attributes.iter().map(|kv| (&kv.key, &kv.value)).collect();
+    let llm_attrs: Vec<(&opentelemetry::Key, &opentelemetry::Value)> = llm_span
+        .attributes
+        .iter()
+        .map(|kv| (&kv.key, &kv.value))
+        .collect();
     assert!(
         llm_attrs.iter().any(|(k, _)| k.as_str() == "agent.model"),
         "agent.llm_call should have agent.model attribute, got: {llm_attrs:?}"
@@ -211,8 +219,11 @@ async fn otel_tool_spans() {
 
     // Verify tool span has agent.tool.name attribute
     let tool_span = spans.iter().find(|s| s.name == "agent.tool").unwrap();
-    let tool_attrs: Vec<(&opentelemetry::Key, &opentelemetry::Value)> =
-        tool_span.attributes.iter().map(|kv| (&kv.key, &kv.value)).collect();
+    let tool_attrs: Vec<(&opentelemetry::Key, &opentelemetry::Value)> = tool_span
+        .attributes
+        .iter()
+        .map(|kv| (&kv.key, &kv.value))
+        .collect();
     assert!(
         tool_attrs
             .iter()
@@ -285,8 +296,7 @@ async fn otel_coexists_with_metrics_collector() {
     let (exporter, _guard) = setup_otel_tracing();
 
     let collector = Arc::new(FlagCollector(AtomicBool::new(false)));
-    let stream_fn: Arc<dyn StreamFn> =
-        Arc::new(MockStreamFn::new(vec![text_only_events("hello")]));
+    let stream_fn: Arc<dyn StreamFn> = Arc::new(MockStreamFn::new(vec![text_only_events("hello")]));
     let mut config = default_config(stream_fn);
     config.metrics_collector = Some(collector.clone());
 
@@ -359,7 +369,10 @@ async fn otel_model_fallback_spans() {
     let spans = exporter.get_finished_spans().unwrap();
 
     // Should have two agent.llm_call spans — one for primary (failed) and one for fallback.
-    let llm_spans: Vec<_> = spans.iter().filter(|s| s.name == "agent.llm_call").collect();
+    let llm_spans: Vec<_> = spans
+        .iter()
+        .filter(|s| s.name == "agent.llm_call")
+        .collect();
     assert_eq!(
         llm_spans.len(),
         2,
@@ -392,8 +405,7 @@ async fn otel_model_fallback_spans() {
         .iter()
         .find(|s| {
             s.attributes.iter().any(|kv| {
-                kv.key.as_str() == "agent.model"
-                    && format!("{:?}", kv.value).contains("test-model")
+                kv.key.as_str() == "agent.model" && format!("{:?}", kv.value).contains("test-model")
             })
         })
         .expect("expected primary model span");

--- a/tests/pause_resume.rs
+++ b/tests/pause_resume.rs
@@ -33,7 +33,9 @@ async fn pause_captures_pending_follow_up_messages() {
             _context: &'a swink_agent::AgentContext,
             _options: &'a swink_agent::StreamOptions,
             _cancellation_token: tokio_util::sync::CancellationToken,
-        ) -> std::pin::Pin<Box<dyn futures::Stream<Item = swink_agent::AssistantMessageEvent> + Send + 'a>> {
+        ) -> std::pin::Pin<
+            Box<dyn futures::Stream<Item = swink_agent::AssistantMessageEvent> + Send + 'a>,
+        > {
             Box::pin(futures::stream::once(async {
                 pending::<()>().await;
                 swink_agent::AssistantMessageEvent::error("unreachable")
@@ -45,18 +47,20 @@ async fn pause_captures_pending_follow_up_messages() {
     let options = AgentOptions::new("Be helpful.", default_model(), stream_fn, default_convert);
     let mut agent = Agent::new(options);
 
-    agent.follow_up(swink_agent::AgentMessage::Llm(swink_agent::LlmMessage::User(
-        swink_agent::UserMessage {
+    agent.follow_up(swink_agent::AgentMessage::Llm(
+        swink_agent::LlmMessage::User(swink_agent::UserMessage {
             content: vec![swink_agent::ContentBlock::Text {
                 text: "queued follow-up".to_string(),
             }],
             timestamp: 1,
             cache_hint: None,
-        },
-    )));
+        }),
+    ));
 
     let _stream = agent.prompt_stream(vec![user_msg("start")]).unwrap();
-    let checkpoint = agent.pause().expect("pause should snapshot a running agent");
+    let checkpoint = agent
+        .pause()
+        .expect("pause should snapshot a running agent");
     assert_eq!(checkpoint.pending_messages.len(), 1);
 }
 
@@ -181,10 +185,8 @@ fn loop_checkpoint_serde_stable() {
 #[test]
 fn loop_checkpoint_to_standard_checkpoint_integration() {
     let msgs = vec![user_msg("hello")];
-    let checkpoint = LoopCheckpoint::new("sys", "prov", "mod", &msgs).with_metadata(
-        "k",
-        serde_json::json!("v"),
-    );
+    let checkpoint =
+        LoopCheckpoint::new("sys", "prov", "mod", &msgs).with_metadata("k", serde_json::json!("v"));
 
     let standard = checkpoint.to_checkpoint("my-id");
     assert_eq!(standard.id, "my-id");

--- a/tests/stream_accumulate_errors.rs
+++ b/tests/stream_accumulate_errors.rs
@@ -18,10 +18,7 @@ fn text_end_invalid_content_index() {
         AssistantMessageEvent::TextEnd { content_index: 0 },
     ];
     let err = accumulate_message(events, "p", "m").unwrap_err();
-    assert!(
-        err.contains("invalid content_index"),
-        "got: {err}"
-    );
+    assert!(err.contains("invalid content_index"), "got: {err}");
 }
 
 // ── 3. TextEnd on non-Text block (e.g. a ToolCall block) ──

--- a/tests/stream_resilience.rs
+++ b/tests/stream_resilience.rs
@@ -9,12 +9,14 @@ mod common;
 use std::sync::Arc;
 use std::time::Duration;
 
-use common::{EventCollector, MockTool, default_convert, default_model, text_only_events, user_msg};
+use common::{
+    EventCollector, MockTool, default_convert, default_model, text_only_events, user_msg,
+};
 
+use swink_agent::testing::ScriptedStreamFn;
 use swink_agent::{
     Agent, AgentOptions, AssistantMessageEvent, DefaultRetryStrategy, StreamFn, accumulate_message,
 };
-use swink_agent::testing::ScriptedStreamFn;
 
 // ═══════════════════════════════════════════════════════════════════════════
 // 1 — Malformed JSON tool call produces accumulation error
@@ -110,8 +112,7 @@ async fn many_tool_calls_no_dropped_events() {
         calls.push((id.as_str(), "mock_tool", "{}"));
     }
 
-    let tool_response =
-        swink_agent::testing::tool_call_events_multi(&calls);
+    let tool_response = swink_agent::testing::tool_call_events_multi(&calls);
     // After tool execution, the agent will call the LLM again — give it a text reply.
     let final_response = text_only_events("done");
 
@@ -136,19 +137,13 @@ async fn many_tool_calls_no_dropped_events() {
     );
 
     // Verify we got tool execution events for each tool call.
-    let tool_exec_starts = events
-        .iter()
-        .filter(|e| *e == "ToolExecutionStart")
-        .count();
+    let tool_exec_starts = events.iter().filter(|e| *e == "ToolExecutionStart").count();
     assert_eq!(
         tool_exec_starts, num_calls,
         "expected {num_calls} ToolExecutionStart events, got {tool_exec_starts}"
     );
 
-    let tool_exec_ends = events
-        .iter()
-        .filter(|e| *e == "ToolExecutionEnd")
-        .count();
+    let tool_exec_ends = events.iter().filter(|e| *e == "ToolExecutionEnd").count();
     assert_eq!(
         tool_exec_ends, num_calls,
         "expected {num_calls} ToolExecutionEnd events, got {tool_exec_ends}"
@@ -161,9 +156,7 @@ async fn many_tool_calls_no_dropped_events() {
 
 #[tokio::test]
 async fn dropped_subscriber_does_not_panic() {
-    let stream_fn = Arc::new(ScriptedStreamFn::new(vec![text_only_events(
-        "hello world",
-    )]));
+    let stream_fn = Arc::new(ScriptedStreamFn::new(vec![text_only_events("hello world")]));
     let mut agent = make_agent(stream_fn);
 
     // Subscribe then immediately drop the subscription handle.

--- a/tests/stress_conversation.rs
+++ b/tests/stress_conversation.rs
@@ -5,9 +5,7 @@ mod common;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
-use swink_agent::{
-    Agent, AgentEvent, AgentOptions, SlidingWindowTransformer, message_provider,
-};
+use swink_agent::{Agent, AgentEvent, AgentOptions, SlidingWindowTransformer, message_provider};
 
 use common::{default_convert, default_model, text_events, user_msg};
 
@@ -24,9 +22,9 @@ async fn many_turns_with_compaction() {
 
     // Use a very small token budget so compaction fires frequently.
     let transformer = SlidingWindowTransformer::new(
-        200,  // normal_budget — very small to force compaction
-        100,  // overflow_budget
-        1,    // anchor — preserve only the first message
+        200, // normal_budget — very small to force compaction
+        100, // overflow_budget
+        1,   // anchor — preserve only the first message
     );
 
     // Pre-build all follow-up messages.
@@ -64,16 +62,14 @@ async fn many_turns_with_compaction() {
     let turn_start_clone = Arc::clone(&turn_start_count);
     let compacted_clone = Arc::clone(&compacted_count);
 
-    agent.subscribe(move |event: &AgentEvent| {
-        match event {
-            AgentEvent::TurnStart => {
-                turn_start_clone.fetch_add(1, Ordering::SeqCst);
-            }
-            AgentEvent::ContextCompacted { .. } => {
-                compacted_clone.fetch_add(1, Ordering::SeqCst);
-            }
-            _ => {}
+    agent.subscribe(move |event: &AgentEvent| match event {
+        AgentEvent::TurnStart => {
+            turn_start_clone.fetch_add(1, Ordering::SeqCst);
         }
+        AgentEvent::ContextCompacted { .. } => {
+            compacted_clone.fetch_add(1, Ordering::SeqCst);
+        }
+        _ => {}
     });
 
     // Run with initial message and a generous timeout.

--- a/tests/stress_orchestrator.rs
+++ b/tests/stress_orchestrator.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use swink_agent::{AgentOptions, AgentOrchestrator};
 
-use common::{default_convert, default_model, text_events, MockStreamFn};
+use common::{MockStreamFn, default_convert, default_model, text_events};
 
 fn make_agent_options(name: &str) -> AgentOptions {
     let reply = format!("I am {name}");
@@ -51,7 +51,10 @@ async fn five_agents_three_concurrent_requests() {
     })
     .await;
 
-    assert!(result.is_ok(), "orchestrator requests timed out (deadlock?)");
+    assert!(
+        result.is_ok(),
+        "orchestrator requests timed out (deadlock?)"
+    );
 
     let (r0, r1, r2) = result.unwrap();
     assert!(r0.is_ok(), "agent_0 returned error: {:?}", r0.err());

--- a/tests/stress_tool_dispatch.rs
+++ b/tests/stress_tool_dispatch.rs
@@ -2,15 +2,15 @@
 
 mod common;
 
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
 use swink_agent::{Agent, AgentEvent, AgentOptions};
 
 use common::{
-    default_convert, default_model, text_events, tool_call_events_multi, user_msg, MockTool,
-    MockStreamFn,
+    MockStreamFn, MockTool, default_convert, default_model, text_events, tool_call_events_multi,
+    user_msg,
 };
 
 const TOOL_COUNT: usize = 50;
@@ -28,10 +28,7 @@ async fn fifty_concurrent_tool_calls() {
         .collect();
 
     // First response: 50 tool calls. Second response: text-only "done".
-    let responses = vec![
-        tool_call_events_multi(&call_refs),
-        text_events("done"),
-    ];
+    let responses = vec![tool_call_events_multi(&call_refs), text_events("done")];
 
     let stream_fn = Arc::new(MockStreamFn::new(responses));
 
@@ -39,7 +36,8 @@ async fn fifty_concurrent_tool_calls() {
     let tools: Vec<Arc<dyn swink_agent::AgentTool>> = (0..TOOL_COUNT)
         .map(|i| {
             Arc::new(
-                MockTool::new(&format!("tool_{i}")).with_delay(Duration::from_millis(TOOL_DELAY_MS)),
+                MockTool::new(&format!("tool_{i}"))
+                    .with_delay(Duration::from_millis(TOOL_DELAY_MS)),
             ) as Arc<dyn swink_agent::AgentTool>
         })
         .collect();
@@ -60,16 +58,14 @@ async fn fifty_concurrent_tool_calls() {
     let start_clone = Arc::clone(&exec_start_count);
     let end_clone = Arc::clone(&exec_end_count);
 
-    agent.subscribe(move |event: &AgentEvent| {
-        match event {
-            AgentEvent::ToolExecutionStart { .. } => {
-                start_clone.fetch_add(1, Ordering::SeqCst);
-            }
-            AgentEvent::ToolExecutionEnd { .. } => {
-                end_clone.fetch_add(1, Ordering::SeqCst);
-            }
-            _ => {}
+    agent.subscribe(move |event: &AgentEvent| match event {
+        AgentEvent::ToolExecutionStart { .. } => {
+            start_clone.fetch_add(1, Ordering::SeqCst);
         }
+        AgentEvent::ToolExecutionEnd { .. } => {
+            end_clone.fetch_add(1, Ordering::SeqCst);
+        }
+        _ => {}
     });
 
     let start = Instant::now();

--- a/tests/sub_agent.rs
+++ b/tests/sub_agent.rs
@@ -33,7 +33,9 @@ async fn sub_agent_runs_and_returns_text() {
 
     let params = serde_json::json!({ "prompt": "what is rust?" });
     let ct = CancellationToken::new();
-    let result = sub.execute("call-1", params, ct, None, test_state(), None).await;
+    let result = sub
+        .execute("call-1", params, ct, None, test_state(), None)
+        .await;
 
     assert!(!result.is_error);
     let text = ContentBlock::extract_text(&result.content);
@@ -66,7 +68,9 @@ async fn sub_agent_error_maps_to_tool_error() {
 
     let params = serde_json::json!({ "prompt": "do something" });
     let ct = CancellationToken::new();
-    let result = sub.execute("call-2", params, ct, None, test_state(), None).await;
+    let result = sub
+        .execute("call-2", params, ct, None, test_state(), None)
+        .await;
 
     // The result should contain text (even error-stopped agents produce text)
     // OR it should be an error. The exact behavior depends on how the agent
@@ -91,7 +95,9 @@ async fn sub_agent_cancellation() {
     let ct = CancellationToken::new();
     // Cancel immediately
     ct.cancel();
-    let result = sub.execute("call-3", params, ct, None, test_state(), None).await;
+    let result = sub
+        .execute("call-3", params, ct, None, test_state(), None)
+        .await;
 
     assert!(result.is_error);
     let text = ContentBlock::extract_text(&result.content);
@@ -140,7 +146,16 @@ async fn default_map_result_with_error_and_no_message() {
         .with_options(move || AgentOptions::new_simple("sys", default_model(), Arc::clone(&sfn2)));
 
     let ct = CancellationToken::new();
-    let result = sub2.execute("c1", json!({"prompt": "go"}), ct, None, std::sync::Arc::new(std::sync::RwLock::new(swink_agent::SessionState::new())), None).await;
+    let result = sub2
+        .execute(
+            "c1",
+            json!({"prompt": "go"}),
+            ct,
+            None,
+            std::sync::Arc::new(std::sync::RwLock::new(swink_agent::SessionState::new())),
+            None,
+        )
+        .await;
 
     assert!(result.is_error);
     let text = ContentBlock::extract_text(&result.content);
@@ -177,7 +192,14 @@ async fn default_map_result_with_no_assistant_messages() {
 
     let ct = CancellationToken::new();
     let result = sub
-        .execute("c1", json!({"prompt": "hello"}), ct, None, std::sync::Arc::new(std::sync::RwLock::new(swink_agent::SessionState::new())), None)
+        .execute(
+            "c1",
+            json!({"prompt": "hello"}),
+            ct,
+            None,
+            std::sync::Arc::new(std::sync::RwLock::new(swink_agent::SessionState::new())),
+            None,
+        )
         .await;
 
     assert!(*called.lock().unwrap());
@@ -197,7 +219,16 @@ async fn custom_map_result() {
         .with_map_result(|_result| AgentToolResult::text("custom mapped"));
 
     let ct = CancellationToken::new();
-    let result = sub.execute("c1", json!({"prompt": "go"}), ct, None, std::sync::Arc::new(std::sync::RwLock::new(swink_agent::SessionState::new())), None).await;
+    let result = sub
+        .execute(
+            "c1",
+            json!({"prompt": "go"}),
+            ct,
+            None,
+            std::sync::Arc::new(std::sync::RwLock::new(swink_agent::SessionState::new())),
+            None,
+        )
+        .await;
 
     assert!(!result.is_error);
     let text = ContentBlock::extract_text(&result.content);
@@ -231,7 +262,16 @@ async fn execute_with_empty_prompt() {
         .with_options(move || AgentOptions::new_simple("sys", default_model(), Arc::clone(&sfn)));
 
     let ct = CancellationToken::new();
-    let result = sub.execute("c1", json!({"prompt": ""}), ct, None, std::sync::Arc::new(std::sync::RwLock::new(swink_agent::SessionState::new())), None).await;
+    let result = sub
+        .execute(
+            "c1",
+            json!({"prompt": ""}),
+            ct,
+            None,
+            std::sync::Arc::new(std::sync::RwLock::new(swink_agent::SessionState::new())),
+            None,
+        )
+        .await;
 
     // Should still complete without panic
     let text = ContentBlock::extract_text(&result.content);
@@ -250,7 +290,16 @@ async fn execute_with_missing_prompt_param() {
 
     let ct = CancellationToken::new();
     // params has no "prompt" key — as_str() returns None, unwrap_or("") kicks in
-    let result = sub.execute("c1", json!({"other": "value"}), ct, None, std::sync::Arc::new(std::sync::RwLock::new(swink_agent::SessionState::new())), None).await;
+    let result = sub
+        .execute(
+            "c1",
+            json!({"other": "value"}),
+            ct,
+            None,
+            std::sync::Arc::new(std::sync::RwLock::new(swink_agent::SessionState::new())),
+            None,
+        )
+        .await;
 
     // Should still complete without panic (empty string used as prompt)
     let text = ContentBlock::extract_text(&result.content);

--- a/tests/tool.rs
+++ b/tests/tool.rs
@@ -137,7 +137,14 @@ async fn mock_tool_executes() {
         .with_result(AgentToolResult::text("read file: /tmp/x"));
     let token = CancellationToken::new();
     let result = tool
-        .execute("tc_1", json!({"path": "/tmp/x"}), token, None, std::sync::Arc::new(std::sync::RwLock::new(swink_agent::SessionState::new())), None)
+        .execute(
+            "tc_1",
+            json!({"path": "/tmp/x"}),
+            token,
+            None,
+            std::sync::Arc::new(std::sync::RwLock::new(swink_agent::SessionState::new())),
+            None,
+        )
         .await;
     assert_eq!(result.content.len(), 1);
     assert!(matches!(&result.content[0], ContentBlock::Text { text } if text.contains("/tmp/x")));

--- a/tests/tool_execution_policy.rs
+++ b/tests/tool_execution_policy.rs
@@ -136,7 +136,9 @@ fn make_config(
         metrics_collector: None,
         fallback: None,
         tool_execution_policy: policy,
-        session_state: std::sync::Arc::new(std::sync::RwLock::new(swink_agent::SessionState::new())),
+        session_state: std::sync::Arc::new(
+            std::sync::RwLock::new(swink_agent::SessionState::new()),
+        ),
         credential_resolver: None,
         cache_config: None,
         cache_state: std::sync::Mutex::new(swink_agent::CacheState::default()),

--- a/tests/tool_middleware.rs
+++ b/tests/tool_middleware.rs
@@ -19,13 +19,17 @@ async fn middleware_runs_in_agent_loop() {
     let counter_clone = counter.clone();
 
     let inner = Arc::new(MockTool::new("echo"));
-    let wrapped = ToolMiddleware::new(inner, move |tool, id, params, cancel, on_update, state, credential| {
-        let c = counter_clone.clone();
-        Box::pin(async move {
-            c.fetch_add(1, Ordering::SeqCst);
-            tool.execute(&id, params, cancel, on_update, state, credential).await
-        })
-    });
+    let wrapped = ToolMiddleware::new(
+        inner,
+        move |tool, id, params, cancel, on_update, state, credential| {
+            let c = counter_clone.clone();
+            Box::pin(async move {
+                c.fetch_add(1, Ordering::SeqCst);
+                tool.execute(&id, params, cancel, on_update, state, credential)
+                    .await
+            })
+        },
+    );
 
     let stream_fn = Arc::new(MockStreamFn::new(vec![
         tool_call_events("call_1", "echo", "{}"),

--- a/tests/tools.rs
+++ b/tests/tools.rs
@@ -36,7 +36,14 @@ async fn bash_echo_success() {
     let tool = BashTool::new();
     let token = CancellationToken::new();
     let result = tool
-        .execute("tc_1", json!({"command": "echo hello"}), token, None, std::sync::Arc::new(std::sync::RwLock::new(swink_agent::SessionState::new())), None)
+        .execute(
+            "tc_1",
+            json!({"command": "echo hello"}),
+            token,
+            None,
+            std::sync::Arc::new(std::sync::RwLock::new(swink_agent::SessionState::new())),
+            None,
+        )
         .await;
     let text = ContentBlock::extract_text(&result.content);
     assert!(
@@ -54,7 +61,14 @@ async fn bash_exit_code_nonzero() {
     let tool = BashTool::new();
     let token = CancellationToken::new();
     let result = tool
-        .execute("tc_2", json!({"command": "exit 42"}), token, None, std::sync::Arc::new(std::sync::RwLock::new(swink_agent::SessionState::new())), None)
+        .execute(
+            "tc_2",
+            json!({"command": "exit 42"}),
+            token,
+            None,
+            std::sync::Arc::new(std::sync::RwLock::new(swink_agent::SessionState::new())),
+            None,
+        )
         .await;
     let text = ContentBlock::extract_text(&result.content);
     assert!(
@@ -68,7 +82,14 @@ async fn bash_stderr_captured() {
     let tool = BashTool::new();
     let token = CancellationToken::new();
     let result = tool
-        .execute("tc_3", json!({"command": "echo err >&2"}), token, None, std::sync::Arc::new(std::sync::RwLock::new(swink_agent::SessionState::new())), None)
+        .execute(
+            "tc_3",
+            json!({"command": "echo err >&2"}),
+            token,
+            None,
+            std::sync::Arc::new(std::sync::RwLock::new(swink_agent::SessionState::new())),
+            None,
+        )
         .await;
     let text = ContentBlock::extract_text(&result.content);
     assert!(
@@ -85,7 +106,16 @@ async fn bash_stderr_captured() {
 async fn bash_invalid_params() {
     let tool = BashTool::new();
     let token = CancellationToken::new();
-    let result = tool.execute("tc_4", json!({}), token, None, std::sync::Arc::new(std::sync::RwLock::new(swink_agent::SessionState::new())), None).await;
+    let result = tool
+        .execute(
+            "tc_4",
+            json!({}),
+            token,
+            None,
+            std::sync::Arc::new(std::sync::RwLock::new(swink_agent::SessionState::new())),
+            None,
+        )
+        .await;
     let text = ContentBlock::extract_text(&result.content);
     assert!(
         text.contains("invalid parameters") || text.contains("error"),
@@ -156,7 +186,14 @@ async fn bash_output_truncation() {
         stderr_file.display()
     );
     let result = tool
-        .execute("tc_7", json!({"command": cmd}), token, None, std::sync::Arc::new(std::sync::RwLock::new(swink_agent::SessionState::new())), None)
+        .execute(
+            "tc_7",
+            json!({"command": cmd}),
+            token,
+            None,
+            std::sync::Arc::new(std::sync::RwLock::new(swink_agent::SessionState::new())),
+            None,
+        )
         .await;
     let text = ContentBlock::extract_text(&result.content);
     assert!(
@@ -309,7 +346,16 @@ async fn read_file_not_found() {
 async fn read_file_invalid_params() {
     let tool = ReadFileTool::new();
     let token = CancellationToken::new();
-    let result = tool.execute("tc_3", json!({}), token, None, std::sync::Arc::new(std::sync::RwLock::new(swink_agent::SessionState::new())), None).await;
+    let result = tool
+        .execute(
+            "tc_3",
+            json!({}),
+            token,
+            None,
+            std::sync::Arc::new(std::sync::RwLock::new(swink_agent::SessionState::new())),
+            None,
+        )
+        .await;
     let text = ContentBlock::extract_text(&result.content);
     assert!(
         text.contains("invalid parameters"),
@@ -323,7 +369,14 @@ async fn read_file_cancellation() {
     let token = CancellationToken::new();
     token.cancel();
     let result = tool
-        .execute("tc_4", json!({"path": "/tmp/anything"}), token, None, std::sync::Arc::new(std::sync::RwLock::new(swink_agent::SessionState::new())), None)
+        .execute(
+            "tc_4",
+            json!({"path": "/tmp/anything"}),
+            token,
+            None,
+            std::sync::Arc::new(std::sync::RwLock::new(swink_agent::SessionState::new())),
+            None,
+        )
         .await;
     let text = ContentBlock::extract_text(&result.content);
     assert!(
@@ -438,7 +491,16 @@ async fn write_file_creates_dirs() {
 async fn write_file_invalid_params() {
     let tool = WriteFileTool::new();
     let token = CancellationToken::new();
-    let result = tool.execute("tc_3", json!({}), token, None, std::sync::Arc::new(std::sync::RwLock::new(swink_agent::SessionState::new())), None).await;
+    let result = tool
+        .execute(
+            "tc_3",
+            json!({}),
+            token,
+            None,
+            std::sync::Arc::new(std::sync::RwLock::new(swink_agent::SessionState::new())),
+            None,
+        )
+        .await;
     let text = ContentBlock::extract_text(&result.content);
     assert!(
         text.contains("invalid parameters"),

--- a/tui/src/app/event_loop.rs
+++ b/tui/src/app/event_loop.rs
@@ -78,7 +78,8 @@ impl App {
 
                 match result {
                     Ok(Some(content)) => {
-                        self.messages.push(DisplayMessage::new(MessageRole::User, content.clone()));
+                        self.messages
+                            .push(DisplayMessage::new(MessageRole::User, content.clone()));
                         self.trim_messages_to_recent_turns();
                         self.conversation.auto_scroll = true;
                         self.send_to_agent(content);

--- a/tui/src/app/persistence.rs
+++ b/tui/src/app/persistence.rs
@@ -78,13 +78,11 @@ impl App {
                                     .chars()
                                     .take(60)
                                     .collect::<String>();
-                                let mut dm =
-                                    DisplayMessage::new(MessageRole::ToolResult, content);
+                                let mut dm = DisplayMessage::new(MessageRole::ToolResult, content);
                                 dm.collapsed = true;
                                 dm.summary = summary;
-                                dm.diff_data = crate::ui::diff::DiffData::from_details(
-                                    &tool_result.details,
-                                );
+                                dm.diff_data =
+                                    crate::ui::diff::DiffData::from_details(&tool_result.details);
                                 self.messages.push(dm);
                             }
                         }

--- a/tui/src/theme.rs
+++ b/tui/src/theme.rs
@@ -316,7 +316,6 @@ mod tests {
         ] {
             set_color_mode(mode);
             assert_ne!(bar_fg(), bar_bg(), "bar_fg == bar_bg in {mode:?}");
-
         }
         reset();
     }
@@ -330,5 +329,4 @@ mod tests {
         assert_eq!(cycle_color_mode(), ColorMode::Custom);
         reset();
     }
-
 }

--- a/tui/src/ui/tool_panel.rs
+++ b/tui/src/ui/tool_panel.rs
@@ -105,7 +105,6 @@ impl ToolPanel {
         });
     }
 
-
     /// Advance the spinner and prune old completed tools (>10s) and resolved approvals (>2s).
     pub fn tick(&mut self) {
         self.spinner_frame = (self.spinner_frame + 1) % SPINNER.len();


### PR DESCRIPTION
## Summary
- Replace stale grok-3/grok-3-fast model presets with 5 current grok-4.x models (reasoning, non-reasoning, fast variants, multi-agent)
- Update all `RemotePresetKey` constants and preset mapping tests
- All new models have 2M context windows and structured_output capability
- Apply `cargo fmt` to workspace (pre-existing formatting drift)

## Tasks completed
- T001: Replace grok-3 catalog entries with 5 grok-4.x models in `src/model_catalog.toml`
- T002: Update `RemotePresetKey` constants in `adapters/src/remote_presets.rs`
- T003: Update `added_provider_presets_map_to_catalog_models` test with new preset keys

## Test plan
- [x] `cargo test -p swink-agent -p swink-agent-adapters` passes
- [x] `cargo test -p swink-agent-adapters --no-default-features --features xai` passes (feature isolation)
- [x] `cargo clippy -p swink-agent -p swink-agent-adapters -- -D warnings` clean
- [x] `cargo fmt --check` clean

## Cross-repo impact
- `RemotePresetKey` constants renamed: `GROK_3` → `GROK_4_20_REASONING` etc. SuperSwink-Core consumers referencing old constants will need updating.

Part of #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)