### PR TITLE
impl(037): Add plugin registry introspection API (Phase 6)

### DIFF
--- a/specs/037-plugin-system/tasks.md
+++ b/specs/037-plugin-system/tasks.md
@@ -112,14 +112,14 @@
 
 ### Tests for User Story 4
 
-- [ ] T026 [US4] Write test: `agent.plugins()` returns all plugins in priority order in `tests/plugin_integration.rs`
-- [ ] T027 [P] [US4] Write test: `agent.plugin("name")` returns correct plugin reference in `tests/plugin_integration.rs`
-- [ ] T028 [P] [US4] Write test: `agent.plugin("nonexistent")` returns None in `tests/plugin_integration.rs`
+- [x] T026 [US4] Write test: `agent.plugins()` returns all plugins in priority order in `tests/plugin_integration.rs`
+- [x] T027 [P] [US4] Write test: `agent.plugin("name")` returns correct plugin reference in `tests/plugin_integration.rs`
+- [x] T028 [P] [US4] Write test: `agent.plugin("nonexistent")` returns None in `tests/plugin_integration.rs`
 
 ### Implementation for User Story 4
 
-- [ ] T029 [US4] Add `plugins: Vec<Arc<dyn Plugin>>` field to `Agent` struct (retained after merge for introspection) in `src/agent.rs`
-- [ ] T030 [US4] Implement `plugins(&self) -> &[Arc<dyn Plugin>]` and `plugin(&self, name: &str) -> Option<&Arc<dyn Plugin>>` methods on Agent in `src/agent.rs`
+- [x] T029 [US4] Add `plugins: Vec<Arc<dyn Plugin>>` field to `Agent` struct (retained after merge for introspection) in `src/agent.rs`
+- [x] T030 [US4] Implement `plugins(&self) -> &[Arc<dyn Plugin>]` and `plugin(&self, name: &str) -> Option<&Arc<dyn Plugin>>` methods on Agent in `src/agent.rs`
 
 **Checkpoint**: Plugin introspection API is functional.
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -187,6 +187,9 @@ pub struct Agent {
     cache_config: Option<crate::context_cache::CacheConfig>,
     /// Optional dynamic system prompt.
     dynamic_system_prompt: Option<Arc<dyn Fn() -> String + Send + Sync>>,
+    /// Registered plugins retained for runtime introspection (priority-sorted).
+    #[cfg(feature = "plugins")]
+    plugins: Vec<Arc<dyn crate::plugin::Plugin>>,
 }
 
 impl Agent {
@@ -276,6 +279,8 @@ impl Agent {
             credential_resolver: options.credential_resolver,
             cache_config: options.cache_config,
             dynamic_system_prompt: options.dynamic_system_prompt.map(Arc::from),
+            #[cfg(feature = "plugins")]
+            plugins: options.plugins,
         }
     }
 
@@ -295,6 +300,20 @@ impl Agent {
     #[must_use]
     pub const fn session_state(&self) -> &Arc<std::sync::RwLock<crate::SessionState>> {
         &self.session_state
+    }
+
+    /// Returns all registered plugins sorted by priority (highest first).
+    #[cfg(feature = "plugins")]
+    #[must_use]
+    pub fn plugins(&self) -> &[Arc<dyn crate::plugin::Plugin>] {
+        &self.plugins
+    }
+
+    /// Look up a registered plugin by name.
+    #[cfg(feature = "plugins")]
+    #[must_use]
+    pub fn plugin(&self, name: &str) -> Option<&Arc<dyn crate::plugin::Plugin>> {
+        self.plugins.iter().find(|p| p.name() == name)
     }
 }
 

--- a/tests/plugin_integration.rs
+++ b/tests/plugin_integration.rs
@@ -577,6 +577,70 @@ async fn no_plugins_direct_policies_behave_identically() {
     );
 }
 
+// ─── Phase 6: User Story 4 — Registry Introspection ──────────────────────
+
+// ─── T026: agent.plugins() returns all plugins in priority order ─────────
+
+#[test]
+fn agent_plugins_returns_all_in_priority_order() {
+    let p_low: Arc<dyn Plugin> = Arc::new(OrderedPolicyPlugin::new(
+        "low",
+        1,
+        Arc::new(AtomicUsize::new(0)),
+    ));
+    let p_mid: Arc<dyn Plugin> = Arc::new(OrderedPolicyPlugin::new(
+        "mid",
+        5,
+        Arc::new(AtomicUsize::new(0)),
+    ));
+    let p_high: Arc<dyn Plugin> = Arc::new(OrderedPolicyPlugin::new(
+        "high",
+        10,
+        Arc::new(AtomicUsize::new(0)),
+    ));
+
+    // Register in low→mid→high order; plugins() should return high→mid→low.
+    let agent = make_agent_with_plugins(vec![p_low, p_mid, p_high]);
+
+    let names: Vec<&str> = agent.plugins().iter().map(|p| p.name()).collect();
+    assert_eq!(
+        names,
+        vec!["high", "mid", "low"],
+        "plugins() should return all plugins sorted by priority descending"
+    );
+}
+
+// ─── T027: agent.plugin("name") returns correct plugin reference ─────────
+
+#[test]
+fn agent_plugin_by_name_returns_correct_reference() {
+    let p_alpha: Arc<dyn Plugin> = Arc::new(ToolPlugin::new("alpha", &["save"]));
+    let p_beta: Arc<dyn Plugin> = Arc::new(ToolPlugin::new("beta", &["load"]));
+
+    let agent = make_agent_with_plugins(vec![p_alpha, p_beta]);
+
+    let found = agent.plugin("beta");
+    assert!(found.is_some(), "plugin 'beta' should be found");
+    assert_eq!(found.unwrap().name(), "beta");
+
+    let found_alpha = agent.plugin("alpha");
+    assert!(found_alpha.is_some(), "plugin 'alpha' should be found");
+    assert_eq!(found_alpha.unwrap().name(), "alpha");
+}
+
+// ─── T028: agent.plugin("nonexistent") returns None ──────────────────────
+
+#[test]
+fn agent_plugin_nonexistent_returns_none() {
+    let p: Arc<dyn Plugin> = Arc::new(ToolPlugin::new("existing", &["tool1"]));
+    let agent = make_agent_with_plugins(vec![p]);
+
+    assert!(
+        agent.plugin("nonexistent").is_none(),
+        "looking up a nonexistent plugin should return None"
+    );
+}
+
 // ─── T024: Plugin Stop prevents ALL direct policies from evaluating ────
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Adds `plugins` field to `Agent` struct (feature-gated behind `plugins`) to retain registered plugins after merge
- Implements `plugins()` (returns priority-sorted slice) and `plugin(name)` (lookup by name) methods on Agent
- Adds 3 integration tests covering priority ordering, name lookup, and nonexistent lookup

## Tasks completed
- T026: Test `agent.plugins()` returns all plugins in priority order
- T027: Test `agent.plugin("name")` returns correct plugin reference
- T028: Test `agent.plugin("nonexistent")` returns None
- T029: Add `plugins: Vec<Arc<dyn Plugin>>` field to Agent struct
- T030: Implement `plugins()` and `plugin()` methods on Agent

## Test plan
- [x] `cargo test --workspace --features testkit` passes (all 12 plugin tests green)
- [x] `cargo test -p swink-agent --no-default-features` passes
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] No public API breakage in downstream crates

Part of #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)