### PR TITLE
fix: Collapse OpenAI-compatible adapters onto shared transport

### DIFF
--- a/adapters/src/azure.rs
+++ b/adapters/src/azure.rs
@@ -1,7 +1,8 @@
 //! Azure `OpenAI` / Azure AI Foundry adapter.
 //!
 //! This adapter targets Azure's OpenAI-v1-compatible chat completions surface.
-//! It reuses the shared OAI-compatible SSE parsing from [`openai_compat`].
+//! It reuses the shared OAI-compatible SSE parsing from [`openai_compat`] and
+//! the shared transport pipeline from [`oai_transport`].
 
 use std::pin::Pin;
 use std::sync::{Arc, RwLock};
@@ -10,16 +11,12 @@ use std::time::{Duration, Instant};
 use futures::stream::{self, Stream, StreamExt as _};
 use serde::Deserialize;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, warn};
+use tracing::debug;
 
 use swink_agent::stream::{AssistantMessageEvent, StreamFn, StreamOptions};
 use swink_agent::types::{AgentContext, ModelSpec};
 
-use crate::base::AdapterBase;
-use crate::convert;
-use crate::openai_compat::{
-    OaiChatRequest, OaiConverter, OaiStreamOptions, build_oai_tools, parse_oai_sse_stream,
-};
+use crate::oai_transport::{oai_send_and_parse, prepare_oai_request};
 
 /// Authentication method for Azure `OpenAI` deployments.
 #[derive(Clone)]
