### PR TITLE
fix: collapse session persistence onto canonical AgentMessage model

### DIFF
--- a/memory/src/jsonl.rs
+++ b/memory/src/jsonl.rs
@@ -345,16 +345,36 @@ impl JsonlSessionStore {
 }
 
 impl SessionStore for JsonlSessionStore {
-    fn save(&self, id: &str, meta: &SessionMeta, messages: &[LlmMessage]) -> io::Result<()> {
-        let entries: Vec<SessionEntry> = messages
-            .iter()
-            .cloned()
-            .map(SessionEntry::Message)
-            .collect();
-        self.save_entries(id, meta, &entries)
+    fn save(&self, id: &str, meta: &SessionMeta, messages: &[AgentMessage]) -> io::Result<()> {
+        validate_session_id(id)?;
+        check_sequence(&self.sessions_dir, id, meta.sequence)?;
+
+        let path = session_path(&self.sessions_dir, id);
+
+        // Increment sequence for the write
+        let mut write_meta = meta.clone();
+        write_meta.sequence += 1;
+
+        let file = std::fs::File::create(&path)?;
+        let mut writer = io::BufWriter::new(file);
+
+        // First line: metadata
+        serde_json::to_writer(&mut writer, &write_meta).map_err(io::Error::other)?;
+        writeln!(writer)?;
+
+        // Subsequent lines: one message per line
+        for msg in messages {
+            if let Some(record) = SessionRecord::from_message(msg, id) {
+                writer.write_all(record.to_json_line()?.as_bytes())?;
+                writeln!(writer)?;
+            }
+        }
+
+        writer.flush()?;
+        Ok(())
     }
 
-    fn append(&self, id: &str, messages: &[LlmMessage]) -> io::Result<()> {
+    fn append(&self, id: &str, messages: &[AgentMessage]) -> io::Result<()> {
         validate_session_id(id)?;
 
         let path = session_path(&self.sessions_dir, id);
@@ -363,20 +383,52 @@ impl SessionStore for JsonlSessionStore {
             id,
             messages
                 .iter()
-                .cloned()
-                .map(|message| SessionRecord::Llm(Box::new(message))),
+                .filter_map(|msg| SessionRecord::from_message(msg, id)),
         )
     }
 
-    fn load(&self, id: &str) -> io::Result<(SessionMeta, Vec<LlmMessage>)> {
-        let (meta, entries) = self.load_entries(id)?;
-        let messages = entries
-            .into_iter()
-            .filter_map(|entry| match entry {
-                SessionEntry::Message(msg) => Some(msg),
-                _ => None,
-            })
-            .collect();
+    fn load(
+        &self,
+        id: &str,
+        registry: Option<&CustomMessageRegistry>,
+    ) -> io::Result<(SessionMeta, Vec<AgentMessage>)> {
+        validate_session_id(id)?;
+
+        let path = session_path(&self.sessions_dir, id);
+        let (meta, lines) = read_meta_and_message_lines(&path, id)?;
+
+        // Check version
+        if meta.version > crate::migrate::CURRENT_VERSION {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "unsupported session version {} (current: {})",
+                    meta.version,
+                    crate::migrate::CURRENT_VERSION
+                ),
+            ));
+        }
+
+        // Parse lines using dual strategy: try SessionRecord first (handles
+        // raw LlmMessage and _custom/_state markers), then fall back to
+        // SessionEntry parsing (handles entry_type-tagged lines from
+        // save_entries). This ensures backward and forward compatibility.
+        let mut messages = Vec::new();
+        for (line_num, line) in lines.into_iter().enumerate() {
+            if line.trim().is_empty() {
+                continue;
+            }
+            // Try SessionRecord parse first (raw format)
+            if let Some(message) = parse_message_record(&line, line_num + 2, id, registry) {
+                messages.push(message);
+                continue;
+            }
+            // Fall back to SessionEntry parse (tagged format)
+            if let Ok(SessionEntry::Message(llm_msg)) = SessionEntry::parse(&line) {
+                messages.push(AgentMessage::Llm(llm_msg));
+            }
+        }
+
         Ok((meta, messages))
     }
 
@@ -423,71 +475,6 @@ impl SessionStore for JsonlSessionStore {
             std::fs::remove_file(int_path)?;
         }
         Ok(())
-    }
-
-    fn save_full(&self, id: &str, meta: &SessionMeta, messages: &[AgentMessage]) -> io::Result<()> {
-        validate_session_id(id)?;
-        check_sequence(&self.sessions_dir, id, meta.sequence)?;
-
-        let path = session_path(&self.sessions_dir, id);
-
-        // Increment sequence for the write
-        let mut write_meta = meta.clone();
-        write_meta.sequence += 1;
-
-        let file = std::fs::File::create(&path)?;
-        let mut writer = io::BufWriter::new(file);
-
-        // First line: metadata
-        serde_json::to_writer(&mut writer, &write_meta).map_err(io::Error::other)?;
-        writeln!(writer)?;
-
-        // Subsequent lines: one message per line
-        for msg in messages {
-            if let Some(record) = SessionRecord::from_message(msg, id) {
-                writer.write_all(record.to_json_line()?.as_bytes())?;
-                writeln!(writer)?;
-            }
-        }
-
-        writer.flush()?;
-        Ok(())
-    }
-
-    fn load_full(
-        &self,
-        id: &str,
-        registry: Option<&CustomMessageRegistry>,
-    ) -> io::Result<(SessionMeta, Vec<AgentMessage>)> {
-        validate_session_id(id)?;
-
-        let path = session_path(&self.sessions_dir, id);
-        let (meta, lines) = read_meta_and_message_lines(&path, id)?;
-
-        // Check version
-        if meta.version > crate::migrate::CURRENT_VERSION {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!(
-                    "unsupported session version {} (current: {})",
-                    meta.version,
-                    crate::migrate::CURRENT_VERSION
-                ),
-            ));
-        }
-
-        // Remaining lines: LlmMessage or custom message envelopes
-        let mut messages = Vec::new();
-        for (line_num, line) in lines.into_iter().enumerate() {
-            if line.trim().is_empty() {
-                continue;
-            }
-            if let Some(message) = parse_message_record(&line, line_num + 2, id, registry) {
-                messages.push(message);
-            }
-        }
-
-        Ok((meta, messages))
     }
 
     fn save_state(&self, id: &str, state: &serde_json::Value) -> io::Result<()> {
@@ -577,11 +564,7 @@ impl SessionStore for JsonlSessionStore {
         // Filter by timestamp (entry timestamps are epoch seconds)
         if let Some(after) = options.after_timestamp {
             let after_secs = after.timestamp().cast_unsigned();
-            entries.retain(|entry| {
-                entry
-                    .timestamp()
-                    .is_some_and(|ts| ts > after_secs)
-            });
+            entries.retain(|entry| entry.timestamp().is_some_and(|ts| ts > after_secs));
         }
 
         // Truncate to last N
@@ -730,7 +713,7 @@ mod tests {
     }
 
     #[test]
-    fn save_full_load_full_roundtrip_with_custom_messages() {
+    fn save_load_roundtrip_with_custom_messages() {
         use swink_agent::{AgentMessage, CustomMessage, CustomMessageRegistry};
 
         #[derive(Debug)]
@@ -786,7 +769,7 @@ mod tests {
             })),
         ];
 
-        store.save_full("test-full", &meta, &messages).unwrap();
+        store.save("test-full", &meta, &messages).unwrap();
 
         // Load with registry — custom message restored
         let mut registry = CustomMessageRegistry::new();
@@ -803,7 +786,7 @@ mod tests {
             }),
         );
 
