### PR TITLE
fix: make context versioning consume explicit compaction results

### DIFF
--- a/src/async_context_transformer.rs
+++ b/src/async_context_transformer.rs
@@ -75,6 +75,7 @@ mod tests {
                             tokens_before: 0,
                             tokens_after: 0,
                             overflow: true,
+                            dropped_messages: Vec::new(),
                         })
                     } else {
                         None

--- a/src/context.rs
+++ b/src/context.rs
@@ -76,6 +76,13 @@ pub struct CompactionReport {
     pub tokens_after: usize,
     /// Whether compaction was triggered by overflow.
     pub overflow: bool,
+    /// The LLM messages that were dropped during this compaction pass.
+    ///
+    /// Only `LlmMessage` variants are included; `CustomMessage` values are
+    /// filtered out. Populated by [`compact_sliding_window_with`]; empty for
+    /// bare-closure transformers that don't have access to the dropped slice.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub dropped_messages: Vec<LlmMessage>,
 }
 
 /// Core sliding window compaction algorithm.
@@ -149,6 +156,15 @@ pub fn compact_sliding_window_with(
 
     let dropped_count = tail_start - effective_anchor;
 
+    // Collect the dropped LLM messages before modifying the slice.
+    let dropped_messages: Vec<LlmMessage> = messages[effective_anchor..tail_start]
+        .iter()
+        .filter_map(|m| match m {
+            AgentMessage::Llm(llm) => Some(llm.clone()),
+            AgentMessage::Custom(_) => None,
+        })
+        .collect();
+
     // Build the compacted list: anchor messages + tail messages.
     let tail: Vec<AgentMessage> = messages.drain(tail_start..).collect();
     messages.truncate(effective_anchor);
@@ -161,6 +177,7 @@ pub fn compact_sliding_window_with(
         tokens_before,
         tokens_after,
         overflow: false,
+        dropped_messages,
     })
 }
 
@@ -619,6 +636,35 @@ mod tests {
         let result = compact_sliding_window(&mut messages, 250, 1);
         assert!(result.is_some());
         assert_eq!(messages.len(), 2);
+    }
+
+    #[test]
+    fn compaction_report_includes_dropped_messages() {
+        // Regression test for #164: CompactionReport.dropped_messages must be
+        // populated by compact_sliding_window_with, not reconstructed via Debug diff.
+        let body = "x".repeat(400); // 100 tokens each
+        // anchor | dropped | dropped | tail
+        let mut messages = vec![
+            text_message(&body),
+            text_message(&body),
+            text_message(&body),
+            text_message(&body),
+        ];
+        // Budget 250, anchor=1: anchor(100t) + tail(100t) = 200t fits; 2 middle dropped.
+        let report = compact_sliding_window_with(&mut messages, 250, 1, None).unwrap();
+
+        assert_eq!(report.dropped_count, 2);
+        assert_eq!(report.dropped_messages.len(), 2);
+        // Surviving: 2 messages.
+        assert_eq!(messages.len(), 2);
+    }
+
+    #[test]
+    fn compaction_report_dropped_messages_empty_when_no_compaction() {
+        let mut messages = vec![text_message("hello"), text_message("world")];
+        let result = compact_sliding_window_with(&mut messages, 10_000, 1, None);
+        // No compaction — result is None, so dropped_messages never exists.
+        assert!(result.is_none());
     }
 
     // ── is_context_overflow tests ──────────────────────────────────────

--- a/src/context_transformer.rs
+++ b/src/context_transformer.rs
@@ -38,6 +38,7 @@ impl<F: Fn(&mut Vec<AgentMessage>, bool) + Send + Sync> ContextTransformer for F
                 tokens_before: 0, // bare closures can't report token counts
                 tokens_after: 0,
                 overflow,
