### PR TITLE
fix: align pre-dispatch policy context with actual loop state

### DIFF
--- a/plugins/web/src/policy/domain_filter.rs
+++ b/plugins/web/src/policy/domain_filter.rs
@@ -1,6 +1,4 @@
-use swink_agent::policy::{
-    PolicyContext, PreDispatchPolicy, PreDispatchVerdict, ToolPolicyContext,
-};
+use swink_agent::policy::{PreDispatchPolicy, PreDispatchVerdict, ToolDispatchContext};
 use url::Url;
 
 use crate::domain::DomainFilter;
@@ -23,18 +21,14 @@ impl PreDispatchPolicy for DomainFilterPolicy {
         "web.domain_filter"
     }
 
-    fn evaluate(
-        &self,
-        _ctx: &PolicyContext<'_>,
-        tool: &mut ToolPolicyContext<'_>,
-    ) -> PreDispatchVerdict {
+    fn evaluate(&self, ctx: &mut ToolDispatchContext<'_>) -> PreDispatchVerdict {
         // Only apply to web.* tools.
-        if !tool.tool_name.starts_with("web.") {
+        if !ctx.tool_name.starts_with("web.") {
             return PreDispatchVerdict::Continue;
         }
 
         // Extract the URL argument; if absent, let the tool handle validation.
-        let url_str = match tool.arguments.get("url").and_then(|v| v.as_str()) {
+        let url_str = match ctx.arguments.get("url").and_then(|v| v.as_str()) {
             Some(s) => s,
             None => return PreDispatchVerdict::Continue,
         };

--- a/plugins/web/src/policy/rate_limiter.rs
+++ b/plugins/web/src/policy/rate_limiter.rs
@@ -2,7 +2,7 @@ use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use swink_agent::policy::{PolicyContext, PreDispatchPolicy, PreDispatchVerdict, ToolPolicyContext};
+use swink_agent::policy::{PreDispatchPolicy, PreDispatchVerdict, ToolDispatchContext};
 
 /// PreDispatch policy that enforces a shared rate limit across all web tools.
 ///
@@ -28,13 +28,9 @@ impl PreDispatchPolicy for RateLimitPolicy {
         "web.rate_limiter"
     }
 
-    fn evaluate(
-        &self,
-        _ctx: &PolicyContext<'_>,
-        tool: &mut ToolPolicyContext<'_>,
-    ) -> PreDispatchVerdict {
+    fn evaluate(&self, ctx: &mut ToolDispatchContext<'_>) -> PreDispatchVerdict {
         // Only apply to web-namespaced tools.
-        if !tool.tool_name.starts_with("web.") {
+        if !ctx.tool_name.starts_with("web.") {
             return PreDispatchVerdict::Continue;
         }
 

--- a/plugins/web/tests/domain_filter_test.rs
+++ b/plugins/web/tests/domain_filter_test.rs
@@ -1,6 +1,6 @@
 use serde_json::json;
-use swink_agent::policy::{PolicyContext, PreDispatchPolicy, PreDispatchVerdict, ToolPolicyContext};
-use swink_agent::{Cost, SessionState, Usage};
+use swink_agent::policy::{PreDispatchPolicy, PreDispatchVerdict, ToolDispatchContext};
+use swink_agent::SessionState;
 use swink_agent_plugin_web::domain::{DomainFilter, DomainFilterError};
 use swink_agent_plugin_web::policy::DomainFilterPolicy;
 use url::Url;
@@ -9,22 +9,16 @@ use url::Url;
 // Helpers
 // ---------------------------------------------------------------------------
 
-fn make_policy_context() -> (Usage, Cost, SessionState) {
-    (Usage::default(), Cost::default(), SessionState::default())
-}
-
-fn ctx_from<'a>(
-    usage: &'a Usage,
-    cost: &'a Cost,
+fn make_dispatch_ctx<'a>(
+    tool_name: &'a str,
+    tool_call_id: &'a str,
+    args: &'a mut serde_json::Value,
     state: &'a SessionState,
-) -> PolicyContext<'a> {
-    PolicyContext {
-        turn_index: 0,
-        accumulated_usage: usage,
-        accumulated_cost: cost,
-        message_count: 0,
-        overflow_signal: false,
-        new_messages: &[],
+) -> ToolDispatchContext<'a> {
+    ToolDispatchContext {
+        tool_name,
+        tool_call_id,
+        arguments: args,
         state,
     }
 }
@@ -184,15 +178,10 @@ fn policy_ignores_non_web_tools() {
         denylist: vec!["evil.com".to_string()],
         ..Default::default()
     });
-    let (usage, cost, state) = make_policy_context();
-    let ctx = ctx_from(&usage, &cost, &state);
+    let state = SessionState::default();
     let mut args = json!({"url": "https://evil.com"});
-    let mut tool = ToolPolicyContext {
-        tool_name: "bash",
-        tool_call_id: "call_1",
-        arguments: &mut args,
-    };
-    let verdict = policy.evaluate(&ctx, &mut tool);
+    let mut ctx = make_dispatch_ctx("bash", "call_1", &mut args, &state);
+    let verdict = policy.evaluate(&mut ctx);
     assert!(matches!(verdict, PreDispatchVerdict::Continue));
 }
 
@@ -206,15 +195,10 @@ fn policy_continues_when_no_url_arg() {
         denylist: vec!["evil.com".to_string()],
         ..Default::default()
     });
-    let (usage, cost, state) = make_policy_context();
-    let ctx = ctx_from(&usage, &cost, &state);
+    let state = SessionState::default();
     let mut args = json!({"query": "rust programming"});
-    let mut tool = ToolPolicyContext {
-        tool_name: "web.search",
-        tool_call_id: "call_2",
-        arguments: &mut args,
-    };
-    let verdict = policy.evaluate(&ctx, &mut tool);
+    let mut ctx = make_dispatch_ctx("web.search", "call_2", &mut args, &state);
+    let verdict = policy.evaluate(&mut ctx);
     assert!(matches!(verdict, PreDispatchVerdict::Continue));
 }
 
@@ -228,15 +212,10 @@ fn policy_blocks_denied_domain() {
         denylist: vec!["evil.com".to_string()],
         ..Default::default()
     });