-        let (loaded_meta, loaded_messages) = store.load_full("test-full", Some(&registry)).unwrap();
+        let (loaded_meta, loaded_messages) = store.load("test-full", Some(&registry)).unwrap();
         assert_eq!(loaded_meta.id, "test-full");
         assert_eq!(loaded_messages.len(), 3);
         assert!(matches!(
@@ -821,14 +804,10 @@ mod tests {
         assert_eq!(custom.data, "custom-payload");
 
         // Load without registry — custom messages skipped
-        let (_, loaded_no_reg) = store.load_full("test-full", None).unwrap();
+        let (_, loaded_no_reg) = store.load("test-full", None).unwrap();
         assert_eq!(loaded_no_reg.len(), 2);
         assert!(matches!(loaded_no_reg[0], AgentMessage::Llm(_)));
         assert!(matches!(loaded_no_reg[1], AgentMessage::Llm(_)));
-
-        // Regular load() still works (skips custom lines with warning)
-        let (_, llm_only) = store.load("test-full").unwrap();
-        assert_eq!(llm_only.len(), 2);
     }
 
     #[test]
@@ -846,31 +825,35 @@ mod tests {
             sequence: 0,
         };
 
-        let initial_messages = vec![LlmMessage::User(swink_agent::UserMessage {
-            content: vec![swink_agent::ContentBlock::Text {
-                text: "hello".to_string(),
-            }],
-            timestamp: 1,
-            cache_hint: None,
-        })];
+        let initial_messages: Vec<AgentMessage> = vec![AgentMessage::Llm(LlmMessage::User(
+            swink_agent::UserMessage {
+                content: vec![swink_agent::ContentBlock::Text {
+                    text: "hello".to_string(),
+                }],
+                timestamp: 1,
+                cache_hint: None,
+            },
+        ))];
         store.save("test-state", &meta, &initial_messages).unwrap();
         store
             .save_state("test-state", &serde_json::json!({ "cursor": 1 }))
             .unwrap();
 
-        let appended_messages = vec![LlmMessage::User(swink_agent::UserMessage {
-            content: vec![swink_agent::ContentBlock::Text {
-                text: "world".to_string(),
-            }],
-            timestamp: 2,
-            cache_hint: None,
-        })];
+        let appended_messages: Vec<AgentMessage> = vec![AgentMessage::Llm(LlmMessage::User(
+            swink_agent::UserMessage {
+                content: vec![swink_agent::ContentBlock::Text {
+                    text: "world".to_string(),
+                }],
+                timestamp: 2,
+                cache_hint: None,
+            },
+        ))];
         store.append("test-state", &appended_messages).unwrap();
 
         let state = store.load_state("test-state").unwrap();
         assert_eq!(state, Some(serde_json::json!({ "cursor": 1 })));
 
-        let (_, messages) = store.load("test-state").unwrap();
+        let (_, messages) = store.load("test-state", None).unwrap();
         assert_eq!(messages.len(), 2);
     }
 }

