### PR TITLE
impl(016): Add Azure live tests and complete adapter documentation

### DIFF
--- a/adapters/CLAUDE.md
+++ b/adapters/CLAUDE.md
@@ -26,7 +26,7 @@ swink-agent-adapters = {}
 | `ollama` | `ollama.rs` | — | Implemented |
 | `gemini` | `google.rs` | — | Implemented |
 | `proxy` | `proxy.rs` | — | Implemented |
-| `azure` | `azure.rs` | — | Stub |
+| `azure` | `azure.rs` | — | Implemented |
 | `bedrock` | `bedrock.rs` | `sha2` | Stub |
 | `mistral` | `mistral.rs` | — | Implemented |
 | `xai` | `xai.rs` | — | Implemented |
@@ -53,13 +53,15 @@ swink-agent-adapters = {}
 | OpenAI | SSE | `/v1/chat/completions` | `data: [DONE]` |
 | Ollama | NDJSON | `/api/chat` | `done: true` in object |
 | Mistral | SSE | `/v1/chat/completions` | `data: [DONE]` |
+| Azure | SSE | `{base_url}/chat/completions` | `data: [DONE]` |
 | Proxy | SSE | `{base_url}/v1/stream` | `type: done`/`type: error` |
 
 ## Lessons Learned
 
 - **Anthropic thinking blocks** — budget = `thinking_level` + `thinking_budgets` map, capped to `max_tokens - 1`. Stripped from outgoing requests (API rejects them). SSE state machine (`SseStreamState`) remaps block indices because provider indices don't match harness indices after filtering.
 - **OpenAI adapter is multi-provider** — works with any `/v1/chat/completions`-compatible endpoint (vLLM, LM Studio, Groq, Together, etc.).
-- **Auth** — Anthropic: `x-api-key`. OpenAI: `Authorization: Bearer`. Ollama: none. Mistral: `Authorization: Bearer`.
+- **Auth** — Anthropic: `x-api-key`. OpenAI: `Authorization: Bearer`. Ollama: none. Mistral: `Authorization: Bearer`. Azure: `api-key` header (API key) or `Authorization: Bearer` (Entra ID OAuth2).
+- **Azure adapter** — reuses `openai_compat` for SSE parsing and tool calls. Azure-specific: URL construction (`{base_url}/chat/completions`), dual auth (`AzureAuth::ApiKey` / `AzureAuth::EntraId`), content filter detection (`finish_reason: "content_filter"` in stream, `ContentFilterBlocked` in HTTP error body → `ContentFiltered` error). Entra ID tokens cached with 5-min proactive refresh margin.
 - **Mistral API divergences from OpenAI** — Tool call IDs must be exactly 9-char `[a-zA-Z0-9]` (Mistral rejects OpenAI-style `call_*` IDs with HTTP 422). `stream_options` field rejected (usage comes automatically in final chunk). Must use `max_tokens` not `max_completion_tokens`. `finish_reason: "model_length"` is Mistral-specific (mapped to `Length` in shared parser). User messages cannot immediately follow tool messages (synthetic assistant message inserted). Adapter holds `AdapterBase` directly (Azure pattern) with custom `MistralChatRequest` and `MistralIdMap` for bidirectional ID remapping.
 
 ## Live Tests
@@ -69,6 +71,7 @@ cargo test -p swink-agent-adapters -- --ignored          # all
 cargo test -p swink-agent-adapters --test anthropic_live -- --ignored
 cargo test -p swink-agent-adapters --test openai_live -- --ignored
 cargo test -p swink-agent-adapters --test mistral_live -- --ignored
+cargo test -p swink-agent-adapters --test azure_live -- --ignored
 ```
 
 Live tests are `#[ignore]`, use cheap models, 30s timeout, validate event sequences not text content. `.env` loaded via dotenvy.

