### PR TITLE
impl(037): Plugin system Phases 8-9 — tool namespacing and removal tests

### DIFF
--- a/specs/037-plugin-system/tasks.md
+++ b/specs/037-plugin-system/tasks.md
@@ -153,13 +153,13 @@
 
 ### Tests for User Story 7
 
-- [ ] T035 [US7] Write test: plugin tools appear as `"{plugin_name}.{tool_name}"` in agent tool list in `tests/plugin_integration.rs`
-- [ ] T036 [P] [US7] Write test: two plugins contributing same-named tools — both appear with distinct namespace prefixes in `tests/plugin_integration.rs`
-- [ ] T037 [P] [US7] Write test: direct tool with same name as namespaced plugin tool — direct tool found first when dispatching in `tests/plugin_integration.rs`
+- [x] T035 [US7] Write test: plugin tools appear as `"{plugin_name}.{tool_name}"` in agent tool list in `tests/plugin_integration.rs`
+- [x] T036 [P] [US7] Write test: two plugins contributing same-named tools — both appear with distinct namespace prefixes in `tests/plugin_integration.rs`
+- [x] T037 [P] [US7] Write test: direct tool with same name as namespaced plugin tool — direct tool found first when dispatching in `tests/plugin_integration.rs`
 
 ### Implementation for User Story 7
 
-- [ ] T038 [US7] Verify tool merge order in `Agent::new()`: direct tools first, then namespaced plugin tools appended in `src/agent.rs`
+- [x] T038 [US7] Verify tool merge order in `Agent::new()`: direct tools first, then namespaced plugin tools appended in `src/agent.rs`
 
 **Checkpoint**: Plugin tools are correctly namespaced and merged.
 
@@ -173,12 +173,12 @@
 
 ### Tests for User Story 6
 
-- [ ] T039 [US6] Write test: unregister plugin by name — verify its contributions are absent after Agent::new() in `tests/plugin_integration.rs`
-- [ ] T040 [P] [US6] Write test: unregister nonexistent name — succeeds silently in `tests/plugin_registry.rs`
+- [x] T039 [US6] Write test: unregister plugin by name — verify its contributions are absent after Agent::new() in `tests/plugin_integration.rs`
+- [x] T040 [P] [US6] Write test: unregister nonexistent name — succeeds silently in `tests/plugin_registry.rs`
 
 ### Implementation for User Story 6
 
-- [ ] T041 [US6] Verify `PluginRegistry::unregister()` removes plugin from the vec and subsequent `Agent::new()` does not include its contributions (should already work from Phase 2 registry + Phase 3 merge logic)
+- [x] T041 [US6] Verify `PluginRegistry::unregister()` removes plugin from the vec and subsequent `Agent::new()` does not include its contributions (should already work from Phase 2 registry + Phase 3 merge logic)
 
 **Checkpoint**: Plugin removal works at configuration time.
 

--- a/tests/plugin_integration.rs
+++ b/tests/plugin_integration.rs
@@ -852,3 +852,138 @@ async fn plugin_stop_prevents_all_direct_policies() {
         "direct policy B should not fire after plugin Stop verdict"
     );
 }
