### PR TITLE
impl(036): Add Phase 4 US2 list/metadata tests (T029-T034)

### DIFF
--- a/artifacts/tests/memory_store.rs
+++ b/artifacts/tests/memory_store.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use swink_agent::{ArtifactData, ArtifactError, ArtifactStore};
+use swink_agent::{ArtifactData, ArtifactError, ArtifactMeta, ArtifactStore};
 use swink_agent_artifacts::InMemoryArtifactStore;
 
 fn text_data(content: &str) -> ArtifactData {
@@ -143,4 +143,92 @@ async fn save_empty_content_succeeds() {
 
     let (loaded, _) = store.load("s1", "empty.bin").await.unwrap().unwrap();
     assert!(loaded.content.is_empty());
+}
+
+// T029: list_returns_all_artifacts
+#[tokio::test]
+async fn list_returns_all_artifacts() {
+    let store = InMemoryArtifactStore::new();
+
+    let csv_data = ArtifactData {
+        content: b"a,b,c".to_vec(),
+        content_type: "text/csv".to_string(),
+        metadata: HashMap::new(),
+    };
+    let json_data = ArtifactData {
+        content: b"{}".to_vec(),
+        content_type: "application/json".to_string(),
+        metadata: HashMap::new(),
+    };
+
+    store
+        .save("s1", "report.md", text_data("hello"))
+        .await
+        .unwrap();
+    store.save("s1", "data.csv", csv_data).await.unwrap();
+    store.save("s1", "config.json", json_data).await.unwrap();
+
+    let mut metas: Vec<ArtifactMeta> = store.list("s1").await.unwrap();
+    metas.sort_by(|a, b| a.name.cmp(&b.name));
+
+    assert_eq!(metas.len(), 3);
+    assert_eq!(metas[0].name, "config.json");
+    assert_eq!(metas[0].content_type, "application/json");
+    assert_eq!(metas[0].latest_version, 1);
+    assert_eq!(metas[1].name, "data.csv");
+    assert_eq!(metas[1].content_type, "text/csv");
+    assert_eq!(metas[1].latest_version, 1);
+    assert_eq!(metas[2].name, "report.md");
+    assert_eq!(metas[2].content_type, "text/plain");
+    assert_eq!(metas[2].latest_version, 1);
+}
+
+// T030: list_empty_session_returns_empty
+#[tokio::test]
+async fn list_empty_session_returns_empty() {
+    let store = InMemoryArtifactStore::new();
+    let metas = store.list("nonexistent-session").await.unwrap();
+    assert!(metas.is_empty());
+}
+
+// T031: list_reflects_latest_version
+#[tokio::test]
+async fn list_reflects_latest_version() {
+    let store = InMemoryArtifactStore::new();
+    store
+        .save("s1", "report.md", text_data("v1"))
+        .await
+        .unwrap();
+    store
+        .save("s1", "report.md", text_data("v2"))
+        .await
+        .unwrap();
+
+    let metas = store.list("s1").await.unwrap();
+    assert_eq!(metas.len(), 1);
+    assert_eq!(metas[0].name, "report.md");
+    assert_eq!(metas[0].latest_version, 2);
+    assert!(metas[0].updated_at >= metas[0].created_at);
+}
+
+// T032: load_includes_custom_metadata
+#[tokio::test]
+async fn load_includes_custom_metadata() {
+    let store = InMemoryArtifactStore::new();
+    let mut metadata = HashMap::new();
+    metadata.insert("author".to_string(), "agent-1".to_string());
+    metadata.insert("source".to_string(), "web-scrape".to_string());
+
+    let data = ArtifactData {
+        content: b"some content".to_vec(),
+        content_type: "text/plain".to_string(),
+        metadata,
+    };
+
+    store.save("s1", "result.txt", data).await.unwrap();
+
+    let (loaded, _) = store.load("s1", "result.txt").await.unwrap().unwrap();
+    assert_eq!(loaded.metadata.get("author").unwrap(), "agent-1");
+    assert_eq!(loaded.metadata.get("source").unwrap(), "web-scrape");
+    assert_eq!(loaded.metadata.len(), 2);
 }

--- a/specs/036-artifact-service/tasks.md
+++ b/specs/036-artifact-service/tasks.md
@@ -87,15 +87,15 @@
 
 ### Tests for User Story 2
 
-- [ ] T029 [P] [US2] Write test `list_returns_all_artifacts` in `artifacts/tests/memory_store.rs` — save 3 artifacts, list returns 3 entries with correct names/versions/types
-- [ ] T030 [P] [US2] Write test `list_empty_session_returns_empty` in `artifacts/tests/memory_store.rs` — list on unknown session returns empty vec
-- [ ] T031 [P] [US2] Write test `list_reflects_latest_version` in `artifacts/tests/memory_store.rs` — save 2 versions of same artifact, list shows `latest_version: 2`
-- [ ] T032 [P] [US2] Write test `load_includes_custom_metadata` in `artifacts/tests/memory_store.rs` — save with metadata map, load returns same metadata
+- [x] T029 [P] [US2] Write test `list_returns_all_artifacts` in `artifacts/tests/memory_store.rs` — save 3 artifacts, list returns 3 entries with correct names/versions/types
+- [x] T030 [P] [US2] Write test `list_empty_session_returns_empty` in `artifacts/tests/memory_store.rs` — list on unknown session returns empty vec
+- [x] T031 [P] [US2] Write test `list_reflects_latest_version` in `artifacts/tests/memory_store.rs` — save 2 versions of same artifact, list shows `latest_version: 2`
+- [x] T032 [P] [US2] Write test `load_includes_custom_metadata` in `artifacts/tests/memory_store.rs` — save with metadata map, load returns same metadata
 
 ### Implementation for User Story 2
 
-- [ ] T033 [US2] Implement `ArtifactStore::list` for `InMemoryArtifactStore` in `artifacts/src/memory_store.rs` — iterate artifacts, build `ArtifactMeta` with timestamps from version records
-- [ ] T034 [US2] Run all US2 tests — verify they pass
+- [x] T033 [US2] Implement `ArtifactStore::list` for `InMemoryArtifactStore` in `artifacts/src/memory_store.rs` — iterate artifacts, build `ArtifactMeta` with timestamps from version records
+- [x] T034 [US2] Run all US2 tests — verify they pass
 
 **Checkpoint**: List returns correct metadata for all artifacts. US1 + US2 tests pass.
 

--- a/specs/spec-status.md
+++ b/specs/spec-status.md
@@ -38,7 +38,7 @@
 | 033-workspace-feature-gates     | ✓     | ✓  | ✓   | ✓ Complete |
 | 034-session-state-store         | ✓     | ✓  | ✓   | ✓ Complete |
 | 035-credential-management       | ✓     | ✓  | ✓   | ✓ Complete |
-| 036-artifact-service            | ✓     | ✓  | ✓   | ● 15/81 (18%) |
+| 036-artifact-service            | ✓     | ✓  | ✓   | ● 34/81 (41%) |
 | 037-plugin-system               | ✓     | ✓  | ✓   | ● 0/47 (0%) |
 | 038-mcp-integration             | ✓     | ✓  | ✓   | ● 48/49 (97%) |
 | 039-multi-agent-patterns        | ✓     | ✓  | ✓   | ● 0/66 (0%) |
@@ -79,7 +79,7 @@
 <!-- feature: 033-workspace-feature-gates has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=25 tasks_completed=25 checklist_files=requirements.md -->
 <!-- feature: 034-session-state-store has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=93 tasks_completed=93 checklist_files=requirements.md -->
 <!-- feature: 035-credential-management has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=73 tasks_completed=73 checklist_files=requirements.md -->
-<!-- feature: 036-artifact-service has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=81 tasks_completed=15 checklist_files=requirements.md -->
+<!-- feature: 036-artifact-service has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=81 tasks_completed=34 checklist_files=requirements.md -->
 <!-- feature: 037-plugin-system has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=47 tasks_completed=0 checklist_files=requirements.md -->
 <!-- feature: 038-mcp-integration has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=49 tasks_completed=48 checklist_files=requirements.md -->
 <!-- feature: 039-multi-agent-patterns has_spec=true has_plan=true has_tasks=true has_research=true has_data_model=true has_quickstart=true has_contracts=true has_checklists=true tasks_total=66 tasks_completed=0 checklist_files=requirements.md -->


### PR DESCRIPTION
## Summary
- Adds 4 tests for `ArtifactStore::list` on `InMemoryArtifactStore` covering list-all, empty-session, version tracking, and metadata round-trip
- The `list` implementation already existed from Phase 3; this phase adds test coverage confirming correct behavior per US2 acceptance criteria
- Marks T029-T034 complete in tasks.md (Phase 4 done)

## Tasks completed
- T029: `list_returns_all_artifacts` — 3 artifacts with different content types
- T030: `list_empty_session_returns_empty` — unknown session returns empty vec
- T031: `list_reflects_latest_version` — 2 versions show `latest_version: 2`
- T032: `load_includes_custom_metadata` — metadata round-trips correctly
- T033: `list` implementation verified (already existed)
- T034: All US2 tests pass

## Test plan
- [x] `cargo test -p swink-agent-artifacts` — all 12 tests pass
- [x] `cargo clippy -p swink-agent-artifacts -- -D warnings` clean
- [x] `cargo test --workspace --features testkit` passes
- [x] `cargo test -p swink-agent --no-default-features` passes

Part of #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)