@@ -65,7 +62,8 @@ struct TokenResponse {
 }
 
 pub struct AzureStreamFn {
-    base: AdapterBase,
+    client: reqwest::Client,
+    base_url: String,
     auth: AzureAuth,
     token_cache: Arc<RwLock<Option<CachedToken>>>,
     /// Override token endpoint URL (for testing). `None` = use Microsoft default.
@@ -75,12 +73,9 @@ pub struct AzureStreamFn {
 impl AzureStreamFn {
     #[must_use]
     pub fn new(base_url: impl Into<String>, auth: AzureAuth) -> Self {
-        let api_key = match &auth {
-            AzureAuth::ApiKey(key) => key.clone(),
-            AzureAuth::EntraId { .. } => String::new(),
-        };
         Self {
-            base: AdapterBase::new(base_url.into().trim_end_matches('/').to_string(), api_key),
+            client: reqwest::Client::new(),
+            base_url: base_url.into().trim_end_matches('/').to_string(),
             auth,
             token_cache: Arc::new(RwLock::new(None)),
             token_endpoint_override: None,
@@ -112,7 +107,6 @@ impl AzureStreamFn {
         ];
 
         let resp = self
-            .base
             .client
             .post(&token_url)
             .form(&params)
@@ -174,12 +168,39 @@ impl AzureStreamFn {
             format!("https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token")
         }
     }
+
+    /// Apply Azure-specific auth headers to the request builder.
+    async fn apply_auth(
+        &self,
+        request: reqwest::RequestBuilder,
+        options: &StreamOptions,
+    ) -> Result<reqwest::RequestBuilder, AssistantMessageEvent> {
+        match &self.auth {
+            AzureAuth::ApiKey(key) => {
+                let api_key = options.api_key.as_deref().unwrap_or(key);
+                Ok(request.header("api-key", api_key))
+            }
+            AzureAuth::EntraId {
+                tenant_id,
+                client_id,
+                client_secret,
+            } => {
+                let token = self
+                    .get_or_refresh_token(tenant_id, client_id, client_secret)
+                    .await
+                    .map_err(|e| {
+                        AssistantMessageEvent::error_network(format!("Azure token error: {e}"))
+                    })?;
+                Ok(request.header("Authorization", format!("Bearer {token}")))
+            }
+        }
+    }
 }
 
 impl std::fmt::Debug for AzureStreamFn {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AzureStreamFn")
-            .field("base_url", &self.base.base_url)
+            .field("base_url", &self.base_url)
             .field("auth", &self.auth)
             .finish_non_exhaustive()
     }
@@ -211,92 +232,32 @@ fn azure_stream<'a>(
     cancellation_token: CancellationToken,
 ) -> impl Stream<Item = AssistantMessageEvent> + Send + 'a {
     stream::once(async move {
-        let response = match send_request(azure, model, context, options).await {
-            Ok(resp) => resp,
+        let url = format!("{}/chat/completions", azure.base_url);
+        debug!(
+            %url,
+            model = %model.model_id,
+            messages = context.messages.len(),
+            "sending Azure request"
+        );
+
+        let request = prepare_oai_request(&azure.client, &url, model, context, options);
+        let request = match azure.apply_auth(request, options).await {
+            Ok(r) => r,
             Err(event) => return stream::iter(vec![event]).left_stream(),
         };
 
-        let status = response.status();
-        if !status.is_success() {
-            let code = status.as_u16();
-            let body = response.text().await.unwrap_or_default();
-            warn!(status = code, "Azure HTTP error");
-
-            // Detect Azure content filter violations in error body
-            if is_content_filter_error(&body) {
-                let event = AssistantMessageEvent::error_content_filtered(format!(
-                    "Azure content filter blocked request (HTTP {code})"
-                ));
-                return stream::iter(vec![event]).left_stream();
+        oai_send_and_parse(request, "Azure", cancellation_token, |status, body| {
+            if is_content_filter_error(body) {
+                Some(AssistantMessageEvent::error_content_filtered(format!(
+                    "Azure content filter blocked request (HTTP {status})"
+                )))
+            } else {
+                None
             }
-
-            let event = crate::classify::error_event_from_status(code, &body, "Azure");
-            return stream::iter(vec![event]).left_stream();
-        }
-
-        parse_oai_sse_stream(response, cancellation_token, "Azure").right_stream()
+        })
+        .right_stream()
     })
     .flatten()
-}
-
-async fn send_request(
-    azure: &AzureStreamFn,
-    model: &ModelSpec,
-    context: &AgentContext,
-    options: &StreamOptions,
-) -> Result<reqwest::Response, AssistantMessageEvent> {
-    let url = format!("{}/chat/completions", azure.base.base_url);
-    debug!(
-        %url,
-        model = %model.model_id,
-        messages = context.messages.len(),
-        "sending Azure request"
-    );
-
-    let messages =
-        convert::convert_messages::<OaiConverter>(&context.messages, &context.system_prompt);
-
-    let (tools, tool_choice) = build_oai_tools(&context.tools);
-
-    let body = OaiChatRequest {
-        model: model.model_id.clone(),
-        messages,
-        stream: true,
-        stream_options: OaiStreamOptions {
-            include_usage: true,
-        },
-        temperature: options.temperature,
-        max_tokens: options.max_tokens,
-        tools,
-        tool_choice,
-    };
-
-    let mut request = azure.base.client.post(&url).json(&body);
-
-    match &azure.auth {
-        AzureAuth::ApiKey(key) => {
-            let api_key = options.api_key.as_deref().unwrap_or(key);
-            request = request.header("api-key", api_key);
-        }
-        AzureAuth::EntraId {
-            tenant_id,
-            client_id,
-            client_secret,
-        } => {
-            let token = azure
-                .get_or_refresh_token(tenant_id, client_id, client_secret)
-                .await
-                .map_err(|e| {
-                    AssistantMessageEvent::error_network(format!("Azure token error: {e}"))
-                })?;
-            request = request.header("Authorization", format!("Bearer {token}"));
-        }
-    }
-
-    request
-        .send()
-        .await
-        .map_err(|e| AssistantMessageEvent::error_network(format!("Azure connection error: {e}")))
 }
 
 /// Check if an HTTP error body contains an Azure content filter violation.

--- a/adapters/src/lib.rs
+++ b/adapters/src/lib.rs
@@ -42,6 +42,16 @@ mod finalize;
     )),
     allow(dead_code)
 )]
+mod oai_transport;
+#[cfg_attr(
+    not(any(
+        feature = "openai",
+        feature = "azure",
+        feature = "mistral",
+        feature = "xai"
+    )),
+    allow(dead_code)
+)]
 mod openai_compat;
 mod remote_presets;
 pub mod sse;

