### PR TITLE
impl(016): Add Azure AD/Entra ID OAuth2 client credentials auth

### DIFF
--- a/adapters/src/azure.rs
+++ b/adapters/src/azure.rs
@@ -5,9 +5,10 @@
 
 use std::pin::Pin;
 use std::sync::{Arc, RwLock};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use futures::stream::{self, Stream, StreamExt as _};
+use serde::Deserialize;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
 
@@ -47,18 +48,28 @@ impl std::fmt::Debug for AzureAuth {
     }
 }
 
-/// Cached `OAuth2` token for Entra ID authentication (used in Phase 5 / US3).
-#[allow(dead_code)]
+/// Refresh tokens proactively 5 minutes before expiry.
+const REFRESH_MARGIN: Duration = Duration::from_secs(300);
+
+/// Cached `OAuth2` token for Entra ID authentication.
 struct CachedToken {
     access_token: String,
     expires_at: Instant,
 }
 
+/// Response from the Microsoft identity platform token endpoint.
+#[derive(Deserialize)]
+struct TokenResponse {
+    access_token: String,
+    expires_in: u64,
+}
+
 pub struct AzureStreamFn {
     base: AdapterBase,
     auth: AzureAuth,
-    #[allow(dead_code)] // Used in Phase 5 (US3) for Entra ID token caching
     token_cache: Arc<RwLock<Option<CachedToken>>>,
+    /// Override token endpoint URL (for testing). `None` = use Microsoft default.
+    token_endpoint_override: Option<String>,
 }
 
 impl AzureStreamFn {
@@ -72,6 +83,95 @@ impl AzureStreamFn {
             base: AdapterBase::new(base_url.into().trim_end_matches('/').to_string(), api_key),
             auth,
             token_cache: Arc::new(RwLock::new(None)),
+            token_endpoint_override: None,
+        }
+    }
+
+    /// Set a custom token endpoint URL (for testing with wiremock).
+    #[must_use]
+    pub fn with_token_endpoint(mut self, url: impl Into<String>) -> Self {
+        self.token_endpoint_override = Some(url.into());
+        self
+    }
+}
+
+impl AzureStreamFn {
+    /// Acquire a fresh token from the Microsoft identity platform.
+    async fn acquire_token(
+        &self,
+        tenant_id: &str,
+        client_id: &str,
+        client_secret: &str,
+    ) -> Result<CachedToken, String> {
+        let token_url = self.token_url(tenant_id);
+        let params = [
+            ("grant_type", "client_credentials"),
+            ("client_id", client_id),
+            ("client_secret", client_secret),
+            ("scope", "https://cognitiveservices.azure.com/.default"),
+        ];
+
+        let resp = self
+            .base
+            .client
+            .post(&token_url)
+            .form(&params)
+            .send()
+            .await
+            .map_err(|e| format!("token request failed: {e}"))?;
+
+        if !resp.status().is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(format!("token endpoint returned error: {body}"));
+        }
+
+        let token_resp: TokenResponse = resp
+            .json()
+            .await
+            .map_err(|e| format!("failed to parse token response: {e}"))?;
+
+        Ok(CachedToken {
+            access_token: token_resp.access_token,
+            expires_at: Instant::now() + Duration::from_secs(token_resp.expires_in),
+        })
+    }
+
+    /// Get a valid token, refreshing if necessary.
+    async fn get_or_refresh_token(
+        &self,
+        tenant_id: &str,
+        client_id: &str,
+        client_secret: &str,
+    ) -> Result<String, String> {
+        // Check cache first
+        {
+            let cache = self.token_cache.read().unwrap_or_else(|e| e.into_inner());
+            if let Some(cached) = cache.as_ref() {
+                if Instant::now() + REFRESH_MARGIN < cached.expires_at {
+                    return Ok(cached.access_token.clone());
+                }
+            }
+        }
+
+        // Acquire new token
+        let token = self
+            .acquire_token(tenant_id, client_id, client_secret)
+            .await?;
+        let access_token = token.access_token.clone();
+
+        // Update cache
+        let mut cache = self.token_cache.write().unwrap_or_else(|e| e.into_inner());
+        *cache = Some(token);
+
+        Ok(access_token)
+    }
+
+    /// Build the token endpoint URL. Uses override if set, otherwise Microsoft default.
+    fn token_url(&self, tenant_id: &str) -> String {
+        if let Some(override_url) = &self.token_endpoint_override {
+            override_url.clone()
+        } else {
+            format!("https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token")
         }
     }
 }
