### PR TITLE
impl(021): Add interrupt state persistence for session resumption

### DIFF
--- a/memory/src/interrupt.rs
+++ b/memory/src/interrupt.rs
@@ -1,0 +1,75 @@
+//! Interrupt state persistence for resuming interrupted agent sessions.
+//!
+//! When an agent is interrupted (e.g., at a tool approval gate or by
+//! cancellation), the [`InterruptState`] captures enough context to resume
+//! exactly where the agent left off after a process restart.
+
+use serde::{Deserialize, Serialize};
+use swink_agent::{LlmMessage, ModelSpec};
+
+/// A tool call awaiting approval at the time of interruption.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PendingToolCall {
+    /// Unique identifier for this tool call invocation.
+    pub tool_call_id: String,
+    /// Name of the tool being called.
+    pub tool_name: String,
+    /// Tool arguments passed to the tool.
+    pub arguments: serde_json::Value,
+}
+
+/// Snapshot of agent state at the point of interruption.
+///
+/// Persisted as `{session_id}.interrupt.json` alongside the session JSONL file.
+/// File existence indicates an active interrupt; deletion means the agent has
+/// resumed.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InterruptState {
+    /// Unix timestamp of when the interrupt occurred.
+    pub interrupted_at: u64,
+    /// Tool calls awaiting approval at interrupt time.
+    pub pending_tool_calls: Vec<PendingToolCall>,
+    /// Conversation context frozen at the interrupt point.
+    pub context_snapshot: Vec<LlmMessage>,
+    /// Active system prompt at interrupt time.
+    pub system_prompt: String,
+    /// Active model at interrupt time.
+    pub model: ModelSpec,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serde_roundtrip() {
+        let state = InterruptState {
+            interrupted_at: 1_710_500_000,
+            pending_tool_calls: vec![
+                PendingToolCall {
+                    tool_call_id: "tc_1".to_string(),
+                    tool_name: "bash".to_string(),
+                    arguments: serde_json::json!({"command": "ls"}),
+                },
+                PendingToolCall {
+                    tool_call_id: "tc_2".to_string(),
+                    tool_name: "read_file".to_string(),
+                    arguments: serde_json::json!({"path": "/tmp/foo.txt"}),
+                },
+            ],
+            context_snapshot: vec![],
+            system_prompt: "You are a helpful assistant.".to_string(),
+            model: ModelSpec::new("openai", "gpt-4"),
+        };
+
+        let json = serde_json::to_string(&state).unwrap();
+        let deserialized: InterruptState = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.interrupted_at, state.interrupted_at);
+        assert_eq!(deserialized.pending_tool_calls, state.pending_tool_calls);
+        assert_eq!(deserialized.system_prompt, state.system_prompt);
+        assert_eq!(
+            deserialized.context_snapshot.len(),
+            state.context_snapshot.len()
+        );
+    }
+}

--- a/memory/src/jsonl.rs
+++ b/memory/src/jsonl.rs
@@ -15,6 +15,7 @@ use swink_agent::{
 };
 
 use crate::entry::SessionEntry;
+use crate::interrupt::InterruptState;
 use crate::meta::SessionMeta;
 use crate::store::SessionStore;
 use crate::time::{format_session_id, now_utc};
@@ -88,6 +89,10 @@ impl SessionRecord {
 
 fn session_path(sessions_dir: &Path, id: &str) -> PathBuf {
     sessions_dir.join(format!("{id}.jsonl"))
+}
+
+fn interrupt_path(sessions_dir: &Path, id: &str) -> PathBuf {
+    sessions_dir.join(format!("{id}.interrupt.json"))
 }
 
 fn not_found(id: &str) -> io::Error {
@@ -410,7 +415,13 @@ impl SessionStore for JsonlSessionStore {
     fn delete(&self, id: &str) -> io::Result<()> {
         validate_session_id(id)?;
         let path = session_path(&self.sessions_dir, id);
-        std::fs::remove_file(path)
+        std::fs::remove_file(path)?;
+        // Cascade-delete the interrupt file if it exists
+        let int_path = interrupt_path(&self.sessions_dir, id);
+        if int_path.exists() {
+            std::fs::remove_file(int_path)?;
+        }
+        Ok(())
     }
 
     fn save_full(&self, id: &str, meta: &SessionMeta, messages: &[AgentMessage]) -> io::Result<()> {
@@ -515,6 +526,39 @@ impl SessionStore for JsonlSessionStore {
         }
 
         Ok(None)
+    }
+
+    fn save_interrupt(&self, id: &str, state: &InterruptState) -> io::Result<()> {
+        validate_session_id(id)?;
+        let path = interrupt_path(&self.sessions_dir, id);
+        let file = std::fs::File::create(&path)?;
+        let writer = io::BufWriter::new(file);
+        serde_json::to_writer_pretty(writer, state).map_err(io::Error::other)
+    }
+
+    fn load_interrupt(&self, id: &str) -> io::Result<Option<InterruptState>> {
+        validate_session_id(id)?;
+        let path = interrupt_path(&self.sessions_dir, id);
+        if !path.exists() {
+            return Ok(None);
+        }
+        let contents = std::fs::read_to_string(&path)?;
+        let state: InterruptState = serde_json::from_str(&contents).map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("corrupted interrupt file for session {id}: {e}"),
+            )
+        })?;
+        Ok(Some(state))
+    }
+
+    fn clear_interrupt(&self, id: &str) -> io::Result<()> {
+        validate_session_id(id)?;
+        let path = interrupt_path(&self.sessions_dir, id);
+        if path.exists() {
+            std::fs::remove_file(path)?;
+        }
+        Ok(())
     }
 }
 