+
+// ─── Phase 8: User Story 7 — Plugin Tool Contribution ──────────────────
+
+// ─── T035: Plugin tools appear as "{plugin_name}.{tool_name}" ───────────
+
+#[test]
+fn plugin_tools_namespaced_format() {
+    let plugin: Arc<dyn Plugin> = Arc::new(ToolPlugin::new("analyzer", &["scan", "report"]));
+
+    let agent = make_agent_with_plugins(vec![plugin]);
+
+    let tool_names: Vec<&str> = agent.state().tools.iter().map(|t| t.name()).collect();
+    assert!(
+        tool_names.contains(&"analyzer.scan"),
+        "expected 'analyzer.scan', got: {tool_names:?}"
+    );
+    assert!(
+        tool_names.contains(&"analyzer.report"),
+        "expected 'analyzer.report', got: {tool_names:?}"
+    );
+}
+
+// ─── T036: Two plugins with same-named tools — distinct namespaces ──────
+
+#[test]
+fn two_plugins_same_tool_names_distinct_namespaces() {
+    let plugin_a: Arc<dyn Plugin> = Arc::new(ToolPlugin::new("alpha", &["run"]));
+    let plugin_b: Arc<dyn Plugin> = Arc::new(ToolPlugin::new("beta", &["run"]));
+
+    let agent = make_agent_with_plugins(vec![plugin_a, plugin_b]);
+
+    let tool_names: Vec<&str> = agent.state().tools.iter().map(|t| t.name()).collect();
+    assert!(
+        tool_names.contains(&"alpha.run"),
+        "expected 'alpha.run', got: {tool_names:?}"
+    );
+    assert!(
+        tool_names.contains(&"beta.run"),
+        "expected 'beta.run', got: {tool_names:?}"
+    );
+    // Both should coexist — no collision.
+    assert_eq!(
+        tool_names.iter().filter(|&&n| n == "alpha.run").count(),
+        1,
+        "alpha.run should appear exactly once"
+    );
+    assert_eq!(
+        tool_names.iter().filter(|&&n| n == "beta.run").count(),
+        1,
+        "beta.run should appear exactly once"
+    );
+}
+
+// ─── T037: Direct tool takes precedence over namespaced plugin tool ─────
+
+#[test]
+fn direct_tool_found_first_over_namespaced_plugin_tool() {
+    // Create a direct tool named "myns.fetch" and a plugin named "myns" contributing "fetch".
+    // The direct tool should be found first by find_tool.
+
+    let direct_tool: Arc<dyn AgentTool> = Arc::new(PluginStubTool::new("myns.fetch"));
+    let plugin: Arc<dyn Plugin> = Arc::new(ToolPlugin::new("myns", &["fetch"]));
+
+    let stream_fn = Arc::new(MockStreamFn::new(vec![text_only_events("hello")]));
+    let options = AgentOptions::new("test", default_model(), stream_fn, default_convert)
+        .with_tools(vec![direct_tool])
+        .with_plugin(plugin);
+
+    let agent = Agent::new(options);
+
+    // The direct tool is first in the list (direct tools before plugin tools).
+    let tool_names: Vec<&str> = agent.state().tools.iter().map(|t| t.name()).collect();
+    // Both should exist.
+    let count = tool_names.iter().filter(|&&n| n == "myns.fetch").count();
+    assert_eq!(
+        count, 2,
+        "both direct and namespaced tool should be present, got {count}"
+    );
+
+    // find_tool returns the first match — should be the direct tool.
+    let found = agent.find_tool("myns.fetch");
+    assert!(found.is_some(), "find_tool should find 'myns.fetch'");
+
+    // Verify it's the direct tool (not the NamespacedTool wrapper).
+    // NamespacedTool has description "plugin stub tool" and label "myns.fetch" (overridden).
+    // Direct PluginStubTool has label "myns.fetch" (set in constructor).
+    // Both have the same description, so check order by position.
+    let first_idx = tool_names.iter().position(|&n| n == "myns.fetch").unwrap();
+    assert_eq!(
+        first_idx, 0,
+        "direct tool should be at index 0 (before plugin tools), got {first_idx}"
+    );
+}
+
+// ─── T038: Verify tool merge order — direct first, then plugin ──────────
+// (Verification task — confirmed by T037 above: direct tools at lower indices,
+//  plugin tools appended after.)
+
+// ─── Phase 9: User Story 6 — Plugin Removal ────────────────────────────
+
+// ─── T039: Unregister plugin — contributions absent after Agent::new() ──
+
+#[test]
+fn unregistered_plugin_contributions_absent() {
+    use swink_agent::plugin::PluginRegistry;
+
+    let mut registry = PluginRegistry::new();
+    let plugin_a: Arc<dyn Plugin> = Arc::new(ToolPlugin::new("keep", &["tool_a"]));
+    let plugin_b: Arc<dyn Plugin> = Arc::new(ToolPlugin::new("remove", &["tool_b"]));
+    registry.register(plugin_a);
+    registry.register(plugin_b);
+
+    // Unregister "remove".
+    registry.unregister("remove");
+
+    // Build agent with remaining plugins only.
+    let plugins: Vec<Arc<dyn Plugin>> = registry.list().into_iter().cloned().collect();
+    let stream_fn = Arc::new(MockStreamFn::new(vec![text_only_events("hello")]));
+    let options = AgentOptions::new("test", default_model(), stream_fn, default_convert)
+        .with_plugins(plugins);
+    let agent = Agent::new(options);
+
+    let tool_names: Vec<&str> = agent.state().tools.iter().map(|t| t.name()).collect();
+    assert!(
+        tool_names.contains(&"keep.tool_a"),
+        "kept plugin's tools should be present: {tool_names:?}"
+    );
+    assert!(
+        !tool_names.iter().any(|&n| n.contains("remove")),
+        "removed plugin's tools should be absent: {tool_names:?}"
+    );
+}
+
+// ─── T040: Unregister nonexistent name — succeeds silently ──────────────
+// (Already covered in tests/plugin_registry.rs: `registry_unregister_nonexistent_is_noop`)


### PR DESCRIPTION
## Summary
- Adds integration tests for plugin tool namespacing (T035-T037): verifying `"{plugin}.{tool}"` format, distinct namespaces for same-named tools across plugins, and direct tool precedence over namespaced plugin tools
- Adds integration test for plugin removal (T039): verifying unregistered plugin contributions are absent after `Agent::new()`
- Verifies tool merge order (T038) and registry unregister flow (T040-T041) through existing + new tests
- Marks T035-T041 complete in tasks.md (progress: 41/47, 87%)

## Tasks completed
- T035: Plugin tools appear as `"{plugin_name}.{tool_name}"`
- T036: Two plugins with same-named tools get distinct namespace prefixes
- T037: Direct tool found first when dispatching (precedence over namespaced)
- T038: Tool merge order verified (direct first, plugin appended)
- T039: Unregistered plugin contributions absent after Agent::new()
- T040: Already covered by `registry_unregister_nonexistent_is_noop` in plugin_registry.rs
- T041: Registry unregister + merge logic verified end-to-end

## Test plan
- [x] `cargo test --workspace --features testkit` passes
- [x] `cargo test -p swink-agent --features plugins,testkit -- plugin` passes (18 integration + 3 registry)
- [x] `cargo test -p swink-agent --no-default-features` passes
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] No public API changes

Part of #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)