### PR TITLE
impl(037): Add plugin contribution merge (Phase 3)

### DIFF
--- a/specs/037-plugin-system/tasks.md
+++ b/specs/037-plugin-system/tasks.md
@@ -47,17 +47,17 @@
 
 ### Tests for User Story 1
 
-- [ ] T009 [US1] Write test: plugin contributing a post-turn policy — verify policy evaluates during the loop in `tests/plugin_integration.rs`
-- [ ] T010 [P] [US1] Write test: plugin contributing tools — verify tools appear namespaced in agent tool list in `tests/plugin_integration.rs`
-- [ ] T011 [P] [US1] Write test: plugin with event observer — verify observer is called for AgentStart event in `tests/plugin_integration.rs`
+- [x] T009 [US1] Write test: plugin contributing a post-turn policy — verify policy evaluates during the loop in `tests/plugin_integration.rs`
+- [x] T010 [P] [US1] Write test: plugin contributing tools — verify tools appear namespaced in agent tool list in `tests/plugin_integration.rs`
+- [x] T011 [P] [US1] Write test: plugin with event observer — verify observer is called for AgentStart event in `tests/plugin_integration.rs`
 
 ### Implementation for User Story 1
 
-- [ ] T012 [US1] Implement `with_plugin()` and `with_plugins()` builder methods on `AgentOptions` in `src/agent_options.rs`
-- [ ] T013 [US1] Implement plugin contribution merge in `Agent::new()` — extract policies from each plugin (priority-sorted), prepend to policy vecs in `src/agent.rs`
-- [ ] T014 [US1] Implement plugin tool extraction in `Agent::new()` — wrap each tool in `NamespacedTool`, append to tools vec in `src/agent.rs`
-- [ ] T015 [US1] Implement plugin event observer integration in `Agent::new()` — convert `on_event` to `EventForwarderFn` closures, prepend to event_forwarders in `src/agent.rs`
-- [ ] T016 [US1] Propagate merged policies and tools through `build_loop_config()` in `src/agent/invoke.rs` (verify existing flow handles merged vecs)
+- [x] T012 [US1] Implement `with_plugin()` and `with_plugins()` builder methods on `AgentOptions` in `src/agent_options.rs`
+- [x] T013 [US1] Implement plugin contribution merge in `Agent::new()` — extract policies from each plugin (priority-sorted), prepend to policy vecs in `src/agent.rs`
+- [x] T014 [US1] Implement plugin tool extraction in `Agent::new()` — wrap each tool in `NamespacedTool`, append to tools vec in `src/agent.rs`
+- [x] T015 [US1] Implement plugin event observer integration in `Agent::new()` — convert `on_event` to `EventForwarderFn` closures, prepend to event_forwarders in `src/agent.rs`
+- [x] T016 [US1] Propagate merged policies and tools through `build_loop_config()` in `src/agent/invoke.rs` (verify existing flow handles merged vecs)
 
 **Checkpoint**: A plugin's policies, tools, and event observer all function correctly. Single-plugin registration is the MVP.
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -193,6 +193,10 @@ impl Agent {
     /// Create a new agent from the given options.
     #[must_use]
     pub fn new(options: AgentOptions) -> Self {
+        // Merge plugin contributions (policies, tools, event observers) into options.
+        #[cfg(feature = "plugins")]
+        let options = merge_plugin_contributions(options);
+
         let primary_model = options.model.clone();
         let primary_stream_fn = Arc::clone(&options.stream_fn);
         let mut available_models = vec![options.model.clone()];
@@ -307,6 +311,71 @@ impl std::fmt::Debug for Agent {
             .field("is_abort_active", &self.abort_controller.is_some())
             .finish_non_exhaustive()
     }
+}
+
+// ─── Plugin merge ───────────────────────────────────────────────────────────
+
+/// Sort plugins by priority and merge their policies, tools, and event
+/// observers into the `AgentOptions`. Plugin policies are prepended before
+/// directly-registered policies; plugin tools are appended after direct tools
+/// (namespaced with the plugin name); plugin event forwarders are prepended.
+#[cfg(feature = "plugins")]
+fn merge_plugin_contributions(mut options: AgentOptions) -> AgentOptions {
+    // Sort plugins by priority descending (stable sort preserves insertion order for ties).
+    options
+        .plugins
+        .sort_by_key(|p| std::cmp::Reverse(p.priority()));
+
+    let mut plugin_pre_turn: Vec<Arc<dyn crate::policy::PreTurnPolicy>> = Vec::new();
+    let mut plugin_pre_dispatch: Vec<Arc<dyn crate::policy::PreDispatchPolicy>> = Vec::new();
+    let mut plugin_post_turn: Vec<Arc<dyn crate::policy::PostTurnPolicy>> = Vec::new();
+    let mut plugin_post_loop: Vec<Arc<dyn crate::policy::PostLoopPolicy>> = Vec::new();
+    let mut plugin_tools: Vec<Arc<dyn AgentTool>> = Vec::new();
+    let mut plugin_forwarders: Vec<crate::event_forwarder::EventForwarderFn> = Vec::new();
+
+    for plugin in &options.plugins {
+        plugin_pre_turn.extend(plugin.pre_turn_policies());
+        plugin_pre_dispatch.extend(plugin.pre_dispatch_policies());
+        plugin_post_turn.extend(plugin.post_turn_policies());
+        plugin_post_loop.extend(plugin.post_loop_policies());
+
+        // Wrap plugin tools in NamespacedTool.
+        let plugin_name = plugin.name().to_owned();
+        for tool in plugin.tools() {
+            plugin_tools.push(Arc::new(crate::plugin::NamespacedTool::new(
+                &plugin_name,
+                tool,
+            )));
+        }
+
+        // Wrap plugin's on_event as EventForwarderFn.
+        let plugin_ref = Arc::clone(plugin);
+        plugin_forwarders.push(Arc::new(move |event: crate::loop_::AgentEvent| {
+            plugin_ref.on_event(&event);
+        }));
+    }
+
+    // Prepend plugin policies before direct policies.
+    plugin_pre_turn.append(&mut options.pre_turn_policies);
+    options.pre_turn_policies = plugin_pre_turn;
+
+    plugin_pre_dispatch.append(&mut options.pre_dispatch_policies);
+    options.pre_dispatch_policies = plugin_pre_dispatch;
+
+    plugin_post_turn.append(&mut options.post_turn_policies);
+    options.post_turn_policies = plugin_post_turn;
+
+    plugin_post_loop.append(&mut options.post_loop_policies);
+    options.post_loop_policies = plugin_post_loop;
+
+    // Append namespaced plugin tools after direct tools.
+    options.tools.extend(plugin_tools);
+
+    // Prepend plugin event forwarders before direct forwarders.
+    plugin_forwarders.append(&mut options.event_forwarders);
+    options.event_forwarders = plugin_forwarders;
+
+    options
 }
 
 // ─── SharedRetryStrategy ─────────────────────────────────────────────────────

--- a/tests/plugin_integration.rs
+++ b/tests/plugin_integration.rs
@@ -1,0 +1,225 @@
+#![cfg(feature = "plugins")]
+
+//! Integration tests for plugin contribution merge in Agent::new().
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+use serde_json::{Value, json};
+use tokio_util::sync::CancellationToken;
+
+use swink_agent::plugin::Plugin;
+use swink_agent::policy::{PolicyContext, PolicyVerdict, PostTurnPolicy, TurnPolicyContext};
+use swink_agent::tool::{AgentTool, AgentToolResult, ToolFuture};
+use swink_agent::{Agent, AgentOptions};
+
+mod common;
+use common::*;
+
+// ─── Test Helpers ──────────────────────────────────────────────────────────
+
+/// A plugin that contributes a post-turn policy which records when it fires.
+struct PolicyPlugin {
+    name: String,
+    fired: Arc<AtomicBool>,
+}
+
+impl PolicyPlugin {
+    fn new(name: &str, fired: Arc<AtomicBool>) -> Self {
+        Self {
+            name: name.to_owned(),
+            fired,
+        }
+    }
+}
+
+impl Plugin for PolicyPlugin {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn post_turn_policies(&self) -> Vec<Arc<dyn PostTurnPolicy>> {
+        let fired = Arc::clone(&self.fired);
+        vec![Arc::new(RecordingPostTurnPolicy { fired })]
+    }
+}
+
+struct RecordingPostTurnPolicy {
+    fired: Arc<AtomicBool>,
+}
+
+impl PostTurnPolicy for RecordingPostTurnPolicy {
+    fn name(&self) -> &str {
+        "recording-post-turn"
+    }
+
+    fn evaluate(&self, _ctx: &PolicyContext<'_>, _turn: &TurnPolicyContext<'_>) -> PolicyVerdict {
+        self.fired.store(true, Ordering::SeqCst);
+        PolicyVerdict::Continue
+    }
+}
+
+/// A simple tool for plugin contribution tests.
+struct PluginStubTool {
+    name: String,
+    schema: Value,
+}
+
+impl PluginStubTool {
+    fn new(name: &str) -> Self {
+        Self {
+            name: name.to_owned(),
+            schema: json!({"type": "object"}),
+        }
+    }
+}
+
+impl AgentTool for PluginStubTool {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn label(&self) -> &str {
+        &self.name
+    }
+
+    fn description(&self) -> &str {
+        "plugin stub tool"
+    }
+
+    fn parameters_schema(&self) -> &Value {
+        &self.schema
+    }
+
+    fn execute(
+        &self,
+        _tool_call_id: &str,
+        _params: Value,
+        _cancellation_token: CancellationToken,
+        _on_update: Option<Box<dyn Fn(AgentToolResult) + Send + Sync>>,
+        _state: Arc<std::sync::RwLock<swink_agent::SessionState>>,
+        _credential: Option<swink_agent::credential::ResolvedCredential>,
+    ) -> ToolFuture<'_> {
+        Box::pin(async { AgentToolResult::text("ok") })
+    }
+}
+
+/// A plugin that contributes tools.
+struct ToolPlugin {
+    name: String,
+    tool_names: Vec<String>,
+}
+
+impl ToolPlugin {
+    fn new(name: &str, tool_names: &[&str]) -> Self {
+        Self {
+            name: name.to_owned(),
+            tool_names: tool_names.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+}
+
+impl Plugin for ToolPlugin {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn tools(&self) -> Vec<Arc<dyn AgentTool>> {
+        self.tool_names
+            .iter()
+            .map(|n| Arc::new(PluginStubTool::new(n)) as Arc<dyn AgentTool>)
+            .collect()
+    }
+}
+
+/// A plugin that tracks event observer calls.
+struct EventPlugin {
+    name: String,
+    event_count: Arc<AtomicUsize>,
+}
+
+impl EventPlugin {
+    fn new(name: &str, event_count: Arc<AtomicUsize>) -> Self {
+        Self {
+            name: name.to_owned(),
+            event_count,
+        }
+    }
+}
+
+impl Plugin for EventPlugin {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn on_event(&self, _event: &swink_agent::AgentEvent) {
+        self.event_count.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+fn make_agent_with_plugins(plugins: Vec<Arc<dyn Plugin>>) -> Agent {
+    let stream_fn = Arc::new(MockStreamFn::new(vec![text_only_events("hello")]));
+    let options = AgentOptions::new("test", default_model(), stream_fn, default_convert)
+        .with_plugins(plugins);
+    Agent::new(options)
+}
+
+// ─── T009: Plugin contributing a post-turn policy ──────────────────────────
+
+#[tokio::test]
+async fn plugin_post_turn_policy_evaluates_during_loop() {
+    let fired = Arc::new(AtomicBool::new(false));
+    let plugin: Arc<dyn Plugin> = Arc::new(PolicyPlugin::new("test-policy", Arc::clone(&fired)));
+
+    let stream_fn = Arc::new(MockStreamFn::new(vec![text_only_events("hello")]));
+    let options =
+        AgentOptions::new("test", default_model(), stream_fn, default_convert).with_plugin(plugin);
+
+    let mut agent = Agent::new(options);
+    let _ = agent.prompt_async(vec![user_msg("hi")]).await;
+
+    assert!(
+        fired.load(Ordering::SeqCst),
+        "post-turn policy should have fired during the loop"
+    );
+}
+
+// ─── T010: Plugin contributing tools appear namespaced ─────────────────────
+
+#[test]
+fn plugin_tools_appear_namespaced_in_agent_tool_list() {
+    let plugin: Arc<dyn Plugin> = Arc::new(ToolPlugin::new("myplugin", &["save", "load"]));
+
+    let agent = make_agent_with_plugins(vec![plugin]);
+
+    let tool_names: Vec<&str> = agent.state().tools.iter().map(|t| t.name()).collect();
+    assert!(
+        tool_names.contains(&"myplugin.save"),
+        "expected namespaced tool 'myplugin.save', got: {tool_names:?}"
+    );
+    assert!(
+        tool_names.contains(&"myplugin.load"),
+        "expected namespaced tool 'myplugin.load', got: {tool_names:?}"
+    );
+}
+
+// ─── T011: Plugin event observer fires for AgentStart ──────────────────────
+
+#[tokio::test]
+async fn plugin_event_observer_called_for_agent_start() {
+    let event_count = Arc::new(AtomicUsize::new(0));
+    let plugin: Arc<dyn Plugin> = Arc::new(EventPlugin::new("observer", Arc::clone(&event_count)));
+
+    let stream_fn = Arc::new(MockStreamFn::new(vec![text_only_events("hello")]));
+    let options =
+        AgentOptions::new("test", default_model(), stream_fn, default_convert).with_plugin(plugin);
+
+    let mut agent = Agent::new(options);
+    let _ = agent.prompt_async(vec![user_msg("hi")]).await;
+
+    let count = event_count.load(Ordering::SeqCst);
+    assert!(
+        count > 0,
+        "event observer should have been called at least once, got {count}"
+    );
+}


### PR DESCRIPTION
## Summary
- Implement `merge_plugin_contributions()` in `src/agent.rs` that sorts plugins by priority (descending, stable), extracts policies/tools/events, prepends plugin policies before direct policies, appends namespaced tools after direct tools, and wraps `on_event` as `EventForwarderFn`
- Add 3 integration tests in `tests/plugin_integration.rs` verifying end-to-end plugin behavior
- T012 (`with_plugin`/`with_plugins`) was already done in Phase 1+2; T016 verified that `build_loop_config()` already clones merged vecs

## Tasks completed
- T009: Integration test — plugin contributing a post-turn policy fires during loop
- T010: Integration test — plugin tools appear namespaced in agent tool list
- T011: Integration test — plugin event observer fires for AgentStart event
- T012: `with_plugin()`/`with_plugins()` builders (already done in Phase 1+2)
- T013: Plugin policy merge in `Agent::new()` — priority-sorted, prepended
- T014: Plugin tool extraction — wrapped in `NamespacedTool`, appended
- T015: Plugin event observer → `EventForwarderFn` closure, prepended
- T016: Verified `build_loop_config()` propagates merged vecs (no changes needed)

## Test plan
- [x] `cargo test --workspace` passes
- [x] `cargo test -p swink-agent --no-default-features` passes
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] 3 new integration tests for plugin contribution merge

Part of #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)