### PR TITLE
impl(036): Add InMemoryArtifactStore with full trait impl (Phase 3)

### DIFF
--- a/artifacts/src/memory_store.rs
+++ b/artifacts/src/memory_store.rs
@@ -1,17 +1,139 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use chrono::Utc;
+use tokio::sync::Mutex;
+
+use swink_agent::{
+    ArtifactData, ArtifactError, ArtifactMeta, ArtifactStore, ArtifactVersion,
+    validate_artifact_name,
+};
+
+type VersionList = Vec<(ArtifactVersion, ArtifactData)>;
+type SessionMap = HashMap<String, HashMap<String, VersionList>>;
+
 /// In-memory artifact store for testing and lightweight use.
 ///
 /// All data lives in heap memory. Not persisted across process restarts.
-pub struct InMemoryArtifactStore;
+pub struct InMemoryArtifactStore {
+    data: Arc<Mutex<SessionMap>>,
+}
 
 impl InMemoryArtifactStore {
     /// Create a new empty in-memory store.
-    pub const fn new() -> Self {
-        Self
+    pub fn new() -> Self {
+        Self {
+            data: Arc::new(Mutex::new(HashMap::new())),
+        }
     }
 }
 
 impl Default for InMemoryArtifactStore {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl ArtifactStore for InMemoryArtifactStore {
+    async fn save(
+        &self,
+        session_id: &str,
+        name: &str,
+        data: ArtifactData,
+    ) -> Result<ArtifactVersion, ArtifactError> {
+        validate_artifact_name(name)?;
+
+        let mut store = self.data.lock().await;
+        let session = store.entry(session_id.to_string()).or_default();
+        let versions = session.entry(name.to_string()).or_default();
+
+        #[allow(clippy::cast_possible_truncation)]
+        let next_version = versions.len() as u32 + 1;
+        let version = ArtifactVersion {
+            name: name.to_string(),
+            version: next_version,
+            created_at: Utc::now(),
+            size: data.content.len(),
+            content_type: data.content_type.clone(),
+        };
+
+        tracing::debug!(
+            session_id,
+            name,
+            version = next_version,
+            size = data.content.len(),
+            "artifact saved"
+        );
+
+        versions.push((version.clone(), data));
+        drop(store);
+        Ok(version)
+    }
+
+    async fn load(
+        &self,
+        session_id: &str,
+        name: &str,
+    ) -> Result<Option<(ArtifactData, ArtifactVersion)>, ArtifactError> {
+        let store = self.data.lock().await;
+        let result = store
+            .get(session_id)
+            .and_then(|session| session.get(name))
+            .and_then(|versions| versions.last())
+            .map(|(v, d)| (d.clone(), v.clone()));
+        drop(store);
+        Ok(result)
+    }
+
+    async fn load_version(
+        &self,
+        session_id: &str,
+        name: &str,
+        version: u32,
+    ) -> Result<Option<(ArtifactData, ArtifactVersion)>, ArtifactError> {
+        let store = self.data.lock().await;
+        let result = store
+            .get(session_id)
+            .and_then(|session| session.get(name))
+            .and_then(|versions| {
+                versions
+                    .iter()
+                    .find(|(v, _)| v.version == version)
+                    .map(|(v, d)| (d.clone(), v.clone()))
+            });
+        drop(store);
+        Ok(result)
+    }
+
+    async fn list(&self, session_id: &str) -> Result<Vec<ArtifactMeta>, ArtifactError> {
+        let store = self.data.lock().await;
+        let Some(session) = store.get(session_id) else {
+            return Ok(Vec::new());
+        };
+
+        let mut metas = Vec::with_capacity(session.len());
+        for (name, versions) in session {
+            if let (Some(first), Some(last)) = (versions.first(), versions.last()) {
+                metas.push(ArtifactMeta {
+                    name: name.clone(),
+                    latest_version: last.0.version,
+                    created_at: first.0.created_at,
+                    updated_at: last.0.created_at,
+                    content_type: last.0.content_type.clone(),
+                });
+            }
+        }
+
+        drop(store);
+        Ok(metas)
+    }
+
+    async fn delete(&self, session_id: &str, name: &str) -> Result<(), ArtifactError> {
+        let mut store = self.data.lock().await;
+        if let Some(session) = store.get_mut(session_id) {
+            session.remove(name);
+        }
+        drop(store);
+        Ok(())
     }
 }

--- a/artifacts/tests/memory_store.rs
+++ b/artifacts/tests/memory_store.rs
@@ -1,0 +1,146 @@
+use std::collections::HashMap;
+
+use swink_agent::{ArtifactData, ArtifactError, ArtifactStore};
+use swink_agent_artifacts::InMemoryArtifactStore;
+
+fn text_data(content: &str) -> ArtifactData {
+    ArtifactData {
+        content: content.as_bytes().to_vec(),
+        content_type: "text/plain".to_string(),
+        metadata: HashMap::new(),
+    }
+}
+
+// T016: save_creates_version_one
+#[tokio::test]
+async fn save_creates_version_one() {
+    let store = InMemoryArtifactStore::new();
+    let version = store
+        .save("s1", "report.md", text_data("hello"))
+        .await
+        .unwrap();
+
+    assert_eq!(version.version, 1);
+    assert_eq!(version.name, "report.md");
+    assert_eq!(version.content_type, "text/plain");
+    assert_eq!(version.size, 5);
+}
+
+// T017: save_same_name_increments_version
+#[tokio::test]
+async fn save_same_name_increments_version() {
+    let store = InMemoryArtifactStore::new();
+    let v1 = store
+        .save("s1", "report.md", text_data("v1"))
+        .await
+        .unwrap();
+    let v2 = store
+        .save("s1", "report.md", text_data("v2"))
+        .await
+        .unwrap();
+
+    assert_eq!(v1.version, 1);
+    assert_eq!(v2.version, 2);
+}
+
+// T018: load_returns_latest_version
+#[tokio::test]
+async fn load_returns_latest_version() {
+    let store = InMemoryArtifactStore::new();
+    store
+        .save("s1", "report.md", text_data("v1"))
+        .await
+        .unwrap();
+    store
+        .save("s1", "report.md", text_data("v2"))
+        .await
+        .unwrap();
+    store
+        .save("s1", "report.md", text_data("v3"))
+        .await
+        .unwrap();
+
+    let (data, version) = store.load("s1", "report.md").await.unwrap().unwrap();
+    assert_eq!(version.version, 3);
+    assert_eq!(data.content, b"v3");
+}
+
+// T019: load_version_returns_specific
+#[tokio::test]
+async fn load_version_returns_specific() {
+    let store = InMemoryArtifactStore::new();
+    store
+        .save("s1", "report.md", text_data("v1"))
+        .await
+        .unwrap();
+    store
+        .save("s1", "report.md", text_data("v2"))
+        .await
+        .unwrap();
+    store
+        .save("s1", "report.md", text_data("v3"))
+        .await
+        .unwrap();
+
+    let (data, version) = store
+        .load_version("s1", "report.md", 1)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(version.version, 1);
+    assert_eq!(data.content, b"v1");
+}
+
+// T020: load_nonexistent_returns_none
+#[tokio::test]
+async fn load_nonexistent_returns_none() {
+    let store = InMemoryArtifactStore::new();
+    let result = store.load("s1", "missing.txt").await.unwrap();
+    assert!(result.is_none());
+}
+
+// T021: load_version_nonexistent_returns_none
+#[tokio::test]
+async fn load_version_nonexistent_returns_none() {
+    let store = InMemoryArtifactStore::new();
+    store
+        .save("s1", "report.md", text_data("v1"))
+        .await
+        .unwrap();
+
+    let result = store.load_version("s1", "report.md", 99).await.unwrap();
+    assert!(result.is_none());
+}
+
+// T022: save_validates_name
+#[tokio::test]
+async fn save_validates_name() {
+    let store = InMemoryArtifactStore::new();
+
+    let result = store.save("s1", "", text_data("x")).await;
+    assert!(matches!(result, Err(ArtifactError::InvalidName { .. })));
+
+    let result = store.save("s1", "../etc/passwd", text_data("x")).await;
+    assert!(matches!(result, Err(ArtifactError::InvalidName { .. })));
+
+    let result = store.save("s1", "/leading", text_data("x")).await;
+    assert!(matches!(result, Err(ArtifactError::InvalidName { .. })));
+}
+
+// T023: save_empty_content_succeeds
+#[tokio::test]
+async fn save_empty_content_succeeds() {
+    let store = InMemoryArtifactStore::new();
+    let data = ArtifactData {
+        content: vec![],
+        content_type: "application/octet-stream".to_string(),
+        metadata: HashMap::new(),
+    };
+    let version = store.save("s1", "empty.bin", data).await.unwrap();
+
+    assert_eq!(version.version, 1);
+    assert_eq!(version.size, 0);
+
+    let (loaded, _) = store.load("s1", "empty.bin").await.unwrap().unwrap();
+    assert!(loaded.content.is_empty());
+}

--- a/specs/036-artifact-service/tasks.md
+++ b/specs/036-artifact-service/tasks.md
@@ -58,22 +58,22 @@
 
 ### Tests for User Story 1
 
-- [ ] T016 [P] [US1] Write test `save_creates_version_one` in `artifacts/tests/memory_store.rs` — save artifact, assert version 1, correct size/content_type
-- [ ] T017 [P] [US1] Write test `save_same_name_increments_version` in `artifacts/tests/memory_store.rs` — save twice, assert versions 1 and 2
-- [ ] T018 [P] [US1] Write test `load_returns_latest_version` in `artifacts/tests/memory_store.rs` — save 3 versions, `load` returns version 3
-- [ ] T019 [P] [US1] Write test `load_version_returns_specific` in `artifacts/tests/memory_store.rs` — save 3 versions, `load_version(1)` returns version 1 content
-- [ ] T020 [P] [US1] Write test `load_nonexistent_returns_none` in `artifacts/tests/memory_store.rs` — `load` unknown name returns `None`
-- [ ] T021 [P] [US1] Write test `load_version_nonexistent_returns_none` in `artifacts/tests/memory_store.rs` — `load_version(99)` returns `None`
-- [ ] T022 [P] [US1] Write test `save_validates_name` in `artifacts/tests/memory_store.rs` — invalid name returns `ArtifactError::InvalidName`
-- [ ] T023 [P] [US1] Write test `save_empty_content_succeeds` in `artifacts/tests/memory_store.rs` — zero-byte artifact saves correctly
+- [x] T016 [P] [US1] Write test `save_creates_version_one` in `artifacts/tests/memory_store.rs` — save artifact, assert version 1, correct size/content_type
+- [x] T017 [P] [US1] Write test `save_same_name_increments_version` in `artifacts/tests/memory_store.rs` — save twice, assert versions 1 and 2
+- [x] T018 [P] [US1] Write test `load_returns_latest_version` in `artifacts/tests/memory_store.rs` — save 3 versions, `load` returns version 3
+- [x] T019 [P] [US1] Write test `load_version_returns_specific` in `artifacts/tests/memory_store.rs` — save 3 versions, `load_version(1)` returns version 1 content
+- [x] T020 [P] [US1] Write test `load_nonexistent_returns_none` in `artifacts/tests/memory_store.rs` — `load` unknown name returns `None`
+- [x] T021 [P] [US1] Write test `load_version_nonexistent_returns_none` in `artifacts/tests/memory_store.rs` — `load_version(99)` returns `None`
+- [x] T022 [P] [US1] Write test `save_validates_name` in `artifacts/tests/memory_store.rs` — invalid name returns `ArtifactError::InvalidName`
+- [x] T023 [P] [US1] Write test `save_empty_content_succeeds` in `artifacts/tests/memory_store.rs` — zero-byte artifact saves correctly
 
 ### Implementation for User Story 1
 
-- [ ] T024 [US1] Implement `InMemoryArtifactStore` struct in `artifacts/src/memory_store.rs` — `Arc<tokio::sync::Mutex<HashMap<String, HashMap<String, Vec<(ArtifactVersion, ArtifactData)>>>>>`, `new()` constructor
-- [ ] T025 [US1] Implement `ArtifactStore::save` for `InMemoryArtifactStore` in `artifacts/src/memory_store.rs` — validate name, increment version, store data, emit `tracing::debug!`
-- [ ] T026 [US1] Implement `ArtifactStore::load` and `ArtifactStore::load_version` for `InMemoryArtifactStore` in `artifacts/src/memory_store.rs`
-- [ ] T027 [US1] Re-export `InMemoryArtifactStore` from `artifacts/src/lib.rs`
-- [ ] T028 [US1] Run all US1 tests — verify they pass
+- [x] T024 [US1] Implement `InMemoryArtifactStore` struct in `artifacts/src/memory_store.rs` — `Arc<tokio::sync::Mutex<HashMap<String, HashMap<String, Vec<(ArtifactVersion, ArtifactData)>>>>>`, `new()` constructor
+- [x] T025 [US1] Implement `ArtifactStore::save` for `InMemoryArtifactStore` in `artifacts/src/memory_store.rs` — validate name, increment version, store data, emit `tracing::debug!`
+- [x] T026 [US1] Implement `ArtifactStore::load` and `ArtifactStore::load_version` for `InMemoryArtifactStore` in `artifacts/src/memory_store.rs`
+- [x] T027 [US1] Re-export `InMemoryArtifactStore` from `artifacts/src/lib.rs`
+- [x] T028 [US1] Run all US1 tests — verify they pass
 
 **Checkpoint**: `InMemoryArtifactStore` saves and loads versioned artifacts. All US1 tests pass.
 

--- a/specs/spec-status.md
+++ b/specs/spec-status.md
@@ -38,7 +38,7 @@
 | 033-workspace-feature-gates     | ✓     | ✓  | ✓   | ✓ Complete |
 | 034-session-state-store         | ✓     | ✓  | ✓   | ✓ Complete |
 | 035-credential-management       | ✓     | ✓  | ✓   | ✓ Complete |
-| 036-artifact-service            | ✓     | ✓  | ✓   | ● 15/81 (19%) |
+| 036-artifact-service            | ✓     | ✓  | ✓   | ● 28/81 (35%) |
 | 037-plugin-system               | ✓     | ✓  | ✓   | ● 0/47 (0%) |
 | 038-mcp-integration             | ✓     | ✓  | ✓   | ● 16/49 (33%) |
 | 039-multi-agent-patterns        | ✓     | ✓  | ✓   | ● 0/66 (0%) |
@@ -79,7 +79,7 @@
 <!-- feature: 033-workspace-feature-gates has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=25 tasks_completed=25 checklist_files=requirements.md -->
 <!-- feature: 034-session-state-store has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=93 tasks_completed=93 checklist_files=requirements.md -->
 <!-- feature: 035-credential-management has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=73 tasks_completed=73 checklist_files=requirements.md -->
-<!-- feature: 036-artifact-service has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=81 tasks_completed=15 checklist_files=requirements.md -->
+<!-- feature: 036-artifact-service has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=81 tasks_completed=28 checklist_files=requirements.md -->
 <!-- feature: 037-plugin-system has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=47 tasks_completed=0 checklist_files=requirements.md -->
 <!-- feature: 038-mcp-integration has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=49 tasks_completed=16 checklist_files=requirements.md -->
 <!-- feature: 039-multi-agent-patterns has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=66 tasks_completed=0 checklist_files=requirements.md -->


### PR DESCRIPTION
## Summary
- Implement `InMemoryArtifactStore` with full `ArtifactStore` trait (save, load, load_version, list, delete)
- Add 8 integration tests covering versioning, name validation, empty content, and nonexistent artifact lookups
- Update spec-status: 036-artifact-service progress 15→28/81 (35%)

## Tasks completed
- T016: `save_creates_version_one` test
- T017: `save_same_name_increments_version` test
- T018: `load_returns_latest_version` test
- T019: `load_version_returns_specific` test
- T020: `load_nonexistent_returns_none` test
- T021: `load_version_nonexistent_returns_none` test
- T022: `save_validates_name` test
- T023: `save_empty_content_succeeds` test
- T024: `InMemoryArtifactStore` struct with `Arc<Mutex<SessionMap>>`
- T025: `ArtifactStore::save` with name validation, versioning, tracing
- T026: `ArtifactStore::load` and `load_version` implementations
- T027: Re-export from `artifacts/src/lib.rs` (already existed)
- T028: All US1 tests pass

## Test plan
- [x] `cargo test -p swink-agent-artifacts` — 25 tests pass (17 validation + 8 new)
- [x] `cargo test --workspace` passes
- [x] `cargo test -p swink-agent --no-default-features` passes
- [x] `cargo clippy --workspace -- -D warnings` clean

Part of #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)