### PR TITLE
impl(036): Add artifact service foundational types and validation tests

### DIFF
--- a/artifacts/src/validate.rs
+++ b/artifacts/src/validate.rs
@@ -5,51 +5,150 @@ use swink_agent::ArtifactError;
 /// Allowed characters: alphanumeric, hyphens, underscores, dots, forward slashes.
 /// Must not be empty, start/end with `/`, or contain `//` or `../`.
 pub fn validate_artifact_name(name: &str) -> Result<(), ArtifactError> {
-    if name.is_empty() {
-        return Err(ArtifactError::InvalidName {
-            name: name.to_string(),
-            reason: "name must not be empty".to_string(),
-        });
+    swink_agent::validate_artifact_name(name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_simple_name() {
+        assert!(validate_artifact_name("report.md").is_ok());
     }
 
-    if name.starts_with('/') {
-        return Err(ArtifactError::InvalidName {
-            name: name.to_string(),
-            reason: "name must not start with '/'".to_string(),
-        });
+    #[test]
+    fn valid_name_with_hyphens_and_underscores() {
+        assert!(validate_artifact_name("my-report_v2.txt").is_ok());
     }
 
-    if name.ends_with('/') {
-        return Err(ArtifactError::InvalidName {
-            name: name.to_string(),
-            reason: "name must not end with '/'".to_string(),
-        });
+    #[test]
+    fn valid_name_with_path() {
+        assert!(validate_artifact_name("tools/output/data.csv").is_ok());
     }
 
-    if name.contains("//") {
-        return Err(ArtifactError::InvalidName {
-            name: name.to_string(),
-            reason: "name must not contain consecutive slashes".to_string(),
-        });
+    #[test]
+    fn valid_alphanumeric_only() {
+        assert!(validate_artifact_name("report2024").is_ok());
     }
 
-    if name.contains("../") || name.contains("/..") || name == ".." {
-        return Err(ArtifactError::InvalidName {
-            name: name.to_string(),
-            reason: "name must not contain path traversal".to_string(),
-        });
+    #[test]
+    fn valid_single_character() {
+        assert!(validate_artifact_name("a").is_ok());
     }
 
-    let valid = name
-        .chars()
-        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.' || c == '/');
-    if !valid {
-        return Err(ArtifactError::InvalidName {
-            name: name.to_string(),
-            reason: "name contains invalid characters (allowed: alphanumeric, -, _, ., /)"
-                .to_string(),
-        });
+    #[test]
+    fn valid_dotfile() {
+        assert!(validate_artifact_name(".gitignore").is_ok());
     }
 
-    Ok(())
+    #[test]
+    fn invalid_empty_name() {
+        let err = validate_artifact_name("").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("empty"), "expected 'empty' in: {msg}");
+    }
+
+    #[test]
+    fn invalid_leading_slash() {
+        let err = validate_artifact_name("/report.md").unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("start with '/'"),
+            "expected start-with-slash message in: {msg}"
+        );
+    }
+
+    #[test]
+    fn invalid_trailing_slash() {
+        let err = validate_artifact_name("report/").unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("end with '/'"),
+            "expected end-with-slash message in: {msg}"
+        );
+    }
+
+    #[test]
+    fn invalid_consecutive_slashes() {
+        let err = validate_artifact_name("tools//output.txt").unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("consecutive slashes"),
+            "expected consecutive-slashes message in: {msg}"
+        );
+    }
+
+    #[test]
+    fn invalid_path_traversal_prefix() {
+        let err = validate_artifact_name("../etc/passwd").unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("path traversal"),
+            "expected path-traversal message in: {msg}"
+        );
+    }
+
+    #[test]
+    fn invalid_path_traversal_mid_path() {
+        let err = validate_artifact_name("tools/../secret.txt").unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("path traversal"),
+            "expected path-traversal message in: {msg}"
+        );
+    }
+
+    #[test]
+    fn invalid_path_traversal_suffix() {
+        let err = validate_artifact_name("tools/..").unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("path traversal"),
+            "expected path-traversal message in: {msg}"
+        );
+    }
+
+    #[test]
+    fn invalid_path_traversal_bare() {
+        let err = validate_artifact_name("..").unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("path traversal"),
+            "expected path-traversal message in: {msg}"
+        );
+    }
+
+    #[test]
+    fn invalid_special_characters() {
+        for ch in ['@', '#', '$', '%', '!', '?', '*', '~', '&'] {
+            let name = format!("report{ch}file.md");
+            let err = validate_artifact_name(&name).unwrap_err();
+            let msg = err.to_string();
+            assert!(
+                msg.contains("invalid character"),
+                "expected invalid-character message for '{ch}' in: {msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_space_in_name() {
+        let err = validate_artifact_name("my report.md").unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("invalid character"),
+            "expected invalid-character message in: {msg}"
+        );
+    }
+
+    #[test]
+    fn invalid_backslash() {
+        let err = validate_artifact_name("tools\\output.txt").unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("invalid character"),
+            "expected invalid-character message in: {msg}"
+        );
+    }
 }

