### PR TITLE
impl(017): Add xAI live tests and complete adapter

### DIFF
--- a/adapters/CLAUDE.md
+++ b/adapters/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-`adapters/` — StreamFn implementations for 9 LLM providers (6 implemented, 3 stubs). Separate crate to keep provider-specific deps out of core.
+`adapters/` — StreamFn implementations for 9 LLM providers (7 implemented, 2 stubs). Separate crate to keep provider-specific deps out of core.
 
 ## Feature Gates
 
@@ -29,7 +29,7 @@ swink-agent-adapters = {}
 | `azure` | `azure.rs` | — | Stub |
 | `bedrock` | `bedrock.rs` | `sha2` | Stub |
 | `mistral` | `mistral.rs` | — | Implemented |
-| `xai` | `xai.rs` | — | Stub |
+| `xai` | `xai.rs` | — | Implemented |
 
 **Always compiled** (shared infra): `base`, `sse`, `classify`, `convert`, `finalize`, `openai_compat`, `remote_presets`.
 

--- a/adapters/src/remote_presets.rs
+++ b/adapters/src/remote_presets.rs
@@ -262,7 +262,8 @@ fn build_remote_connection_from_values(
             preset.api_version.clone().unwrap_or(ApiVersion::V1beta),
         )),
         #[cfg(feature = "azure")]
