### PR TITLE
impl(037): Plugin system Phase 10 — MockPlugin, docs, polish

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,15 @@ MSRV **1.88** (edition 2024). Workspace deps centralized in root `Cargo.toml`.
 - `AgentToolResult.is_error` replaces old `text.starts_with("error")` heuristic. Use `error()` / `text()` constructors.
 - `ToolCallTransformer` runs unconditionally (not gated by approval). Distinct from `ToolValidator` (rejects vs rewrites).
 
+### Plugin System (`src/plugin.rs`)
+
+- `Plugin` trait: only `name()` required; all other methods (`priority()`, `on_init()`, policy/tool contributions) have default no-op implementations.
+- `PluginRegistry` stores plugins in insertion order; `list()` returns them sorted by priority (highest first, stable sort). Duplicate names replace silently with a warning.
+- `NamespacedTool` prefixes plugin name onto tool name (`"plugin.tool"`) to avoid cross-plugin collisions. `metadata().namespace` is set automatically.
+- Plugin contributions (policies, tools, event observer) are merged in `Agent::new()` — policies prepended in priority order, tools wrapped in `NamespacedTool`.
+- `on_init()` is called in priority order during `Agent::new()` after full configuration. Panics are caught via `catch_unwind` and logged.
+- Entire module gated behind `#[cfg(feature = "plugins")]` — zero cost when disabled. `MockPlugin` test helper in `testing.rs` also feature-gated.
+
 ### Checkpoint / Persistence
 
 - Checkpoint and SessionStore now support CustomMessage persistence via `custom_messages` field and `save_full`/`load_full`. Old checkpoints without `custom_messages` field deserialize fine (backward compat via `#[serde(default)]`).
@@ -116,6 +125,7 @@ MSRV **1.88** (edition 2024). Workspace deps centralized in root `Cargo.toml`.
 **Root crate (`swink-agent`):**
 - `builtin-tools` (default-enabled) — gates `BashTool`, `ReadFileTool`, `WriteFileTool`.
 - `testkit` — gates the `testing` module (mock `StreamFn`/`AgentTool` implementations, event/message builders). Not default-enabled; consumers add `features = ["testkit"]` in dev-dependencies. Integration tests in `/tests/` are gated with `#![cfg(feature = "testkit")]`.
+- `plugins` — gates `plugin` module (`Plugin` trait, `PluginRegistry`, `NamespacedTool`). Not default-enabled. `MockPlugin` in `testing.rs` also gated behind this feature.
 - Root crate cannot re-export adapters/local-llm/TUI (cyclic dependency). Consumers depend on sub-crates directly.
 
 **Adapters crate (`swink-agent-adapters`):**

--- a/specs/037-plugin-system/tasks.md
+++ b/specs/037-plugin-system/tasks.md
@@ -188,12 +188,12 @@
 
 **Purpose**: Documentation, test helpers, and feature gate verification
 
-- [ ] T042 [P] Add `MockPlugin` test helper to `tests/common/mod.rs` (configurable name, priority, contributed policies/tools, init tracking)
-- [ ] T043 [P] Verify `cargo test -p swink-agent --no-default-features` passes (plugins feature disabled, no compile errors)
-- [ ] T044 [P] Verify `cargo test -p swink-agent --features plugins` passes (all plugin tests run)
-- [ ] T045 [P] Verify `cargo clippy --workspace -- -D warnings` passes with plugins feature enabled
-- [ ] T046 Update `src/lib.rs` public API re-exports: `Plugin`, `PluginRegistry` behind `#[cfg(feature = "plugins")]`
-- [ ] T047 Add plugin system entry to CLAUDE.md lessons learned section
+- [x] T042 [P] Add `MockPlugin` test helper to `tests/common/mod.rs` (configurable name, priority, contributed policies/tools, init tracking)
+- [x] T043 [P] Verify `cargo test -p swink-agent --no-default-features` passes (plugins feature disabled, no compile errors)
+- [x] T044 [P] Verify `cargo test -p swink-agent --features plugins` passes (all plugin tests run)
+- [x] T045 [P] Verify `cargo clippy --workspace -- -D warnings` passes with plugins feature enabled
+- [x] T046 Update `src/lib.rs` public API re-exports: `Plugin`, `PluginRegistry` behind `#[cfg(feature = "plugins")]`
+- [x] T047 Add plugin system entry to CLAUDE.md lessons learned section
 
 ---
 