--- a/memory/src/lib.rs
+++ b/memory/src/lib.rs
@@ -28,6 +28,7 @@
 
 pub mod compaction;
 pub mod entry;
+pub mod interrupt;
 pub mod jsonl;
 pub mod meta;
 pub mod migrate;
@@ -37,6 +38,7 @@ pub mod time;
 
 pub use compaction::{CompactionResult, SummarizingCompactor};
 pub use entry::SessionEntry;
+pub use interrupt::{InterruptState, PendingToolCall};
 pub use jsonl::JsonlSessionStore;
 pub use meta::SessionMeta;
 pub use migrate::SessionMigrator;

--- a/memory/src/store.rs
+++ b/memory/src/store.rs
@@ -4,6 +4,7 @@ use std::io;
 
 use swink_agent::{AgentMessage, CustomMessageRegistry, LlmMessage};
 
+use crate::interrupt::InterruptState;
 use crate::meta::SessionMeta;
 
 /// Pluggable session persistence.
@@ -70,5 +71,32 @@ pub trait SessionStore: Send + Sync {
     fn load_state(&self, id: &str) -> io::Result<Option<serde_json::Value>> {
         let _ = id;
         Ok(None)
+    }
+
+    /// Persist interrupt state for a session.
+    ///
+    /// Stores the interrupt as `{session_id}.interrupt.json`. Overwrites any
+    /// existing interrupt for the same session. Default: no-op.
+    fn save_interrupt(&self, id: &str, state: &InterruptState) -> io::Result<()> {
+        let _ = (id, state);
+        Ok(())
+    }
+
+    /// Load interrupt state for a session.
+    ///
+    /// Returns `Some` if an interrupt file exists, `None` otherwise.
+    /// Returns an error if the file exists but is corrupted. Default: `None`.
+    fn load_interrupt(&self, id: &str) -> io::Result<Option<InterruptState>> {
+        let _ = id;
+        Ok(None)
+    }
+
+    /// Clear interrupt state for a session.
+    ///
+    /// Deletes the `{session_id}.interrupt.json` file. Idempotent — safe to
+    /// call if no interrupt exists. Default: no-op.
+    fn clear_interrupt(&self, id: &str) -> io::Result<()> {
+        let _ = id;
+        Ok(())
     }
 }

--- a/memory/src/store_async.rs
+++ b/memory/src/store_async.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 
 use swink_agent::LlmMessage;
 
+use crate::interrupt::InterruptState;
 use crate::meta::SessionMeta;
 
 /// A boxed future returned by [`AsyncSessionStore`] methods.
@@ -43,6 +44,15 @@ pub trait AsyncSessionStore: Send + Sync {
 
     /// Delete a session by ID asynchronously.
     fn delete(&self, id: &str) -> SessionStoreFuture<'_, ()>;
+
+    /// Persist interrupt state for a session asynchronously.
+    fn save_interrupt(&self, id: &str, state: &InterruptState) -> SessionStoreFuture<'_, ()>;
+
+    /// Load interrupt state for a session asynchronously.
+    fn load_interrupt(&self, id: &str) -> SessionStoreFuture<'_, Option<InterruptState>>;
+
+    /// Clear interrupt state for a session asynchronously.
+    fn clear_interrupt(&self, id: &str) -> SessionStoreFuture<'_, ()>;
 }
 
 /// Adapter that wraps a synchronous [`SessionStore`](crate::store::SessionStore)