@@ -169,12 +269,18 @@ async fn send_request(
             let api_key = options.api_key.as_deref().unwrap_or(key);
             request = request.header("api-key", api_key);
         }
-        AzureAuth::EntraId { .. } => {
-            // Entra ID token acquisition will be implemented in Phase 5 (US3).
-            // For now, if a runtime api_key override is provided, use it as a Bearer token.
-            if let Some(token) = options.api_key.as_deref() {
-                request = request.header("Authorization", format!("Bearer {token}"));
-            }
+        AzureAuth::EntraId {
+            tenant_id,
+            client_id,
+            client_secret,
+        } => {
+            let token = azure
+                .get_or_refresh_token(tenant_id, client_id, client_secret)
+                .await
+                .map_err(|e| {
+                    AssistantMessageEvent::error_network(format!("Azure token error: {e}"))
+                })?;
+            request = request.header("Authorization", format!("Bearer {token}"));
         }
     }
 

--- a/adapters/src/remote_presets.rs
+++ b/adapters/src/remote_presets.rs
@@ -262,7 +262,8 @@ fn build_remote_connection_from_values(
             preset.api_version.clone().unwrap_or(ApiVersion::V1beta),
         )),
         #[cfg(feature = "azure")]
-        #[allow(clippy::redundant_clone)] // Clone needed when multiple adapter features enabled
+        #[allow(clippy::redundant_clone)]
+        // Clone needed when multiple adapter features enabled
         "azure" => Arc::new(AzureStreamFn::new(
             resolved_base_url()?,
             AzureAuth::ApiKey(api_key.clone()),

--- a/adapters/tests/azure.rs
+++ b/adapters/tests/azure.rs
@@ -5,8 +5,8 @@ mod common;
 
 use futures::StreamExt;
 use tokio_util::sync::CancellationToken;
-use wiremock::matchers::{header, method, path};
-use wiremock::{Mock, MockServer};
+use wiremock::matchers::{body_string_contains, header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use swink_agent::{AssistantMessageEvent, ModelSpec, StopReason, StreamFn, StreamOptions};
 use swink_agent_adapters::{AzureAuth, AzureStreamFn};
@@ -422,4 +422,237 @@ async fn tool_call_arguments_form_valid_json() {
         serde_json::from_str(&arguments).expect("tool call arguments should be valid JSON");
     assert_eq!(parsed["path"], "out.txt");
     assert_eq!(parsed["content"], "hello world");
+}
+
+// ── Phase 5: User Story 3 — Deployment Routing & Azure AD Auth ────────────
+
+/// Helper: standard SSE body for a simple successful response.
+fn simple_sse_body() -> String {
+    [
+        r#"data: {"choices":[{"delta":{"content":"ok"}}]}"#,
+        "",
+        r#"data: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}"#,
+        "",
+        "data: [DONE]",
+        "",
+    ]
+    .join("\n")
+}
+
+/// Helper: JSON body for a successful token response.
+fn token_response_body(access_token: &str, expires_in: u64) -> String {
+    serde_json::json!({
+        "access_token": access_token,
+        "token_type": "Bearer",
+        "expires_in": expires_in,
+    })
+    .to_string()
+}
+
+/// Helper: build an `AzureStreamFn` with Entra ID auth pointing at mock servers.
+fn entra_stream_fn(api_server: &MockServer, token_url: &str) -> AzureStreamFn {
+    AzureStreamFn::new(
+        api_server.uri(),
+        AzureAuth::EntraId {
+            tenant_id: "test-tenant".into(),
+            client_id: "test-client-id".into(),
+            client_secret: "test-client-secret".into(),
+        },
+    )
+    .with_token_endpoint(token_url.to_string())
+}
+
+// ── T032: Entra ID token acquisition — verify POST params ─────────────────
+
+#[tokio::test]
+async fn entra_id_token_acquisition_params() {
+    let token_server = MockServer::start().await;
+    let api_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/token"))
+        .and(body_string_contains("grant_type=client_credentials"))
+        .and(body_string_contains("client_id=test-client-id"))
+        .and(body_string_contains("client_secret=test-client-secret"))
+        .and(body_string_contains("scope=https"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_string(token_response_body("fresh-token", 3600)),
+        )
+        .expect(1)
+        .mount(&token_server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(sse_response(&simple_sse_body()))
+        .mount(&api_server)
+        .await;
+
+    let token_url = format!("{}/token", token_server.uri());
+    let stream_fn = entra_stream_fn(&api_server, &token_url);
+    let events = collect_events(&stream_fn).await;
+
+    assert!(events.iter().any(|e| matches!(
+        e,
+        AssistantMessageEvent::Done {
+            stop_reason: StopReason::Stop,
+            ..
+        }
+    )));
+}
+
+// ── T033: Token caching — two requests reuse same token ───────────────────
+
+#[tokio::test]
+async fn entra_id_token_caching() {
+    let token_server = MockServer::start().await;
+    let api_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/token"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string(token_response_body("cached-token", 3600)),
+        )
+        .expect(1) // Token endpoint should be called exactly once
+        .mount(&token_server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(sse_response(&simple_sse_body()))
+        .mount(&api_server)
+        .await;
+
+    let token_url = format!("{}/token", token_server.uri());
+    let stream_fn = entra_stream_fn(&api_server, &token_url);
+
+    // First request
+    let events = collect_events(&stream_fn).await;
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, AssistantMessageEvent::Done { .. }))
+    );
+
+    // Second request — should reuse cached token (token endpoint not called again)
+    let events = collect_events(&stream_fn).await;
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, AssistantMessageEvent::Done { .. }))
+    );
+
+    // wiremock will verify expect(1) on drop
+}
+
+// ── T034: Token refresh — expired token triggers re-acquisition ───────────
+
+#[tokio::test]
+async fn entra_id_token_refresh_on_expiry() {
+    let token_server = MockServer::start().await;
+    let api_server = MockServer::start().await;
+
+    // Return a token that expires immediately (within the refresh margin)
+    Mock::given(method("POST"))
+        .and(path("/token"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                // expires_in=1 means it will be within REFRESH_MARGIN immediately
+                .set_body_string(token_response_body("short-lived-token", 1)),
+        )
+        .expect(2) // Should be called twice since first token expires immediately
+        .mount(&token_server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(sse_response(&simple_sse_body()))
+        .mount(&api_server)
+        .await;
+
+    let token_url = format!("{}/token", token_server.uri());
+    let stream_fn = entra_stream_fn(&api_server, &token_url);
+
+    // First request — acquires token
+    let events = collect_events(&stream_fn).await;
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, AssistantMessageEvent::Done { .. }))
+    );
+
+    // Second request — token is expired (within REFRESH_MARGIN), must re-acquire
+    let events = collect_events(&stream_fn).await;
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, AssistantMessageEvent::Done { .. }))
+    );
+}
+
+// ── T035: Bearer token appears in Authorization header ─────────��──────────
+
+#[tokio::test]
+async fn entra_id_bearer_token_in_auth_header() {
+    let token_server = MockServer::start().await;
+    let api_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/token"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string(token_response_body("my-bearer-token", 3600)),
+        )
+        .mount(&token_server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .and(header("Authorization", "Bearer my-bearer-token"))
+        .respond_with(sse_response(&simple_sse_body()))
+        .expect(1)
+        .mount(&api_server)
+        .await;
+
+    let token_url = format!("{}/token", token_server.uri());
+    let stream_fn = entra_stream_fn(&api_server, &token_url);
+    let events = collect_events(&stream_fn).await;
+
+    // If the header didn't match, wiremock would return 404 → error event
+    assert!(events.iter().any(|e| matches!(
+        e,
+        AssistantMessageEvent::Done {
+            stop_reason: StopReason::Stop,
+            ..
+        }
+    )));
+}
+
+// ── T036: URL constructed as {base_url}/chat/completions ──────────────────
+
+#[tokio::test]
+async fn url_construction_with_deployment_path() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/openai/deployments/gpt-4/chat/completions"))
+        .and(header("api-key", "test-key"))
+        .respond_with(sse_response(&simple_sse_body()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // base_url includes the deployment path
+    let auth = AzureAuth::ApiKey("test-key".into());
+    let stream_fn = AzureStreamFn::new(format!("{}/openai/deployments/gpt-4", server.uri()), auth);
+    let events = collect_events(&stream_fn).await;
+
+    assert!(events.iter().any(|e| matches!(
+        e,
+        AssistantMessageEvent::Done {
+            stop_reason: StopReason::Stop,
+            ..
+        }
+    )));
 }

--- a/memory/src/migrate.rs
+++ b/memory/src/migrate.rs
@@ -25,8 +25,11 @@ pub trait SessionMigrator: Send + Sync {
     ///
     /// The implementation may modify, add, or remove entries. It must NOT
     /// modify `meta.version` — the runner handles that.
-    fn migrate(&self, meta: &SessionMeta, entries: Vec<SessionEntry>)
-        -> io::Result<Vec<SessionEntry>>;
+    fn migrate(
+        &self,
+        meta: &SessionMeta,
+        entries: Vec<SessionEntry>,
+    ) -> io::Result<Vec<SessionEntry>>;
 }
 
 /// The current schema version for new sessions.

--- a/memory/tests/round_trip.rs
+++ b/memory/tests/round_trip.rs
@@ -314,13 +314,17 @@ fn sequence_increments_on_save() {
     let store = JsonlSessionStore::new(tmp.path().to_path_buf()).unwrap();
 
     let meta = sample_meta("seq_test", "Sequence test");
-    store.save("seq_test", &meta, &[user_message("first")]).unwrap();
+    store
+        .save("seq_test", &meta, &[user_message("first")])
+        .unwrap();
 
     let (loaded1, _) = store.load("seq_test").unwrap();
     assert_eq!(loaded1.sequence, 1);
 
     // Save again with the loaded meta (sequence=1)
-    store.save("seq_test", &loaded1, &[user_message("second")]).unwrap();
+    store
+        .save("seq_test", &loaded1, &[user_message("second")])
+        .unwrap();
 
     let (loaded2, _) = store.load("seq_test").unwrap();
     assert_eq!(loaded2.sequence, 2);
@@ -332,17 +336,23 @@ fn optimistic_concurrency_rejects_stale_sequence() {
     let store = JsonlSessionStore::new(tmp.path().to_path_buf()).unwrap();
 
     let meta = sample_meta("conc_test", "Concurrency test");
-    store.save("conc_test", &meta, &[user_message("v1")]).unwrap();
+    store
+        .save("conc_test", &meta, &[user_message("v1")])
+        .unwrap();
 
     // Load meta (sequence=1)
     let (stale_meta, _) = store.load("conc_test").unwrap();
     assert_eq!(stale_meta.sequence, 1);
 
     // Simulate another writer saving (bumps sequence to 2)
-    store.save("conc_test", &stale_meta, &[user_message("v2")]).unwrap();
+    store
+        .save("conc_test", &stale_meta, &[user_message("v2")])
+        .unwrap();
 
     // Attempt save with stale meta (sequence=1, but file has sequence=2)
-    let err = store.save("conc_test", &stale_meta, &[user_message("v3")]).unwrap_err();
+    let err = store
+        .save("conc_test", &stale_meta, &[user_message("v3")])
+        .unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::AlreadyExists);
     assert!(err.to_string().contains("sequence conflict"));
 }
@@ -354,7 +364,11 @@ fn unsupported_future_version_returns_error() {
 
     // Write a JSONL file with version: 999
     let meta_json = r#"{"id":"future_001","title":"Future session","created_at":"2025-03-15T12:00:00Z","updated_at":"2025-03-15T12:00:00Z","version":999,"sequence":0}"#;
-    std::fs::write(tmp.path().join("future_001.jsonl"), format!("{meta_json}\n")).unwrap();
+    std::fs::write(
+        tmp.path().join("future_001.jsonl"),
+        format!("{meta_json}\n"),
+    )
+    .unwrap();
 
     let err = store.load("future_001").unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::InvalidData);

--- a/policies/tests/composition.rs
+++ b/policies/tests/composition.rs
@@ -1,3 +1,9 @@
+#![cfg(all(
+    feature = "audit",
+    feature = "content-filter",
+    feature = "pii",
+    feature = "prompt-guard"
+))]
 //! Integration tests for policy composition.
 
 use swink_agent::{

--- a/specs/016-adapter-azure/tasks.md
+++ b/specs/016-adapter-azure/tasks.md
@@ -92,16 +92,16 @@
 
 ### Implementation for User Story 3
 
-- [ ] T028 [US3] Implement `acquire_token` async function — POST to `https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token` with client credentials in `adapters/src/azure.rs`
-- [ ] T029 [US3] Implement `get_or_refresh_token` — check cache, acquire if empty/expired, cache result with `expires_at` derived from `expires_in` response field in `adapters/src/azure.rs`
-- [ ] T030 [US3] Add refresh margin constant (e.g., 300 seconds) — tokens refresh proactively before expiry in `adapters/src/azure.rs`
-- [ ] T031 [US3] Update `send_request` to call `get_or_refresh_token` when auth is `EntraId` and set `Authorization: Bearer {token}` header in `adapters/src/azure.rs`
-- [ ] T032 [US3] Add wiremock test: Entra ID token acquisition — mock token endpoint, verify POST params (grant_type, client_id, client_secret, scope) in `adapters/tests/azure.rs`
-- [ ] T033 [US3] Add wiremock test: token caching — two requests reuse same token (token endpoint called once) in `adapters/tests/azure.rs`
-- [ ] T034 [US3] Add wiremock test: token refresh — expired token triggers re-acquisition in `adapters/tests/azure.rs`
-- [ ] T035 [US3] Add wiremock test: Bearer token appears in Authorization header on API requests in `adapters/tests/azure.rs`
-- [ ] T036 [US3] Add wiremock test: URL constructed as `{base_url}/chat/completions` with deployment in base_url path in `adapters/tests/azure.rs`
-- [ ] T037 [US3] Run `cargo test -p swink-agent-adapters --features azure` to verify all US3 tests pass
+- [x] T028 [US3] Implement `acquire_token` async function — POST to `https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token` with client credentials in `adapters/src/azure.rs`
+- [x] T029 [US3] Implement `get_or_refresh_token` — check cache, acquire if empty/expired, cache result with `expires_at` derived from `expires_in` response field in `adapters/src/azure.rs`
+- [x] T030 [US3] Add refresh margin constant (e.g., 300 seconds) — tokens refresh proactively before expiry in `adapters/src/azure.rs`
+- [x] T031 [US3] Update `send_request` to call `get_or_refresh_token` when auth is `EntraId` and set `Authorization: Bearer {token}` header in `adapters/src/azure.rs`
+- [x] T032 [US3] Add wiremock test: Entra ID token acquisition — mock token endpoint, verify POST params (grant_type, client_id, client_secret, scope) in `adapters/tests/azure.rs`
+- [x] T033 [US3] Add wiremock test: token caching — two requests reuse same token (token endpoint called once) in `adapters/tests/azure.rs`
+- [x] T034 [US3] Add wiremock test: token refresh — expired token triggers re-acquisition in `adapters/tests/azure.rs`
+- [x] T035 [US3] Add wiremock test: Bearer token appears in Authorization header on API requests in `adapters/tests/azure.rs`
+- [x] T036 [US3] Add wiremock test: URL constructed as `{base_url}/chat/completions` with deployment in base_url path in `adapters/tests/azure.rs`
+- [x] T037 [US3] Run `cargo test -p swink-agent-adapters --features azure` to verify all US3 tests pass
 
 **Checkpoint**: Azure AD auth and deployment routing work end-to-end.
 

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -243,7 +243,7 @@ fn build_extra_models(_primary_id: &str) -> Vec<(ModelSpec, Arc<dyn StreamFn>)> 
 }
 
 /// Append local model to extra models list when the `local` feature is enabled.