+                dropped_messages: Vec::new(), // bare closures don't have access to the dropped slice
             })
         } else {
             None

--- a/src/context_version.rs
+++ b/src/context_version.rs
@@ -202,16 +202,6 @@ struct VersioningState {
     turn_counter: u64,
 }
 
-fn extract_llm_messages(messages: &[AgentMessage]) -> Vec<LlmMessage> {
-    messages
-        .iter()
-        .filter_map(|m| match m {
-            AgentMessage::Llm(llm) => Some(llm.clone()),
-            AgentMessage::Custom(_) => None,
-        })
-        .collect()
-}
-
 impl VersioningTransformer {
     /// Create a new versioning transformer wrapping an inner transformer.
     pub fn new(
@@ -248,48 +238,15 @@ impl ContextTransformer for VersioningTransformer {
         messages: &mut Vec<AgentMessage>,
         overflow: bool,
     ) -> Option<CompactionReport> {
-        let before_len = messages.len();
-
-        // Snapshot LLM messages before compaction so we can identify dropped ones.
-        let snapshot: Vec<LlmMessage> = extract_llm_messages(messages);
-
-        // Run the inner transformer.
+        // Run the inner transformer. The report carries the dropped LLM messages
+        // directly — no snapshot/diff reconstruction needed.
         let report = self.inner.transform(messages, overflow)?;
 
-        let after_len = messages.len();
-        let dropped_count = before_len - after_len;
-
-        if dropped_count == 0 {
+        if report.dropped_messages.is_empty() {
             return Some(report);
         }
 
-        // Collect the LLM messages that survived compaction.
-        let surviving: Vec<LlmMessage> = extract_llm_messages(messages);
-
-        // The dropped LLM messages are those in the snapshot but not in the
-        // surviving set. Sliding window removes a contiguous middle section,
-        // so we can diff by finding the anchor prefix and tail suffix that
-        // match, and the middle is what was dropped.
-        let anchor_count = snapshot
-            .iter()
-            .zip(surviving.iter())
-            .take_while(|(a, b)| format!("{a:?}") == format!("{b:?}"))
-            .count();
-
-        let tail_count = surviving.len().saturating_sub(anchor_count);
-        let snapshot_tail_start = snapshot.len().saturating_sub(tail_count);
-
-        let dropped_messages: Vec<LlmMessage> = if anchor_count < snapshot_tail_start {
-            snapshot[anchor_count..snapshot_tail_start].to_vec()
-        } else {
-            Vec::new()
-        };
-
-        if dropped_messages.is_empty() {
-            return Some(report);
-        }
-
-        // Build the version.
+        // Build the version from the report's explicit dropped-message list.
         let mut state = self
             .state
             .lock()
@@ -299,13 +256,13 @@ impl ContextTransformer for VersioningTransformer {
         let summary = self
             .summarizer
             .as_ref()
-            .and_then(|s| s.summarize(&dropped_messages));
+            .and_then(|s| s.summarize(&report.dropped_messages));
 
         let version = ContextVersion {
             version: state.next_version,
             turn: state.turn_counter,
             timestamp: crate::util::now_timestamp(),
-            messages: dropped_messages,
+            messages: report.dropped_messages.clone(),
             summary,
         };
 
@@ -499,5 +456,101 @@ mod tests {
 
         // Verify store() returns the same store.
         assert!(transformer.store().list_versions().is_empty());
+    }
+
+    // Regression tests for #164: explicit compaction results (no Debug-string diff)
+
+    #[test]
+    fn report_dropped_messages_populated_by_compaction() {
+        // Verify that CompactionReport.dropped_messages contains the correct
+        // messages after compact_sliding_window_with runs — not reconstructed
+        // via Debug-string diffing.
+        use crate::context::compact_sliding_window_with;
+
+        // Each message: 400 chars / 4 = 100 tokens.
+        let body = "x".repeat(400);
+        let mut messages = vec![
+            text_message(&body), // anchor (100t)
+            text_message(&body), // dropped (100t)
+            text_message(&body), // dropped (100t)
+            text_message(&body), // tail (100t)
+        ];
+        // Total: 400t. Budget 250 with anchor=1:
+        // anchor(100t) + tail(100t) = 200t fits; middle 2 dropped.
+        let report = compact_sliding_window_with(&mut messages, 250, 1, None).unwrap();
+
+        // The middle two messages should be in dropped_messages.
+        assert_eq!(report.dropped_messages.len(), 2);
+        // Anchor and tail survive.
+        assert_eq!(messages.len(), 2);
+    }
+
+    #[test]
+    fn versioning_uses_report_dropped_messages_not_debug_diff() {
+        // Verify VersioningTransformer correctly captures dropped content
+        // from the report rather than through snapshot diffing.
+        let store: Arc<dyn ContextVersionStore> = Arc::new(InMemoryVersionStore::new());
+        let inner = SlidingWindowTransformer::new(250, 100, 1);
+        let transformer = VersioningTransformer::new(inner, Arc::clone(&store));
+
+        let body_a = "a".repeat(400); // 100 tokens
+        let body_b = "b".repeat(400); // 100 tokens
+
+        // Messages: anchor(a), dropped(a), dropped(b), tail(b).
+        // Budget 250, anchor=1: anchor(100t) + tail(100t) = 200t fits.
+        // Middle 2 messages (body_a, body_b) dropped.
+        let mut messages = vec![
+            text_message(&body_a),
+            text_message(&body_a),
+            text_message(&body_b),
+            text_message(&body_b),
+        ];
+
+        let report = transformer.transform(&mut messages, false);
+        assert!(report.is_some());
+
+        let v = store.load_version(1).unwrap();
+        // Two middle messages were dropped.
+        assert_eq!(v.messages.len(), 2);
+        // Verify dropped content — if debug-string diffing were used and broke,
+        // the wrong messages would be captured.
+        if let LlmMessage::User(ref u) = v.messages[0] {
+            if let ContentBlock::Text { ref text } = u.content[0] {
+                assert_eq!(text, &body_a);
+            } else {
+                panic!("expected text block");
+            }
+        } else {
+            panic!("expected user message");
+        }
+    }
+
+    #[test]
+    fn custom_messages_excluded_from_dropped_messages() {
+        // Custom messages should be filtered out of CompactionReport.dropped_messages
+        // (they're not LlmMessage variants).
+        use crate::context::compact_sliding_window_with;
+        use crate::types::CustomMessage;
+
+        #[derive(Debug)]
+        struct Marker;
+        impl CustomMessage for Marker {
+            fn as_any(&self) -> &dyn std::any::Any {
+                self
+            }
+        }
+
+        let body = "x".repeat(400); // 100 tokens each
+        let mut messages = vec![
+            text_message(&body),                                     // anchor
+            AgentMessage::Custom(Box::new(Marker)),                  // custom — dropped but excluded
+            text_message(&body),                                     // dropped
+            text_message(&body),                                     // tail
+        ];
+        // Budget 250, anchor=1: anchor(100t) + tail(100t) fits.
+        let report = compact_sliding_window_with(&mut messages, 250, 1, None).unwrap();
+
+        // Custom message is filtered out; only the LlmMessage is in dropped_messages.
+        assert_eq!(report.dropped_messages.len(), 1);
     }
 }

--- a/tests/agent_event_serde.rs
+++ b/tests/agent_event_serde.rs
@@ -170,6 +170,7 @@ fn all_agent_event_variants_serialize_to_json() {
                     tokens_before: 10000,
                     tokens_after: 5000,
                     overflow: false,
+                    dropped_messages: Vec::new(),
                 },
             },
         ),
@@ -254,6 +255,7 @@ fn context_compacted_serializes_report_fields() {
             tokens_before: 20000,
             tokens_after: 8000,
             overflow: true,
+            dropped_messages: Vec::new(),
         },
     };
     let val = serde_json::to_value(&event).unwrap();
@@ -452,6 +454,7 @@ fn agent_event_roundtrip_all_variants() {
                     tokens_before: 10000,
                     tokens_after: 5000,
                     overflow: false,
+                    dropped_messages: Vec::new(),
                 },
             },
         ),