--- a/specs/036-artifact-service/tasks.md
+++ b/specs/036-artifact-service/tasks.md
@@ -35,16 +35,16 @@
 
 **⚠️ CRITICAL**: No user story work can begin until this phase is complete.
 
-- [ ] T006 Define `ArtifactError` enum (`InvalidName`, `Storage`, `NotConfigured`) with `thiserror` derives in `src/artifact.rs`
-- [ ] T007 [P] Define `ArtifactData` struct (`content: Vec<u8>`, `content_type: String`, `metadata: HashMap<String, String>`) with serde derives in `src/artifact.rs`
-- [ ] T008 [P] Define `ArtifactVersion` struct (`name`, `version: u32`, `created_at: DateTime<Utc>`, `size: usize`, `content_type`) with serde derives in `src/artifact.rs`
-- [ ] T009 [P] Define `ArtifactMeta` struct (`name`, `latest_version: u32`, `created_at`, `updated_at`, `content_type`) with serde derives in `src/artifact.rs`
-- [ ] T010 Define `ArtifactStore` async trait (`save`, `load`, `load_version`, `list`, `delete`) with `Send + Sync` bounds in `src/artifact.rs` per contracts/public-api.md signatures
-- [ ] T011 Implement `validate_artifact_name` function in `artifacts/src/validate.rs` — allowed chars `[a-zA-Z0-9\-_./]`, no empty, no leading/trailing `/`, no `//`
-- [ ] T012 [P] Write unit tests for `validate_artifact_name` in `artifacts/src/validate.rs` — valid names, invalid chars, empty, leading/trailing slash, consecutive slashes, path traversal (`../`)
-- [ ] T013 Add `AgentEvent::ArtifactSaved { session_id, name, version }` variant to `src/loop_/event.rs` behind `#[cfg(feature = "artifact-store")]`
-- [ ] T014 Add re-exports of `ArtifactStore`, `ArtifactData`, `ArtifactVersion`, `ArtifactMeta`, `ArtifactError`, `validate_artifact_name` in `src/lib.rs` behind `#[cfg(feature = "artifact-store")]`
-- [ ] T015 Verify `cargo build --workspace` and `cargo test --workspace` pass with both features enabled and disabled
+- [x] T006 Define `ArtifactError` enum (`InvalidName`, `Storage`, `NotConfigured`) with `thiserror` derives in `src/artifact.rs`
+- [x] T007 [P] Define `ArtifactData` struct (`content: Vec<u8>`, `content_type: String`, `metadata: HashMap<String, String>`) with serde derives in `src/artifact.rs`
+- [x] T008 [P] Define `ArtifactVersion` struct (`name`, `version: u32`, `created_at: DateTime<Utc>`, `size: usize`, `content_type`) with serde derives in `src/artifact.rs`
+- [x] T009 [P] Define `ArtifactMeta` struct (`name`, `latest_version: u32`, `created_at`, `updated_at`, `content_type`) with serde derives in `src/artifact.rs`
+- [x] T010 Define `ArtifactStore` async trait (`save`, `load`, `load_version`, `list`, `delete`) with `Send + Sync` bounds in `src/artifact.rs` per contracts/public-api.md signatures
+- [x] T011 Implement `validate_artifact_name` function in `artifacts/src/validate.rs` — allowed chars `[a-zA-Z0-9\-_./]`, no empty, no leading/trailing `/`, no `//`
+- [x] T012 [P] Write unit tests for `validate_artifact_name` in `artifacts/src/validate.rs` — valid names, invalid chars, empty, leading/trailing slash, consecutive slashes, path traversal (`../`)
+- [x] T013 Add `AgentEvent::ArtifactSaved { session_id, name, version }` variant to `src/loop_/event.rs` behind `#[cfg(feature = "artifact-store")]`
+- [x] T014 Add re-exports of `ArtifactStore`, `ArtifactData`, `ArtifactVersion`, `ArtifactMeta`, `ArtifactError`, `validate_artifact_name` in `src/lib.rs` behind `#[cfg(feature = "artifact-store")]`
+- [x] T015 Verify `cargo build --workspace` and `cargo test --workspace` pass with both features enabled and disabled
 
 **Checkpoint**: Foundation ready — core trait and types compile, validation tested, event variant wired.
 

