### PR TITLE
fix: Detect Tokio runtime in sync APIs, return error instead of panicking

### DIFF
--- a/src/agent/invoke.rs
+++ b/src/agent/invoke.rs
@@ -58,10 +58,11 @@ impl Agent {
     ///
     /// # Errors
     ///
-    /// Returns [`AgentError::AlreadyRunning`] if the agent is already running.
+    /// Returns [`AgentError::AlreadyRunning`] if the agent is already running,
+    /// or [`AgentError::SyncInAsyncContext`] if called from within a Tokio runtime.
     pub fn prompt_sync(&mut self, input: Vec<AgentMessage>) -> Result<AgentResult, AgentError> {
         self.check_not_running()?;
-        let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
+        let rt = new_blocking_runtime()?;
         rt.block_on(async {
             let stream = self.start_loop(input, false)?;
             self.collect_stream(stream).await
@@ -145,11 +146,11 @@ impl Agent {
     /// # Errors
     ///
     /// Returns [`AgentError::AlreadyRunning`], [`AgentError::NoMessages`],
-    /// or [`AgentError::InvalidContinue`].
+    /// [`AgentError::InvalidContinue`], or [`AgentError::SyncInAsyncContext`].
     pub fn continue_sync(&mut self) -> Result<AgentResult, AgentError> {
         self.check_not_running()?;
         self.validate_continue()?;
-        let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
+        let rt = new_blocking_runtime()?;
         rt.block_on(async {
             let stream = self.start_loop(Vec::new(), true)?;
             self.collect_stream(stream).await
@@ -283,4 +284,14 @@ impl Agent {
             dynamic_system_prompt: self.dynamic_system_prompt.clone(),
         }
     }
+}
+
+/// Create a new Tokio runtime for blocking sync APIs, returning
+/// [`AgentError::SyncInAsyncContext`] if a runtime is already active on
+/// the current thread.
+pub(super) fn new_blocking_runtime() -> Result<tokio::runtime::Runtime, AgentError> {
+    if tokio::runtime::Handle::try_current().is_ok() {
+        return Err(AgentError::SyncInAsyncContext);
+    }
+    Ok(tokio::runtime::Runtime::new().expect("failed to create tokio runtime"))
 }

--- a/src/agent/structured_output.rs
+++ b/src/agent/structured_output.rs
@@ -29,12 +29,16 @@ impl Agent {
     }
 
     /// Run a structured output extraction loop, blocking the current thread.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AgentError::SyncInAsyncContext`] if called from within a Tokio runtime.
     pub fn structured_output_sync(
         &mut self,
         prompt: String,
         schema: Value,
     ) -> Result<Value, AgentError> {
-        let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
+        let rt = super::invoke::new_blocking_runtime()?;
         rt.block_on(self.structured_output(prompt, schema))
     }
 
@@ -52,12 +56,16 @@ impl Agent {
     }
 
     /// Run structured output extraction, deserialize into a typed result, blocking.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AgentError::SyncInAsyncContext`] if called from within a Tokio runtime.
     pub fn structured_output_typed_sync<T: serde::de::DeserializeOwned>(
         &mut self,
         prompt: String,
         schema: Value,
     ) -> Result<T, AgentError> {
-        let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
+        let rt = super::invoke::new_blocking_runtime()?;
         rt.block_on(self.structured_output_typed(prompt, schema))
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -95,6 +95,15 @@ pub enum AgentError {
     /// auth or network errors.
     #[error("content filtered by provider safety policy")]
     ContentFiltered,
+
+    /// A synchronous API (`prompt_sync`, `continue_sync`, etc.) was called
+    /// from within an active Tokio runtime.
+    ///
+    /// These methods create their own Tokio runtime internally.  Calling them
+    /// from async code (or any thread that already has a Tokio runtime) would
+    /// panic.  Use the `_async` or `_stream` variants instead.
+    #[error("sync API called inside an active Tokio runtime — use the async variant instead")]
+    SyncInAsyncContext,
 }
 
 impl AgentError {
@@ -182,5 +191,12 @@ mod tests {
             format!("{err}"),
             "content filtered by provider safety policy"
         );
+    }
+
+    #[test]
+    fn sync_in_async_context_not_retryable() {
+        let err = AgentError::SyncInAsyncContext;
+        assert!(!err.is_retryable());
+        assert!(format!("{err}").contains("sync API"));
     }
 }

--- a/tests/ac_resilience.rs
+++ b/tests/ac_resilience.rs
@@ -270,6 +270,65 @@ fn sync_api_blocks_until_complete() {
 }
 
 // ═════════════════════════════════════════════════════════════════════════════
+// Regression: sync APIs return SyncInAsyncContext instead of panicking
+// when called from inside a Tokio runtime.
+// ═════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn prompt_sync_returns_error_inside_tokio() {
+    let stream_fn = Arc::new(MockStreamFn::new(vec![text_only_events("never")]));
+    let mut agent = Agent::new(
+        AgentOptions::new("test", default_model(), stream_fn, default_convert).with_retry_strategy(
+            Box::new(
+                DefaultRetryStrategy::default()
+                    .with_jitter(false)
+                    .with_base_delay(Duration::from_millis(1)),
+            ),
+        ),
+    );
+
+    let err = agent.prompt_sync(vec![user_msg("hi")]).unwrap_err();
+    assert!(
+        matches!(err, swink_agent::AgentError::SyncInAsyncContext),
+        "expected SyncInAsyncContext, got: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn continue_sync_returns_error_inside_tokio() {
+    // Use two turns so continue_sync has a valid state to resume from:
+    // first turn returns a tool call, second turn provides the tool result.
+    let stream_fn = Arc::new(MockStreamFn::new(vec![
+        tool_call_events("tool-1", "mock_tool", "{}"),
+        text_only_events("done"),
+    ]));
+    let tool = Arc::new(MockTool::new("mock_tool"));
+    let mut agent = Agent::new(
+        AgentOptions::new("test", default_model(), stream_fn, default_convert)
+            .with_retry_strategy(Box::new(
+                DefaultRetryStrategy::default()
+                    .with_jitter(false)
+                    .with_base_delay(Duration::from_millis(1)),
+            ))
+            .with_tools(vec![tool]),
+    );
+
+    // Run the full loop (tool call + result + second turn)
+    let result = agent.prompt_async(vec![user_msg("seed")]).await.unwrap();
+    assert!(!result.messages.is_empty());
+
+    // Enqueue a follow-up so continue validation passes
+    agent.follow_up(user_msg("follow up"));
+
+    // Now try the sync continue — should detect the runtime
+    let err = agent.continue_sync().unwrap_err();
+    assert!(
+        matches!(err, swink_agent::AgentError::SyncInAsyncContext),
+        "expected SyncInAsyncContext, got: {err:?}"
+    );
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
 // T030 — followup_decision_controls_continuation (AC 21)
 //
 // Verify that when the agent produces a text-only response (no tool calls),


### PR DESCRIPTION
## Summary
- Sync Agent APIs (`prompt_sync`, `continue_sync`, `structured_output_sync`, `structured_output_typed_sync`) now detect when called inside an active Tokio runtime and return `AgentError::SyncInAsyncContext` instead of panicking
- Added new `SyncInAsyncContext` variant to `AgentError` with clear error message guiding users to async variants
- Extracted shared `new_blocking_runtime()` helper that checks `Handle::try_current()` before creating a runtime

## Tasks completed
- Added `AgentError::SyncInAsyncContext` error variant (non-retryable)
- Updated all 4 sync methods to use runtime detection via `new_blocking_runtime()`
- Added 2 regression tests (`prompt_sync_returns_error_inside_tokio`, `continue_sync_returns_error_inside_tokio`)
- Added unit test for new error variant (`sync_in_async_context_not_retryable`)

## Test plan
- [x] `cargo test -p swink-agent --features testkit` — all tests pass
- [x] `cargo test -p swink-agent --no-default-features` — passes
- [x] `cargo test --workspace --features testkit` — full workspace passes
- [x] `cargo clippy -p swink-agent --features testkit -- -D warnings` — clean
- [x] Existing `sync_api_blocks_until_complete` test still passes (non-Tokio context)

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)