--- a/tests/loop_overflow.rs
+++ b/tests/loop_overflow.rs
@@ -124,6 +124,7 @@ impl swink_agent::AsyncContextTransformer for MockAsyncTransformer {
                     tokens_before: removed * 100,
                     tokens_after: 100,
                     overflow: true,
+                    dropped_messages: Vec::new(),
                 })
             } else {
                 None


### PR DESCRIPTION
## Summary

- Replaces the Debug-string snapshot/diff in `VersioningTransformer` with explicit dropped-message data from `CompactionReport`
- Adds `dropped_messages: Vec<LlmMessage>` to `CompactionReport`, populated directly by `compact_sliding_window_with` before the drain
- Removes pre-/post-compaction snapshots and the `format!("{a:?}") == format!("{b:?}")` diff logic entirely
- Backward-compatible: `#[serde(default, skip_serializing_if = "Vec::is_empty")]` ensures old JSON deserializes and new JSON stays compact

## What changed

- **`src/context.rs`**: New `dropped_messages` field on `CompactionReport`; collected in `compact_sliding_window_with` (before drain, filtering out `CustomMessage` variants)
- **`src/context_version.rs`**: `VersioningTransformer::transform()` simplified to use `report.dropped_messages` directly; removed `extract_llm_messages` helper and all snapshot/diff code
- **`src/context_transformer.rs`**, **`src/async_context_transformer.rs`**: Updated struct literals with `dropped_messages: Vec::new()` (bare closures/test stubs don't have access to the dropped slice)
- **`tests/agent_event_serde.rs`**, **`tests/loop_overflow.rs`**: Updated `CompactionReport` struct literals

## Test plan

- [x] 3 new regression tests in `context_version::tests`:
  - `report_dropped_messages_populated_by_compaction` — report field correctly populated
  - `versioning_uses_report_dropped_messages_not_debug_diff` — distinct content confirms no diff reconstruction
  - `custom_messages_excluded_from_dropped_messages` — filter contract
- [x] `cargo test -p swink-agent --lib` — 314 tests pass (0 failed)
- [x] `cargo test -p swink-agent --test agent_event_serde --test loop_overflow --features testkit` — 19 tests pass
- [x] `cargo clippy -p swink-agent -- -D warnings` — clean
- [x] `cargo test -p swink-agent --no-default-features` — pre-existing `bash_output_truncation` failure only (unrelated)
- [x] No public API breakage in downstream crates (CompactionReport is extended, not narrowed; serde default handles old JSON)

Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)