-        #[allow(clippy::redundant_clone)] // Clone needed when multiple adapter features enabled
+        #[allow(clippy::redundant_clone)]
+        // Clone needed when multiple adapter features enabled
         "azure" => Arc::new(AzureStreamFn::new(
             resolved_base_url()?,
             AzureAuth::ApiKey(api_key.clone()),

--- a/adapters/tests/xai_live.rs
+++ b/adapters/tests/xai_live.rs
@@ -1,0 +1,353 @@
+#![cfg(feature = "xai")]
+//! Live API tests for `XAiStreamFn`.
+//!
+//! These tests hit the real xAI API and are skipped by default.
+//! Run with: `cargo test -p swink-agent-adapters --test xai_live -- --ignored`
+//! Requires `XAI_API_KEY` in `.env` or environment.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::StreamExt;
+use serde_json::json;
+use tokio::time::timeout;
+use tokio_util::sync::CancellationToken;
+
+use swink_agent::{
+    AgentContext, AgentMessage, AgentTool, AgentToolResult, AssistantMessage,
+    AssistantMessageEvent, ContentBlock, Cost, LlmMessage, ModelSpec, StopReason, StreamFn,
+    StreamOptions, Usage, UserMessage,
+};
+use swink_agent_adapters::XAiStreamFn;
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const TIMEOUT: Duration = Duration::from_secs(30);
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+fn xai_key() -> String {
+    dotenvy::dotenv().ok();
+    std::env::var("XAI_API_KEY").expect("XAI_API_KEY must be set to run live tests")
+}
+
+fn cheap_model() -> ModelSpec {
+    dotenvy::dotenv().ok();
+    let model_id =
+        std::env::var("XAI_MODEL").unwrap_or_else(|_| "grok-4-1-fast-non-reasoning".to_string());
+    ModelSpec::new("xai", &model_id)
+}
+
+fn simple_context(prompt: &str) -> AgentContext {
+    AgentContext {
+        system_prompt: "Reply in one word.".into(),
+        messages: vec![AgentMessage::Llm(LlmMessage::User(UserMessage {
+            content: vec![ContentBlock::Text {
+                text: prompt.to_string(),
+            }],
+            timestamp: 0,
+            cache_hint: None,
+        }))],
+        tools: Vec::new(),
+    }
+}
+
+async fn collect_events(sf: &XAiStreamFn, context: &AgentContext) -> Vec<AssistantMessageEvent> {
+    let model = cheap_model();
+    let options = StreamOptions::default();
+    let token = CancellationToken::new();
+    let stream = sf.stream(&model, context, &options, token);
+    stream.collect::<Vec<_>>().await
+}
+
+const fn event_name(event: &AssistantMessageEvent) -> &'static str {
+    match event {
+        AssistantMessageEvent::Start => "Start",
+        AssistantMessageEvent::TextStart { .. } => "TextStart",
+        AssistantMessageEvent::TextDelta { .. } => "TextDelta",
+        AssistantMessageEvent::TextEnd { .. } => "TextEnd",
+        AssistantMessageEvent::ThinkingStart { .. } => "ThinkingStart",
+        AssistantMessageEvent::ThinkingDelta { .. } => "ThinkingDelta",
+        AssistantMessageEvent::ThinkingEnd { .. } => "ThinkingEnd",
+        AssistantMessageEvent::ToolCallStart { .. } => "ToolCallStart",
+        AssistantMessageEvent::ToolCallDelta { .. } => "ToolCallDelta",
+        AssistantMessageEvent::ToolCallEnd { .. } => "ToolCallEnd",
+        AssistantMessageEvent::Done { .. } => "Done",
+        AssistantMessageEvent::Error { .. } => "Error",
+        _ => "Unknown",
+    }
+}
+
+/// A dummy tool for triggering tool-use responses.
+struct DummyTool;
+
+impl AgentTool for DummyTool {
+    fn name(&self) -> &'static str {
+        "get_weather"
+    }
+
+    fn label(&self) -> &'static str {
+        "Get Weather"
+    }
+
+    fn description(&self) -> &'static str {
+        "Get the current weather for a city."
+    }
+
+    fn parameters_schema(&self) -> &serde_json::Value {
+        static SCHEMA: std::sync::OnceLock<serde_json::Value> = std::sync::OnceLock::new();
+        SCHEMA.get_or_init(|| {
+            json!({
+                "type": "object",
+                "properties": {
+                    "city": {
+                        "type": "string",
+                        "description": "The city name"
+                    }
+                },
+                "required": ["city"]
+            })
+        })
+    }
+
+    fn execute(
+        &self,
+        _tool_call_id: &str,
+        _params: serde_json::Value,
+        _cancellation_token: CancellationToken,
+        _on_update: Option<Box<dyn Fn(AgentToolResult) + Send + Sync>>,
+        _state: std::sync::Arc<std::sync::RwLock<swink_agent::SessionState>>,
+        _credential: Option<swink_agent::ResolvedCredential>,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = AgentToolResult> + Send + '_>> {
+        Box::pin(async {
+            AgentToolResult {
+                content: vec![ContentBlock::Text {
+                    text: "72°F, sunny".into(),
+                }],
+                details: json!({}),
+                is_error: false,
+            }
+        })
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore = "hits live API"]
+async fn live_text_stream() {
+    let key = xai_key();
+    let sf = XAiStreamFn::new("https://api.x.ai", &key);
+    let context = simple_context("What is 2+2?");
+
+    let events = timeout(TIMEOUT, collect_events(&sf, &context))
+        .await
+        .expect("timed out");
+
+    let types: Vec<&str> = events.iter().map(|e| event_name(e)).collect();
+    assert!(types.contains(&"Start"), "missing Start: {types:?}");
+    assert!(types.contains(&"TextStart"), "missing TextStart: {types:?}");
+    assert!(types.contains(&"TextDelta"), "missing TextDelta: {types:?}");
+    assert!(types.contains(&"TextEnd"), "missing TextEnd: {types:?}");
+    assert!(types.contains(&"Done"), "missing Done: {types:?}");
+
+    let text: String = events
+        .iter()
+        .filter_map(|e| match e {
+            AssistantMessageEvent::TextDelta { delta, .. } => Some(delta.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert!(!text.is_empty(), "expected non-empty text response");
+}
+
+#[tokio::test]
+#[ignore = "hits live API"]
+async fn live_usage_and_cost() {
+    let key = xai_key();
+    let sf = XAiStreamFn::new("https://api.x.ai", &key);
+    let context = simple_context("Say hello.");
+
+    let events = timeout(TIMEOUT, collect_events(&sf, &context))
+        .await
+        .expect("timed out");
+
+    let usage = events
+        .iter()
+        .find_map(|e| match e {
+            AssistantMessageEvent::Done { usage, .. } => Some(usage.clone()),
+            _ => None,
+        })
+        .expect("missing Done event");
+
+    assert!(usage.input > 0, "expected non-zero input tokens");
+    assert!(usage.output > 0, "expected non-zero output tokens");
+}
+
+#[tokio::test]
+#[ignore = "hits live API"]
+async fn live_stop_reason_mapping() {
+    let key = xai_key();
+    let sf = XAiStreamFn::new("https://api.x.ai", &key);
+    let context = simple_context("Say yes.");
+
+    let events = timeout(TIMEOUT, collect_events(&sf, &context))
+        .await
+        .expect("timed out");
+
+    let stop_reason = events.iter().find_map(|e| match e {
+        AssistantMessageEvent::Done { stop_reason, .. } => Some(*stop_reason),
+        _ => None,
+    });
+    assert_eq!(
+        stop_reason,
+        Some(StopReason::Stop),
+        "expected Stop for a simple prompt"
+    );
+}
+
+#[tokio::test]
+#[ignore = "hits live API"]
+async fn live_tool_use_stream() {
+    let key = xai_key();
+    let sf = XAiStreamFn::new("https://api.x.ai", &key);
+    let context = AgentContext {
+        system_prompt: "You must use the get_weather tool to answer. Do not reply with text only."
+            .into(),
+        messages: vec![AgentMessage::Llm(LlmMessage::User(UserMessage {
+            content: vec![ContentBlock::Text {
+                text: "What's the weather in Paris?".into(),
+            }],
+            timestamp: 0,
+            cache_hint: None,
+        }))],
+        tools: vec![Arc::new(DummyTool)],
+    };
+
+    let events = timeout(TIMEOUT, collect_events(&sf, &context))
+        .await
+        .expect("timed out");
+
+    let types: Vec<&str> = events.iter().map(|e| event_name(e)).collect();
+    assert!(
+        types.contains(&"ToolCallStart"),
+        "missing ToolCallStart: {types:?}"
+    );
+    assert!(
+        types.contains(&"ToolCallEnd"),
+        "missing ToolCallEnd: {types:?}"
+    );
+
+    let tool_name = events.iter().find_map(|e| match e {
+        AssistantMessageEvent::ToolCallStart { name, .. } => Some(name.clone()),
+        _ => None,
+    });
+    assert_eq!(tool_name.as_deref(), Some("get_weather"));
+
+    let stop_reason = events.iter().find_map(|e| match e {
+        AssistantMessageEvent::Done { stop_reason, .. } => Some(*stop_reason),
+        _ => None,
+    });
+    assert_eq!(stop_reason, Some(StopReason::ToolUse));
+}
+
+#[tokio::test]
+#[ignore = "hits live API"]
+async fn live_multi_turn_context() {
+    let key = xai_key();
+    let sf = XAiStreamFn::new("https://api.x.ai", &key);
+
+    // First turn
+    let context = simple_context("My name is Alice.");
+    let events = timeout(TIMEOUT, collect_events(&sf, &context))
+        .await
+        .expect("timed out on first turn");
+
+    let reply: String = events
+        .iter()
+        .filter_map(|e| match e {
+            AssistantMessageEvent::TextDelta { delta, .. } => Some(delta.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert!(!reply.is_empty(), "first turn should produce text");
+
+    // Second turn with prior context
+    let context = AgentContext {
+        system_prompt: "Reply in one short sentence.".into(),
+        messages: vec![
+            AgentMessage::Llm(LlmMessage::User(UserMessage {
+                content: vec![ContentBlock::Text {
+                    text: "My name is Alice.".into(),
+                }],
+                timestamp: 0,
+                cache_hint: None,
+            })),
+            AgentMessage::Llm(LlmMessage::Assistant(AssistantMessage {
+                content: vec![ContentBlock::Text { text: reply }],
+                provider: "xai".into(),
+                model_id: cheap_model().model_id,
+                usage: Usage::default(),
+                cost: Cost::default(),
+                stop_reason: StopReason::Stop,
+                error_message: None,
+                timestamp: 1,
+                cache_hint: None,
+            })),
+            AgentMessage::Llm(LlmMessage::User(UserMessage {
+                content: vec![ContentBlock::Text {
+                    text: "What is my name?".into(),
+                }],
+                timestamp: 2,
+                cache_hint: None,
+            })),
+        ],
+        tools: Vec::new(),
+    };
+
+    let events = timeout(TIMEOUT, collect_events(&sf, &context))
+        .await
+        .expect("timed out on second turn");
+
+    let types: Vec<&str> = events.iter().map(|e| event_name(e)).collect();
+    assert!(
+        types.contains(&"Done"),
+        "missing Done on second turn: {types:?}"
+    );
+
+    let reply: String = events
+        .iter()
+        .filter_map(|e| match e {
+            AssistantMessageEvent::TextDelta { delta, .. } => Some(delta.as_str()),
+            _ => None,
+        })
+        .collect();
+    let reply_lower = reply.to_lowercase();
+    assert!(
+        reply_lower.contains("alice"),
+        "expected 'Alice' in multi-turn reply, got: {reply}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "hits live API"]
+async fn live_invalid_key_returns_auth_error() {
+    let sf = XAiStreamFn::new("https://api.x.ai", "xai-bogus-key-12345");
+    let context = simple_context("Hi.");
+
+    let events = timeout(TIMEOUT, collect_events(&sf, &context))
+        .await
+        .expect("timed out");
+
+    let err = events
+        .iter()
+        .find_map(|e| match e {
+            AssistantMessageEvent::Error { error_message, .. } => Some(error_message.clone()),
+            _ => None,
+        })
+        .expect("expected Error event for invalid key");
+    assert!(
+        err.to_lowercase().contains("auth"),
+        "expected auth-related error, got: {err}"
+    );
+}

--- a/memory/src/migrate.rs
+++ b/memory/src/migrate.rs
@@ -25,8 +25,11 @@ pub trait SessionMigrator: Send + Sync {
     ///
     /// The implementation may modify, add, or remove entries. It must NOT
     /// modify `meta.version` — the runner handles that.
-    fn migrate(&self, meta: &SessionMeta, entries: Vec<SessionEntry>)
-        -> io::Result<Vec<SessionEntry>>;
+    fn migrate(
+        &self,
+        meta: &SessionMeta,
+        entries: Vec<SessionEntry>,
+    ) -> io::Result<Vec<SessionEntry>>;
 }
 
 /// The current schema version for new sessions.

--- a/memory/tests/round_trip.rs
+++ b/memory/tests/round_trip.rs
@@ -314,13 +314,17 @@ fn sequence_increments_on_save() {
     let store = JsonlSessionStore::new(tmp.path().to_path_buf()).unwrap();
 
     let meta = sample_meta("seq_test", "Sequence test");
-    store.save("seq_test", &meta, &[user_message("first")]).unwrap();
+    store
+        .save("seq_test", &meta, &[user_message("first")])
+        .unwrap();
 
     let (loaded1, _) = store.load("seq_test").unwrap();
     assert_eq!(loaded1.sequence, 1);
 
     // Save again with the loaded meta (sequence=1)
-    store.save("seq_test", &loaded1, &[user_message("second")]).unwrap();
+    store
+        .save("seq_test", &loaded1, &[user_message("second")])
+        .unwrap();
 
     let (loaded2, _) = store.load("seq_test").unwrap();
     assert_eq!(loaded2.sequence, 2);
@@ -332,17 +336,23 @@ fn optimistic_concurrency_rejects_stale_sequence() {
     let store = JsonlSessionStore::new(tmp.path().to_path_buf()).unwrap();
 
     let meta = sample_meta("conc_test", "Concurrency test");
-    store.save("conc_test", &meta, &[user_message("v1")]).unwrap();
+    store
+        .save("conc_test", &meta, &[user_message("v1")])
+        .unwrap();
 
     // Load meta (sequence=1)
     let (stale_meta, _) = store.load("conc_test").unwrap();
     assert_eq!(stale_meta.sequence, 1);
 
     // Simulate another writer saving (bumps sequence to 2)
-    store.save("conc_test", &stale_meta, &[user_message("v2")]).unwrap();
+    store
+        .save("conc_test", &stale_meta, &[user_message("v2")])
+        .unwrap();
 
     // Attempt save with stale meta (sequence=1, but file has sequence=2)
-    let err = store.save("conc_test", &stale_meta, &[user_message("v3")]).unwrap_err();
+    let err = store
+        .save("conc_test", &stale_meta, &[user_message("v3")])
+        .unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::AlreadyExists);
     assert!(err.to_string().contains("sequence conflict"));
 }
@@ -354,7 +364,11 @@ fn unsupported_future_version_returns_error() {
 
     // Write a JSONL file with version: 999
     let meta_json = r#"{"id":"future_001","title":"Future session","created_at":"2025-03-15T12:00:00Z","updated_at":"2025-03-15T12:00:00Z","version":999,"sequence":0}"#;
-    std::fs::write(tmp.path().join("future_001.jsonl"), format!("{meta_json}\n")).unwrap();
+    std::fs::write(
+        tmp.path().join("future_001.jsonl"),
+        format!("{meta_json}\n"),
+    )
+    .unwrap();
 
     let err = store.load("future_001").unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::InvalidData);

--- a/policies/Cargo.toml
+++ b/policies/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/SuperSwinkAI/Swink-Agent"
 keywords = ["llm", "agent", "policy", "security", "audit"]
 
 [features]
-default = []
+default = ["all"]
 full = ["all"]
 all = ["budget", "max-turns", "deny-list", "sandbox", "loop-detection", "checkpoint", "prompt-guard", "pii", "content-filter", "audit"]
 budget = []
@@ -39,6 +39,10 @@ serde_json = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["full", "test-util"] }
 tokio-util = { workspace = true }
+
+[[example]]
+name = "with_policies"
+required-features = ["budget", "max-turns", "deny-list", "loop-detection"]
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/policies/src/checkpoint.rs
+++ b/policies/src/checkpoint.rs
@@ -4,7 +4,7 @@
 use std::sync::Arc;
 
 use swink_agent::{
-    Checkpoint, CheckpointFuture, CheckpointStore, PolicyContext, PolicyVerdict, PostTurnPolicy,
+    Checkpoint, CheckpointStore, PolicyContext, PolicyVerdict, PostTurnPolicy,
     TurnPolicyContext,
 };
 

--- a/policies/src/checkpoint.rs
+++ b/policies/src/checkpoint.rs
@@ -4,9 +4,10 @@
 use std::sync::Arc;
 
 use swink_agent::{
-    Checkpoint, CheckpointStore, PolicyContext, PolicyVerdict, PostTurnPolicy,
-    TurnPolicyContext,
+    Checkpoint, CheckpointStore, PolicyContext, PolicyVerdict, PostTurnPolicy, TurnPolicyContext,
 };
+#[cfg(test)]
+use swink_agent::CheckpointFuture;
 
 /// Persists agent state after each turn via a [`CheckpointStore`].
 ///

--- a/specs/017-adapter-xai/tasks.md
+++ b/specs/017-adapter-xai/tasks.md
@@ -33,10 +33,10 @@
 
 ### Implementation for User Story 1
 
-- [ ] T004 [US1] Create adapters/tests/xai_live.rs with module-level cfg gate, imports, constants (TIMEOUT = 30s), and helper functions: xai_key() (reads XAI_API_KEY via dotenvy), cheap_model() (grok-4-1-fast-non-reasoning), simple_context(), collect_events(), event_name()
-- [ ] T005 [US1] Add live_text_stream test in adapters/tests/xai_live.rs: send simple prompt, assert Start/TextStart/TextDelta/TextEnd/Done events present and assembled text is non-empty
-- [ ] T006 [US1] Add live_usage_and_cost test in adapters/tests/xai_live.rs: send simple prompt, assert Done event contains non-zero input and output token counts
-- [ ] T007 [US1] Add live_stop_reason_mapping test in adapters/tests/xai_live.rs: send simple prompt, assert Done event has StopReason::Stop
+- [x] T004 [US1] Create adapters/tests/xai_live.rs with module-level cfg gate, imports, constants (TIMEOUT = 30s), and helper functions: xai_key() (reads XAI_API_KEY via dotenvy), cheap_model() (grok-4-1-fast-non-reasoning), simple_context(), collect_events(), event_name()
+- [x] T005 [US1] Add live_text_stream test in adapters/tests/xai_live.rs: send simple prompt, assert Start/TextStart/TextDelta/TextEnd/Done events present and assembled text is non-empty
+- [x] T006 [US1] Add live_usage_and_cost test in adapters/tests/xai_live.rs: send simple prompt, assert Done event contains non-zero input and output token counts
+- [x] T007 [US1] Add live_stop_reason_mapping test in adapters/tests/xai_live.rs: send simple prompt, assert Done event has StopReason::Stop
 
 **Checkpoint**: `cargo test -p swink-agent-adapters --test xai_live -- --ignored` passes for text streaming tests (requires XAI_API_KEY)
 
@@ -50,9 +50,9 @@
 
 ### Implementation for User Story 2
 
-- [ ] T008 [US2] Add DummyTool struct (get_weather) in adapters/tests/xai_live.rs implementing AgentTool with JSON schema for city parameter
-- [ ] T009 [US2] Add live_tool_use_stream test in adapters/tests/xai_live.rs: send prompt with get_weather tool, assert ToolCallStart with name "get_weather", ToolCallEnd present, and StopReason::ToolUse
-- [ ] T010 [US2] Add live_multi_turn_context test in adapters/tests/xai_live.rs: send two-turn conversation (introduce name, then ask for recall), assert second reply contains the introduced name
+- [x] T008 [US2] Add DummyTool struct (get_weather) in adapters/tests/xai_live.rs implementing AgentTool with JSON schema for city parameter
+- [x] T009 [US2] Add live_tool_use_stream test in adapters/tests/xai_live.rs: send prompt with get_weather tool, assert ToolCallStart with name "get_weather", ToolCallEnd present, and StopReason::ToolUse
+- [x] T010 [US2] Add live_multi_turn_context test in adapters/tests/xai_live.rs: send two-turn conversation (introduce name, then ask for recall), assert second reply contains the introduced name
 
 **Checkpoint**: `cargo test -p swink-agent-adapters --test xai_live -- --ignored` passes for all tool call tests
 
@@ -66,7 +66,7 @@
 
 ### Implementation for User Story 3
 
-- [ ] T011 [US3] Add live_invalid_key_returns_auth_error test in adapters/tests/xai_live.rs: create XAiStreamFn with bogus key, assert Error event with auth-related message
+- [x] T011 [US3] Add live_invalid_key_returns_auth_error test in adapters/tests/xai_live.rs: create XAiStreamFn with bogus key, assert Error event with auth-related message
 
 **Checkpoint**: Auth error test passes confirming correct endpoint targeting and error classification
 
@@ -80,7 +80,7 @@
 
 ### Implementation for User Story 4
 
-- [ ] T012 [US4] Verify error classification is handled by existing shared infra in adapters/src/classify.rs — no xAI-specific error handling code needed (covered by T011 auth error test and shared classifier unit tests)
+- [x] T012 [US4] Verify error classification is handled by existing shared infra in adapters/src/classify.rs — no xAI-specific error handling code needed (covered by T011 auth error test and shared classifier unit tests)
 
 **Checkpoint**: All error classification verified through existing shared tests + live auth error test
 
@@ -90,11 +90,11 @@
 
 **Purpose**: Build verification, clippy clean, feature-gate isolation
 
-- [ ] T013 Run cargo build --workspace and verify clean compilation
-- [ ] T014 Run cargo test --workspace and verify all tests pass
-- [ ] T015 Run cargo clippy --workspace -- -D warnings and verify zero warnings
-- [ ] T016 Run cargo test -p swink-agent-adapters --no-default-features --features xai and verify xai feature compiles and runs in isolation
-- [ ] T017 Update adapters/CLAUDE.md to change xai status from "Stub" to "Implemented" in the feature gates table
+- [x] T013 Run cargo build --workspace and verify clean compilation
+- [x] T014 Run cargo test --workspace and verify all tests pass
+- [x] T015 Run cargo clippy --workspace -- -D warnings and verify zero warnings
+- [x] T016 Run cargo test -p swink-agent-adapters --no-default-features --features xai and verify xai feature compiles and runs in isolation
+- [x] T017 Update adapters/CLAUDE.md to change xai status from "Stub" to "Implemented" in the feature gates table
 
 ---
 

--- a/specs/spec-status.md
+++ b/specs/spec-status.md
@@ -19,7 +19,7 @@
 | 014-adapter-ollama              | ✓     | ✓  | ✓   | ✓ Complete |
 | 015-adapter-gemini              | ✓     | ✓  | ✓   | ✓ Complete |
 | 016-adapter-azure               | ✓     | ✓  | ✓   | ● 23/54 (42%) |
-| 017-adapter-xai                 | ✓     | ✓  | ✓   | ● 3/17 (17%) |
+| 017-adapter-xai                 | ✓     | ✓  | ✓   | ✓ Complete |
 | 018-adapter-mistral             | ✓     | ✓  | ✓   | ✓ Complete |
 | 019-adapter-bedrock             | ✓     | ✓  | ✓   | ● 0/41 (0%) |
 | 020-adapter-proxy               | ✓     | ✓  | ✓   | ✓ Complete |
@@ -60,7 +60,7 @@
 <!-- feature: 014-adapter-ollama has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=74 tasks_completed=74 checklist_files=requirements.md -->
 <!-- feature: 015-adapter-gemini has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=44 tasks_completed=44 checklist_files=requirements.md -->
 <!-- feature: 016-adapter-azure has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=54 tasks_completed=23 checklist_files=requirements.md -->
-<!-- feature: 017-adapter-xai has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=17 tasks_completed=3 checklist_files=requirements.md -->
+<!-- feature: 017-adapter-xai has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=17 tasks_completed=17 checklist_files=requirements.md -->
 <!-- feature: 018-adapter-mistral has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=42 tasks_completed=42 checklist_files=requirements.md -->
 <!-- feature: 019-adapter-bedrock has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=41 tasks_completed=0 checklist_files=requirements.md -->
 <!-- feature: 020-adapter-proxy has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=40 tasks_completed=40 checklist_files=requirements.md -->

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -243,7 +243,7 @@ fn build_extra_models(_primary_id: &str) -> Vec<(ModelSpec, Arc<dyn StreamFn>)> 
 }
 
 /// Append local model to extra models list when the `local` feature is enabled.
-#[allow(unused_variables)]
+#[allow(unused_variables, clippy::ptr_arg, clippy::needless_pass_by_ref_mut)]
 fn append_local_model(extra: &mut Vec<(ModelSpec, Arc<dyn StreamFn>)>) {
     #[cfg(feature = "local")]
     {


### PR DESCRIPTION
## Summary
- Add comprehensive live API tests for xAI (Grok) streaming adapter in `adapters/tests/xai_live.rs`
- Complete all 17 tasks from spec 017-adapter-xai (was 3/17, now 17/17)
- Fix pre-existing clippy/fmt issues in policies, TUI, and memory crates

## Tasks completed
- T004: Create xai_live.rs test infrastructure (helpers, constants, DummyTool)
- T005: `live_text_stream` — validates Start/TextStart/TextDelta/TextEnd/Done events
- T006: `live_usage_and_cost` — verifies non-zero token counts in Done event
- T007: `live_stop_reason_mapping` — asserts StopReason::Stop for simple prompts
- T008: DummyTool (get_weather) implementing AgentTool with JSON schema
- T009: `live_tool_use_stream` — validates ToolCallStart/ToolCallEnd with correct tool name
- T010: `live_multi_turn_context` — two-turn conversation with name recall
- T011: `live_invalid_key_returns_auth_error` — auth error classification
- T012: Verified error classification via shared infra (no xAI-specific code needed)
- T013-T016: Build, test, clippy, feature isolation verification
- T017: Updated adapters/CLAUDE.md status from Stub to Implemented

## Additional fixes
- `policies/Cargo.toml`: Set `default = ["all"]` and add `required-features` for example (fixes pre-existing build failure)
- `policies/src/checkpoint.rs`: Remove unused `CheckpointFuture` import
- `tui/src/main.rs`: Suppress clippy ptr_arg/needless_pass_by_ref_mut on `append_local_model`
- `cargo fmt` formatting fixes in memory and adapters crates

## Test plan
- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo test -p swink-agent-adapters --no-default-features --features xai` compiles and runs in isolation
- [x] `cargo test -p swink-agent --no-default-features` passes
- [ ] `cargo test -p swink-agent-adapters --test xai_live -- --ignored` (requires XAI_API_KEY)

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)