--- a/specs/spec-status.md
+++ b/specs/spec-status.md
@@ -38,7 +38,7 @@
 | 033-workspace-feature-gates     | ✓     | ✓  | ✓   | ✓ Complete |
 | 034-session-state-store         | ✓     | ✓  | ✓   | ✓ Complete |
 | 035-credential-management       | ✓     | ✓  | ✓   | ✓ Complete |
-| 036-artifact-service            | ✓     | ✓  | ✓   | ● 0/81 (0%) |
+| 036-artifact-service            | ✓     | ✓  | ✓   | ● 15/81 (19%) |
 | 037-plugin-system               | ✓     | ✓  | ✓   | ● 0/47 (0%) |
 | 038-mcp-integration             | ✓     | ✓  | ✓   | ● 9/49 (18%) |
 | 039-multi-agent-patterns        | ✓     | ✓  | ✓   | ● 0/66 (0%) |
@@ -79,7 +79,7 @@
 <!-- feature: 033-workspace-feature-gates has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=25 tasks_completed=25 checklist_files=requirements.md -->
 <!-- feature: 034-session-state-store has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=93 tasks_completed=93 checklist_files=requirements.md -->
 <!-- feature: 035-credential-management has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=73 tasks_completed=73 checklist_files=requirements.md -->
-<!-- feature: 036-artifact-service has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=81 tasks_completed=0 checklist_files=requirements.md -->
+<!-- feature: 036-artifact-service has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=81 tasks_completed=15 checklist_files=requirements.md -->
 <!-- feature: 037-plugin-system has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=47 tasks_completed=0 checklist_files=requirements.md -->
 <!-- feature: 038-mcp-integration has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=49 tasks_completed=9 checklist_files=requirements.md -->
 <!-- feature: 039-multi-agent-patterns has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=66 tasks_completed=0 checklist_files=requirements.md -->

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -75,8 +75,9 @@ pub trait ArtifactStore: Send + Sync {
         &self,
         session_id: &str,
         name: &str,
-    ) -> impl std::future::Future<Output = Result<Option<(ArtifactData, ArtifactVersion)>, ArtifactError>>
-           + Send;
+    ) -> impl std::future::Future<
+        Output = Result<Option<(ArtifactData, ArtifactVersion)>, ArtifactError>,
+    > + Send;
 
     /// Load a specific version of the named artifact.
     ///
@@ -86,8 +87,9 @@ pub trait ArtifactStore: Send + Sync {
         session_id: &str,
         name: &str,
         version: u32,
-    ) -> impl std::future::Future<Output = Result<Option<(ArtifactData, ArtifactVersion)>, ArtifactError>>
-           + Send;
+    ) -> impl std::future::Future<
+        Output = Result<Option<(ArtifactData, ArtifactVersion)>, ArtifactError>,
+    > + Send;
 
     /// List metadata for all artifacts in a session.
     ///
@@ -105,4 +107,58 @@ pub trait ArtifactStore: Send + Sync {
         session_id: &str,
         name: &str,
     ) -> impl std::future::Future<Output = Result<(), ArtifactError>> + Send;