@@ -99,6 +109,25 @@ impl<S: crate::store::SessionStore + 'static> AsyncSessionStore for BlockingSess
         let inner = Arc::clone(&self.inner);
         let id = id.to_string();
         spawn_store_call(move || inner.delete(&id))
+    }
+
+    fn save_interrupt(&self, id: &str, state: &InterruptState) -> SessionStoreFuture<'_, ()> {
+        let inner = Arc::clone(&self.inner);
+        let id = id.to_string();
+        let state = state.clone();
+        spawn_store_call(move || inner.save_interrupt(&id, &state))
+    }
+
+    fn load_interrupt(&self, id: &str) -> SessionStoreFuture<'_, Option<InterruptState>> {
+        let inner = Arc::clone(&self.inner);
+        let id = id.to_string();
+        spawn_store_call(move || inner.load_interrupt(&id))
+    }
+
+    fn clear_interrupt(&self, id: &str) -> SessionStoreFuture<'_, ()> {
+        let inner = Arc::clone(&self.inner);
+        let id = id.to_string();
+        spawn_store_call(move || inner.clear_interrupt(&id))
     }
 }
 

--- a/memory/tests/round_trip.rs
+++ b/memory/tests/round_trip.rs
@@ -6,7 +6,9 @@ use std::io;
 
 use chrono::DateTime;
 use swink_agent::{LlmMessage, ModelSpec};
-use swink_agent_memory::{JsonlSessionStore, SessionEntry, SessionMeta, SessionStore};
+use swink_agent_memory::{
+    InterruptState, JsonlSessionStore, PendingToolCall, SessionEntry, SessionMeta, SessionStore,
+};
 
 use common::{assistant_message, sample_meta, sample_meta_with_times, user_message};
 
@@ -373,4 +375,115 @@ fn unsupported_future_version_returns_error() {
     let err = store.load("future_001").unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::InvalidData);
     assert!(err.to_string().contains("unsupported session version 999"));
+}
+
+// --- US8: Interrupt State Persistence ---
+
+fn sample_interrupt() -> InterruptState {
+    InterruptState {
+        interrupted_at: 1_710_500_000,
+        pending_tool_calls: vec![
+            PendingToolCall {
+                tool_call_id: "tc_1".to_string(),
+                tool_name: "bash".to_string(),
+                arguments: serde_json::json!({"command": "ls -la"}),
+            },
+            PendingToolCall {
+                tool_call_id: "tc_2".to_string(),
+                tool_name: "read_file".to_string(),
+                arguments: serde_json::json!({"path": "/tmp/foo.txt"}),
+            },
+        ],
+        context_snapshot: vec![user_message("hello"), assistant_message("hi")],
+        system_prompt: "You are a helpful assistant.".to_string(),
+        model: ModelSpec::new("openai", "gpt-4"),
+    }
+}
+
+#[test]
+fn interrupt_save_and_load_roundtrip() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = JsonlSessionStore::new(tmp.path().to_path_buf()).unwrap();
+
+    let meta = sample_meta("int_001", "Interrupt test");
+    store.save("int_001", &meta, &[user_message("hi")]).unwrap();
+
+    let state = sample_interrupt();
+    store.save_interrupt("int_001", &state).unwrap();
+
+    let loaded = store.load_interrupt("int_001").unwrap();
+    assert!(loaded.is_some());
+    let loaded = loaded.unwrap();
+    assert_eq!(loaded.interrupted_at, 1_710_500_000);
+    assert_eq!(loaded.pending_tool_calls.len(), 2);
+    assert_eq!(loaded.pending_tool_calls[0].tool_name, "bash");
+    assert_eq!(loaded.pending_tool_calls[1].tool_name, "read_file");
+    assert_eq!(loaded.context_snapshot.len(), 2);
+    assert_eq!(loaded.system_prompt, "You are a helpful assistant.");
+    assert_eq!(loaded.model.provider, "openai");
+    assert_eq!(loaded.model.model_id, "gpt-4");
+}
+
+#[test]
+fn interrupt_none_when_not_saved() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = JsonlSessionStore::new(tmp.path().to_path_buf()).unwrap();
+
+    let result = store.load_interrupt("no_such_session").unwrap();
+    assert!(result.is_none());
+}
+
+#[test]
+fn interrupt_cleared_after_resume() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = JsonlSessionStore::new(tmp.path().to_path_buf()).unwrap();
+
+    let meta = sample_meta("int_clear", "Clear test");
+    store
+        .save("int_clear", &meta, &[user_message("hi")])
+        .unwrap();
+
+    let state = sample_interrupt();
+    store.save_interrupt("int_clear", &state).unwrap();
+    assert!(store.load_interrupt("int_clear").unwrap().is_some());
+
+    store.clear_interrupt("int_clear").unwrap();
+    assert!(store.load_interrupt("int_clear").unwrap().is_none());
+}
+
+#[test]
+fn delete_session_also_deletes_interrupt() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = JsonlSessionStore::new(tmp.path().to_path_buf()).unwrap();
+
+    let meta = sample_meta("int_del", "Delete cascade test");
+    store.save("int_del", &meta, &[user_message("hi")]).unwrap();
+
+    let state = sample_interrupt();
+    store.save_interrupt("int_del", &state).unwrap();
+
+    // Verify interrupt file exists
+    assert!(tmp.path().join("int_del.interrupt.json").exists());
+
+    store.delete("int_del").unwrap();
+
+    // Both session and interrupt should be gone
+    assert!(!tmp.path().join("int_del.jsonl").exists());
+    assert!(!tmp.path().join("int_del.interrupt.json").exists());
+}
+
+#[test]
+fn corrupted_interrupt_returns_error() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = JsonlSessionStore::new(tmp.path().to_path_buf()).unwrap();
+
+    // Write garbage to interrupt file
+    std::fs::write(
+        tmp.path().join("corrupt_int.interrupt.json"),
+        "this is not valid json{{{",
+    )
+    .unwrap();
+
+    let err = store.load_interrupt("corrupt_int").unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
 }