--- a/memory/src/store.rs
+++ b/memory/src/store.rs
@@ -22,8 +22,8 @@ pub trait SessionStore: Send + Sync {
     ///
     /// Overwrites any existing session with the same ID. Custom messages that
     /// cannot be serialized are logged and skipped — callers should ensure
-    /// custom types implement [`CustomMessage::to_json`] and
-    /// [`CustomMessage::type_name`].
+    /// custom types implement `CustomMessage::to_json` and
+    /// `CustomMessage::type_name`.
     fn save(&self, id: &str, meta: &SessionMeta, messages: &[AgentMessage]) -> io::Result<()>;
 
     /// Append messages to an existing session without rewriting the entire file.

--- a/memory/src/store.rs
+++ b/memory/src/store.rs
@@ -2,7 +2,7 @@
 
 use std::io;
 
-use swink_agent::{AgentMessage, CustomMessageRegistry, LlmMessage};
+use swink_agent::{AgentMessage, CustomMessageRegistry};
 
 use crate::entry::SessionEntry;
 use crate::interrupt::InterruptState;
@@ -11,57 +11,39 @@ use crate::meta::SessionMeta;
 
 /// Pluggable session persistence.
 ///
-/// Implementations store and retrieve conversation sessions. The default
-/// implementation ([`JsonlSessionStore`](crate::JsonlSessionStore)) uses
-/// JSONL files, but alternative backends (`SQLite`, S3, etc.) can implement
-/// this trait directly.
+/// All save/load methods use [`AgentMessage`] as the canonical message type,
+/// preserving both LLM and custom messages without silent data loss.
+///
+/// The default implementation ([`JsonlSessionStore`](crate::JsonlSessionStore))
+/// uses JSONL files, but alternative backends (`SQLite`, S3, etc.) can
+/// implement this trait directly.
 pub trait SessionStore: Send + Sync {
-    /// Persist a session. Overwrites any existing session with the same ID.
-    fn save(&self, id: &str, meta: &SessionMeta, messages: &[LlmMessage]) -> io::Result<()>;
+    /// Persist a session, including both LLM and custom messages.
+    ///
+    /// Overwrites any existing session with the same ID. Custom messages that
+    /// cannot be serialized are logged and skipped — callers should ensure
+    /// custom types implement [`CustomMessage::to_json`] and
+    /// [`CustomMessage::type_name`].
+    fn save(&self, id: &str, meta: &SessionMeta, messages: &[AgentMessage]) -> io::Result<()>;
 
     /// Append messages to an existing session without rewriting the entire file.
-    fn append(&self, id: &str, messages: &[LlmMessage]) -> io::Result<()>;
+    fn append(&self, id: &str, messages: &[AgentMessage]) -> io::Result<()>;
 
-    /// Load a session by ID, returning metadata and messages.
-    fn load(&self, id: &str) -> io::Result<(SessionMeta, Vec<LlmMessage>)>;
+    /// Load a session by ID.
+    ///
+    /// If `registry` is `Some`, custom messages are deserialized using the
+    /// provided registry. If `None`, custom messages are skipped.
+    fn load(
+        &self,
+        id: &str,
+        registry: Option<&CustomMessageRegistry>,
+    ) -> io::Result<(SessionMeta, Vec<AgentMessage>)>;
 
     /// List all saved sessions, sorted by last updated (newest first).
     fn list(&self) -> io::Result<Vec<SessionMeta>>;
 
     /// Delete a session by ID.
     fn delete(&self, id: &str) -> io::Result<()>;
-
-    /// Persist a session including both LLM and custom messages.
-    ///
-    /// The default implementation filters to `LlmMessage` only and delegates
-    /// to [`save`](Self::save).
-    fn save_full(&self, id: &str, meta: &SessionMeta, messages: &[AgentMessage]) -> io::Result<()> {
-        let llm_messages: Vec<LlmMessage> = messages
-            .iter()
-            .filter_map(|m| match m {
-                AgentMessage::Llm(llm) => Some(llm.clone()),
-                AgentMessage::Custom(_) => None,
-            })
-            .collect();
-        self.save(id, meta, &llm_messages)
-    }
-
-    /// Load a session including custom messages.
-    ///
-    /// If `registry` is `Some`, custom messages are deserialized using the
-    /// provided registry. The default implementation delegates to
-    /// [`load`](Self::load) and wraps each `LlmMessage` in
-    /// `AgentMessage::Llm`.
-    fn load_full(
-        &self,
-        id: &str,
-        registry: Option<&CustomMessageRegistry>,
-    ) -> io::Result<(SessionMeta, Vec<AgentMessage>)> {
-        let _ = registry; // unused in default impl
-        let (meta, llm_messages) = self.load(id)?;
-        let messages = llm_messages.into_iter().map(AgentMessage::Llm).collect();
-        Ok((meta, messages))
-    }
 
     /// Save session state snapshot. Default: no-op.
     fn save_state(&self, id: &str, state: &serde_json::Value) -> io::Result<()> {

--- a/memory/src/store_async.rs
+++ b/memory/src/store_async.rs
@@ -5,7 +5,7 @@ use std::io;
 use std::pin::Pin;
 use std::sync::Arc;
 
-use swink_agent::LlmMessage;
+use swink_agent::{AgentMessage, CustomMessageRegistry};
 
 use crate::entry::SessionEntry;
 use crate::interrupt::InterruptState;
@@ -26,26 +26,48 @@ fn spawn_store_call<T: Send + 'static>(
 }
 
 /// Async session persistence for non-blocking backends (Redis, S3, cloud storage).
+///
+/// Mirrors [`SessionStore`](crate::store::SessionStore) with async signatures.
+/// All save/load methods use [`AgentMessage`] as the canonical message type.
 pub trait AsyncSessionStore: Send + Sync {
-    /// Persist a session asynchronously.
+    /// Persist a session asynchronously, including both LLM and custom messages.
     fn save(
         &self,
         id: &str,
         meta: &SessionMeta,
-        messages: &[LlmMessage],
+        messages: &[AgentMessage],
     ) -> SessionStoreFuture<'_, ()>;
 
     /// Append messages to an existing session asynchronously.
-    fn append(&self, id: &str, messages: &[LlmMessage]) -> SessionStoreFuture<'_, ()>;
+    fn append(&self, id: &str, messages: &[AgentMessage]) -> SessionStoreFuture<'_, ()>;
 
     /// Load a session by ID asynchronously.
-    fn load(&self, id: &str) -> SessionStoreFuture<'_, (SessionMeta, Vec<LlmMessage>)>;
+    ///
+    /// If `registry` is `Some`, custom messages are deserialized using the
+    /// provided registry. If `None`, custom messages are skipped.
+    fn load(
+        &self,
+        id: &str,
+        registry: Option<&CustomMessageRegistry>,
+    ) -> SessionStoreFuture<'_, (SessionMeta, Vec<AgentMessage>)>;
 
     /// List all saved sessions asynchronously.
     fn list(&self) -> SessionStoreFuture<'_, Vec<SessionMeta>>;
 
     /// Delete a session by ID asynchronously.
     fn delete(&self, id: &str) -> SessionStoreFuture<'_, ()>;
+
+    /// Save session state snapshot asynchronously. Default: no-op.
+    fn save_state(&self, id: &str, state: &serde_json::Value) -> SessionStoreFuture<'_, ()> {
+        let _ = (id, state);
+        Box::pin(async { Ok(()) })
+    }
+
+    /// Load session state snapshot asynchronously. Default: `None`.
+    fn load_state(&self, id: &str) -> SessionStoreFuture<'_, Option<serde_json::Value>> {
+        let _ = id;
+        Box::pin(async { Ok(None) })
+    }
 
     /// Persist interrupt state for a session asynchronously.
     fn save_interrupt(&self, id: &str, state: &InterruptState) -> SessionStoreFuture<'_, ()>;
@@ -82,31 +104,57 @@ impl<S: crate::store::SessionStore + 'static> BlockingSessionStore<S> {
     }
 }
 
