### PR TITLE
fix: enforce single terminal event in accumulate_message

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -361,8 +361,32 @@ pub fn accumulate_message(
     let mut cost: Option<Cost> = None;
     let mut error_message: Option<String> = None;
     let mut saw_start = false;
+    let mut saw_terminal = false;
 
     for event in events {
+        // Reject content-block events after a terminal event.
+        match &event {
+            AssistantMessageEvent::TextStart { .. }
+            | AssistantMessageEvent::TextDelta { .. }
+            | AssistantMessageEvent::TextEnd { .. }
+            | AssistantMessageEvent::ThinkingStart { .. }
+            | AssistantMessageEvent::ThinkingDelta { .. }
+            | AssistantMessageEvent::ThinkingEnd { .. }
+            | AssistantMessageEvent::ToolCallStart { .. }
+            | AssistantMessageEvent::ToolCallDelta { .. }
+            | AssistantMessageEvent::ToolCallEnd { .. } => {
+                if saw_terminal {
+                    return Err("content event after terminal event".into());
+                }
+            }
+            AssistantMessageEvent::Done { .. } | AssistantMessageEvent::Error { .. } => {
+                if saw_terminal {
+                    return Err("duplicate terminal event".into());
+                }
+            }
+            AssistantMessageEvent::Start => {}
+        }
+
         match event {
             AssistantMessageEvent::Start => {
                 if saw_start {
@@ -546,6 +570,7 @@ pub fn accumulate_message(
                 stop_reason = Some(sr);
                 usage = Some(u);
                 cost = Some(c);
+                saw_terminal = true;
             }
 
             AssistantMessageEvent::Error {
@@ -559,6 +584,7 @@ pub fn accumulate_message(
                 if let Some(u) = u {
                     usage = Some(u);
                 }
+                saw_terminal = true;
             }
         }
     }

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -513,3 +513,134 @@ fn assistant_message_delta_variants() {
         }
     ));
 }
+
+// ── Terminal event enforcement ──
+
+#[test]
+fn duplicate_done_rejected() {
+    let events = vec![
+        AssistantMessageEvent::Start,
+        AssistantMessageEvent::TextStart { content_index: 0 },
+        AssistantMessageEvent::TextDelta {
+            content_index: 0,
+            delta: "hello".into(),
+        },
+        AssistantMessageEvent::TextEnd { content_index: 0 },
+        AssistantMessageEvent::Done {
+            stop_reason: StopReason::Stop,
+            usage: Usage::default(),
+            cost: Cost::default(),
+        },
+        AssistantMessageEvent::Done {
+            stop_reason: StopReason::Stop,
+            usage: Usage::default(),
+            cost: Cost::default(),
+        },
+    ];
+    let result = accumulate_message(events, "p", "m");
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("duplicate terminal"));
+}
+
+#[test]
+fn duplicate_error_rejected() {
+    let events = vec![
+        AssistantMessageEvent::Start,
+        AssistantMessageEvent::Error {
+            stop_reason: StopReason::Error,
+            error_message: "first".into(),
+            usage: None,
+            error_kind: None,
+        },
+        AssistantMessageEvent::Error {
+            stop_reason: StopReason::Error,
+            error_message: "second".into(),
+            usage: None,
+            error_kind: None,
+        },
+    ];
+    let result = accumulate_message(events, "p", "m");
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("duplicate terminal"));
+}
+
+#[test]
+fn content_after_done_rejected() {
+    let events = vec![
+        AssistantMessageEvent::Start,
+        AssistantMessageEvent::Done {
+            stop_reason: StopReason::Stop,
+            usage: Usage::default(),
+            cost: Cost::default(),
+        },
+        AssistantMessageEvent::TextDelta {
+            content_index: 0,
+            delta: "late".into(),
+        },
+    ];
+    let result = accumulate_message(events, "p", "m");
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("after terminal"));
+}
+
+#[test]
+fn content_after_error_rejected() {
+    let events = vec![
+        AssistantMessageEvent::Start,
+        AssistantMessageEvent::Error {
+            stop_reason: StopReason::Error,
+            error_message: "oops".into(),
+            usage: None,
+            error_kind: None,
+        },
+        AssistantMessageEvent::TextDelta {
+            content_index: 0,
+            delta: "late".into(),
+        },
+    ];
+    let result = accumulate_message(events, "p", "m");
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("after terminal"));
+}
+
+#[test]
+fn done_then_error_rejected() {
+    let events = vec![
+        AssistantMessageEvent::Start,
+        AssistantMessageEvent::Done {
+            stop_reason: StopReason::Stop,
+            usage: Usage::default(),
+            cost: Cost::default(),
+        },
+        AssistantMessageEvent::Error {
+            stop_reason: StopReason::Error,
+            error_message: "late error".into(),
+            usage: None,
+            error_kind: None,
+        },
+    ];
+    let result = accumulate_message(events, "p", "m");
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("duplicate terminal"));
+}
+
+#[test]
+fn error_then_done_rejected() {
+    let events = vec![
+        AssistantMessageEvent::Start,
+        AssistantMessageEvent::Error {
+            stop_reason: StopReason::Error,
+            error_message: "error first".into(),
+            usage: None,
+            error_kind: None,
+        },
+        AssistantMessageEvent::Done {
+            stop_reason: StopReason::Stop,
+            usage: Usage::default(),
+            cost: Cost::default(),
+        },
+    ];
+    let result = accumulate_message(events, "p", "m");
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("duplicate terminal"));
+}


### PR DESCRIPTION
## Summary
- Add state machine tracking to `accumulate_message` that rejects duplicate terminal events (Done/Error) and content-block events after terminal
- Hardens the streaming protocol boundary between adapters and the core harness
- 6 new regression tests for terminal event enforcement

## Test plan
- [x] cargo test --workspace passes
- [x] cargo clippy --workspace -- -D warnings clean
- [x] cargo test -p swink-agent --no-default-features passes
- [x] No public API breakage

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)