--- a/adapters/src/mistral.rs
+++ b/adapters/src/mistral.rs
@@ -12,8 +12,9 @@
 //! - **Message ordering**: Mistral rejects `user` immediately after `tool`;
 //!   a synthetic assistant message must be inserted.
 //!
-//! This adapter holds [`AdapterBase`] directly (like Azure) and reuses the
-//! shared `openai_compat` types for message serialization and SSE parsing.
+//! This adapter uses the shared [`oai_transport`] pipeline for HTTP send,
+//! error classification, and SSE parsing, while handling Mistral-specific
+//! message normalization and tool-call ID remapping locally.
 
 use std::collections::HashMap;
 use std::pin::Pin;
@@ -21,14 +22,15 @@ use std::pin::Pin;
 use futures::stream::{self, Stream, StreamExt as _};
 use serde::Serialize;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, warn};
+use tracing::debug;
 
 use swink_agent::stream::{AssistantMessageEvent, StreamFn, StreamOptions};
 use swink_agent::types::{AgentContext, AgentMessage, ModelSpec};
 
 use crate::base::AdapterBase;
 use crate::convert;
-use crate::openai_compat::{OaiConverter, OaiMessage, build_oai_tools, parse_oai_sse_stream};
+use crate::oai_transport::oai_send_and_parse;
+use crate::openai_compat::{OaiConverter, OaiMessage, build_oai_tools};
 
 /// Charset for generating Mistral-compatible 9-char tool call IDs.
 const MISTRAL_ID_CHARSET: &[u8] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
@@ -181,72 +183,42 @@ fn mistral_stream<'a>(
     cancellation_token: CancellationToken,
 ) -> impl Stream<Item = AssistantMessageEvent> + Send + 'a {
     stream::once(async move {
-        // Build the ID map from existing tool call IDs in context.
         let mut id_map = MistralIdMap::new();
 
-        let response = match send_request(mistral, model, context, options, &mut id_map).await {
-            Ok(resp) => resp,
-            Err(event) => return stream::iter(vec![event]).left_stream(),
+        let url = format!("{}/v1/chat/completions", mistral.base.base_url);
+        debug!(
+            %url,
+            model = %model.model_id,
+            messages = context.messages.len(),
+            "sending Mistral request"
+        );
+
+        let messages =
+            convert_messages_for_mistral(&context.messages, &context.system_prompt, &mut id_map);
+        let (tools, tool_choice) = build_oai_tools(&context.tools);
+
+        let body = MistralChatRequest {
+            model: model.model_id.clone(),
+            messages,
+            stream: true,
+            temperature: options.temperature,
+            max_tokens: options.max_tokens,
+            tools,
+            tool_choice,
         };
 
-        let status = response.status();
-        if !status.is_success() {
-            let code = status.as_u16();
-            let body = response.text().await.unwrap_or_default();
-            warn!(status = code, "Mistral HTTP error");
-            let event = crate::classify::error_event_from_status(code, &body, "Mistral");
-            return stream::iter(vec![event]).left_stream();
-        }
+        let api_key = options.api_key.as_deref().unwrap_or(&mistral.base.api_key);
+        let request = mistral
+            .base
+            .client
+            .post(&url)
+            .header("Authorization", format!("Bearer {api_key}"))
+            .json(&body);
 
-        // Parse SSE then normalize response events.
-        let raw_stream = parse_oai_sse_stream(response, cancellation_token, "Mistral");
-        normalize_response_stream(raw_stream, id_map).right_stream()
+        let raw_stream = oai_send_and_parse(request, "Mistral", cancellation_token, |_, _| None);
+        normalize_response_stream(raw_stream, id_map)
     })
     .flatten()
-}
-
-/// Construct and send the HTTP POST request with Mistral-specific normalization.
-async fn send_request(
-    mistral: &MistralStreamFn,
-    model: &ModelSpec,
-    context: &AgentContext,
-    options: &StreamOptions,
-    id_map: &mut MistralIdMap,
-) -> Result<reqwest::Response, AssistantMessageEvent> {
-    let url = format!("{}/v1/chat/completions", mistral.base.base_url);
-    debug!(
-        %url,
-        model = %model.model_id,
-        messages = context.messages.len(),
-        "sending Mistral request"
-    );
-
-    // Convert messages with Mistral-specific normalization.
-    let messages = convert_messages_for_mistral(&context.messages, &context.system_prompt, id_map);
-
-    let (tools, tool_choice) = build_oai_tools(&context.tools);
-
-    let body = MistralChatRequest {
-        model: model.model_id.clone(),
-        messages,
-        stream: true,
-        temperature: options.temperature,
-        max_tokens: options.max_tokens,
-        tools,
-        tool_choice,
-    };
-
-    let api_key = options.api_key.as_deref().unwrap_or(&mistral.base.api_key);
-
-    mistral
-        .base
-        .client
-        .post(&url)
-        .header("Authorization", format!("Bearer {api_key}"))
-        .json(&body)
-        .send()
-        .await
-        .map_err(|e| AssistantMessageEvent::error_network(format!("Mistral connection error: {e}")))
 }
 
 // ─── Message conversion ────────────────────────────────────────────────────
