### PR TITLE
impl(037): Add priority-based plugin execution order (Phase 4)

### DIFF
--- a/specs/037-plugin-system/tasks.md
+++ b/specs/037-plugin-system/tasks.md
@@ -71,14 +71,14 @@
 
 ### Tests for User Story 2
 
-- [ ] T017 [US2] Write test: two plugins with different priorities — verify higher priority policy runs first in `tests/plugin_integration.rs`
-- [ ] T018 [P] [US2] Write test: two plugins with same priority — verify insertion order preserved in `tests/plugin_integration.rs`
-- [ ] T019 [P] [US2] Write test: higher-priority plugin returns Stop — verify lower-priority plugin's policy is not evaluated (short-circuit) in `tests/plugin_integration.rs`
+- [x] T017 [US2] Write test: two plugins with different priorities — verify higher priority policy runs first in `tests/plugin_integration.rs`
+- [x] T018 [P] [US2] Write test: two plugins with same priority — verify insertion order preserved in `tests/plugin_integration.rs`
+- [x] T019 [P] [US2] Write test: higher-priority plugin returns Stop — verify lower-priority plugin's policy is not evaluated (short-circuit) in `tests/plugin_integration.rs`
 
 ### Implementation for User Story 2
 
-- [ ] T020 [US2] Ensure `Agent::new()` sorts plugins by priority (descending, stable) before extracting contributions in `src/agent.rs`
-- [ ] T021 [US2] Verify short-circuit semantics work across merged policy list (plugin + direct policies) — no changes to `src/policy.rs` expected, add test to confirm
+- [x] T020 [US2] Ensure `Agent::new()` sorts plugins by priority (descending, stable) before extracting contributions in `src/agent.rs`
+- [x] T021 [US2] Verify short-circuit semantics work across merged policy list (plugin + direct policies) — no changes to `src/policy.rs` expected, add test to confirm
 
 **Checkpoint**: Multi-plugin priority ordering is deterministic and short-circuit works across the merged list.
 

--- a/tests/plugin_integration.rs
+++ b/tests/plugin_integration.rs
@@ -9,7 +9,9 @@ use serde_json::{Value, json};
 use tokio_util::sync::CancellationToken;
 
 use swink_agent::plugin::Plugin;
-use swink_agent::policy::{PolicyContext, PolicyVerdict, PostTurnPolicy, TurnPolicyContext};
+use swink_agent::policy::{
+    PolicyContext, PolicyVerdict, PostTurnPolicy, PreTurnPolicy, TurnPolicyContext,
+};
 use swink_agent::tool::{AgentTool, AgentToolResult, ToolFuture};
 use swink_agent::{Agent, AgentOptions};
 