+}
+
+/// Validate an artifact name. Returns `Ok(())` if valid.
+///
+/// Allowed characters: alphanumeric, hyphens, underscores, dots, forward slashes.
+/// Must not be empty, start/end with `/`, contain `//`, or contain path traversal (`..`).
+pub fn validate_artifact_name(name: &str) -> Result<(), ArtifactError> {
+    if name.is_empty() {
+        return Err(ArtifactError::InvalidName {
+            name: name.to_string(),
+            reason: "name must not be empty".to_string(),
+        });
+    }
+
+    if name.starts_with('/') {
+        return Err(ArtifactError::InvalidName {
+            name: name.to_string(),
+            reason: "name must not start with '/'".to_string(),
+        });
+    }
+
+    if name.ends_with('/') {
+        return Err(ArtifactError::InvalidName {
+            name: name.to_string(),
+            reason: "name must not end with '/'".to_string(),
+        });
+    }
+
+    if name.contains("//") {
+        return Err(ArtifactError::InvalidName {
+            name: name.to_string(),
+            reason: "name must not contain consecutive slashes".to_string(),
+        });
+    }
+
+    if name.contains("../") || name.contains("/..") || name == ".." {
+        return Err(ArtifactError::InvalidName {
+            name: name.to_string(),
+            reason: "name must not contain path traversal".to_string(),
+        });
+    }
+
+    let valid = name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.' || c == '/');
+    if !valid {
+        return Err(ArtifactError::InvalidName {
+            name: name.to_string(),
+            reason: "name contains invalid characters (allowed: alphanumeric, -, _, ., /)"
+                .to_string(),
+        });
+    }
+
+    Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@ mod agent;
 mod agent_id;
 pub mod agent_options;
 pub(crate) mod agent_subscriptions;
+#[cfg(feature = "artifact-store")]
+pub mod artifact;
 mod async_context_transformer;
 mod checkpoint;
 mod config;
@@ -19,8 +21,6 @@ mod event_forwarder;
 mod fallback;
 mod fn_tool;
 mod handle;
-#[cfg(feature = "artifact-store")]
-mod artifact;
 #[cfg(feature = "hot-reload")]
 pub mod hot_reload;
 mod loop_;
@@ -146,6 +146,7 @@ pub use util::now_timestamp;
 #[cfg(feature = "artifact-store")]
 pub use artifact::{
     ArtifactData, ArtifactError, ArtifactMeta, ArtifactStore, ArtifactVersion,
+    validate_artifact_name,
 };
 pub use display::{CoreDisplayMessage, DisplayRole, IntoDisplayMessages};
 #[cfg(feature = "plugins")]

--- a/src/loop_/event.rs
+++ b/src/loop_/event.rs
@@ -158,6 +158,17 @@ pub enum AgentEvent {
         is_error: bool,
     },
 
+    /// Emitted when an artifact version is successfully saved.
+    #[cfg(feature = "artifact-store")]
+    ArtifactSaved {
+        /// The session this artifact belongs to.
+        session_id: String,
+        /// The artifact name.
+        name: String,
+        /// The version number that was saved.
+        version: u32,
+    },
+
     /// A custom event emitted via [`Agent::emit`](crate::Agent::emit).
     Custom(crate::emit::Emission),
 }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -640,5 +640,7 @@ pub fn event_variant_name(event: &AgentEvent) -> String {
         AgentEvent::McpToolsDiscovered { .. } => "McpToolsDiscovered".into(),
         AgentEvent::McpToolCallStarted { .. } => "McpToolCallStarted".into(),
         AgentEvent::McpToolCallCompleted { .. } => "McpToolCallCompleted".into(),
+        #[cfg(feature = "artifact-store")]
+        AgentEvent::ArtifactSaved { .. } => "ArtifactSaved".into(),
     }
 }


### PR DESCRIPTION
## Summary
- Adds `validate_artifact_name` to core crate (`src/artifact.rs`) with full validation rules
- Adds `AgentEvent::ArtifactSaved` variant behind `artifact-store` feature gate
- Adds 17 comprehensive unit tests for artifact name validation in the artifacts crate
- Wires `validate_artifact_name` re-export in `src/lib.rs`
- Handles new event variant in `testing.rs` match arm

## Tasks completed
- T006-T015 (Phase 2: Foundational) — all marked complete in tasks.md
- Note: T001-T005 (Phase 1: Setup) were completed in #97

## Test plan
- [x] `cargo test --workspace` passes (all 17 new validation tests pass)
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo build -p swink-agent --features artifact-store` compiles
- [x] `cargo build -p swink-agent --no-default-features` compiles
- [x] `cargo test -p swink-agent --no-default-features` passes

Part of #75

Generated with [Claude Code](https://claude.com/claude-code)