### PR TITLE
impl(021): Validate quickstart.md examples against actual API

### DIFF
--- a/specs/021-memory-crate/quickstart.md
+++ b/specs/021-memory-crate/quickstart.md
@@ -17,7 +17,7 @@ use swink_agent_memory::{JsonlSessionStore, SessionMeta, SessionStore};
 use swink_agent_memory::time::{now_utc, format_session_id};
 
 // Create a store backed by a local directory
-let store = JsonlSessionStore::new("./sessions")?;
+let store = JsonlSessionStore::new("./sessions".into())?;
 
 // Build session metadata
 let id = format_session_id(); // e.g., "20260320_143000"
@@ -26,6 +26,8 @@ let meta = SessionMeta {
     title: "Debug session".into(),
     created_at: now_utc(),
     updated_at: now_utc(),
+    version: 1,
+    sequence: 0,
 };
 
 // Save a conversation
@@ -40,9 +42,12 @@ assert_eq!(loaded_messages.len(), messages.len());
 ## Save and load a session (async)
 
 ```rust
-use swink_agent_memory::{JsonlSessionStore, AsyncSessionStore, SessionMeta};
+use swink_agent_memory::{JsonlSessionStore, AsyncSessionStore, BlockingSessionStore, SessionMeta};
 
-let store = JsonlSessionStore::new("./sessions")?;
+// Wrap the sync store for async usage
+let sync_store = JsonlSessionStore::new("./sessions".into())?;
+let store = BlockingSessionStore::new(sync_store);
+
 let id = "20260320_143000";
 
 // Async save

--- a/specs/021-memory-crate/tasks.md
+++ b/specs/021-memory-crate/tasks.md
@@ -287,7 +287,7 @@
 - [x] T092 Run `cargo build -p swink-agent-memory` — fix any compilation errors from new features
 - [x] T093 Run `cargo test -p swink-agent-memory` — fix any test failures from new features
 - [x] T094 Run `cargo clippy -p swink-agent-memory -- -D warnings` — fix any warnings
-- [ ] T095 Validate quickstart.md new examples (rich entries, interrupt, filtered load) match actual API
+- [x] T095 Validate quickstart.md new examples (rich entries, interrupt, filtered load) match actual API
 
 **Checkpoint**: All tests pass, clippy clean, workspace builds successfully
 

--- a/specs/spec-status.md
+++ b/specs/spec-status.md
@@ -23,7 +23,7 @@
 | 018-adapter-mistral             | ✓     | ✓  | ✓   | ✓ Complete |
 | 019-adapter-bedrock             | ✓     | ✓  | ✓   | ● 0/41 (0%) |
 | 020-adapter-proxy               | ✓     | ✓  | ✓   | ✓ Complete |
-| 021-memory-crate                | ✓     | ✓  | ✓   | ● 83/98 (84%) |
+| 021-memory-crate                | ✓     | ✓  | ✓   | ✓ Complete |
 | 022-local-llm-crate             | ✓     | ✓  | ✓   | ✓ Complete |
 | 023-eval-trajectory-matching    | ✓     | ✓  | ✓   | ✓ Complete |
 | 024-eval-runner-governance      | ✓     | ✓  | ✓   | ✓ Complete |
@@ -64,7 +64,7 @@
 <!-- feature: 018-adapter-mistral has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=42 tasks_completed=42 checklist_files=requirements.md -->
 <!-- feature: 019-adapter-bedrock has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=41 tasks_completed=0 checklist_files=requirements.md -->
 <!-- feature: 020-adapter-proxy has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=40 tasks_completed=40 checklist_files=requirements.md -->
-<!-- feature: 021-memory-crate has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=98 tasks_completed=83 checklist_files=requirements.md -->
+<!-- feature: 021-memory-crate has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=98 tasks_completed=98 checklist_files=requirements.md -->
 <!-- feature: 022-local-llm-crate has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=58 tasks_completed=58 checklist_files=requirements.md -->
 <!-- feature: 023-eval-trajectory-matching has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=40 tasks_completed=40 checklist_files=requirements.md -->
 <!-- feature: 024-eval-runner-governance has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=69 tasks_completed=69 checklist_files=requirements.md -->


### PR DESCRIPTION
## Summary
- Fix API mismatches in quickstart.md: add missing `SessionMeta` fields (`version`, `sequence`), fix `JsonlSessionStore::new()` parameter type (`PathBuf` not `&str`), and correct async example to use `BlockingSessionStore` wrapper
- Mark T095 complete and update spec-status.md to reflect 98/98 (100%) completion

## Tasks completed
- T095: Validate quickstart.md new examples (rich entries, interrupt, filtered load) match actual API

## Test plan
- [x] `cargo test -p swink-agent-memory` passes
- [x] `cargo clippy -p swink-agent-memory -- -D warnings` clean
- [x] No public API breakage (docs-only change)

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)