### PR TITLE
impl(037): Add plugin on_init callback with panic safety (Phase 7)

### DIFF
--- a/specs/037-plugin-system/tasks.md
+++ b/specs/037-plugin-system/tasks.md
@@ -133,13 +133,13 @@
 
 ### Tests for User Story 5
 
-- [ ] T031 [US5] Write test: plugin on_init is called once during Agent::new() in `tests/plugin_integration.rs`
-- [ ] T032 [P] [US5] Write test: multiple plugins — on_init fires in priority order in `tests/plugin_integration.rs`
-- [ ] T033 [P] [US5] Write test: panicking on_init is caught, agent construction continues, plugin policies still active in `tests/plugin_integration.rs`
+- [x] T031 [US5] Write test: plugin on_init is called once during Agent::new() in `tests/plugin_integration.rs`
+- [x] T032 [P] [US5] Write test: multiple plugins — on_init fires in priority order in `tests/plugin_integration.rs`
+- [x] T033 [P] [US5] Write test: panicking on_init is caught, agent construction continues, plugin policies still active in `tests/plugin_integration.rs`
 
 ### Implementation for User Story 5
 
-- [ ] T034 [US5] Implement `on_init` dispatch loop in `Agent::new()` — iterate priority-sorted plugins, call `on_init(&self)` wrapped in `catch_unwind`, log panics via `tracing::warn!` in `src/agent.rs`
+- [x] T034 [US5] Implement `on_init` dispatch loop in `Agent::new()` — iterate priority-sorted plugins, call `on_init(&self)` wrapped in `catch_unwind`, log panics via `tracing::warn!` in `src/agent.rs`
 
 **Checkpoint**: Init callbacks fire correctly with panic safety.
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -230,7 +230,7 @@ impl Agent {
             (_, tc) => tc,
         };
 
-        Self {
+        let agent = Self {
             id: AgentId::next(),
             state: AgentState {
                 system_prompt: effective_prompt,
@@ -281,7 +281,33 @@ impl Agent {
             dynamic_system_prompt: options.dynamic_system_prompt.map(Arc::from),
             #[cfg(feature = "plugins")]
             plugins: options.plugins,
+        };
+
+        // Dispatch on_init to each plugin in priority order (already sorted).
+        // Panics are caught and logged — the plugin's other contributions
+        // (policies, tools, event observers) remain active.
+        #[cfg(feature = "plugins")]
+        {
+            for plugin in &agent.plugins {
+                let name = plugin.name().to_owned();
+                let plugin_ref = Arc::clone(plugin);
+                let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    plugin_ref.on_init(&agent);
+                }));
+                if let Err(cause) = result {
+                    let msg = if let Some(s) = cause.downcast_ref::<&str>() {
+                        (*s).to_owned()
+                    } else if let Some(s) = cause.downcast_ref::<String>() {
+                        s.clone()
+                    } else {
+                        "unknown panic".to_owned()
+                    };
+                    tracing::warn!(plugin = %name, error = %msg, "plugin on_init panicked");
+                }
+            }
         }
+
+        agent
     }
 
     /// Returns this agent's unique identifier.

--- a/tests/plugin_integration.rs
+++ b/tests/plugin_integration.rs
@@ -641,6 +641,169 @@ fn agent_plugin_nonexistent_returns_none() {
     );
 }
 