--- a/specs/spec-status.md
+++ b/specs/spec-status.md
@@ -39,7 +39,7 @@
 | 034-session-state-store         | ✓     | ✓  | ✓   | ✓ Complete |
 | 035-credential-management       | ✓     | ✓  | ✓   | ✓ Complete |
 | 036-artifact-service            | ✓     | ✓  | ✓   | ● 28/81 (35%) |
-| 037-plugin-system               | ✓     | ✓  | ✓   | ● 0/47 (0%) |
+| 037-plugin-system               | ✓     | ✓  | ✓   | ✅ 47/47 (100%) |
 | 038-mcp-integration             | ✓     | ✓  | ✓   | ● 16/49 (33%) |
 | 039-multi-agent-patterns        | ✓     | ✓  | ✓   | ● 0/66 (0%) |
 | 040-agent-transfer-handoff      | ✓     | ✓  | ✓   | ● 0/49 (0%) |
@@ -80,7 +80,7 @@
 <!-- feature: 034-session-state-store has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=93 tasks_completed=93 checklist_files=requirements.md -->
 <!-- feature: 035-credential-management has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=73 tasks_completed=73 checklist_files=requirements.md -->
 <!-- feature: 036-artifact-service has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=81 tasks_completed=28 checklist_files=requirements.md -->
-<!-- feature: 037-plugin-system has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=47 tasks_completed=0 checklist_files=requirements.md -->
+<!-- feature: 037-plugin-system has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=47 tasks_completed=47 checklist_files=requirements.md -->
 <!-- feature: 038-mcp-integration has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=49 tasks_completed=16 checklist_files=requirements.md -->
 <!-- feature: 039-multi-agent-patterns has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=66 tasks_completed=0 checklist_files=requirements.md -->
 <!-- feature: 040-agent-transfer-handoff has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=49 tasks_completed=0 checklist_files=requirements.md -->

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -645,3 +645,141 @@ pub fn event_variant_name(event: &AgentEvent) -> String {
         AgentEvent::ArtifactSaved { .. } => "ArtifactSaved".into(),
     }
 }