+/// Extract `LlmMessage` variants from a slice of `AgentMessage`, cloning each.
+/// Custom messages are filtered out (they are not `Clone` and cannot cross
+/// `spawn_blocking` boundaries). The inner `SessionStore::save` will still
+/// persist them if the concrete backend supports it — this limitation only
+/// applies to the `BlockingSessionStore` adapter.
+fn clone_llm_messages(messages: &[AgentMessage]) -> Vec<AgentMessage> {
+    messages
+        .iter()
+        .filter_map(|m| match m {
+            AgentMessage::Llm(llm) => Some(AgentMessage::Llm(llm.clone())),
+            AgentMessage::Custom(_) => None,
+        })
+        .collect()
+}
+
 impl<S: crate::store::SessionStore + 'static> AsyncSessionStore for BlockingSessionStore<S> {
     fn save(
         &self,
         id: &str,
         meta: &SessionMeta,
-        messages: &[LlmMessage],
+        messages: &[AgentMessage],
     ) -> SessionStoreFuture<'_, ()> {
         let inner = Arc::clone(&self.inner);
         let id = id.to_string();
         let meta = meta.clone();
-        let messages = messages.to_vec();
+        // Clone LLM messages for thread transfer; custom messages are filtered
+        // since Box<dyn CustomMessage> is not Clone. Callers requiring full
+        // custom message persistence should use the sync store directly.
+        let messages = clone_llm_messages(messages);
         spawn_store_call(move || inner.save(&id, &meta, &messages))
     }
 
-    fn append(&self, id: &str, messages: &[LlmMessage]) -> SessionStoreFuture<'_, ()> {
+    fn append(&self, id: &str, messages: &[AgentMessage]) -> SessionStoreFuture<'_, ()> {
         let inner = Arc::clone(&self.inner);
         let id = id.to_string();
-        let messages = messages.to_vec();
+        let messages = clone_llm_messages(messages);
         spawn_store_call(move || inner.append(&id, &messages))
     }
 
-    fn load(&self, id: &str) -> SessionStoreFuture<'_, (SessionMeta, Vec<LlmMessage>)> {
+    fn load(
+        &self,
+        id: &str,
+        registry: Option<&CustomMessageRegistry>,
+    ) -> SessionStoreFuture<'_, (SessionMeta, Vec<AgentMessage>)> {
         let inner = Arc::clone(&self.inner);
         let id = id.to_string();
-        spawn_store_call(move || inner.load(&id))
+        // CustomMessageRegistry is not Send, so we load without registry from
+        // the blocking adapter. Callers needing custom message deserialization
+        // should use the sync store directly or a native async backend.
+        let _ = registry;
+        spawn_store_call(move || inner.load(&id, None))
     }
 
     fn list(&self) -> SessionStoreFuture<'_, Vec<SessionMeta>> {
@@ -118,6 +166,19 @@ impl<S: crate::store::SessionStore + 'static> AsyncSessionStore for BlockingSess
         let inner = Arc::clone(&self.inner);
         let id = id.to_string();
         spawn_store_call(move || inner.delete(&id))
+    }
+
+    fn save_state(&self, id: &str, state: &serde_json::Value) -> SessionStoreFuture<'_, ()> {
+        let inner = Arc::clone(&self.inner);
+        let id = id.to_string();
+        let state = state.clone();
+        spawn_store_call(move || inner.save_state(&id, &state))
+    }
+
+    fn load_state(&self, id: &str) -> SessionStoreFuture<'_, Option<serde_json::Value>> {
+        let inner = Arc::clone(&self.inner);
+        let id = id.to_string();
+        spawn_store_call(move || inner.load_state(&id))
     }
 
     fn save_interrupt(&self, id: &str, state: &InterruptState) -> SessionStoreFuture<'_, ()> {
