### PR TITLE
fix: Make CheckpointPolicy persist truthful snapshots

### DIFF
--- a/policies/src/audit_logger.rs
+++ b/policies/src/audit_logger.rs
@@ -259,10 +259,15 @@ mod tests {
         let cost = Cost::default();
         let state = swink_agent::SessionState::new();
         let ctx = make_ctx(&usage, &cost, &state);
+        static MODEL: std::sync::LazyLock<swink_agent::ModelSpec> =
+            std::sync::LazyLock::new(|| swink_agent::ModelSpec::new("test", "test-model"));
         let turn = TurnPolicyContext {
             assistant_message: &msg,
             tool_results: &[],
             stop_reason: StopReason::Stop,
+            system_prompt: "",
+            model_spec: &MODEL,
+            context_messages: &[],
         };
 
         let verdict = logger.evaluate(&ctx, &turn);
@@ -282,10 +287,15 @@ mod tests {
         let cost = Cost::default();
         let state = swink_agent::SessionState::new();
         let ctx = make_ctx(&usage, &cost, &state);
+        static MODEL: std::sync::LazyLock<swink_agent::ModelSpec> =
+            std::sync::LazyLock::new(|| swink_agent::ModelSpec::new("test", "test-model"));
         let turn = TurnPolicyContext {
             assistant_message: &msg,
             tool_results: &[],
             stop_reason: StopReason::Stop,
+            system_prompt: "",
+            model_spec: &MODEL,
+            context_messages: &[],
         };
 
         logger.evaluate(&ctx, &turn);
@@ -324,10 +334,15 @@ mod tests {
         let cost = Cost::default();
         let state = swink_agent::SessionState::new();
         let ctx = make_ctx(&usage, &cost, &state);
+        static MODEL2: std::sync::LazyLock<swink_agent::ModelSpec> =
+            std::sync::LazyLock::new(|| swink_agent::ModelSpec::new("test", "test-model"));
         let turn = TurnPolicyContext {
             assistant_message: &msg,
             tool_results: &[],
             stop_reason: StopReason::ToolUse,
+            system_prompt: "",
+            model_spec: &MODEL2,
+            context_messages: &[],
         };
 
         logger.evaluate(&ctx, &turn);

--- a/policies/src/checkpoint.rs
+++ b/policies/src/checkpoint.rs
@@ -11,9 +11,11 @@ use swink_agent::{
 
 /// Persists agent state after each turn via a [`CheckpointStore`].
 ///
-/// Uses `tokio::spawn` (fire-and-forget) to avoid blocking the sync
-/// policy evaluation loop. Captures a `tokio::runtime::Handle` at
-/// construction time.
+/// Uses `tokio::spawn` to avoid blocking the sync policy evaluation loop.
+/// Captures a `tokio::runtime::Handle` at construction time.
+///
+/// The checkpoint includes the real system prompt, model identity, and full
+/// message history from the turn context.
 ///
 /// Always returns [`PolicyVerdict::Continue`] — persistence is a side effect.
 ///
@@ -63,13 +65,13 @@ impl PostTurnPolicy for CheckpointPolicy {
         "checkpoint"
     }
 
-    fn evaluate(&self, ctx: &PolicyContext<'_>, _turn: &TurnPolicyContext<'_>) -> PolicyVerdict {
+    fn evaluate(&self, ctx: &PolicyContext<'_>, turn: &TurnPolicyContext<'_>) -> PolicyVerdict {
         let checkpoint = Checkpoint::new(
             format!("turn-{}", ctx.turn_index),
-            String::new(), // system_prompt not available in PolicyContext
-            String::new(), // provider
-            String::new(), // model_id
-            &[],           // messages snapshot not available in PolicyContext
+            turn.system_prompt,
+            &turn.model_spec.provider,
+            &turn.model_spec.model_id,
+            turn.context_messages,
         )
         .with_turn_count(ctx.turn_index)
         .with_usage(ctx.accumulated_usage.clone())
@@ -91,7 +93,7 @@ mod tests {
     use super::*;
     use std::collections::HashMap;
 
-    use swink_agent::{AssistantMessage, Cost, StopReason, Usage};
+    use swink_agent::{AgentMessage, AssistantMessage, Cost, ModelSpec, StopReason, Usage};
 
     /// Minimal in-memory checkpoint store for testing.
     struct MockCheckpointStore {
@@ -103,6 +105,11 @@ mod tests {
             Self {
                 data: std::sync::Mutex::new(HashMap::new()),
             }
+        }
+
+        fn get(&self, id: &str) -> Option<Checkpoint> {
+            let guard = self.data.lock().unwrap();
+            guard.get(id).map(|s| serde_json::from_str(s).unwrap())
         }
     }
 
@@ -137,6 +144,40 @@ mod tests {
         }
     }
 
+    fn sample_model_spec() -> ModelSpec {
+        ModelSpec::new("anthropic", "claude-sonnet-4-20250514")
+    }
+
+    fn sample_assistant_message() -> AssistantMessage {
+        AssistantMessage {
+            content: vec![swink_agent::ContentBlock::Text {
+                text: "Hello!".to_string(),
+            }],
+            provider: "anthropic".to_string(),
+            model_id: "claude-sonnet-4-20250514".to_string(),
+            usage: Usage::default(),
+            cost: Cost::default(),
+            stop_reason: StopReason::Stop,
+            error_message: None,
+            timestamp: 0,
+            cache_hint: None,
+        }
+    }
+
+    fn sample_messages() -> Vec<AgentMessage> {
+        use swink_agent::{ContentBlock, LlmMessage, UserMessage};
+        vec![
+            AgentMessage::Llm(LlmMessage::User(UserMessage {
+                content: vec![ContentBlock::Text {
+                    text: "What is 2+2?".to_string(),
+                }],
+                timestamp: 100,
+                cache_hint: None,
+            })),
+            AgentMessage::Llm(LlmMessage::Assistant(sample_assistant_message())),
+        ]
+    }
+
     #[test]
     fn name_returns_checkpoint() {
         let rt = tokio::runtime::Runtime::new().unwrap();
@@ -167,24 +208,197 @@ mod tests {
             new_messages: &[],
             state: &state,
         };
-        let msg = AssistantMessage {
-            content: vec![],
-            provider: String::new(),
-            model_id: String::new(),
-            usage: Usage::default(),
-            cost: Cost::default(),
-            stop_reason: StopReason::Stop,
-            error_message: None,
-            timestamp: 0,
-            cache_hint: None,
-        };
+        let msg = sample_assistant_message();
+        let model = sample_model_spec();
+        let messages = sample_messages();
         let turn = TurnPolicyContext {
             assistant_message: &msg,
             tool_results: &[],
             stop_reason: StopReason::Stop,
+            system_prompt: "Be helpful.",
+            model_spec: &model,
+            context_messages: &messages,
         };
 
         let result = policy.evaluate(&ctx, &turn);
         assert!(matches!(result, PolicyVerdict::Continue));
+    }
+
+    #[tokio::test]
+    async fn checkpoint_contains_system_prompt() {
+        let store = Arc::new(MockCheckpointStore::new());
+        let policy = CheckpointPolicy::new(store.clone() as Arc<dyn CheckpointStore>);
+
+        let usage = Usage::default();
+        let cost = Cost::default();
+        let state = swink_agent::SessionState::new();
+        let ctx = PolicyContext {
+            turn_index: 0,
+            accumulated_usage: &usage,
+            accumulated_cost: &cost,
+            message_count: 2,
+            overflow_signal: false,
+            new_messages: &[],
+            state: &state,
+        };
+        let msg = sample_assistant_message();
+        let model = sample_model_spec();
+        let messages = sample_messages();
+        let turn = TurnPolicyContext {
+            assistant_message: &msg,
+            tool_results: &[],
+            stop_reason: StopReason::Stop,
+            system_prompt: "You are a helpful math tutor.",
+            model_spec: &model,
+            context_messages: &messages,
+        };
+
+        policy.evaluate(&ctx, &turn);
+        // Let spawned task complete
+        tokio::task::yield_now().await;
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let cp = store.get("turn-0").expect("checkpoint should exist");
+        assert_eq!(cp.system_prompt, "You are a helpful math tutor.");
+    }
+
+    #[tokio::test]
+    async fn checkpoint_contains_model_identity() {
+        let store = Arc::new(MockCheckpointStore::new());
+        let policy = CheckpointPolicy::new(store.clone() as Arc<dyn CheckpointStore>);
+
+        let usage = Usage::default();
+        let cost = Cost::default();
+        let state = swink_agent::SessionState::new();
+        let ctx = PolicyContext {
+            turn_index: 1,
+            accumulated_usage: &usage,
+            accumulated_cost: &cost,
+            message_count: 2,
+            overflow_signal: false,
+            new_messages: &[],
+            state: &state,
+        };
+        let msg = sample_assistant_message();
+        let model = sample_model_spec();
+        let messages = sample_messages();
+        let turn = TurnPolicyContext {
+            assistant_message: &msg,
+            tool_results: &[],
+            stop_reason: StopReason::Stop,
+            system_prompt: "prompt",
+            model_spec: &model,
+            context_messages: &messages,
+        };
+
+        policy.evaluate(&ctx, &turn);
+        tokio::task::yield_now().await;
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let cp = store.get("turn-1").expect("checkpoint should exist");
+        assert_eq!(cp.provider, "anthropic");
+        assert_eq!(cp.model_id, "claude-sonnet-4-20250514");
+    }
+
+    #[tokio::test]
+    async fn checkpoint_contains_message_history() {
+        let store = Arc::new(MockCheckpointStore::new());
+        let policy = CheckpointPolicy::new(store.clone() as Arc<dyn CheckpointStore>);
+
+        let usage = Usage::default();
+        let cost = Cost::default();
+        let state = swink_agent::SessionState::new();
+        let ctx = PolicyContext {
+            turn_index: 0,
+            accumulated_usage: &usage,
+            accumulated_cost: &cost,
+            message_count: 2,
+            overflow_signal: false,
+            new_messages: &[],
+            state: &state,
+        };
+        let msg = sample_assistant_message();
+        let model = sample_model_spec();
+        let messages = sample_messages();
+        let turn = TurnPolicyContext {
+            assistant_message: &msg,
+            tool_results: &[],
+            stop_reason: StopReason::Stop,
+            system_prompt: "prompt",
+            model_spec: &model,
+            context_messages: &messages,
+        };
+
+        policy.evaluate(&ctx, &turn);
+        tokio::task::yield_now().await;
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let cp = store.get("turn-0").expect("checkpoint should exist");
+        assert_eq!(
+            cp.messages.len(),
+            2,
+            "should contain both user and assistant messages"
+        );
+    }
+
+    #[tokio::test]
+    async fn checkpoint_roundtrip_save_load() {
+        let store = Arc::new(MockCheckpointStore::new());
+        let policy = CheckpointPolicy::new(store.clone() as Arc<dyn CheckpointStore>);
+
+        let usage = Usage {
+            input: 100,
+            output: 50,
+            ..Default::default()
+        };
+        let cost = Cost {
+            input: 0.01,
+            output: 0.005,
+            ..Default::default()
+        };
+        let state = swink_agent::SessionState::new();
+        let ctx = PolicyContext {
+            turn_index: 3,
+            accumulated_usage: &usage,
+            accumulated_cost: &cost,
+            message_count: 2,
+            overflow_signal: false,
+            new_messages: &[],
+            state: &state,
+        };
+        let msg = sample_assistant_message();
+        let model = sample_model_spec();
+        let messages = sample_messages();
+        let turn = TurnPolicyContext {
+            assistant_message: &msg,
+            tool_results: &[],
+            stop_reason: StopReason::Stop,
+            system_prompt: "You are a math tutor.",
+            model_spec: &model,
+            context_messages: &messages,
+        };
+
+        policy.evaluate(&ctx, &turn);
+        tokio::task::yield_now().await;
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        // Load via the CheckpointStore trait
+        let loaded = store
+            .load_checkpoint("turn-3")
+            .await
+            .expect("load should succeed")
+            .expect("checkpoint should exist");
+
+        assert_eq!(loaded.system_prompt, "You are a math tutor.");
+        assert_eq!(loaded.provider, "anthropic");
+        assert_eq!(loaded.model_id, "claude-sonnet-4-20250514");
+        assert_eq!(loaded.messages.len(), 2);
+        assert_eq!(loaded.turn_count, 3);
+        assert_eq!(loaded.usage.input, 100);
+        assert_eq!(loaded.usage.output, 50);
+
+        // Restore messages and verify content
+        let restored = loaded.restore_messages(None);
+        assert_eq!(restored.len(), 2);
     }
 }

--- a/policies/src/content_filter.rs
+++ b/policies/src/content_filter.rs
@@ -312,10 +312,15 @@ mod tests {
     }
 
     fn make_turn_ctx(msg: &AssistantMessage) -> TurnPolicyContext<'_> {
+        static MODEL: std::sync::LazyLock<swink_agent::ModelSpec> =
+            std::sync::LazyLock::new(|| swink_agent::ModelSpec::new("test", "test-model"));
         TurnPolicyContext {
             assistant_message: msg,
             tool_results: &[],
             stop_reason: StopReason::Stop,
+            system_prompt: "",
+            model_spec: &MODEL,
+            context_messages: &[],
         }
     }
 

--- a/policies/src/loop_detection.rs
+++ b/policies/src/loop_detection.rs
@@ -173,10 +173,15 @@ mod tests {
         msg: &'a AssistantMessage,
         results: &'a [swink_agent::ToolResultMessage],
     ) -> TurnPolicyContext<'a> {
+        static MODEL: std::sync::LazyLock<swink_agent::ModelSpec> =
+            std::sync::LazyLock::new(|| swink_agent::ModelSpec::new("test", "test-model"));
         TurnPolicyContext {
             assistant_message: msg,
             tool_results: results,
             stop_reason: StopReason::Stop,
+            system_prompt: "",
+            model_spec: &MODEL,
+            context_messages: &[],
         }
     }
 

--- a/policies/src/pii_redactor.rs
+++ b/policies/src/pii_redactor.rs
@@ -205,10 +205,15 @@ mod tests {
             new_messages: &[],
             state: &state,
         };
+        static MODEL: std::sync::LazyLock<swink_agent::ModelSpec> =
+            std::sync::LazyLock::new(|| swink_agent::ModelSpec::new("test", "test-model"));
         let turn = TurnPolicyContext {
             assistant_message: &msg,
             tool_results: &results,
             stop_reason: StopReason::Stop,
+            system_prompt: "",
+            model_spec: &MODEL,
+            context_messages: &[],
         };
         policy.evaluate(&ctx, &turn)
     }

--- a/policies/src/prompt_guard.rs
+++ b/policies/src/prompt_guard.rs
@@ -210,10 +210,15 @@ mod tests {
         assistant: &'a AssistantMessage,
         tool_results: &'a [ToolResultMessage],
     ) -> TurnPolicyContext<'a> {
+        static MODEL: std::sync::LazyLock<swink_agent::ModelSpec> =
+            std::sync::LazyLock::new(|| swink_agent::ModelSpec::new("test", "test-model"));
         TurnPolicyContext {
             assistant_message: assistant,
             tool_results,
             stop_reason: StopReason::Stop,
+            system_prompt: "",
+            model_spec: &MODEL,
+            context_messages: &[],
         }
     }
 

--- a/policies/tests/composition.rs
+++ b/policies/tests/composition.rs
@@ -80,10 +80,14 @@ fn all_policies_compose() {
     // PostTurn: all policies evaluate without interference
     let msg = make_assistant_msg("This is a clean response with no PII or blocked terms.");
     let tool_results: Vec<ToolResultMessage> = vec![];
+    let model = swink_agent::ModelSpec::new("test", "test-model");
     let turn_ctx = TurnPolicyContext {
         assistant_message: &msg,
         tool_results: &tool_results,
         stop_reason: StopReason::Stop,
+        system_prompt: "",
+        model_spec: &model,
+        context_messages: &[],
     };
 
     assert!(matches!(

--- a/src/loop_/mod.rs
+++ b/src/loop_/mod.rs
@@ -197,6 +197,9 @@ async fn run_loop_inner(
                         assistant_message: msg,
                         tool_results: &state.last_tool_results,
                         stop_reason: msg.stop_reason,
+                        system_prompt: &system_prompt,
+                        model_spec: &config.model,
+                        context_messages: &state.context_messages,
                     };
                     match run_post_turn_policies(&config.post_turn_policies, &policy_ctx, &turn_ctx)
                     {

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -22,7 +22,9 @@ use std::sync::Arc;
 
 use tracing::{debug, warn};
 
-use crate::types::{AgentMessage, AssistantMessage, Cost, StopReason, ToolResultMessage, Usage};
+use crate::types::{
+    AgentMessage, AssistantMessage, Cost, ModelSpec, StopReason, ToolResultMessage, Usage,
+};
 
 // ─── Verdict Enums ──────────────────────────────────────────────────────────
 
@@ -115,6 +117,12 @@ pub struct TurnPolicyContext<'a> {
     pub tool_results: &'a [ToolResultMessage],
     /// Why the turn ended.
     pub stop_reason: StopReason,
+    /// The system prompt active during this turn.
+    pub system_prompt: &'a str,
+    /// The model specification active during this turn.
+    pub model_spec: &'a ModelSpec,
+    /// All context messages (the full conversation history).
+    pub context_messages: &'a [AgentMessage],
 }
 
 // ─── Slot Traits ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Expands `TurnPolicyContext` with `system_prompt`, `model_spec`, and `context_messages` fields so PostTurn policies have access to the real loop state
- Updates `CheckpointPolicy` to write checkpoints with actual system prompt, model identity, and full message history instead of empty placeholders
- Removes the empty-string workaround comments ("system_prompt not available", "messages snapshot not available")

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo test --workspace` passes
- [x] `cargo test -p swink-agent --no-default-features` passes
- [x] New tests verify checkpoint contains non-empty system prompt
- [x] New tests verify checkpoint contains model identity (provider + model_id)
- [x] New tests verify checkpoint contains message history
- [x] Round-trip checkpoint save/load verified

**Public API change**: `TurnPolicyContext` gains three new fields (`system_prompt`, `model_spec`, `context_messages`). Existing `PostTurnPolicy` implementations that destructure `TurnPolicyContext` will need updating to include these fields.

Closes #103
🤖 Generated with [Claude Code](https://claude.com/claude-code)