+
+// ─── MockPlugin (plugins feature only) ──────────────────────────────────
+
+#[cfg(feature = "plugins")]
+mod mock_plugin {
+    use super::*;
+    use crate::plugin::Plugin;
+    use crate::policy::{PostLoopPolicy, PostTurnPolicy, PreDispatchPolicy, PreTurnPolicy};
+    use std::sync::atomic::AtomicUsize;
+
+    /// A configurable mock [`Plugin`] for testing plugin registration, ordering,
+    /// and contribution merging.
+    ///
+    /// Tracks `on_init` invocations and records the order relative to other plugins.
+    pub struct MockPlugin {
+        name: String,
+        priority: i32,
+        tools: Vec<Arc<dyn AgentTool>>,
+        pre_turn: Vec<Arc<dyn PreTurnPolicy>>,
+        pre_dispatch: Vec<Arc<dyn PreDispatchPolicy>>,
+        post_turn: Vec<Arc<dyn PostTurnPolicy>>,
+        post_loop: Vec<Arc<dyn PostLoopPolicy>>,
+        init_count: Arc<AtomicUsize>,
+        init_order: Option<Arc<AtomicUsize>>,
+    }
+
+    impl MockPlugin {
+        /// Create a minimal plugin with the given name and default priority 0.
+        #[must_use]
+        pub fn new(name: &str) -> Self {
+            Self {
+                name: name.to_owned(),
+                priority: 0,
+                tools: Vec::new(),
+                pre_turn: Vec::new(),
+                pre_dispatch: Vec::new(),
+                post_turn: Vec::new(),
+                post_loop: Vec::new(),
+                init_count: Arc::new(AtomicUsize::new(0)),
+                init_order: None,
+            }
+        }
+
+        /// Set the priority.
+        #[must_use]
+        pub const fn with_priority(mut self, priority: i32) -> Self {
+            self.priority = priority;
+            self
+        }
+
+        /// Add a tool to the plugin's contributions.
+        #[must_use]
+        pub fn with_tool(mut self, tool: Arc<dyn AgentTool>) -> Self {
+            self.tools.push(tool);
+            self
+        }
+
+        /// Add a pre-turn policy.
+        #[must_use]
+        pub fn with_pre_turn_policy(mut self, policy: Arc<dyn PreTurnPolicy>) -> Self {
+            self.pre_turn.push(policy);
+            self
+        }
+
+        /// Add a pre-dispatch policy.
+        #[must_use]
+        pub fn with_pre_dispatch_policy(mut self, policy: Arc<dyn PreDispatchPolicy>) -> Self {
+            self.pre_dispatch.push(policy);
+            self
+        }
+
+        /// Add a post-turn policy.
+        #[must_use]
+        pub fn with_post_turn_policy(mut self, policy: Arc<dyn PostTurnPolicy>) -> Self {
+            self.post_turn.push(policy);
+            self
+        }
+
+        /// Add a post-loop policy.
+        #[must_use]
+        pub fn with_post_loop_policy(mut self, policy: Arc<dyn PostLoopPolicy>) -> Self {
+            self.post_loop.push(policy);
+            self
+        }
+
+        /// Provide a shared counter for tracking init order across plugins.
+        #[must_use]
+        pub fn with_init_order(mut self, order: Arc<AtomicUsize>) -> Self {
+            self.init_order = Some(order);
+            self
+        }
+
+        /// Number of times `on_init` was called.
+        pub fn init_count(&self) -> usize {
+            self.init_count.load(Ordering::SeqCst)
+        }
+    }
+
+    impl Plugin for MockPlugin {
+        fn name(&self) -> &str {
+            &self.name
+        }
+
+        fn priority(&self) -> i32 {
+            self.priority
+        }
+
+        fn on_init(&self, _agent: &crate::Agent) {
+            self.init_count.fetch_add(1, Ordering::SeqCst);
+            if let Some(order) = &self.init_order {
+                order.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        fn pre_turn_policies(&self) -> Vec<Arc<dyn PreTurnPolicy>> {
+            self.pre_turn.clone()
+        }
+
+        fn pre_dispatch_policies(&self) -> Vec<Arc<dyn PreDispatchPolicy>> {
+            self.pre_dispatch.clone()
+        }
+
+        fn post_turn_policies(&self) -> Vec<Arc<dyn PostTurnPolicy>> {
+            self.post_turn.clone()
+        }
+
+        fn post_loop_policies(&self) -> Vec<Arc<dyn PostLoopPolicy>> {
+            self.post_loop.clone()
+        }
+
+        fn tools(&self) -> Vec<Arc<dyn AgentTool>> {
+            self.tools.clone()
+        }
+    }
+}
+
+#[cfg(feature = "plugins")]
+pub use mock_plugin::MockPlugin;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -15,3 +15,7 @@ pub use swink_agent::testing::{
 
 #[allow(unused_imports)]
 pub use swink_agent::AssistantMessageEvent;
+
+#[cfg(all(feature = "plugins", feature = "testkit"))]
+#[allow(unused_imports)]
+pub use swink_agent::testing::MockPlugin;

--- a/tests/plugin_integration.rs
+++ b/tests/plugin_integration.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "plugins")]
+#![cfg(all(feature = "plugins", feature = "testkit"))]
 
 //! Integration tests for plugin contribution merge in Agent::new().
 


### PR DESCRIPTION
## Summary
- Add configurable `MockPlugin` test helper to `src/testing.rs` (feature-gated behind `plugins`)
- Re-export `MockPlugin` in `tests/common/mod.rs` for integration tests
- Fix `plugin_integration.rs` cfg gate to require both `testkit` and `plugins` features (prevents compile error when running with `--features plugins` alone)
- Add plugin system lessons learned section to `CLAUDE.md`
- Document `plugins` feature gate in Feature Gates section
- Mark all Phase 10 tasks complete (T042-T047)
- Update `spec-status.md`: 037-plugin-system now at 47/47 (100%)

## Tasks completed
- T042: Add `MockPlugin` test helper with builder pattern (name, priority, tools, policies, init tracking)
- T043: Verified `cargo test -p swink-agent --no-default-features` passes
- T044: Verified `cargo test -p swink-agent --features "testkit,plugins"` passes
- T045: Verified `cargo clippy --workspace -- -D warnings` clean
- T046: Already done (lib.rs re-exports were in place)
- T047: Added plugin system entry to CLAUDE.md lessons learned

## Test plan
- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo test -p swink-agent --no-default-features` passes (plugins disabled)
- [x] `cargo test -p swink-agent --features plugins` passes (plugins-only)
- [x] `cargo test -p swink-agent --features "testkit,plugins"` passes (full integration)
- [x] No public API breakage in downstream crates

Part of #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)