@@ -221,5 +223,259 @@ async fn plugin_event_observer_called_for_agent_start() {
     assert!(
         count > 0,
         "event observer should have been called at least once, got {count}"
+    );
+}
+
+// ─── Phase 4 Helpers: Priority-Based Execution Order ─────────────────────
+
+/// Shared counter to track policy evaluation order across plugins.
+static GLOBAL_ORDER: AtomicUsize = AtomicUsize::new(0);
+
+/// A pre-turn policy that records its execution order.
+struct OrderRecordingPreTurnPolicy {
+    label: String,
+    order: Arc<AtomicUsize>,
+}
+
+impl PreTurnPolicy for OrderRecordingPreTurnPolicy {
+    fn name(&self) -> &str {
+        &self.label
+    }
+
+    fn evaluate(&self, _ctx: &PolicyContext<'_>) -> PolicyVerdict {
+        let seq = GLOBAL_ORDER.fetch_add(1, Ordering::SeqCst);
+        self.order.store(seq, Ordering::SeqCst);
+        PolicyVerdict::Continue
+    }
+}
+
+/// A pre-turn policy that returns Stop to test short-circuit behavior.
+struct StoppingPreTurnPolicy {
+    label: String,
+}
+
+impl PreTurnPolicy for StoppingPreTurnPolicy {
+    fn name(&self) -> &str {
+        &self.label
+    }
+
+    fn evaluate(&self, _ctx: &PolicyContext<'_>) -> PolicyVerdict {
+        PolicyVerdict::Stop("stopped by policy".into())
+    }
+}
+
+/// A plugin that contributes a pre-turn policy recording its execution order.
+struct OrderedPolicyPlugin {
+    name: String,
+    priority: i32,
+    order: Arc<AtomicUsize>,
+}
+
+impl OrderedPolicyPlugin {
+    fn new(name: &str, priority: i32, order: Arc<AtomicUsize>) -> Self {
+        Self {
+            name: name.to_owned(),
+            priority,
+            order,
+        }
+    }
+}
+
+impl Plugin for OrderedPolicyPlugin {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn priority(&self) -> i32 {
+        self.priority
+    }
+
+    fn pre_turn_policies(&self) -> Vec<Arc<dyn PreTurnPolicy>> {
+        vec![Arc::new(OrderRecordingPreTurnPolicy {
+            label: format!("{}-pre-turn", self.name),
+            order: Arc::clone(&self.order),
+        })]
+    }
+}
+
+/// A plugin that contributes a stopping pre-turn policy.
+struct StoppingPolicyPlugin {
+    name: String,
+    priority: i32,
+}
+
+impl StoppingPolicyPlugin {
+    fn new(name: &str, priority: i32) -> Self {
+        Self {
+            name: name.to_owned(),
+            priority,
+        }
+    }
+}
+
+impl Plugin for StoppingPolicyPlugin {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn priority(&self) -> i32 {
+        self.priority
+    }
+
+    fn pre_turn_policies(&self) -> Vec<Arc<dyn PreTurnPolicy>> {
+        vec![Arc::new(StoppingPreTurnPolicy {
+            label: format!("{}-stopping", self.name),
+        })]
+    }
+}
+
+// ─── T017: Two plugins with different priorities ─────────────────────────
+
+#[tokio::test]
+async fn higher_priority_plugin_policy_runs_first() {
+    // Reset global counter for this test.
+    GLOBAL_ORDER.store(0, Ordering::SeqCst);
+
+    let low_order = Arc::new(AtomicUsize::new(usize::MAX));
+    let high_order = Arc::new(AtomicUsize::new(usize::MAX));
+
+    let low_plugin: Arc<dyn Plugin> =
+        Arc::new(OrderedPolicyPlugin::new("low", 1, Arc::clone(&low_order)));
+    let high_plugin: Arc<dyn Plugin> = Arc::new(OrderedPolicyPlugin::new(
+        "high",
+        10,
+        Arc::clone(&high_order),
+    ));
+
+    // Register low first, high second — priority should override insertion order.
+    let stream_fn = Arc::new(MockStreamFn::new(vec![text_only_events("hello")]));
+    let options = AgentOptions::new("test", default_model(), stream_fn, default_convert)
+        .with_plugins(vec![low_plugin, high_plugin]);
+
+    let mut agent = Agent::new(options);
+    let _ = agent.prompt_async(vec![user_msg("hi")]).await;
+
+    let high_seq = high_order.load(Ordering::SeqCst);
+    let low_seq = low_order.load(Ordering::SeqCst);
+
+    assert!(
+        high_seq < low_seq,
+        "high-priority plugin should run first: high={high_seq}, low={low_seq}"
+    );
+}
+
+// ─── T018: Two plugins with same priority — insertion order preserved ────
+
+#[tokio::test]
+async fn same_priority_plugins_preserve_insertion_order() {
+    GLOBAL_ORDER.store(0, Ordering::SeqCst);
+
+    let first_order = Arc::new(AtomicUsize::new(usize::MAX));
+    let second_order = Arc::new(AtomicUsize::new(usize::MAX));
+
+    let first_plugin: Arc<dyn Plugin> = Arc::new(OrderedPolicyPlugin::new(
+        "first",
+        0,
+        Arc::clone(&first_order),
+    ));
+    let second_plugin: Arc<dyn Plugin> = Arc::new(OrderedPolicyPlugin::new(
+        "second",
+        0,
+        Arc::clone(&second_order),
+    ));
+
+    let stream_fn = Arc::new(MockStreamFn::new(vec![text_only_events("hello")]));
+    let options = AgentOptions::new("test", default_model(), stream_fn, default_convert)
+        .with_plugins(vec![first_plugin, second_plugin]);
+
+    let mut agent = Agent::new(options);
+    let _ = agent.prompt_async(vec![user_msg("hi")]).await;
+
+    let first_seq = first_order.load(Ordering::SeqCst);
+    let second_seq = second_order.load(Ordering::SeqCst);
+
+    assert!(
+        first_seq < second_seq,
+        "first-registered plugin should run first when priorities are equal: first={first_seq}, second={second_seq}"
+    );
+}
+
+// ─── T019: Higher-priority Stop prevents lower-priority evaluation ───────
+
+#[tokio::test]
+async fn higher_priority_stop_short_circuits_lower_priority() {
+    GLOBAL_ORDER.store(0, Ordering::SeqCst);
+
+    let low_order = Arc::new(AtomicUsize::new(usize::MAX));
+
+    // High-priority plugin returns Stop.
+    let high_plugin: Arc<dyn Plugin> = Arc::new(StoppingPolicyPlugin::new("blocker", 10));
+    // Low-priority plugin should never run.
+    let low_plugin: Arc<dyn Plugin> = Arc::new(OrderedPolicyPlugin::new(
+        "victim",
+        1,
+        Arc::clone(&low_order),
+    ));
+
+    let stream_fn = Arc::new(MockStreamFn::new(vec![text_only_events("hello")]));
+    let options = AgentOptions::new("test", default_model(), stream_fn, default_convert)
+        .with_plugins(vec![low_plugin, high_plugin]);
+
+    let mut agent = Agent::new(options);
+    let result = agent.prompt_async(vec![user_msg("hi")]).await.unwrap();
+
+    // The low-priority plugin's policy should not have been evaluated.
+    let low_seq = low_order.load(Ordering::SeqCst);
+    assert_eq!(
+        low_seq,
+        usize::MAX,
+        "low-priority plugin policy should not have run after Stop, but got order={low_seq}"
+    );
+
+    // Agent should have produced no assistant messages (stopped before LLM call).
+    assert!(
+        result.messages.is_empty(),
+        "expected no messages after pre-turn Stop, got {}",
+        result.messages.len()
+    );
+}
+
+// ─── T021: Short-circuit across merged list (plugin + direct policies) ───
+
+#[tokio::test]
+async fn plugin_stop_prevents_direct_policy_evaluation() {
+    let direct_fired = Arc::new(AtomicBool::new(false));
+    let direct_fired_clone = Arc::clone(&direct_fired);
+
+    // Direct pre-turn policy that records whether it fired.
+    struct DirectPreTurnPolicy {
+        fired: Arc<AtomicBool>,
+    }
+    impl PreTurnPolicy for DirectPreTurnPolicy {
+        fn name(&self) -> &str {
+            "direct-pre-turn"
+        }
+        fn evaluate(&self, _ctx: &PolicyContext<'_>) -> PolicyVerdict {
+            self.fired.store(true, Ordering::SeqCst);
+            PolicyVerdict::Continue
+        }
+    }
+
+    // Plugin with Stop policy (priority 10 — runs before direct policies).
+    let stopping_plugin: Arc<dyn Plugin> = Arc::new(StoppingPolicyPlugin::new("blocker", 10));
+
+    let stream_fn = Arc::new(MockStreamFn::new(vec![text_only_events("hello")]));
+    let options = AgentOptions::new("test", default_model(), stream_fn, default_convert)
+        .with_plugin(stopping_plugin)
+        .with_pre_turn_policy(DirectPreTurnPolicy {
+            fired: direct_fired_clone,
+        });
+
+    let mut agent = Agent::new(options);
+    let _ = agent.prompt_async(vec![user_msg("hi")]).await;
+
+    assert!(
+        !direct_fired.load(Ordering::SeqCst),
+        "direct pre-turn policy should not fire after plugin Stop verdict"
     );
 }


### PR DESCRIPTION
## Summary
- Adds 4 integration tests verifying priority-based plugin execution order (T017-T019, T021)
- Confirms existing sort-by-priority implementation in `merge_plugin_contributions` is correct (T020)
- Tests cover: higher priority runs first, stable sort preserves insertion order, Stop verdict short-circuits lower-priority plugins, and plugin Stop prevents direct policy evaluation

## Tasks completed
- T017: Test two plugins with different priorities — higher priority runs first
- T018: Test two plugins with same priority — insertion order preserved
- T019: Test higher-priority Stop short-circuits lower-priority evaluation
- T020: Verified `Agent::new()` already sorts by priority descending (stable)
- T021: Test plugin Stop verdict prevents direct policy evaluation

## Test plan
- [x] `cargo test --workspace` passes (0 failures)
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test -p swink-agent --no-default-features` passes
- [x] No public API changes — test-only additions

Part of #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)