-    let (usage, cost, state) = make_policy_context();
-    let ctx = ctx_from(&usage, &cost, &state);
+    let state = SessionState::default();
     let mut args = json!({"url": "https://evil.com/page"});
-    let mut tool = ToolPolicyContext {
-        tool_name: "web.fetch",
-        tool_call_id: "call_3",
-        arguments: &mut args,
-    };
-    let verdict = policy.evaluate(&ctx, &mut tool);
+    let mut ctx = make_dispatch_ctx("web.fetch", "call_3", &mut args, &state);
+    let verdict = policy.evaluate(&mut ctx);
     assert!(
         matches!(verdict, PreDispatchVerdict::Skip(_)),
         "expected Skip, got {verdict:?}"
@@ -250,15 +229,10 @@ fn policy_blocks_denied_domain() {
 #[test]
 fn policy_allows_valid_domain() {
     let policy = DomainFilterPolicy::new(DomainFilter::default());
-    let (usage, cost, state) = make_policy_context();
-    let ctx = ctx_from(&usage, &cost, &state);
+    let state = SessionState::default();
     let mut args = json!({"url": "https://example.com"});
-    let mut tool = ToolPolicyContext {
-        tool_name: "web.fetch",
-        tool_call_id: "call_4",
-        arguments: &mut args,
-    };
-    let verdict = policy.evaluate(&ctx, &mut tool);
+    let mut ctx = make_dispatch_ctx("web.fetch", "call_4", &mut args, &state);
+    let verdict = policy.evaluate(&mut ctx);
     assert!(matches!(verdict, PreDispatchVerdict::Continue));
 }
 
@@ -269,15 +243,10 @@ fn policy_allows_valid_domain() {
 #[test]
 fn policy_rejects_file_scheme() {
     let policy = DomainFilterPolicy::new(DomainFilter::default());
-    let (usage, cost, state) = make_policy_context();
-    let ctx = ctx_from(&usage, &cost, &state);
+    let state = SessionState::default();
     let mut args = json!({"url": "file:///etc/passwd"});
-    let mut tool = ToolPolicyContext {
-        tool_name: "web.fetch",
-        tool_call_id: "call_5",
-        arguments: &mut args,
-    };
-    let verdict = policy.evaluate(&ctx, &mut tool);
+    let mut ctx = make_dispatch_ctx("web.fetch", "call_5", &mut args, &state);
+    let verdict = policy.evaluate(&mut ctx);
     assert!(
         matches!(verdict, PreDispatchVerdict::Skip(_)),
         "expected Skip for file:// scheme"
@@ -291,15 +260,10 @@ fn policy_rejects_file_scheme() {
 #[test]
 fn policy_skips_invalid_url() {
     let policy = DomainFilterPolicy::new(DomainFilter::default());
-    let (usage, cost, state) = make_policy_context();
-    let ctx = ctx_from(&usage, &cost, &state);
+    let state = SessionState::default();
     let mut args = json!({"url": "not a url at all"});
-    let mut tool = ToolPolicyContext {
-        tool_name: "web.fetch",
-        tool_call_id: "call_6",
-        arguments: &mut args,
-    };
-    let verdict = policy.evaluate(&ctx, &mut tool);
+    let mut ctx = make_dispatch_ctx("web.fetch", "call_6", &mut args, &state);
+    let verdict = policy.evaluate(&mut ctx);
     assert!(
         matches!(verdict, PreDispatchVerdict::Skip(_)),
         "expected Skip for unparseable URL"

--- a/plugins/web/tests/rate_limiter_test.rs
+++ b/plugins/web/tests/rate_limiter_test.rs
@@ -3,36 +3,30 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use serde_json::json;
-use swink_agent::policy::{PolicyContext, PreDispatchPolicy, PreDispatchVerdict, ToolPolicyContext};
-use swink_agent::{Cost, SessionState, Usage};
+use swink_agent::policy::{PreDispatchPolicy, PreDispatchVerdict, ToolDispatchContext};
+use swink_agent::SessionState;
 use swink_agent_plugin_web::policy::RateLimitPolicy;
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-fn make_policy_context() -> (Usage, Cost, SessionState) {
-    (Usage::default(), Cost::default(), SessionState::default())
-}
-
-fn ctx_from<'a>(
-    usage: &'a Usage,
-    cost: &'a Cost,
-    state: &'a SessionState,
-) -> PolicyContext<'a> {
-    PolicyContext {
-        turn_index: 0,
-        accumulated_usage: usage,
-        accumulated_cost: cost,
-        message_count: 0,
-        overflow_signal: false,
-        new_messages: &[],
-        state,
-    }
-}
-
 fn shared_state() -> Arc<Mutex<VecDeque<Instant>>> {
     Arc::new(Mutex::new(VecDeque::new()))
+}
+
+fn make_dispatch_ctx<'a>(
+    tool_name: &'a str,
+    tool_call_id: &'a str,
+    args: &'a mut serde_json::Value,
+    state: &'a SessionState,
+) -> ToolDispatchContext<'a> {
+    ToolDispatchContext {
+        tool_name,
+        tool_call_id,
+        arguments: args,
+        state,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -41,19 +35,15 @@ fn shared_state() -> Arc<Mutex<VecDeque<Instant>>> {
 
 #[test]
 fn requests_within_limit_return_continue() {
-    let state = shared_state();
-    let policy = RateLimitPolicy::new(state, 5);
-    let (usage, cost, session) = make_policy_context();
-    let ctx = ctx_from(&usage, &cost, &session);
+    let rl_state = shared_state();
+    let policy = RateLimitPolicy::new(rl_state, 5);
+    let session = SessionState::default();
 
     for i in 0..5 {
+        let call_id = format!("tc_{i}");
         let mut args = json!({"url": "https://example.com"});
-        let mut tool = ToolPolicyContext {
-            tool_name: "web.fetch",
-            tool_call_id: &format!("tc_{i}"),
-            arguments: &mut args,
-        };
-        let verdict = policy.evaluate(&ctx, &mut tool);
+        let mut ctx = make_dispatch_ctx("web.fetch", &call_id, &mut args, &session);
+        let verdict = policy.evaluate(&mut ctx);
         assert!(
             matches!(verdict, PreDispatchVerdict::Continue),
             "request {i} should pass within limit"
@@ -67,31 +57,23 @@ fn requests_within_limit_return_continue() {
 
 #[test]
 fn exceeding_limit_returns_skip() {
-    let state = shared_state();
-    let policy = RateLimitPolicy::new(state, 3);
-    let (usage, cost, session) = make_policy_context();
-    let ctx = ctx_from(&usage, &cost, &session);
+    let rl_state = shared_state();
+    let policy = RateLimitPolicy::new(rl_state, 3);
+    let session = SessionState::default();
 
     // Use up the limit.
     for i in 0..3 {
+        let call_id = format!("tc_{i}");
         let mut args = json!({"url": "https://example.com"});
-        let mut tool = ToolPolicyContext {
-            tool_name: "web.fetch",
-            tool_call_id: &format!("tc_{i}"),
-            arguments: &mut args,
-        };
-        let verdict = policy.evaluate(&ctx, &mut tool);
+        let mut ctx = make_dispatch_ctx("web.fetch", &call_id, &mut args, &session);
+        let verdict = policy.evaluate(&mut ctx);
         assert!(matches!(verdict, PreDispatchVerdict::Continue));
     }
 
     // Next request should be skipped.
     let mut args = json!({"url": "https://example.com"});
-    let mut tool = ToolPolicyContext {
-        tool_name: "web.fetch",
-        tool_call_id: "tc_over",
-        arguments: &mut args,
-    };
-    let verdict = policy.evaluate(&ctx, &mut tool);
+    let mut ctx = make_dispatch_ctx("web.fetch", "tc_over", &mut args, &session);
+    let verdict = policy.evaluate(&mut ctx);
     assert!(
         matches!(verdict, PreDispatchVerdict::Skip(_)),
         "expected Skip when limit exceeded, got {verdict:?}"
@@ -104,28 +86,22 @@ fn exceeding_limit_returns_skip() {
 
 #[test]
 fn old_timestamps_are_pruned_allowing_new_requests() {
-    let state = shared_state();
+    let rl_state = shared_state();
 
     // Pre-fill with timestamps from >60 seconds ago.
     {
-        let mut timestamps = state.lock().unwrap();
+        let mut timestamps = rl_state.lock().unwrap();
         let old = Instant::now() - Duration::from_secs(120);
         for _ in 0..5 {
             timestamps.push_back(old);
         }
     }
 
-    let policy = RateLimitPolicy::new(state, 5);
-    let (usage, cost, session) = make_policy_context();
-    let ctx = ctx_from(&usage, &cost, &session);
-
+    let policy = RateLimitPolicy::new(rl_state, 5);
+    let session = SessionState::default();
     let mut args = json!({"url": "https://example.com"});
-    let mut tool = ToolPolicyContext {
-        tool_name: "web.fetch",
-        tool_call_id: "tc_after_prune",
-        arguments: &mut args,
-    };
-    let verdict = policy.evaluate(&ctx, &mut tool);
+    let mut ctx = make_dispatch_ctx("web.fetch", "tc_after_prune", &mut args, &session);
+    let verdict = policy.evaluate(&mut ctx);
     assert!(
         matches!(verdict, PreDispatchVerdict::Continue),
         "should pass after stale timestamps are pruned"
@@ -138,19 +114,13 @@ fn old_timestamps_are_pruned_allowing_new_requests() {
 
 #[test]
 fn non_web_tool_returns_continue() {
-    let state = shared_state();
+    let rl_state = shared_state();
     // Even with a zero limit, non-web tools should not be affected.
-    let policy = RateLimitPolicy::new(state, 0);
-    let (usage, cost, session) = make_policy_context();
-    let ctx = ctx_from(&usage, &cost, &session);
-
+    let policy = RateLimitPolicy::new(rl_state, 0);
+    let session = SessionState::default();
     let mut args = json!({"command": "ls"});
-    let mut tool = ToolPolicyContext {
-        tool_name: "bash",
-        tool_call_id: "tc_bash",
-        arguments: &mut args,
-    };
-    let verdict = policy.evaluate(&ctx, &mut tool);
+    let mut ctx = make_dispatch_ctx("bash", "tc_bash", &mut args, &session);
+    let verdict = policy.evaluate(&mut ctx);
     assert!(
         matches!(verdict, PreDispatchVerdict::Continue),
         "non-web tools should always pass through"
@@ -163,19 +133,15 @@ fn non_web_tool_returns_continue() {
 
 #[test]
 fn default_30_rpm_allows_30_requests() {
-    let state = shared_state();
-    let policy = RateLimitPolicy::new(state, 30);
-    let (usage, cost, session) = make_policy_context();
-    let ctx = ctx_from(&usage, &cost, &session);
+    let rl_state = shared_state();
+    let policy = RateLimitPolicy::new(rl_state, 30);
+    let session = SessionState::default();
 
     for i in 0..30 {
+        let call_id = format!("tc_{i}");
         let mut args = json!({"url": "https://example.com"});
-        let mut tool = ToolPolicyContext {
-            tool_name: "web.search",
-            tool_call_id: &format!("tc_{i}"),
-            arguments: &mut args,
-        };
-        let verdict = policy.evaluate(&ctx, &mut tool);
+        let mut ctx = make_dispatch_ctx("web.search", &call_id, &mut args, &session);
+        let verdict = policy.evaluate(&mut ctx);
         assert!(
             matches!(verdict, PreDispatchVerdict::Continue),
             "request {i} of 30 should pass"
@@ -184,12 +150,8 @@ fn default_30_rpm_allows_30_requests() {
 
     // Request 31 should be rate-limited.
     let mut args = json!({"url": "https://example.com"});
-    let mut tool = ToolPolicyContext {
-        tool_name: "web.search",
-        tool_call_id: "tc_31",
-        arguments: &mut args,
-    };
-    let verdict = policy.evaluate(&ctx, &mut tool);
+    let mut ctx = make_dispatch_ctx("web.search", "tc_31", &mut args, &session);
+    let verdict = policy.evaluate(&mut ctx);
     assert!(
         matches!(verdict, PreDispatchVerdict::Skip(_)),
         "31st request should be rate-limited at 30 RPM"

--- a/policies/src/deny_list.rs
+++ b/policies/src/deny_list.rs
@@ -3,7 +3,7 @@
 
 use std::collections::HashSet;
 
-use swink_agent::{PolicyContext, PreDispatchPolicy, PreDispatchVerdict, ToolPolicyContext};
+use swink_agent::{PreDispatchPolicy, PreDispatchVerdict, ToolDispatchContext};
 
 /// Rejects tool calls whose names appear in the deny list.
 ///
@@ -34,13 +34,9 @@ impl PreDispatchPolicy for ToolDenyListPolicy {
         "tool_deny_list"
     }
 
-    fn evaluate(
-        &self,
-        _ctx: &PolicyContext<'_>,
-        tool: &mut ToolPolicyContext<'_>,
-    ) -> PreDispatchVerdict {
-        if self.denied.contains(tool.tool_name) {
-            PreDispatchVerdict::Skip(format!("tool '{}' is denied by policy", tool.tool_name))
+    fn evaluate(&self, ctx: &mut ToolDispatchContext<'_>) -> PreDispatchVerdict {
+        if self.denied.contains(ctx.tool_name) {
+            PreDispatchVerdict::Skip(format!("tool '{}' is denied by policy", ctx.tool_name))
         } else {
             PreDispatchVerdict::Continue
         }
@@ -50,20 +46,16 @@ impl PreDispatchPolicy for ToolDenyListPolicy {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use swink_agent::{Cost, Usage};
 
-    fn make_ctx<'a>(
-        usage: &'a Usage,
-        cost: &'a Cost,
+    fn make_dispatch_ctx<'a>(
+        tool_name: &'a str,
+        args: &'a mut serde_json::Value,
         state: &'a swink_agent::SessionState,
-    ) -> PolicyContext<'a> {
-        PolicyContext {
-            turn_index: 0,
-            accumulated_usage: usage,
-            accumulated_cost: cost,
-            message_count: 0,
-            overflow_signal: false,
-            new_messages: &[],
+    ) -> ToolDispatchContext<'a> {
+        ToolDispatchContext {
+            tool_name,
+            tool_call_id: "id1",
+            arguments: args,
             state,
         }
     }
@@ -71,51 +63,30 @@ mod tests {
     #[test]
     fn denies_listed_tool() {
         let policy = ToolDenyListPolicy::new(["bash", "write_file"]);
-        let usage = Usage::default();
-        let cost = Cost::default();
         let state = swink_agent::SessionState::new();
-        let ctx = make_ctx(&usage, &cost, &state);
         let mut args = serde_json::json!({"command": "ls"});
-        let mut tool_ctx = ToolPolicyContext {
-            tool_name: "bash",
-            tool_call_id: "id1",
-            arguments: &mut args,
-        };
-        let result = policy.evaluate(&ctx, &mut tool_ctx);
+        let mut ctx = make_dispatch_ctx("bash", &mut args, &state);
+        let result = policy.evaluate(&mut ctx);
         assert!(matches!(result, PreDispatchVerdict::Skip(ref e) if e.contains("denied")));
     }
 
     #[test]
     fn allows_unlisted_tool() {
         let policy = ToolDenyListPolicy::new(["bash"]);
-        let usage = Usage::default();
-        let cost = Cost::default();
         let state = swink_agent::SessionState::new();
-        let ctx = make_ctx(&usage, &cost, &state);
         let mut args = serde_json::json!({"path": "/tmp/file"});
-        let mut tool_ctx = ToolPolicyContext {
-            tool_name: "read_file",
-            tool_call_id: "id1",
-            arguments: &mut args,
-        };
-        let result = policy.evaluate(&ctx, &mut tool_ctx);
+        let mut ctx = make_dispatch_ctx("read_file", &mut args, &state);
+        let result = policy.evaluate(&mut ctx);
         assert!(matches!(result, PreDispatchVerdict::Continue));
     }
 
     #[test]
     fn empty_deny_list_allows_all() {
         let policy = ToolDenyListPolicy::new(Vec::<String>::new());
-        let usage = Usage::default();
-        let cost = Cost::default();
         let state = swink_agent::SessionState::new();
-        let ctx = make_ctx(&usage, &cost, &state);
         let mut args = serde_json::json!({});
-        let mut tool_ctx = ToolPolicyContext {
-            tool_name: "bash",
-            tool_call_id: "id1",
-            arguments: &mut args,
-        };
-        let result = policy.evaluate(&ctx, &mut tool_ctx);
+        let mut ctx = make_dispatch_ctx("bash", &mut args, &state);
+        let result = policy.evaluate(&mut ctx);
         assert!(matches!(result, PreDispatchVerdict::Continue));
     }
 }

--- a/policies/src/sandbox.rs
+++ b/policies/src/sandbox.rs
@@ -3,7 +3,7 @@
 
 use std::path::{Path, PathBuf};
 
-use swink_agent::{PolicyContext, PreDispatchPolicy, PreDispatchVerdict, ToolPolicyContext};
+use swink_agent::{PreDispatchPolicy, PreDispatchVerdict, ToolDispatchContext};
 
 /// Rejects tool calls that reference file paths outside an allowed root directory.
 ///
@@ -73,12 +73,8 @@ impl PreDispatchPolicy for SandboxPolicy {
         "sandbox"
     }
 
-    fn evaluate(
-        &self,
-        _ctx: &PolicyContext<'_>,
-        tool: &mut ToolPolicyContext<'_>,
-    ) -> PreDispatchVerdict {
-        let Some(obj) = tool.arguments.as_object() else {
+    fn evaluate(&self, ctx: &mut ToolDispatchContext<'_>) -> PreDispatchVerdict {
+        let Some(obj) = ctx.arguments.as_object() else {
             return PreDispatchVerdict::Continue;
         };
 
@@ -102,20 +98,16 @@ impl PreDispatchPolicy for SandboxPolicy {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use swink_agent::{Cost, Usage};
 
-    fn make_ctx<'a>(
-        usage: &'a Usage,
-        cost: &'a Cost,
+    fn make_dispatch_ctx<'a>(
+        tool_name: &'a str,
+        args: &'a mut serde_json::Value,
         state: &'a swink_agent::SessionState,
-    ) -> PolicyContext<'a> {
-        PolicyContext {
-            turn_index: 0,
-            accumulated_usage: usage,
-            accumulated_cost: cost,
-            message_count: 0,
-            overflow_signal: false,
-            new_messages: &[],
+    ) -> ToolDispatchContext<'a> {
+        ToolDispatchContext {
+            tool_name,
+            tool_call_id: "id1",
+            arguments: args,
             state,
         }
     }
@@ -123,69 +115,41 @@ mod tests {
     #[test]
     fn rejects_path_outside_root() {
         let policy = SandboxPolicy::new("/tmp/workspace");
-        let usage = Usage::default();
-        let cost = Cost::default();
         let state = swink_agent::SessionState::new();
-        let ctx = make_ctx(&usage, &cost, &state);
         let mut args = serde_json::json!({"path": "/etc/passwd"});
-        let mut tool_ctx = ToolPolicyContext {
-            tool_name: "write_file",
-            tool_call_id: "id1",
-            arguments: &mut args,
-        };
-        let result = policy.evaluate(&ctx, &mut tool_ctx);
+        let mut ctx = make_dispatch_ctx("write_file", &mut args, &state);
+        let result = policy.evaluate(&mut ctx);
         assert!(matches!(result, PreDispatchVerdict::Skip(ref e) if e.contains("/etc/passwd")));
     }
 
     #[test]
     fn allows_path_inside_root() {
         let policy = SandboxPolicy::new("/tmp/workspace");
-        let usage = Usage::default();
-        let cost = Cost::default();
         let state = swink_agent::SessionState::new();
-        let ctx = make_ctx(&usage, &cost, &state);
         let mut args = serde_json::json!({"path": "/tmp/workspace/output.txt"});
-        let mut tool_ctx = ToolPolicyContext {
-            tool_name: "write_file",
-            tool_call_id: "id1",
-            arguments: &mut args,
-        };
-        let result = policy.evaluate(&ctx, &mut tool_ctx);
+        let mut ctx = make_dispatch_ctx("write_file", &mut args, &state);
+        let result = policy.evaluate(&mut ctx);
         assert!(matches!(result, PreDispatchVerdict::Continue));
     }
 
     #[test]
     fn handles_path_traversal_attack() {
         let policy = SandboxPolicy::new("/tmp/workspace");
-        let usage = Usage::default();
-        let cost = Cost::default();
         let state = swink_agent::SessionState::new();
-        let ctx = make_ctx(&usage, &cost, &state);
         let mut args = serde_json::json!({"path": "/tmp/workspace/../../etc/passwd"});
-        let mut tool_ctx = ToolPolicyContext {
-            tool_name: "write_file",
-            tool_call_id: "id1",
-            arguments: &mut args,
-        };
-        let result = policy.evaluate(&ctx, &mut tool_ctx);
+        let mut ctx = make_dispatch_ctx("write_file", &mut args, &state);
+        let result = policy.evaluate(&mut ctx);
         assert!(matches!(result, PreDispatchVerdict::Skip(_)));
     }
 
     #[test]
     fn only_checks_configured_fields() {
         let policy = SandboxPolicy::new("/tmp/workspace");
-        let usage = Usage::default();
-        let cost = Cost::default();
         let state = swink_agent::SessionState::new();
-        let ctx = make_ctx(&usage, &cost, &state);
         // "command" is not in the default path_fields, so it won't be checked
         let mut args = serde_json::json!({"command": "/etc/passwd"});
-        let mut tool_ctx = ToolPolicyContext {
-            tool_name: "bash",
-            tool_call_id: "id1",
-            arguments: &mut args,
-        };
-        let result = policy.evaluate(&ctx, &mut tool_ctx);
+        let mut ctx = make_dispatch_ctx("bash", &mut args, &state);
+        let result = policy.evaluate(&mut ctx);
         assert!(matches!(result, PreDispatchVerdict::Continue));
     }
 
@@ -193,17 +157,10 @@ mod tests {
     fn custom_path_fields() {
         let policy =
             SandboxPolicy::new("/tmp/workspace").with_path_fields(["target_dir", "output"]);
-        let usage = Usage::default();
-        let cost = Cost::default();
         let state = swink_agent::SessionState::new();
-        let ctx = make_ctx(&usage, &cost, &state);
         let mut args = serde_json::json!({"target_dir": "/etc/shadow"});
-        let mut tool_ctx = ToolPolicyContext {
-            tool_name: "deploy",
-            tool_call_id: "id1",
-            arguments: &mut args,
-        };
-        let result = policy.evaluate(&ctx, &mut tool_ctx);
+        let mut ctx = make_dispatch_ctx("deploy", &mut args, &state);
+        let result = policy.evaluate(&mut ctx);
         assert!(matches!(result, PreDispatchVerdict::Skip(_)));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,7 +158,7 @@ pub use display::{CoreDisplayMessage, DisplayRole, IntoDisplayMessages};
 pub use plugin::{NamespacedTool, Plugin, PluginRegistry};
 pub use policy::{
     PolicyContext, PolicyVerdict, PostLoopPolicy, PostTurnPolicy, PreDispatchPolicy,
-    PreDispatchVerdict, PreTurnPolicy, ToolPolicyContext, TurnPolicyContext, run_policies,
+    PreDispatchVerdict, PreTurnPolicy, ToolDispatchContext, TurnPolicyContext, run_policies,
     run_post_loop_policies, run_post_turn_policies, run_pre_dispatch_policies,
 };
 #[cfg(feature = "transfer")]

--- a/src/loop_/tool_dispatch.rs
+++ b/src/loop_/tool_dispatch.rs
@@ -141,9 +141,7 @@ pub async fn execute_tools_concurrently(
         // ── PreDispatch policies ──
         let mut effective_arguments = tc.arguments.clone();
         {
-            use crate::policy::{
-                PolicyContext, PreDispatchVerdict, ToolPolicyContext, run_pre_dispatch_policies,
-            };
+            use crate::policy::{PreDispatchVerdict, ToolDispatchContext, run_pre_dispatch_policies};
 
             let state_snapshot = {
                 let guard = config
@@ -152,25 +150,13 @@ pub async fn execute_tools_concurrently(
                     .unwrap_or_else(std::sync::PoisonError::into_inner);
                 guard.clone()
             };
-            let policy_ctx = PolicyContext {
-                turn_index: 0, // tool dispatch doesn't track turn index
-                accumulated_usage: &crate::types::Usage::default(),
-                accumulated_cost: &crate::types::Cost::default(),
-                message_count: 0,
-                overflow_signal: false,
-                new_messages: &[],
-                state: &state_snapshot,
-            };
-            let mut tool_ctx = ToolPolicyContext {
+            let mut dispatch_ctx = ToolDispatchContext {
                 tool_name: &tc.name,
                 tool_call_id: &tc.id,
                 arguments: &mut effective_arguments,
+                state: &state_snapshot,
             };
-            match run_pre_dispatch_policies(
-                &config.pre_dispatch_policies,
-                &policy_ctx,
-                &mut tool_ctx,
-            ) {
+            match run_pre_dispatch_policies(&config.pre_dispatch_policies, &mut dispatch_ctx) {
                 PreDispatchVerdict::Continue | PreDispatchVerdict::Inject(_) => {}
                 PreDispatchVerdict::Stop(reason) => {
                     let error_result = AgentToolResult {

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -76,7 +76,6 @@ pub struct PolicyContext<'a> {
     ///
     /// - **`PreTurn`**: user/pending messages appended since the previous turn.
     /// - **`PostTurn`** / **`PostLoop`**: empty — current-turn data is in [`TurnPolicyContext`].
-    /// - **`PreDispatch`**: empty — tool-call data is in [`ToolPolicyContext`].
     ///
     /// Policies should only scan this slice, never the full session history,
     /// to avoid redundant work on messages that have already been evaluated.
@@ -85,22 +84,27 @@ pub struct PolicyContext<'a> {
     pub state: &'a crate::SessionState,
 }
 
-/// Per-tool-call context for `PreDispatch` policies.
+/// Combined context for `PreDispatch` policies.
 ///
-/// Provides mutable access to arguments so policies can rewrite them
-/// (e.g., sandboxing, path normalization).
-pub struct ToolPolicyContext<'a> {
+/// Contains only the data reliably available during tool dispatch — the per-call
+/// fields and read-only session state. Loop-level metrics (turn index, accumulated
+/// usage/cost, message count, overflow signal) are intentionally excluded: they are
+/// not tracked at the tool dispatch call site, and fabricating placeholder values
+/// would give policies incorrect data to reason from.
+pub struct ToolDispatchContext<'a> {
     /// Name of the tool being called.
     pub tool_name: &'a str,
     /// Unique identifier for this tool call.
     pub tool_call_id: &'a str,
-    /// Mutable reference to tool call arguments.
+    /// Mutable reference to tool call arguments (policies may rewrite them).
     pub arguments: &'a mut serde_json::Value,
+    /// Read-only access to the session state.
+    pub state: &'a crate::SessionState,
 }
 
-impl std::fmt::Debug for ToolPolicyContext<'_> {
+impl std::fmt::Debug for ToolDispatchContext<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ToolPolicyContext")
+        f.debug_struct("ToolDispatchContext")
             .field("tool_name", &self.tool_name)
             .field("tool_call_id", &self.tool_call_id)
             .field("arguments", &"<redacted>")
@@ -143,17 +147,13 @@ pub trait PreTurnPolicy: Send + Sync {
 
 /// Slot 2: Evaluated per tool call, before approval and execution.
 ///
-/// Can inspect and mutate tool call arguments via [`ToolPolicyContext`].
+/// Can inspect and mutate tool call arguments via [`ToolDispatchContext`].
 /// Returns [`PreDispatchVerdict`] which includes `Skip` for per-tool rejection.
 pub trait PreDispatchPolicy: Send + Sync {
     /// Policy identifier for tracing and debugging.
     fn name(&self) -> &str;
     /// Evaluate the policy. Returns [`PreDispatchVerdict`].
-    fn evaluate(
-        &self,
-        ctx: &PolicyContext<'_>,
-        tool: &mut ToolPolicyContext<'_>,
-    ) -> PreDispatchVerdict;
+    fn evaluate(&self, ctx: &mut ToolDispatchContext<'_>) -> PreDispatchVerdict;
 }
 
 /// Slot 3: Evaluated after each completed turn.
@@ -295,14 +295,13 @@ fn run_policies_inner<'a>(
 /// - **Panics** are caught and treated as Continue.
 pub fn run_pre_dispatch_policies(
     policies: &[Arc<dyn PreDispatchPolicy>],
-    ctx: &PolicyContext<'_>,
-    tool: &mut ToolPolicyContext<'_>,
+    ctx: &mut ToolDispatchContext<'_>,
 ) -> PreDispatchVerdict {
     let mut injections: Vec<AgentMessage> = Vec::new();
 
     for policy in policies {
         let policy_name = policy.name().to_string();
-        let result = std::panic::catch_unwind(AssertUnwindSafe(|| policy.evaluate(ctx, tool)));
+        let result = std::panic::catch_unwind(AssertUnwindSafe(|| policy.evaluate(ctx)));
 
         match result {
             Ok(PreDispatchVerdict::Continue) => {}
@@ -403,11 +402,7 @@ mod tests {
         fn name(&self) -> &str {
             &self.policy_name
         }
-        fn evaluate(
-            &self,
-            _ctx: &PolicyContext<'_>,
-            _tool: &mut ToolPolicyContext<'_>,
-        ) -> PreDispatchVerdict {
+        fn evaluate(&self, _ctx: &mut ToolDispatchContext<'_>) -> PreDispatchVerdict {
             self.call_count.fetch_add(1, Ordering::SeqCst);
             (self.make_verdict)()
         }
@@ -418,11 +413,7 @@ mod tests {
         fn name(&self) -> &'static str {
             "panicker"
         }
-        fn evaluate(
-            &self,
-            _ctx: &PolicyContext<'_>,
-            _tool: &mut ToolPolicyContext<'_>,
-        ) -> PreDispatchVerdict {
+        fn evaluate(&self, _ctx: &mut ToolDispatchContext<'_>) -> PreDispatchVerdict {
             panic!("pre-dispatch policy panicked");
         }
     }
@@ -432,12 +423,8 @@ mod tests {
         fn name(&self) -> &'static str {
             "mutator"
         }
-        fn evaluate(
-            &self,
-            _ctx: &PolicyContext<'_>,
-            tool: &mut ToolPolicyContext<'_>,
-        ) -> PreDispatchVerdict {
-            if let Some(obj) = tool.arguments.as_object_mut() {
+        fn evaluate(&self, ctx: &mut ToolDispatchContext<'_>) -> PreDispatchVerdict {
+            if let Some(obj) = ctx.arguments.as_object_mut() {
                 obj.insert("injected".to_string(), serde_json::json!("by_policy"));
             }
             PreDispatchVerdict::Continue
@@ -451,12 +438,8 @@ mod tests {
         fn name(&self) -> &'static str {
             "verifier"
         }
-        fn evaluate(
-            &self,
-            _ctx: &PolicyContext<'_>,
-            tool: &mut ToolPolicyContext<'_>,
-        ) -> PreDispatchVerdict {
-            if tool.arguments.get(&self.expected_key).is_some() {
+        fn evaluate(&self, ctx: &mut ToolDispatchContext<'_>) -> PreDispatchVerdict {
+            if ctx.arguments.get(&self.expected_key).is_some() {
                 PreDispatchVerdict::Continue
             } else {
                 PreDispatchVerdict::Skip(format!("missing key: {}", self.expected_key))
@@ -488,6 +471,18 @@ mod tests {
             message_count: 5,
             overflow_signal: false,
             new_messages: &[],
+            state,
+        }
+    }
+
+    fn make_dispatch_ctx<'a>(
+        args: &'a mut serde_json::Value,
+        state: &'a crate::SessionState,
+    ) -> ToolDispatchContext<'a> {
+        ToolDispatchContext {
+            tool_name: "test_tool",
+            tool_call_id: "id1",
+            arguments: args,
             state,
         }
     }
@@ -618,16 +613,10 @@ mod tests {
     #[test]
     fn pre_dispatch_empty_vec_returns_continue() {
         let policies: Vec<Arc<dyn PreDispatchPolicy>> = vec![];
-        let (usage, cost) = test_context();
         let state = crate::SessionState::new();
-        let ctx = make_ctx(&usage, &cost, &state);
         let mut args = serde_json::json!({});
-        let mut tool_ctx = ToolPolicyContext {
-            tool_name: "test",
-            tool_call_id: "id1",
-            arguments: &mut args,
-        };
-        let result = run_pre_dispatch_policies(&policies, &ctx, &mut tool_ctx);
+        let mut ctx = make_dispatch_ctx(&mut args, &state);
+        let result = run_pre_dispatch_policies(&policies, &mut ctx);
         assert!(matches!(result, PreDispatchVerdict::Continue));
     }
 
@@ -640,16 +629,10 @@ mod tests {
             PreDispatchVerdict::Continue
         }));
         let policies: Vec<Arc<dyn PreDispatchPolicy>> = vec![p1.clone(), p2.clone()];
-        let (usage, cost) = test_context();
         let state = crate::SessionState::new();
-        let ctx = make_ctx(&usage, &cost, &state);
         let mut args = serde_json::json!({});
-        let mut tool_ctx = ToolPolicyContext {
-            tool_name: "test",
-            tool_call_id: "id1",
-            arguments: &mut args,
-        };
-        let result = run_pre_dispatch_policies(&policies, &ctx, &mut tool_ctx);
+        let mut ctx = make_dispatch_ctx(&mut args, &state);
+        let result = run_pre_dispatch_policies(&policies, &mut ctx);
         assert!(matches!(result, PreDispatchVerdict::Skip(ref e) if e == "denied"));
         assert_eq!(p1.calls(), 1);
         assert_eq!(p2.calls(), 0);
@@ -664,16 +647,10 @@ mod tests {
             PreDispatchVerdict::Continue
         }));
         let policies: Vec<Arc<dyn PreDispatchPolicy>> = vec![p1, p2.clone()];
-        let (usage, cost) = test_context();
         let state = crate::SessionState::new();
-        let ctx = make_ctx(&usage, &cost, &state);
         let mut args = serde_json::json!({});
-        let mut tool_ctx = ToolPolicyContext {
-            tool_name: "test",
-            tool_call_id: "id1",
-            arguments: &mut args,
-        };
-        let result = run_pre_dispatch_policies(&policies, &ctx, &mut tool_ctx);
+        let mut ctx = make_dispatch_ctx(&mut args, &state);
+        let result = run_pre_dispatch_policies(&policies, &mut ctx);
         assert!(matches!(result, PreDispatchVerdict::Stop(ref r) if r == "halt"));
         assert_eq!(p2.calls(), 0);
     }
@@ -687,16 +664,10 @@ mod tests {
             PreDispatchVerdict::Inject(vec![test_message()])
         }));
         let policies: Vec<Arc<dyn PreDispatchPolicy>> = vec![p1, p2];
-        let (usage, cost) = test_context();
         let state = crate::SessionState::new();
-        let ctx = make_ctx(&usage, &cost, &state);
         let mut args = serde_json::json!({});
-        let mut tool_ctx = ToolPolicyContext {
-            tool_name: "test",
-            tool_call_id: "id1",
-            arguments: &mut args,
-        };
-        let result = run_pre_dispatch_policies(&policies, &ctx, &mut tool_ctx);
+        let mut ctx = make_dispatch_ctx(&mut args, &state);
+        let result = run_pre_dispatch_policies(&policies, &mut ctx);
         match result {
             PreDispatchVerdict::Inject(msgs) => assert_eq!(msgs.len(), 2),
             _ => panic!("expected Inject"),
@@ -710,16 +681,10 @@ mod tests {
             PreDispatchVerdict::Continue
         }));
         let policies: Vec<Arc<dyn PreDispatchPolicy>> = vec![p1, p2.clone()];
-        let (usage, cost) = test_context();
         let state = crate::SessionState::new();
-        let ctx = make_ctx(&usage, &cost, &state);
         let mut args = serde_json::json!({});
-        let mut tool_ctx = ToolPolicyContext {
-            tool_name: "test",
-            tool_call_id: "id1",
-            arguments: &mut args,
-        };
-        let result = run_pre_dispatch_policies(&policies, &ctx, &mut tool_ctx);
+        let mut ctx = make_dispatch_ctx(&mut args, &state);
+        let result = run_pre_dispatch_policies(&policies, &mut ctx);
         assert!(matches!(result, PreDispatchVerdict::Continue));
         assert_eq!(p2.calls(), 1);
     }
@@ -731,19 +696,35 @@ mod tests {
             expected_key: "injected".to_string(),
         });
         let policies: Vec<Arc<dyn PreDispatchPolicy>> = vec![mutator, verifier];
-        let (usage, cost) = test_context();
         let state = crate::SessionState::new();
-        let ctx = make_ctx(&usage, &cost, &state);
         let mut args = serde_json::json!({"original": "value"});
-        let mut tool_ctx = ToolPolicyContext {
-            tool_name: "test",
-            tool_call_id: "id1",
-            arguments: &mut args,
-        };
-        let result = run_pre_dispatch_policies(&policies, &ctx, &mut tool_ctx);
+        let mut ctx = make_dispatch_ctx(&mut args, &state);
+        let result = run_pre_dispatch_policies(&policies, &mut ctx);
         // If mutator didn't inject "injected" key, verifier would return Skip
         assert!(matches!(result, PreDispatchVerdict::Continue));
-        // Verify the mutation is visible in the original args
+        // Verify the mutation is visible in the original args after dispatch
         assert_eq!(args["injected"], "by_policy");
+    }
+
+    #[test]
+    fn tool_dispatch_context_contains_only_reliable_fields() {
+        // Regression: ToolDispatchContext must not include loop-level metrics
+        // (turn_index, usage, cost, message_count, overflow_signal, new_messages)
+        // because those are not tracked at the tool dispatch call site.
+        let state = crate::SessionState::new();
+        let mut args = serde_json::json!({"path": "/tmp/file"});
+        let ctx = ToolDispatchContext {
+            tool_name: "write_file",
+            tool_call_id: "call-123",
+            arguments: &mut args,
+            state: &state,
+        };
+        assert_eq!(ctx.tool_name, "write_file");
+        assert_eq!(ctx.tool_call_id, "call-123");
+        assert_eq!(ctx.arguments["path"], "/tmp/file");
+        // Debug output does not expose argument values
+        let debug_str = format!("{ctx:?}");
+        assert!(debug_str.contains("write_file"));
+        assert!(!debug_str.contains("/tmp/file"), "arguments must be redacted in Debug");
     }
 }

--- a/tests/ac_tools.rs
+++ b/tests/ac_tools.rs
@@ -349,12 +349,8 @@ impl swink_agent::PreDispatchPolicy for InjectFieldPolicy {
         "inject_field"
     }
 
-    fn evaluate(
-        &self,
-        _ctx: &swink_agent::PolicyContext<'_>,
-        tool: &mut swink_agent::ToolPolicyContext<'_>,
-    ) -> swink_agent::PreDispatchVerdict {
-        if let Some(obj) = tool.arguments.as_object_mut() {
+    fn evaluate(&self, ctx: &mut swink_agent::ToolDispatchContext<'_>) -> swink_agent::PreDispatchVerdict {
+        if let Some(obj) = ctx.arguments.as_object_mut() {
             obj.insert("injected".to_string(), json!(true));
         }
         swink_agent::PreDispatchVerdict::Continue
@@ -411,12 +407,8 @@ impl swink_agent::PreDispatchPolicy for BlockToolPolicy {
         "block_tool"
     }
 
-    fn evaluate(
-        &self,
-        _ctx: &swink_agent::PolicyContext<'_>,
-        tool: &mut swink_agent::ToolPolicyContext<'_>,
-    ) -> swink_agent::PreDispatchVerdict {
-        if tool.tool_name == "blocked" {
+    fn evaluate(&self, ctx: &mut swink_agent::ToolDispatchContext<'_>) -> swink_agent::PreDispatchVerdict {
+        if ctx.tool_name == "blocked" {
             swink_agent::PreDispatchVerdict::Skip("blocked".into())
         } else {
             swink_agent::PreDispatchVerdict::Continue


### PR DESCRIPTION
## Summary

- Replaces fabricated `PolicyContext` + `ToolPolicyContext` pair in the `PreDispatch` slot with a new `ToolDispatchContext` containing only the data reliably available at tool dispatch time
- `ToolDispatchContext` exposes: `tool_name`, `tool_call_id`, `arguments` (mutable), `state` — exactly what the runtime knows
- Removes placeholder values (`turn_index=0`, empty `Usage`/`Cost`, `message_count=0`, `overflow_signal=false`) that previously misled policies into making decisions on incorrect data
- `PreDispatchPolicy::evaluate` signature simplifies from `fn evaluate(&self, ctx: &PolicyContext, tool: &mut ToolPolicyContext)` to `fn evaluate(&self, ctx: &mut ToolDispatchContext)`
- Updated all implementations: `ToolDenyListPolicy`, `SandboxPolicy`, `DomainFilterPolicy`, `RateLimitPolicy`, and integration test inline policies

## Test plan

- [x] `cargo clippy -p swink-agent -p swink-agent-policies -p swink-agent-plugin-web -- -D warnings` clean
- [x] `cargo test -p swink-agent --lib --features testkit` — 320 tests pass
- [x] `cargo test -p swink-agent --test ac_tools --features testkit` — 8 integration tests pass
- [x] `cargo test -p swink-agent-plugin-web` — 10 tests pass
- [x] `cargo test -p swink-agent-policies` — 60 tests pass, 2 pre-existing Windows path failures (not introduced by this PR)
- [x] `cargo test -p swink-agent --no-default-features` — pre-existing `bash_output_truncation` failure only
- [x] Regression test `tool_dispatch_context_contains_only_reliable_fields` confirms the new struct cannot include loop-level metrics

**Pre-existing failures** (not introduced by this change):
- `bash_output_truncation` — Windows stdout buffering issue in builtin tool tests
- `sandbox::tests::rejects_path_outside_root` / `custom_path_fields` — Windows path `is_absolute()` returns false for `/etc/passwd`, pre-dates this PR

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)