@@ -156,6 +217,7 @@ mod tests {
     use super::*;
     use crate::jsonl::JsonlSessionStore;
     use crate::time::now_utc;
+    use swink_agent::AgentMessage;
 
     #[tokio::test]
     async fn blocking_session_store_adapter_works() {
@@ -175,7 +237,7 @@ mod tests {
         };
 
         // Save via async adapter.
-        let messages: Vec<LlmMessage> = vec![];
+        let messages: Vec<AgentMessage> = vec![];
         async_store
             .save("test_async", &meta, &messages)
             .await
@@ -188,7 +250,7 @@ mod tests {
         assert_eq!(sessions[0].title, "Async test");
 
         // Load via async adapter.
-        let (loaded_meta, loaded_messages) = async_store.load("test_async").await.unwrap();
+        let (loaded_meta, loaded_messages) = async_store.load("test_async", None).await.unwrap();
         assert_eq!(loaded_meta.id, "test_async");
         assert!(loaded_messages.is_empty());
 
@@ -196,5 +258,31 @@ mod tests {
         async_store.delete("test_async").await.unwrap();
         let sessions = async_store.list().await.unwrap();
         assert!(sessions.is_empty());
+    }
+
+    #[tokio::test]
+    async fn blocking_adapter_bridges_state_methods() {
+        let dir = tempfile::tempdir().unwrap();
+        let jsonl_store = JsonlSessionStore::new(dir.path().to_path_buf()).unwrap();
+        let async_store = BlockingSessionStore::new(jsonl_store);
+
+        let now = now_utc();
+        let meta = SessionMeta {
+            id: "state_async".to_string(),
+            title: "State test".to_string(),
+            created_at: now,
+            updated_at: now,
+            version: 1,
+            sequence: 0,
+        };
+
+        async_store.save("state_async", &meta, &[]).await.unwrap();
+        async_store
+            .save_state("state_async", &serde_json::json!({"scroll": 42}))
+            .await
+            .unwrap();
+
+        let state = async_store.load_state("state_async").await.unwrap();
+        assert_eq!(state, Some(serde_json::json!({"scroll": 42})));
     }
 }

--- a/memory/tests/async_store.rs
+++ b/memory/tests/async_store.rs
@@ -17,7 +17,7 @@ async fn async_save_and_load_roundtrip() {
 
     store.save("async_rt", &meta, &messages).await.unwrap();
 
-    let (loaded_meta, loaded_msgs) = store.load("async_rt").await.unwrap();
+    let (loaded_meta, loaded_msgs) = store.load("async_rt", None).await.unwrap();
     assert_eq!(loaded_meta.id, meta.id);
     assert_eq!(loaded_meta.title, meta.title);
     assert_eq!(loaded_meta.sequence, 1); // incremented on save
@@ -38,7 +38,7 @@ async fn concurrent_async_operations_on_different_sessions() {
             let meta = sample_meta(&id, &format!("Session {i}"));
             let messages = vec![user_message(&format!("message from {i}"))];
             store.save(&id, &meta, &messages).await.unwrap();
-            let (loaded_meta, loaded_msgs) = store.load(&id).await.unwrap();
+            let (loaded_meta, loaded_msgs) = store.load(&id, None).await.unwrap();
             assert_eq!(loaded_meta.id, id);
             assert_eq!(loaded_msgs.len(), 1);
         });

--- a/memory/tests/common/mod.rs
+++ b/memory/tests/common/mod.rs
@@ -4,24 +4,24 @@
 
 use chrono::{DateTime, Utc};
 use swink_agent::{
-    AssistantMessage, ContentBlock, Cost, LlmMessage, StopReason, Usage, UserMessage,
+    AgentMessage, AssistantMessage, ContentBlock, Cost, LlmMessage, StopReason, Usage, UserMessage,
 };
 use swink_agent_memory::SessionMeta;
 
-/// Create a sample `UserMessage` with the given text.
-pub fn user_message(text: &str) -> LlmMessage {
-    LlmMessage::User(UserMessage {
+/// Create a sample `UserMessage` wrapped as `AgentMessage`.
+pub fn user_message(text: &str) -> AgentMessage {
+    AgentMessage::Llm(LlmMessage::User(UserMessage {
         content: vec![ContentBlock::Text {
             text: text.to_owned(),
         }],
         timestamp: 0,
         cache_hint: None,
-    })
+    }))
 }
 
-/// Create a sample `AssistantMessage` with the given text.
-pub fn assistant_message(text: &str) -> LlmMessage {
-    LlmMessage::Assistant(AssistantMessage {
+/// Create a sample `AssistantMessage` wrapped as `AgentMessage`.
+pub fn assistant_message(text: &str) -> AgentMessage {
+    AgentMessage::Llm(LlmMessage::Assistant(AssistantMessage {
         content: vec![ContentBlock::Text {
             text: text.to_owned(),
         }],
@@ -33,16 +33,46 @@ pub fn assistant_message(text: &str) -> LlmMessage {
         error_message: None,
         timestamp: 0,
         cache_hint: None,
-    })
+    }))
 }
 
-/// Create a sample `UserMessage` with the given text and timestamp.
+/// Create a sample `UserMessage` with timestamp, as raw `LlmMessage`.
+///
+/// Used for `SessionEntry::Message` which takes `LlmMessage` directly.
 pub fn user_message_at(text: &str, timestamp: u64) -> LlmMessage {
     LlmMessage::User(UserMessage {
         content: vec![ContentBlock::Text {
             text: text.to_owned(),
         }],
         timestamp,
+        cache_hint: None,
+    })
+}
+
+/// Create a raw `LlmMessage::User` for use with `SessionEntry::Message`.
+pub fn llm_user_message(text: &str) -> LlmMessage {
+    LlmMessage::User(UserMessage {
+        content: vec![ContentBlock::Text {
+            text: text.to_owned(),
+        }],
+        timestamp: 0,
+        cache_hint: None,
+    })
+}
+
+/// Create a raw `LlmMessage::Assistant` for use with `SessionEntry::Message`.
+pub fn llm_assistant_message(text: &str) -> LlmMessage {
+    LlmMessage::Assistant(AssistantMessage {
+        content: vec![ContentBlock::Text {
+            text: text.to_owned(),
+        }],
+        provider: "test".to_string(),
+        model_id: "test-model".to_string(),
+        usage: Usage::default(),
+        cost: Cost::default(),
+        stop_reason: StopReason::Stop,
+        error_message: None,
+        timestamp: 0,
         cache_hint: None,
     })
 }

--- a/memory/tests/corruption.rs
+++ b/memory/tests/corruption.rs
@@ -54,7 +54,7 @@ fn corrupted_line_recovers_remaining_messages() {
     std::fs::write(&path, lines.join("\n")).unwrap();
 
     // Load should recover 4 of 5 messages
-    let (loaded_meta, loaded_msgs) = store.load("corrupt_test").unwrap();
+    let (loaded_meta, loaded_msgs) = store.load("corrupt_test", None).unwrap();
     assert_eq!(loaded_meta.id, "corrupt_test");
     assert_eq!(loaded_msgs.len(), 4);
 }
@@ -71,7 +71,7 @@ fn all_message_lines_corrupted_returns_empty_messages() {
     std::fs::write(tmp.path().join("all_corrupt.jsonl"), &content).unwrap();
 
     let store = JsonlSessionStore::new(tmp.path().to_path_buf()).unwrap();
-    let (loaded_meta, loaded_msgs) = store.load("all_corrupt").unwrap();
+    let (loaded_meta, loaded_msgs) = store.load("all_corrupt", None).unwrap();
     assert_eq!(loaded_meta.id, "all_corrupt");
     assert!(loaded_msgs.is_empty());
 }
@@ -103,6 +103,6 @@ fn append_does_not_rewrite_file() {
     );
 
     // Verify all 5 messages are present
-    let (_, loaded_msgs) = store.load("append_test").unwrap();
+    let (_, loaded_msgs) = store.load("append_test", None).unwrap();
     assert_eq!(loaded_msgs.len(), 5);
 }

--- a/memory/tests/round_trip.rs
+++ b/memory/tests/round_trip.rs
@@ -11,7 +11,10 @@ use swink_agent_memory::{
     SessionStore,
 };
 
-use common::{assistant_message, sample_meta, sample_meta_with_times, user_message, user_message_at};
+use common::{
+    assistant_message, llm_assistant_message, llm_user_message, sample_meta,
+    sample_meta_with_times, user_message, user_message_at,
+};
 
 // --- US1: Save and Load ---
 
@@ -25,7 +28,7 @@ fn save_and_load_roundtrip() {
 
     store.save("test_001", &meta, &messages).unwrap();
 
-    let (loaded_meta, loaded_msgs) = store.load("test_001").unwrap();
+    let (loaded_meta, loaded_msgs) = store.load("test_001", None).unwrap();
     assert_eq!(loaded_meta.id, meta.id);
     assert_eq!(loaded_meta.title, meta.title);
     assert_eq!(loaded_meta.version, 1);
@@ -43,7 +46,7 @@ fn save_overwrites_existing_session() {
     store.save("overwrite_test", &meta1, &msgs1).unwrap();
 
     // Load to get updated sequence after first save
-    let (saved_meta, _) = store.load("overwrite_test").unwrap();
+    let (saved_meta, _) = store.load("overwrite_test", None).unwrap();
     let meta2 = SessionMeta {
         title: "Version 2".to_string(),
         ..saved_meta
@@ -51,7 +54,7 @@ fn save_overwrites_existing_session() {
     let msgs2 = vec![user_message("second"), user_message("third")];
     store.save("overwrite_test", &meta2, &msgs2).unwrap();
 
-    let (loaded_meta, loaded_msgs) = store.load("overwrite_test").unwrap();
+    let (loaded_meta, loaded_msgs) = store.load("overwrite_test", None).unwrap();
     assert_eq!(loaded_meta.title, "Version 2");
     assert_eq!(loaded_msgs.len(), 2);
 }
@@ -61,7 +64,7 @@ fn load_nonexistent_session_returns_not_found() {
     let tmp = tempfile::tempdir().unwrap();
     let store = JsonlSessionStore::new(tmp.path().to_path_buf()).unwrap();
 
-    let err = store.load("nonexistent").unwrap_err();
+    let err = store.load("nonexistent", None).unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::NotFound);
 }
 
@@ -73,7 +76,7 @@ fn load_empty_file_returns_invalid_data() {
     // Create an empty .jsonl file
     std::fs::write(tmp.path().join("empty.jsonl"), "").unwrap();
 
-    let err = store.load("empty").unwrap_err();
+    let err = store.load("empty", None).unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::InvalidData);
 }
 
@@ -90,7 +93,7 @@ fn save_and_load_preserves_message_content() {
     ];
 
     store.save("content_test", &meta, &messages).unwrap();
-    let (_, loaded_msgs) = store.load("content_test").unwrap();
+    let (_, loaded_msgs) = store.load("content_test", None).unwrap();
 
     assert_eq!(loaded_msgs.len(), 3);
     // Verify content is preserved by checking serialization roundtrip
@@ -119,7 +122,7 @@ fn invalid_session_id_rejected_on_load() {
     let store = JsonlSessionStore::new(tmp.path().to_path_buf()).unwrap();
 
     for bad_id in &["foo/bar", "foo\\bar", "..secret", "null\0byte", ""] {
-        let err = store.load(bad_id).unwrap_err();
+        let err = store.load(bad_id, None).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput, "id={bad_id:?}");
     }
 }
@@ -175,7 +178,7 @@ fn delete_removes_session() {
 
     store.delete("to_delete").unwrap();
 
-    let err = store.load("to_delete").unwrap_err();
+    let err = store.load("to_delete", None).unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::NotFound);
 
     let sessions = store.list().unwrap();
@@ -200,7 +203,7 @@ fn rich_entries_roundtrip() {
 
     let meta = sample_meta("rich_001", "Rich entries test");
     let entries = vec![
-        SessionEntry::Message(user_message("hello")),
+        SessionEntry::Message(llm_user_message("hello")),
         SessionEntry::ModelChange {
             from: ModelSpec {
                 provider: "openai".to_string(),
@@ -257,7 +260,7 @@ fn rich_entries_roundtrip() {
     }
 
     // load() (LlmMessage-only) should return only the Message entry
-    let (_, messages) = store.load("rich_001").unwrap();
+    let (_, messages) = store.load("rich_001", None).unwrap();
     assert_eq!(messages.len(), 1);
 }
 
@@ -268,8 +271,8 @@ fn rich_entries_backward_compat() {
 
     // Create an old-format JSONL file: meta line + raw LlmMessage lines (no entry_type)
     let meta = sample_meta("compat_001", "Old format session");
-    let msg1 = user_message("first message");
-    let msg2 = assistant_message("second message");
+    let msg1 = llm_user_message("first message");
+    let msg2 = llm_assistant_message("second message");
 
     let meta_json = serde_json::to_string(&meta).unwrap();
     let msg1_json = serde_json::to_string(&msg1).unwrap();
@@ -301,11 +304,11 @@ fn version_defaults_for_old_sessions() {
 
     // Write an old-format JSONL file without version/sequence fields
     let meta_json = r#"{"id":"old_001","title":"Old session","created_at":"2025-03-15T12:00:00Z","updated_at":"2025-03-15T12:00:00Z"}"#;
-    let msg_json = serde_json::to_string(&user_message("hello")).unwrap();
+    let msg_json = serde_json::to_string(&llm_user_message("hello")).unwrap();
     let content = format!("{meta_json}\n{msg_json}\n");
     std::fs::write(tmp.path().join("old_001.jsonl"), content).unwrap();
 
-    let (loaded_meta, msgs) = store.load("old_001").unwrap();
+    let (loaded_meta, msgs) = store.load("old_001", None).unwrap();
     assert_eq!(loaded_meta.version, 1); // default
     assert_eq!(loaded_meta.sequence, 0); // default
     assert_eq!(msgs.len(), 1);
@@ -321,7 +324,7 @@ fn sequence_increments_on_save() {
         .save("seq_test", &meta, &[user_message("first")])
         .unwrap();
 
-    let (loaded1, _) = store.load("seq_test").unwrap();
+    let (loaded1, _) = store.load("seq_test", None).unwrap();
     assert_eq!(loaded1.sequence, 1);
 
     // Save again with the loaded meta (sequence=1)
@@ -329,7 +332,7 @@ fn sequence_increments_on_save() {
         .save("seq_test", &loaded1, &[user_message("second")])
         .unwrap();
 
-    let (loaded2, _) = store.load("seq_test").unwrap();
+    let (loaded2, _) = store.load("seq_test", None).unwrap();
     assert_eq!(loaded2.sequence, 2);
 }
 
@@ -344,7 +347,7 @@ fn optimistic_concurrency_rejects_stale_sequence() {
         .unwrap();
 
     // Load meta (sequence=1)
-    let (stale_meta, _) = store.load("conc_test").unwrap();
+    let (stale_meta, _) = store.load("conc_test", None).unwrap();
     assert_eq!(stale_meta.sequence, 1);
 
     // Simulate another writer saving (bumps sequence to 2)
@@ -373,7 +376,7 @@ fn unsupported_future_version_returns_error() {
     )
     .unwrap();
 
-    let err = store.load("future_001").unwrap_err();
+    let err = store.load("future_001", None).unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::InvalidData);
     assert!(err.to_string().contains("unsupported session version 999"));
 }
@@ -395,7 +398,7 @@ fn sample_interrupt() -> InterruptState {
                 arguments: serde_json::json!({"path": "/tmp/foo.txt"}),
             },
         ],
-        context_snapshot: vec![user_message("hello"), assistant_message("hi")],
+        context_snapshot: vec![llm_user_message("hello"), llm_assistant_message("hi")],
         system_prompt: "You are a helpful assistant.".to_string(),
         model: ModelSpec::new("openai", "gpt-4"),
     }
@@ -549,7 +552,7 @@ fn load_by_entry_type() {
 
     let meta = sample_meta("filter_type", "Entry type filter test");
     let entries = vec![
-        SessionEntry::Message(user_message("hello")),
+        SessionEntry::Message(llm_user_message("hello")),
         SessionEntry::ModelChange {
             from: ModelSpec::new("a", "a"),
             to: ModelSpec::new("b", "b"),
@@ -560,12 +563,10 @@ fn load_by_entry_type() {
             message_index: 0,
             timestamp: 200,
         },
-        SessionEntry::Message(user_message("world")),
+        SessionEntry::Message(llm_user_message("world")),
     ];
 
-    store
-        .save_entries("filter_type", &meta, &entries)
-        .unwrap();
+    store.save_entries("filter_type", &meta, &entries).unwrap();
 
     let options = LoadOptions {
         entry_types: Some(vec!["message".to_string()]),
@@ -583,18 +584,16 @@ fn load_options_all_none_returns_full() {
 
     let meta = sample_meta("filter_none", "Default options test");
     let entries = vec![
-        SessionEntry::Message(user_message("hello")),
+        SessionEntry::Message(llm_user_message("hello")),
         SessionEntry::Label {
             text: "note".to_string(),
             message_index: 0,
             timestamp: 100,
         },
-        SessionEntry::Message(user_message("world")),
+        SessionEntry::Message(llm_user_message("world")),
     ];
 
-    store
-        .save_entries("filter_none", &meta, &entries)
-        .unwrap();
+    store.save_entries("filter_none", &meta, &entries).unwrap();
 
     let options = LoadOptions::default();
     let (_, loaded) = store.load_with_options("filter_none", &options).unwrap();

--- a/memory/tests/stress_append.rs
+++ b/memory/tests/stress_append.rs
@@ -4,6 +4,7 @@ mod common;
 
 use std::time::Instant;
 
+use swink_agent::{AgentMessage, LlmMessage};
 use swink_agent_memory::{JsonlSessionStore, SessionStore};
 
 use common::{assistant_message, sample_meta, user_message};
@@ -30,12 +31,12 @@ fn sequential_append_500_messages() {
 
     let elapsed = start.elapsed();
 
-    let (_, loaded) = store.load("stress_500").unwrap();
+    let (_, loaded) = store.load("stress_500", None).unwrap();
     assert_eq!(loaded.len(), 501); // 1 seed + 500 appended
 
     // Verify ordering: first message is the seed
     let first_text = match &loaded[0] {
-        swink_agent::LlmMessage::User(u) => match &u.content[0] {
+        AgentMessage::Llm(LlmMessage::User(u)) => match &u.content[0] {
             swink_agent::ContentBlock::Text { text } => text.clone(),
             _ => panic!("unexpected content block"),
         },
@@ -45,7 +46,7 @@ fn sequential_append_500_messages() {
 
     // Verify last message
     let last_text = match &loaded[500] {
-        swink_agent::LlmMessage::Assistant(a) => match &a.content[0] {
+        AgentMessage::Llm(LlmMessage::Assistant(a)) => match &a.content[0] {
             swink_agent::ContentBlock::Text { text } => text.clone(),
             _ => panic!("unexpected content block"),
         },
@@ -81,7 +82,7 @@ fn slow_path_triggered_by_title_change() {
 
     // Change the title to something longer, triggering the slow path on next append.
     // We do this by saving the full session with the new meta + all existing messages.
-    let (mut loaded_meta, existing) = store.load("slow_path").unwrap();
+    let (mut loaded_meta, existing) = store.load("slow_path", None).unwrap();
     loaded_meta.title = "a much longer title that changes meta line byte length".to_string();
     store.save("slow_path", &loaded_meta, &existing).unwrap();
 
@@ -97,7 +98,7 @@ fn slow_path_triggered_by_title_change() {
             .unwrap();
     }
 
-    let (loaded_meta, loaded) = store.load("slow_path").unwrap();
+    let (loaded_meta, loaded) = store.load("slow_path", None).unwrap();
 
     // 2 seed + 5 before + 5 after = 12
     assert_eq!(loaded.len(), 12);
@@ -109,15 +110,15 @@ fn slow_path_triggered_by_title_change() {
     // Verify ordering: seed messages first, then before-change, then after-change
     let text_at = |idx: usize| -> String {
         match &loaded[idx] {
-            swink_agent::LlmMessage::User(u) => match &u.content[0] {
+            AgentMessage::Llm(LlmMessage::User(u)) => match &u.content[0] {
                 swink_agent::ContentBlock::Text { text } => text.clone(),
                 other => panic!("unexpected content block at {idx}: {other:?}"),
             },
-            swink_agent::LlmMessage::Assistant(a) => match &a.content[0] {
+            AgentMessage::Llm(LlmMessage::Assistant(a)) => match &a.content[0] {
                 swink_agent::ContentBlock::Text { text } => text.clone(),
                 other => panic!("unexpected content block at {idx}: {other:?}"),
             },
-            other @ swink_agent::LlmMessage::ToolResult(_) => {
+            other => {
                 panic!("unexpected message type at {idx}: {other:?}")
             }
         }
@@ -157,7 +158,7 @@ fn append_performance_no_quadratic_regression() {
     }
     let last_100 = t2.elapsed();
 
-    let (_, loaded) = store.load("perf_guard").unwrap();
+    let (_, loaded) = store.load("perf_guard", None).unwrap();
     assert_eq!(loaded.len(), 200);
 
     // The last 100 appends operate on a larger file, so some slowdown is expected

--- a/tui/src/app/persistence.rs
+++ b/tui/src/app/persistence.rs
@@ -28,16 +28,7 @@ impl App {
             version: 1,
             sequence: 0,
         };
-        // Filter AgentMessages to LlmMessages for storage.
-        let llm_messages: Vec<LlmMessage> = state
-            .messages
-            .iter()
-            .filter_map(|m| match m {
-                AgentMessage::Llm(llm) => Some(llm.clone()),
-                AgentMessage::Custom(_) => None,
-            })
-            .collect();
-        let _ = store.save(&self.session_id, &meta, &llm_messages);
+        let _ = store.save(&self.session_id, &meta, &state.messages);
     }
 
     pub(super) fn save_session(&mut self) {
@@ -53,24 +44,24 @@ impl App {
             return;
         };
         info!(session_id = %id, "loading session");
-        match store.load(id) {
+        match store.load(id, None) {
             Ok((meta, messages)) => {
                 self.messages.clear();
                 for msg in &messages {
                     match msg {
-                        LlmMessage::User(user) => {
+                        AgentMessage::Llm(LlmMessage::User(user)) => {
                             self.messages.push(DisplayMessage::new(
                                 MessageRole::User,
                                 ContentBlock::extract_text(&user.content),
                             ));
                         }
-                        LlmMessage::Assistant(assistant) => {
+                        AgentMessage::Llm(LlmMessage::Assistant(assistant)) => {
                             self.messages.push(DisplayMessage::new(
                                 MessageRole::Assistant,
                                 ContentBlock::extract_text(&assistant.content),
                             ));
                         }
-                        LlmMessage::ToolResult(tool_result) => {
+                        AgentMessage::Llm(LlmMessage::ToolResult(tool_result)) => {
                             let content = ContentBlock::extract_text(&tool_result.content);
                             if !content.is_empty() {
                                 let summary = content
@@ -88,6 +79,9 @@ impl App {
                                 self.messages.push(dm);
                             }
                         }
+                        AgentMessage::Custom(_) => {
+                            // Custom messages are not displayed in the TUI
+                        }
                     }
                 }
                 self.session_id = id.to_string();
@@ -95,10 +89,7 @@ impl App {
                 self.conversation = ConversationView::new();
                 self.trim_messages_to_recent_turns();
                 if let Some(agent) = &mut self.agent {
-                    // Convert LlmMessages back to AgentMessages for the agent.
-                    let agent_messages: Vec<AgentMessage> =
-                        messages.into_iter().map(AgentMessage::Llm).collect();
-                    agent.set_messages(agent_messages);
+                    agent.set_messages(messages);
                 }
                 self.push_system_message(format!(
                     "Loaded session: {} ({} messages)",

--- a/tui/src/app/tests/input_ui.rs
+++ b/tui/src/app/tests/input_ui.rs
@@ -4,7 +4,6 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKi
 use ratatui::layout::Rect;
 use tempfile::tempdir;
 
-use swink_agent::LlmMessage;
 use swink_agent::testing::ScriptedStreamFn;
 
 use crate::config::TuiConfig;
@@ -203,14 +202,6 @@ async fn load_session_keeps_full_agent_state_but_trims_visible_history() {
         full_messages.push(make_user_agent_message(&format!("user {turn}")));
         full_messages.push(make_assistant_agent_message(&format!("assistant {turn}")));
     }
-    // Convert AgentMessages to LlmMessages for the store.
-    let llm_messages: Vec<LlmMessage> = full_messages
-        .iter()
-        .filter_map(|m| match m {
-            swink_agent::AgentMessage::Llm(llm) => Some(llm.clone()),
-            swink_agent::AgentMessage::Custom(_) => None,
-        })
-        .collect();
     let session_id = "session-1";
     let now = swink_agent_memory::now_utc();
     let meta = SessionMeta {
@@ -221,7 +212,7 @@ async fn load_session_keeps_full_agent_state_but_trims_visible_history() {
         version: 1,
         sequence: 0,
     };
-    store.save(session_id, &meta, &llm_messages).unwrap();
+    store.save(session_id, &meta, &full_messages).unwrap();
 
     let stream_fn = Arc::new(ScriptedStreamFn::new(vec![]));
     let agent = make_test_agent(stream_fn);


### PR DESCRIPTION
## Summary
- Unified `save`/`save_full` into a single `save(&self, id, meta, &[AgentMessage])` method and `load`/`load_full` into `load(&self, id, registry)` across `SessionStore`, `AsyncSessionStore`, and `JsonlSessionStore`
- Updated `append` to accept `&[AgentMessage]` instead of `&[LlmMessage]`
- Added dual-strategy parsing in `load()` to handle both raw `LlmMessage` format and tagged `SessionEntry` format for backward compatibility
- Updated `BlockingSessionStore` adapter with `clone_llm_messages` helper (filters Custom variants since `Box<dyn CustomMessage>` is not `Clone`)
- Updated all consumers: TUI persistence, tests (round_trip, corruption, stress_append, async_store)

Closes #48

## Test plan
- [x] All existing tests pass (`cargo test -p swink-agent-memory`)
- [x] Full workspace tests pass (`cargo test --workspace`)
- [x] `cargo test -p swink-agent --no-default-features` passes
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --check` passes
- [x] Backward compat: old-format JSONL files still load correctly
- [x] `rich_entries_roundtrip` test exercises dual-strategy parsing

🤖 Generated with [Claude Code](https://claude.com/claude-code)