+// ─── Phase 7: User Story 5 — Initialization Callback ───────────────────
+
+/// A plugin that tracks on_init calls.
+struct InitPlugin {
+    name: String,
+    priority: i32,
+    init_called: Arc<AtomicBool>,
+    init_order: Arc<AtomicUsize>,
+}
+
+impl InitPlugin {
+    fn new(name: &str, init_called: Arc<AtomicBool>) -> Self {
+        Self {
+            name: name.to_owned(),
+            priority: 0,
+            init_called,
+            init_order: Arc::new(AtomicUsize::new(usize::MAX)),
+        }
+    }
+
+    fn with_priority(mut self, priority: i32) -> Self {
+        self.priority = priority;
+        self
+    }
+
+    fn with_order(mut self, init_order: Arc<AtomicUsize>) -> Self {
+        self.init_order = init_order;
+        self
+    }
+}
+
+impl Plugin for InitPlugin {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn priority(&self) -> i32 {
+        self.priority
+    }
+
+    fn on_init(&self, _agent: &Agent) {
+        self.init_called.store(true, Ordering::SeqCst);
+        let seq = GLOBAL_ORDER.fetch_add(1, Ordering::SeqCst);
+        self.init_order.store(seq, Ordering::SeqCst);
+    }
+}
+
+/// A plugin whose on_init panics, but still contributes a post-turn policy.
+struct PanickingInitPlugin {
+    name: String,
+    fired: Arc<AtomicBool>,
+}
+
+impl PanickingInitPlugin {
+    fn new(name: &str, fired: Arc<AtomicBool>) -> Self {
+        Self {
+            name: name.to_owned(),
+            fired,
+        }
+    }
+}
+
+impl Plugin for PanickingInitPlugin {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn on_init(&self, _agent: &Agent) {
+        panic!("intentional panic in on_init");
+    }
+
+    fn post_turn_policies(&self) -> Vec<Arc<dyn PostTurnPolicy>> {
+        let fired = Arc::clone(&self.fired);
+        vec![Arc::new(RecordingPostTurnPolicy { fired })]
+    }
+}
+
+// ─── T031: Plugin on_init is called once during Agent::new() ───────────
+
+#[test]
+fn plugin_on_init_called_once_during_agent_new() {
+    let init_called = Arc::new(AtomicBool::new(false));
+    let plugin: Arc<dyn Plugin> = Arc::new(InitPlugin::new("init-test", Arc::clone(&init_called)));
+
+    let _agent = make_agent_with_plugins(vec![plugin]);
+
+    assert!(
+        init_called.load(Ordering::SeqCst),
+        "on_init should have been called during Agent::new()"
+    );
+}
+
+// ─── T032: Multiple plugins — on_init fires in priority order ──────────
+
+#[test]
+fn plugin_on_init_fires_in_priority_order() {
+    GLOBAL_ORDER.store(0, Ordering::SeqCst);
+
+    let low_called = Arc::new(AtomicBool::new(false));
+    let high_called = Arc::new(AtomicBool::new(false));
+    let low_order = Arc::new(AtomicUsize::new(usize::MAX));
+    let high_order = Arc::new(AtomicUsize::new(usize::MAX));
+
+    let low_plugin: Arc<dyn Plugin> = Arc::new(
+        InitPlugin::new("low-init", Arc::clone(&low_called))
+            .with_priority(1)
+            .with_order(Arc::clone(&low_order)),
+    );
+    let high_plugin: Arc<dyn Plugin> = Arc::new(
+        InitPlugin::new("high-init", Arc::clone(&high_called))
+            .with_priority(10)
+            .with_order(Arc::clone(&high_order)),
+    );
+
+    // Register low first, high second — priority should determine init order.
+    let _agent = make_agent_with_plugins(vec![low_plugin, high_plugin]);
+
+    assert!(
+        low_called.load(Ordering::SeqCst),
+        "low plugin on_init should have been called"
+    );
+    assert!(
+        high_called.load(Ordering::SeqCst),
+        "high plugin on_init should have been called"
+    );
+
+    let high_seq = high_order.load(Ordering::SeqCst);
+    let low_seq = low_order.load(Ordering::SeqCst);
+
+    assert!(
+        high_seq < low_seq,
+        "high-priority plugin on_init should fire first: high={high_seq}, low={low_seq}"
+    );
+}
+
+// ─── T033: Panicking on_init is caught, agent continues, policies active ─
+
+#[tokio::test]
+async fn panicking_on_init_caught_agent_continues() {
+    let policy_fired = Arc::new(AtomicBool::new(false));
+
+    // Plugin whose on_init panics but contributes a post-turn policy.
+    let panicking: Arc<dyn Plugin> = Arc::new(PanickingInitPlugin::new(
+        "panicker",
+        Arc::clone(&policy_fired),
+    ));
+
+    let stream_fn = Arc::new(MockStreamFn::new(vec![text_only_events("hello")]));
+    let options = AgentOptions::new("test", default_model(), stream_fn, default_convert)
+        .with_plugin(panicking);
+
+    // Agent construction should NOT panic.
+    let mut agent = Agent::new(options);
+
+    // Run a conversation — the panicking plugin's policy should still be active.
+    let _ = agent.prompt_async(vec![user_msg("hi")]).await;
+
+    assert!(
+        policy_fired.load(Ordering::SeqCst),
+        "panicking plugin's post-turn policy should still fire after on_init panic"
+    );
+}
+
 // ─── T024: Plugin Stop prevents ALL direct policies from evaluating ────
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Implement plugin `on_init()` dispatch in `Agent::new()` — called once per plugin in priority order after full agent construction
- `catch_unwind` + `AssertUnwindSafe` wraps each call — panicking plugins are logged via `tracing::warn!` but do not abort construction
- Plugin's other contributions (policies, tools, event observers) remain active even if `on_init` panics

## Tasks completed
- T031: Test — plugin `on_init` is called once during `Agent::new()`
- T032: Test — multiple plugins' `on_init` fires in priority order
- T033: Test — panicking `on_init` is caught, agent construction continues, plugin policies still active
- T034: Implementation — `on_init` dispatch loop in `Agent::new()` with panic safety

## Test plan
- [x] `cargo test -p swink-agent --features "testkit,plugins"` — 16/16 plugin integration tests pass
- [x] `cargo test --workspace --features testkit` — all workspace tests pass
- [x] `cargo test -p swink-agent --no-default-features` — passes (plugins disabled)
- [x] `cargo clippy --workspace -- -D warnings` — clean

Progress: 34/38 tasks (89%)

Part of #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)