--- a/specs/021-memory-crate/tasks.md
+++ b/specs/021-memory-crate/tasks.md
@@ -227,19 +227,19 @@
 
 ### Tests for User Story 8
 
-- [ ] T072 [P] [US8] Integration test `interrupt_save_and_load_roundtrip` in `memory/tests/round_trip.rs`: save interrupt with 2 pending tool calls, load, verify all fields match
-- [ ] T073 [P] [US8] Integration test `interrupt_none_when_not_saved` in `memory/tests/round_trip.rs`: load interrupt for session without one, verify `None` returned
-- [ ] T074 [P] [US8] Integration test `interrupt_cleared_after_resume` in `memory/tests/round_trip.rs`: save interrupt, clear it, load, verify `None`
-- [ ] T075 [P] [US8] Integration test `delete_session_also_deletes_interrupt` in `memory/tests/round_trip.rs`: save session + interrupt, delete session, verify interrupt file also gone
-- [ ] T075b [P] [US8] Integration test `corrupted_interrupt_returns_error` in `memory/tests/round_trip.rs`: write garbage to `{session_id}.interrupt.json`, call `load_interrupt`, verify `InvalidData` error returned
+- [x] T072 [P] [US8] Integration test `interrupt_save_and_load_roundtrip` in `memory/tests/round_trip.rs`: save interrupt with 2 pending tool calls, load, verify all fields match
+- [x] T073 [P] [US8] Integration test `interrupt_none_when_not_saved` in `memory/tests/round_trip.rs`: load interrupt for session without one, verify `None` returned
+- [x] T074 [P] [US8] Integration test `interrupt_cleared_after_resume` in `memory/tests/round_trip.rs`: save interrupt, clear it, load, verify `None`
+- [x] T075 [P] [US8] Integration test `delete_session_also_deletes_interrupt` in `memory/tests/round_trip.rs`: save session + interrupt, delete session, verify interrupt file also gone
+- [x] T075b [P] [US8] Integration test `corrupted_interrupt_returns_error` in `memory/tests/round_trip.rs`: write garbage to `{session_id}.interrupt.json`, call `load_interrupt`, verify `InvalidData` error returned
 
 ### Implementation for User Story 8
 
