### PR TITLE
fix: Remove nonexistent testkit feature gate from eval runner tests

### DIFF
--- a/eval/tests/runner.rs
+++ b/eval/tests/runner.rs
@@ -1,4 +1,3 @@
-#![cfg(feature = "testkit")]
 //! Integration tests for `EvalRunner` — suite execution, empty suites, and error continuation.
 
 mod common;


### PR DESCRIPTION
## Summary
- `eval/tests/runner.rs` was gated behind `#![cfg(feature = "testkit")]`, but `swink-agent-eval` never defined a `testkit` feature — silently excluding 4 integration tests from `cargo test --workspace`
- Removed the bogus feature gate so the runner tests now compile and run normally
- The dev-dependency on `swink-agent` already enables `testkit`, making all test helpers available without a crate-level feature gate

## Test plan
- [x] `cargo test -p swink-agent-eval --test runner` — all 4 tests pass
- [x] `cargo clippy -p swink-agent-eval -- -D warnings` — clean
- [x] `cargo test -p swink-agent --no-default-features` — passes

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)