@@ -309,7 +281,7 @@ fn convert_messages_for_mistral(
 /// `StopReason::Stop` (catch-all) which is acceptable — errors from the
 /// Mistral side are rare and the stop reason still allows callers to inspect.
 fn normalize_response_stream(
-    raw: Pin<Box<dyn Stream<Item = AssistantMessageEvent> + Send>>,
+    raw: impl Stream<Item = AssistantMessageEvent> + Send,
     mut id_map: MistralIdMap,
 ) -> impl Stream<Item = AssistantMessageEvent> + Send {
     raw.map(move |event| match event {

--- a/adapters/src/oai_transport.rs
+++ b/adapters/src/oai_transport.rs
@@ -1,0 +1,103 @@
+//! Shared OpenAI-compatible transport layer.
+//!
+//! Provides [`prepare_oai_request`] for building standard request bodies and
+//! [`oai_send_and_parse`] for the shared HTTP send → error classification →
+//! SSE parsing pipeline. Together they eliminate the duplicated request/send/
+//! status/parse shell across OpenAI-protocol adapters (`OpenAI`, Azure, Mistral,
+//! xAI).
+//!
+//! Adapters that need provider-specific hooks (Azure auth, Mistral message
+//! ordering, etc.) apply those before or after calling into this module.
+
+use futures::stream::{self, Stream, StreamExt as _};
+use tracing::warn;
+
+use swink_agent::stream::{AssistantMessageEvent, StreamOptions};
+use swink_agent::types::{AgentContext, ModelSpec};
+
+use crate::convert;
+use crate::openai_compat::{
+    OaiChatRequest, OaiConverter, OaiStreamOptions, build_oai_tools, parse_oai_sse_stream,
+};
+
+/// Build a standard OAI-compatible HTTP request (without auth headers).
+///
+/// Handles message conversion, tool extraction, and body serialization.
+/// Returns a `reqwest::RequestBuilder` ready for auth header injection.
+///
+/// Used by adapters that follow the standard OAI message format (`OpenAI`,
+/// Azure, xAI). Mistral uses its own message conversion and body type.
+pub fn prepare_oai_request(
+    client: &reqwest::Client,
+    url: &str,
+    model: &ModelSpec,
+    context: &AgentContext,
+    options: &StreamOptions,
+) -> reqwest::RequestBuilder {
+    let messages =
+        convert::convert_messages::<OaiConverter>(&context.messages, &context.system_prompt);
+    let (tools, tool_choice) = build_oai_tools(&context.tools);
+    let body = OaiChatRequest {
+        model: model.model_id.clone(),
+        messages,
+        stream: true,
+        stream_options: Some(OaiStreamOptions {
+            include_usage: true,
+        }),
+        temperature: options.temperature,
+        max_tokens: options.max_tokens,
+        tools,
+        tool_choice,
+    };
+    client.post(url).json(&body)
+}
+
+/// Send an OAI-compatible request and parse the SSE response stream.
+///
+/// This is the shared transport pipeline for OpenAI-protocol adapters:
+/// 1. Send the HTTP request
+/// 2. Classify HTTP errors (provider-specific override first, then standard)
+/// 3. Parse the SSE response into [`AssistantMessageEvent`]s
+///
+/// Callers build the `RequestBuilder` with provider-specific URL, auth,
+/// and body; this function handles everything after that.
+///
+/// The `classify_error` callback allows providers to intercept specific
+/// error conditions (e.g., Azure content filter violations). Return
+/// `Some(event)` to override the default classification, `None` to fall
+/// through to standard HTTP status mapping.
+pub fn oai_send_and_parse<'a>(
+    request: reqwest::RequestBuilder,
+    provider: &'static str,
+    cancellation_token: tokio_util::sync::CancellationToken,
+    classify_error: impl Fn(u16, &str) -> Option<AssistantMessageEvent> + Send + 'a,
+) -> impl Stream<Item = AssistantMessageEvent> + Send + 'a {
+    stream::once(async move {
+        let response = match request.send().await {
+            Ok(resp) => resp,
+            Err(e) => {
+                return stream::iter(vec![AssistantMessageEvent::error_network(format!(
+                    "{provider} connection error: {e}"
+                ))])
+                .left_stream();
+            }
+        };
+
+        let status = response.status();
+        if !status.is_success() {
+            let code = status.as_u16();
+            let body = response.text().await.unwrap_or_default();
+            warn!(status = code, "{provider} HTTP error");
+
+            if let Some(event) = classify_error(code, &body) {
+                return stream::iter(vec![event]).left_stream();
+            }
+
+            let event = crate::classify::error_event_from_status(code, &body, provider);
+            return stream::iter(vec![event]).left_stream();
+        }
+
+        parse_oai_sse_stream(response, cancellation_token, provider).right_stream()
+    })
+    .flatten()
+}

--- a/adapters/src/openai.rs
+++ b/adapters/src/openai.rs
@@ -6,18 +6,15 @@
 
 use std::pin::Pin;
 
-use futures::stream::{self, Stream, StreamExt as _};
+use futures::Stream;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, warn};
+use tracing::debug;
 
 use swink_agent::stream::{AssistantMessageEvent, StreamFn, StreamOptions};
 use swink_agent::types::{AgentContext, ModelSpec};
 
 use crate::base::AdapterBase;
-use crate::convert;
-use crate::openai_compat::{
-    OaiChatRequest, OaiConverter, OaiStreamOptions, build_oai_tools, parse_oai_sse_stream,
-};
+use crate::oai_transport::{oai_send_and_parse, prepare_oai_request};
 
 // ─── OpenAiStreamFn ─────────────────────────────────────────────────────────
 
@@ -61,89 +58,26 @@ impl StreamFn for OpenAiStreamFn {
         options: &'a StreamOptions,
         cancellation_token: CancellationToken,
     ) -> Pin<Box<dyn Stream<Item = AssistantMessageEvent> + Send + 'a>> {
-        Box::pin(openai_stream(
-            self,
-            model,
-            context,
-            options,
+        let url = format!("{}/v1/chat/completions", self.base.base_url);
+        let api_key = options.api_key.as_deref().unwrap_or(&self.base.api_key);
+
+        debug!(
+            %url,
+            model = %model.model_id,
+            messages = context.messages.len(),
+            "sending OpenAI request"
+        );
+
+        let request = prepare_oai_request(&self.base.client, &url, model, context, options)
+            .header("Authorization", format!("Bearer {api_key}"));
+
+        Box::pin(oai_send_and_parse(
+            request,
+            "OpenAI",
             cancellation_token,
+            |_, _| None,
         ))
     }
-}
-
-// ─── Stream implementation ──────────────────────────────────────────────────
-
-fn openai_stream<'a>(
-    openai: &'a OpenAiStreamFn,
-    model: &'a ModelSpec,
-    context: &'a AgentContext,
-    options: &'a StreamOptions,
-    cancellation_token: CancellationToken,
-) -> impl Stream<Item = AssistantMessageEvent> + Send + 'a {
-    stream::once(async move {
-        let response = match send_request(openai, model, context, options).await {
-            Ok(resp) => resp,
-            Err(event) => return stream::iter(vec![event]).left_stream(),
-        };
-
-        let status = response.status();
-        if !status.is_success() {
-            let code = status.as_u16();
-            let body = response.text().await.unwrap_or_default();
-            warn!(status = code, "OpenAI HTTP error");
-            let event = crate::classify::error_event_from_status(code, &body, "OpenAI");
-            return stream::iter(vec![event]).left_stream();
-        }
-
-        parse_oai_sse_stream(response, cancellation_token, "OpenAI").right_stream()
-    })
-    .flatten()
-}
-
-/// Send the HTTP POST request to the OpenAI-compatible endpoint.
-async fn send_request(
-    openai: &OpenAiStreamFn,
-    model: &ModelSpec,
-    context: &AgentContext,
-    options: &StreamOptions,
-) -> Result<reqwest::Response, AssistantMessageEvent> {
-    let url = format!("{}/v1/chat/completions", openai.base.base_url);
-    debug!(
-        %url,
-        model = %model.model_id,
-        messages = context.messages.len(),
-        "sending OpenAI request"
-    );
-
-    let messages =
-        convert::convert_messages::<OaiConverter>(&context.messages, &context.system_prompt);
-
-    let (tools, tool_choice) = build_oai_tools(&context.tools);
-
-    let body = OaiChatRequest {
-        model: model.model_id.clone(),
-        messages,
-        stream: true,
-        stream_options: OaiStreamOptions {
-            include_usage: true,
-        },
-        temperature: options.temperature,
-        max_tokens: options.max_tokens,
-        tools,
-        tool_choice,
-    };
-
-    let api_key = options.api_key.as_deref().unwrap_or(&openai.base.api_key);
-
-    openai
-        .base
-        .client
-        .post(&url)
-        .header("Authorization", format!("Bearer {api_key}"))
-        .json(&body)
-        .send()
-        .await
-        .map_err(|e| AssistantMessageEvent::error_network(format!("OpenAI connection error: {e}")))
 }
 
 // ─── Compile-time assertions ────────────────────────────────────────────────