--- a/adapters/src/openai_compat.rs
+++ b/adapters/src/openai_compat.rs
@@ -360,9 +360,9 @@ pub fn process_oai_chunk(
         if let Some(reason) = &choice.finish_reason {
             if reason == "content_filter" {
                 events.extend(crate::finalize::finalize_blocks(state));
-                events.push(AssistantMessageEvent::error_content_filtered(
-                    format!("{provider} response stopped by content filter"),
-                ));
+                events.push(AssistantMessageEvent::error_content_filtered(format!(
+                    "{provider} response stopped by content filter"
+                )));
                 return;
             }
 

--- a/adapters/tests/azure.rs
+++ b/adapters/tests/azure.rs
@@ -681,7 +681,10 @@ async fn http_429_rate_limit_error() {
     let error_event = events
         .iter()
         .find(|e| matches!(e, AssistantMessageEvent::Error { .. }));
-    assert!(error_event.is_some(), "expected an Error event for HTTP 429");
+    assert!(
+        error_event.is_some(),
+        "expected an Error event for HTTP 429"
+    );
     match error_event.unwrap() {
         AssistantMessageEvent::Error { error_kind, .. } => {
             assert_eq!(*error_kind, Some(StreamErrorKind::Throttled));
@@ -698,8 +701,7 @@ async fn http_401_auth_error() {
     Mock::given(method("POST"))
         .and(path("/chat/completions"))
         .respond_with(
-            ResponseTemplate::new(401)
-                .set_body_string(r#"{"error":{"message":"Invalid key"}}"#),
+            ResponseTemplate::new(401).set_body_string(r#"{"error":{"message":"Invalid key"}}"#),
         )
         .mount(&server)
         .await;
@@ -711,7 +713,10 @@ async fn http_401_auth_error() {
     let error_event = events
         .iter()
         .find(|e| matches!(e, AssistantMessageEvent::Error { .. }));
-    assert!(error_event.is_some(), "expected an Error event for HTTP 401");
+    assert!(
+        error_event.is_some(),
+        "expected an Error event for HTTP 401"
+    );
     match error_event.unwrap() {
         AssistantMessageEvent::Error { error_kind, .. } => {
             assert_eq!(*error_kind, Some(StreamErrorKind::Auth));
@@ -742,7 +747,10 @@ async fn http_404_non_retryable_error() {
     let error_event = events
         .iter()
         .find(|e| matches!(e, AssistantMessageEvent::Error { .. }));
-    assert!(error_event.is_some(), "expected an Error event for HTTP 404");
+    assert!(
+        error_event.is_some(),
+        "expected an Error event for HTTP 404"
+    );
     match error_event.unwrap() {
         AssistantMessageEvent::Error {
             error_kind,
@@ -768,8 +776,7 @@ async fn http_500_network_error() {
     Mock::given(method("POST"))
         .and(path("/chat/completions"))
         .respond_with(
-            ResponseTemplate::new(500)
-                .set_body_string(r#"{"error":{"message":"Server error"}}"#),
+            ResponseTemplate::new(500).set_body_string(r#"{"error":{"message":"Server error"}}"#),
         )
         .mount(&server)
         .await;
@@ -781,7 +788,10 @@ async fn http_500_network_error() {
     let error_event = events
         .iter()
         .find(|e| matches!(e, AssistantMessageEvent::Error { .. }));
-    assert!(error_event.is_some(), "expected an Error event for HTTP 500");
+    assert!(
+        error_event.is_some(),
+        "expected an Error event for HTTP 500"
+    );
     match error_event.unwrap() {
         AssistantMessageEvent::Error { error_kind, .. } => {
             assert_eq!(*error_kind, Some(StreamErrorKind::Network));

--- a/adapters/tests/azure_live.rs
+++ b/adapters/tests/azure_live.rs
@@ -1,16 +1,29 @@
 #![cfg(feature = "azure")]
 //! Live API tests for `AzureStreamFn`.
+//!
+//! These tests hit a real Azure OpenAI deployment and are skipped by default.
+//! Run with: `cargo test -p swink-agent-adapters --test azure_live -- --ignored`
+//! Requires `AZURE_BASE_URL` and `AZURE_API_KEY` in `.env` or environment.
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use futures::StreamExt;
+use serde_json::json;
 use tokio::time::timeout;
 use tokio_util::sync::CancellationToken;
 
-use swink_agent::{AgentContext, AssistantMessageEvent, ModelSpec, StreamFn, StreamOptions};
+use swink_agent::{
+    AgentContext, AgentMessage, AgentTool, AgentToolResult, AssistantMessageEvent, ContentBlock,
+    LlmMessage, ModelSpec, StreamFn, StreamOptions, UserMessage,
+};
 use swink_agent_adapters::{AzureAuth, AzureStreamFn};
 
+// ── Constants ────────────────────────────────────────────────────────────────
+
 const TIMEOUT: Duration = Duration::from_secs(30);
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
 
 fn stream_fn() -> AzureStreamFn {
     dotenvy::dotenv().ok();
@@ -20,27 +33,190 @@ fn stream_fn() -> AzureStreamFn {
     )
 }
 
+fn cheap_model() -> ModelSpec {
+    dotenvy::dotenv().ok();
+    let model_id = std::env::var("AZURE_MODEL").unwrap_or_else(|_| "gpt-5.4".to_string());
+    ModelSpec::new("azure", &model_id)
+}
+
+fn simple_context(prompt: &str) -> AgentContext {
+    AgentContext {
+        system_prompt: "Reply in one word.".into(),
+        messages: vec![AgentMessage::Llm(LlmMessage::User(UserMessage {
+            content: vec![ContentBlock::Text {
+                text: prompt.to_string(),
+            }],
+            timestamp: 0,
+            cache_hint: None,
+        }))],
+        tools: Vec::new(),
+    }
+}
+
+async fn collect_events(sf: &AzureStreamFn, context: &AgentContext) -> Vec<AssistantMessageEvent> {
+    let model = cheap_model();
+    let options = StreamOptions::default();
+    let token = CancellationToken::new();
+    let stream = sf.stream(&model, context, &options, token);
+    stream.collect::<Vec<_>>().await
+}
+
+const fn event_name(event: &AssistantMessageEvent) -> &'static str {
+    match event {
+        AssistantMessageEvent::Start => "Start",
+        AssistantMessageEvent::TextStart { .. } => "TextStart",
+        AssistantMessageEvent::TextDelta { .. } => "TextDelta",
+        AssistantMessageEvent::TextEnd { .. } => "TextEnd",
+        AssistantMessageEvent::ThinkingStart { .. } => "ThinkingStart",
+        AssistantMessageEvent::ThinkingDelta { .. } => "ThinkingDelta",
+        AssistantMessageEvent::ThinkingEnd { .. } => "ThinkingEnd",
+        AssistantMessageEvent::ToolCallStart { .. } => "ToolCallStart",
+        AssistantMessageEvent::ToolCallDelta { .. } => "ToolCallDelta",
+        AssistantMessageEvent::ToolCallEnd { .. } => "ToolCallEnd",
+        AssistantMessageEvent::Done { .. } => "Done",
+        AssistantMessageEvent::Error { .. } => "Error",
+        _ => "Unknown",
+    }
+}
+
+/// A dummy tool for triggering tool-use responses.
+struct DummyTool;
+
+impl AgentTool for DummyTool {
+    fn name(&self) -> &'static str {
+        "get_weather"
+    }
+
+    fn label(&self) -> &'static str {
+        "Get Weather"
+    }
+
+    fn description(&self) -> &'static str {
+        "Get the current weather for a city."
+    }
+
+    fn parameters_schema(&self) -> &serde_json::Value {
+        static SCHEMA: std::sync::OnceLock<serde_json::Value> = std::sync::OnceLock::new();
+        SCHEMA.get_or_init(|| {
+            json!({
+                "type": "object",
+                "properties": {
+                    "city": {
+                        "type": "string",
+                        "description": "The city name"
+                    }
+                },
+                "required": ["city"]
+            })
+        })
+    }
+
+    fn execute(
+        &self,
+        _tool_call_id: &str,
+        _params: serde_json::Value,
+        _cancellation_token: CancellationToken,
+        _on_update: Option<Box<dyn Fn(AgentToolResult) + Send + Sync>>,
+        _state: std::sync::Arc<std::sync::RwLock<swink_agent::SessionState>>,
+        _credential: Option<swink_agent::ResolvedCredential>,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = AgentToolResult> + Send + '_>> {
+        Box::pin(async {
+            AgentToolResult {
+                content: vec![ContentBlock::Text {
+                    text: "72°F, sunny".into(),
+                }],
+                details: json!({}),
+                is_error: false,
+            }
+        })
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
 #[tokio::test]
 #[ignore = "hits live API"]
 async fn live_text_stream() {
-    let stream_fn = stream_fn();
-    let model = ModelSpec::new(
-        "azure",
-        std::env::var("AZURE_MODEL").unwrap_or_else(|_| "gpt-5.4".into()),
-    );
-    let context = AgentContext {
-        system_prompt: String::new(),
-        messages: Vec::new(),
-        tools: Vec::new(),
-    };
-    let options = StreamOptions::default();
-    let stream = stream_fn.stream(&model, &context, &options, CancellationToken::new());
-    let events = timeout(TIMEOUT, stream.collect::<Vec<AssistantMessageEvent>>())
+    let sf = stream_fn();
+    let context = simple_context("What is 2+2?");
+
+    let events = timeout(TIMEOUT, collect_events(&sf, &context))
         .await
-        .unwrap();
+        .expect("timed out");
+
+    let types: Vec<&str> = events.iter().map(|e| event_name(e)).collect();
+    assert!(types.contains(&"Start"), "missing Start: {types:?}");
+    assert!(types.contains(&"TextStart"), "missing TextStart: {types:?}");
+    assert!(types.contains(&"TextDelta"), "missing TextDelta: {types:?}");
+    assert!(types.contains(&"TextEnd"), "missing TextEnd: {types:?}");
+    assert!(types.contains(&"Done"), "missing Done: {types:?}");
+
+    let text: String = events
+        .iter()
+        .filter_map(|e| match e {
+            AssistantMessageEvent::TextDelta { delta, .. } => Some(delta.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert!(!text.is_empty(), "expected non-empty text response");
+}
+
+#[tokio::test]
+#[ignore = "hits live API"]
+async fn live_tool_call_stream() {
+    let sf = stream_fn();
+    let context = AgentContext {
+        system_prompt: "You must use the get_weather tool to answer. Do not reply with text only."
+            .into(),
+        messages: vec![AgentMessage::Llm(LlmMessage::User(UserMessage {
+            content: vec![ContentBlock::Text {
+                text: "What's the weather in Paris?".into(),
+            }],
+            timestamp: 0,
+            cache_hint: None,
+        }))],
+        tools: vec![Arc::new(DummyTool)],
+    };
+
+    let events = timeout(TIMEOUT, collect_events(&sf, &context))
+        .await
+        .expect("timed out");
+
+    let types: Vec<&str> = events.iter().map(|e| event_name(e)).collect();
     assert!(
-        events
-            .iter()
-            .any(|e| matches!(e, AssistantMessageEvent::Done { .. }))
+        types.contains(&"ToolCallStart"),
+        "missing ToolCallStart: {types:?}"
     );
+    assert!(
+        types.contains(&"ToolCallEnd"),
+        "missing ToolCallEnd: {types:?}"
+    );
+
+    let tool_name = events.iter().find_map(|e| match e {
+        AssistantMessageEvent::ToolCallStart { name, .. } => Some(name.clone()),
+        _ => None,
+    });
+    assert_eq!(tool_name.as_deref(), Some("get_weather"));
+}
+
+#[tokio::test]
+#[ignore = "hits live API"]
+async fn live_invalid_key_returns_error() {
+    let sf = AzureStreamFn::new(
+        {
+            dotenvy::dotenv().ok();
+            std::env::var("AZURE_BASE_URL").expect("AZURE_BASE_URL must be set")
+        },
+        AzureAuth::ApiKey("bogus-api-key-12345".into()),
+    );
+    let context = simple_context("Hi.");
+
+    let events = timeout(TIMEOUT, collect_events(&sf, &context))
+        .await
+        .expect("timed out");
+
+    let has_error = events
+        .iter()
+        .any(|e| matches!(e, AssistantMessageEvent::Error { .. }));
+    assert!(has_error, "expected Error event for invalid key");
 }

--- a/policies/src/checkpoint.rs
+++ b/policies/src/checkpoint.rs
@@ -3,11 +3,11 @@
 
 use std::sync::Arc;
 
+#[cfg(test)]
+use swink_agent::CheckpointFuture;
 use swink_agent::{
     Checkpoint, CheckpointStore, PolicyContext, PolicyVerdict, PostTurnPolicy, TurnPolicyContext,
 };
-#[cfg(test)]
-use swink_agent::CheckpointFuture;
 
 /// Persists agent state after each turn via a [`CheckpointStore`].
 ///

--- a/specs/016-adapter-azure/tasks.md
+++ b/specs/016-adapter-azure/tasks.md
@@ -134,13 +134,13 @@
 
 **Purpose**: Live tests, documentation, and final validation.
 
-- [ ] T048 [P] Create live test file `adapters/tests/azure_live.rs` with `#[ignore]` tests for text streaming against real Azure deployment
-- [ ] T049 [P] Add live test for tool call streaming in `adapters/tests/azure_live.rs`
-- [ ] T050 [P] Add live test for error handling (invalid API key) in `adapters/tests/azure_live.rs`
-- [ ] T051 Update `adapters/CLAUDE.md` — change Azure status from "Stub" to "Implemented", add auth/protocol notes to Lessons Learned
-- [ ] T052 Run `cargo test --workspace` to verify no regressions across entire workspace
-- [ ] T053 Run `cargo clippy --workspace -- -D warnings` to verify zero warnings
-- [ ] T054 Run `cargo test -p swink-agent-adapters --features azure` as final validation of all Azure adapter tests
+- [x] T048 [P] Create live test file `adapters/tests/azure_live.rs` with `#[ignore]` tests for text streaming against real Azure deployment
+- [x] T049 [P] Add live test for tool call streaming in `adapters/tests/azure_live.rs`
+- [x] T050 [P] Add live test for error handling (invalid API key) in `adapters/tests/azure_live.rs`
+- [x] T051 Update `adapters/CLAUDE.md` — change Azure status from "Stub" to "Implemented", add auth/protocol notes to Lessons Learned
+- [x] T052 Run `cargo test --workspace` to verify no regressions across entire workspace
+- [x] T053 Run `cargo clippy --workspace -- -D warnings` to verify zero warnings
+- [x] T054 Run `cargo test -p swink-agent-adapters --features azure` as final validation of all Azure adapter tests
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds comprehensive live integration tests for Azure OpenAI adapter (text streaming, tool calls, invalid API key error handling)
- Updates `adapters/CLAUDE.md` to mark Azure as "Implemented" with protocol, auth, and lessons learned documentation
- Fixes pre-existing `cargo fmt` issues in `openai_compat.rs`, `azure.rs` tests, and `checkpoint.rs`
- Marks all Phase 7 tasks (T048-T054) complete — spec 016-adapter-azure is now 54/54 (100%)

## Tasks completed
- T048: Live test for text streaming against real Azure deployment
- T049: Live test for tool call streaming
- T050: Live test for error handling (invalid API key)
- T051: Update adapters/CLAUDE.md — Azure status Stub→Implemented
- T052: `cargo test --workspace` — no regressions
- T053: `cargo clippy --workspace -- -D warnings` — zero warnings
- T054: `cargo test -p swink-agent-adapters --features azure` — all Azure tests pass

## Test plan
- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo test -p swink-agent --no-default-features` passes
- [x] `cargo test -p swink-agent-adapters --features azure` passes
- [x] No public API breakage in downstream crates

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)