-- [ ] T076 [US8] Implement `InterruptState` and `PendingToolCall` structs in `memory/src/interrupt.rs`. Derive `Serialize`, `Deserialize`.
-- [ ] T077 [US8] Add `save_interrupt`, `load_interrupt`, `clear_interrupt` methods to `SessionStore` trait in `memory/src/store.rs`.
-- [ ] T078 [US8] Implement interrupt methods in `JsonlSessionStore`: persist as `{session_id}.interrupt.json`, delete on `clear_interrupt` and `delete`.
-- [ ] T079 [US8] Add interrupt methods to `AsyncSessionStore` trait and `BlockingSessionStore` adapter in `memory/src/store_async.rs`.
-- [ ] T080 [US8] Re-export `InterruptState`, `PendingToolCall` from `memory/src/lib.rs`.
+- [x] T076 [US8] Implement `InterruptState` and `PendingToolCall` structs in `memory/src/interrupt.rs`. Derive `Serialize`, `Deserialize`.
+- [x] T077 [US8] Add `save_interrupt`, `load_interrupt`, `clear_interrupt` methods to `SessionStore` trait in `memory/src/store.rs`.
+- [x] T078 [US8] Implement interrupt methods in `JsonlSessionStore`: persist as `{session_id}.interrupt.json`, delete on `clear_interrupt` and `delete`.
+- [x] T079 [US8] Add interrupt methods to `AsyncSessionStore` trait and `BlockingSessionStore` adapter in `memory/src/store_async.rs`.
+- [x] T080 [US8] Re-export `InterruptState`, `PendingToolCall` from `memory/src/lib.rs`.
 
 **Checkpoint**: US8 complete — agent interrupts persist across restarts
 

--- a/specs/spec-status.md
+++ b/specs/spec-status.md
@@ -23,7 +23,7 @@
 | 018-adapter-mistral             | ✓     | ✓  | ✓   | ✓ Complete |
 | 019-adapter-bedrock             | ✓     | ✓  | ✓   | ● 0/41 (0%) |
 | 020-adapter-proxy               | ✓     | ✓  | ✓   | ✓ Complete |
-| 021-memory-crate                | ✓     | ✓  | ✓   | ● 57/98 (58%) |
+| 021-memory-crate                | ✓     | ✓  | ✓   | ● 83/98 (84%) |
 | 022-local-llm-crate             | ✓     | ✓  | ✓   | ✓ Complete |
 | 023-eval-trajectory-matching    | ✓     | ✓  | ✓   | ✓ Complete |
 | 024-eval-runner-governance      | ✓     | ✓  | ✓   | ✓ Complete |
@@ -64,7 +64,7 @@
 <!-- feature: 018-adapter-mistral has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=42 tasks_completed=42 checklist_files=requirements.md -->
 <!-- feature: 019-adapter-bedrock has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=41 tasks_completed=0 checklist_files=requirements.md -->
 <!-- feature: 020-adapter-proxy has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=40 tasks_completed=40 checklist_files=requirements.md -->
-<!-- feature: 021-memory-crate has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=98 tasks_completed=57 checklist_files=requirements.md -->
+<!-- feature: 021-memory-crate has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=98 tasks_completed=83 checklist_files=requirements.md -->
 <!-- feature: 022-local-llm-crate has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=58 tasks_completed=58 checklist_files=requirements.md -->
 <!-- feature: 023-eval-trajectory-matching has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=40 tasks_completed=40 checklist_files=requirements.md -->
 <!-- feature: 024-eval-runner-governance has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=69 tasks_completed=69 checklist_files=requirements.md -->


### PR DESCRIPTION
## Summary
- Implements Phase 10 (US8) of spec 021-memory-crate: interrupt state persistence
- New `InterruptState` and `PendingToolCall` types in `memory/src/interrupt.rs`
- `save_interrupt`, `load_interrupt`, `clear_interrupt` methods on `SessionStore` trait (with defaults)
- `JsonlSessionStore` persists interrupts as `{session_id}.interrupt.json` sidecar files
- Session deletion cascades to remove interrupt files
- Full `AsyncSessionStore` + `BlockingSessionStore` adapter support

## Tasks completed
- T072: Integration test `interrupt_save_and_load_roundtrip`
- T073: Integration test `interrupt_none_when_not_saved`
- T074: Integration test `interrupt_cleared_after_resume`
- T075: Integration test `delete_session_also_deletes_interrupt`
- T075b: Integration test `corrupted_interrupt_returns_error`
- T076: `InterruptState` and `PendingToolCall` structs
- T077: Trait methods on `SessionStore`
- T078: `JsonlSessionStore` implementation
- T079: `AsyncSessionStore` + `BlockingSessionStore` adapter
- T080: Re-exports from `lib.rs`

## Test plan
- [x] `cargo test -p swink-agent-memory` — 27 tests pass (5 new interrupt tests)
- [x] `cargo clippy -p swink-agent-memory -- -D warnings` clean
- [x] `cargo clippy --workspace --lib --bins -- -D warnings` clean
- [x] `cargo test --workspace` — passes (pre-existing policies example issue excluded)
- [x] No public API breakage in downstream crates

Progress: 83/98 tasks (84%)

Part of #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)