--- a/adapters/src/openai_compat.rs
+++ b/adapters/src/openai_compat.rs
@@ -81,7 +81,8 @@ pub struct OaiChatRequest {
     pub model: String,
     pub messages: Vec<OaiMessage>,
     pub stream: bool,
-    pub stream_options: OaiStreamOptions,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stream_options: Option<OaiStreamOptions>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub temperature: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## Summary
- Extracts the duplicated request/send/classify/parse pipeline from OpenAI, Azure, Mistral, and xAI adapters into a shared `oai_transport` module
- Two reusable functions: `prepare_oai_request` (standard body construction) and `oai_send_and_parse` (HTTP send, error classification, SSE parsing)
- Makes `OaiChatRequest.stream_options` optional so providers can omit it without separate request types
- Each adapter now focuses solely on its provider-specific hooks (auth, message ordering, error classification)

## What changed per adapter
- **OpenAI**: Collapsed `send_request` + `openai_stream` into direct `StreamFn::stream` using shared transport
- **Azure**: Extracted `apply_auth` method, replaced `send_request` + `azure_stream` with shared transport + custom error classifier
- **Mistral**: Uses shared `oai_send_and_parse` for transport, keeps its own message conversion and response normalization
- **xAI**: No changes (already delegates to OpenAI)

## Test plan
- [x] `cargo fmt --check` — clean (pre-existing issues in unrelated files only)
- [x] `cargo clippy --workspace -- -D warnings` — zero warnings
- [x] `cargo test --workspace` — all tests pass (including 20+ Azure wiremock tests)
- [x] `cargo test -p swink-agent --no-default-features` — passes
- [x] No public API changes — `AzureStreamFn::new()`, `.with_token_endpoint()`, `MistralStreamFn::new()`, `OpenAiStreamFn::new()` all preserved

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)