-#[allow(unused_variables)]
+#[allow(unused_variables, clippy::ptr_arg, clippy::needless_pass_by_ref_mut)]
 fn append_local_model(extra: &mut Vec<(ModelSpec, Arc<dyn StreamFn>)>) {
     #[cfg(feature = "local")]
     {


### PR DESCRIPTION
## Summary
- Implement Entra ID OAuth2 client credentials flow for Azure OpenAI adapter (Phase 5, T028–T037)
- Add `acquire_token` and `get_or_refresh_token` with proactive 5-minute refresh margin
- Mark Phase 4 (T024–T027) complete — tool call streaming wiremock tests were already present
- Fix pre-existing clippy/fmt issues in tui, policies, memory crates

## Tasks completed
- T028: `acquire_token` async function — POST to Microsoft token endpoint with client credentials
- T029: `get_or_refresh_token` — cache check, acquire if empty/expired, cache result
- T030: `REFRESH_MARGIN` constant (300 seconds) for proactive token refresh
- T031: Wire `get_or_refresh_token` into `send_request` for Entra ID auth
- T032: Wiremock test for token acquisition POST params (grant_type, client_id, client_secret, scope)
- T033: Wiremock test for token caching (two requests, token endpoint called once)
- T034: Wiremock test for token refresh (short-lived token triggers re-acquisition)
- T035: Wiremock test for Bearer token in Authorization header
- T036: Wiremock test for URL construction with deployment path
- T037: All Azure adapter tests pass (14/14)

## Test plan
- [x] `cargo test -p swink-agent-adapters --features azure --test azure` — 14/14 pass
- [x] `cargo test -p swink-agent-adapters --no-default-features --features azure --test azure` — feature isolation verified
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] No public API breakage in downstream crates

Progress: 37/56 tasks (66%)

Part of #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)