### PR TITLE
fix: collapse overlapping memory persistence abstractions

### DIFF
--- a/memory/src/codec.rs
+++ b/memory/src/codec.rs
@@ -1,0 +1,149 @@
+//! Canonical [`AgentMessage`] encode / decode used by all storage backends.
+//!
+//! Both the `JSONL` and `SQLite` backends previously duplicated the logic for
+//! serializing / deserializing [`AgentMessage`] values (calling
+//! [`serialize_custom_message`] / [`deserialize_custom_message`] inline,
+//! each with its own warn-and-skip pattern). This module centralises that
+//! shared concern so backends only deal with their own storage format.
+
+use std::io;
+
+use swink_agent::{
+    AgentMessage, CustomMessageRegistry, LlmMessage, restore_single_custom,
+    serialize_custom_message,
+};
+
+/// Discriminator tag for an encoded agent message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MessageKind {
+    /// An [`LlmMessage`] (user, assistant, tool result).
+    Llm,
+    /// A custom message serialised via [`CustomMessage::to_json`].
+    Custom,
+}
+
+impl MessageKind {
+    /// The string tag stored in the `SQLite` `kind` column.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Llm => "llm",
+            Self::Custom => "custom",
+        }
+    }
+
+    /// Parse a stored tag back to a [`MessageKind`]. Returns `None` for
+    /// unknown tags so callers can skip unrecognised rows gracefully.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "llm" => Some(Self::Llm),
+            "custom" => Some(Self::Custom),
+            _ => None,
+        }
+    }
+}
+
+/// Encode an [`AgentMessage`] to a `(kind, json)` pair.
+///
+/// Returns `None` and emits a `tracing::warn` for custom messages that cannot
+/// be serialised (i.e. their [`CustomMessage::to_json`] / [`CustomMessage::type_name`]
+/// implementations return `None`). LLM messages always succeed unless
+/// `serde_json` itself errors, which should not happen in practice.
+pub fn encode(msg: &AgentMessage, session_id: &str) -> Option<(MessageKind, String)> {
+    match msg {
+        AgentMessage::Llm(llm) => serde_json::to_string(llm)
+            .ok()
+            .map(|json| (MessageKind::Llm, json)),
+        AgentMessage::Custom(custom) => {
+            let Some(envelope) = serialize_custom_message(custom.as_ref()) else {
+                tracing::warn!(
+                    session_id,
+                    "skipping non-serializable CustomMessage: {custom:?}"
+                );
+                return None;
+            };
+            serde_json::to_string(&envelope)
+                .ok()
+                .map(|json| (MessageKind::Custom, json))
+        }
+    }
+}
+
+/// Decode a `(kind, json)` pair back to an [`AgentMessage`].
+///
+/// - `Llm`: deserialises the JSON directly; returns `Err` on malformed data.
+/// - `Custom`: returns `Ok(None)` when no `registry` is provided (the caller
+///   chose not to restore custom messages). Returns `Ok(None)` on a
+///   deserialisation error so callers can skip without propagating.
+pub fn decode(
+    kind: MessageKind,
+    data: &str,
+    registry: Option<&CustomMessageRegistry>,
+) -> io::Result<Option<AgentMessage>> {
+    match kind {
+        MessageKind::Llm => serde_json::from_str::<LlmMessage>(data)
+            .map(|m| Some(AgentMessage::Llm(m)))
+            .map_err(io::Error::other),
+        MessageKind::Custom => {
+            let envelope: serde_json::Value =
+                serde_json::from_str(data).map_err(io::Error::other)?;
+            restore_single_custom(registry, &envelope)
+                .map(|opt| opt.map(AgentMessage::Custom))
+                .map_err(io::Error::other)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use swink_agent::{ContentBlock, LlmMessage, UserMessage};
+
+    fn user_msg() -> AgentMessage {
+        AgentMessage::Llm(LlmMessage::User(UserMessage {
+            content: vec![ContentBlock::Text {
+                text: "hello".to_string(),
+            }],
+            timestamp: 1,
+            cache_hint: None,
+        }))
+    }
+
+    #[test]
+    fn encode_decode_llm_roundtrip() {
+        let msg = user_msg();
+        let (kind, json) = encode(&msg, "test-session").expect("llm encodes");
+        assert_eq!(kind, MessageKind::Llm);
+
+        let decoded = decode(MessageKind::Llm, &json, None)
+            .expect("no io error")
+            .expect("decoded to Some");
+        assert!(matches!(decoded, AgentMessage::Llm(LlmMessage::User(_))));
+    }
+
+    #[test]
+    fn message_kind_parse_and_as_str() {
+        assert_eq!(MessageKind::parse("llm"), Some(MessageKind::Llm));
+        assert_eq!(MessageKind::parse("custom"), Some(MessageKind::Custom));
+        assert_eq!(MessageKind::parse("unknown"), None);
+        assert_eq!(MessageKind::Llm.as_str(), "llm");
+        assert_eq!(MessageKind::Custom.as_str(), "custom");
+    }
+
+    #[test]
+    fn decode_llm_errors_on_malformed_json() {
+        let result = decode(MessageKind::Llm, "not-valid-json", None);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn decode_custom_returns_none_without_registry() {
+        // A minimal valid custom-message envelope.
+        let envelope = serde_json::json!({
+            "type_name": "MyType",
+            "data": {}
+        });
+        let json = serde_json::to_string(&envelope).unwrap();
+        let result = decode(MessageKind::Custom, &json, None).expect("no io error");
+        assert!(result.is_none(), "no registry → None, not an error");
+    }
+}

--- a/memory/src/jsonl.rs
+++ b/memory/src/jsonl.rs
@@ -33,7 +33,13 @@ impl SessionRecord {
         match message {
             AgentMessage::Llm(llm) => Some(Self::Llm(Box::new(llm.clone()))),
             AgentMessage::Custom(custom) => {
-                let mut envelope = serialize_custom_message(custom.as_ref())?;
+                let Some(mut envelope) = serialize_custom_message(custom.as_ref()) else {
+                    tracing::warn!(
+                        session_id,
+                        "skipping non-serializable CustomMessage: {custom:?}"
+                    );
+                    return None;
+                };
                 envelope
                     .as_object_mut()
                     .expect("custom message envelope must be an object")
@@ -41,15 +47,6 @@ impl SessionRecord {
                 Some(Self::Custom(envelope))
             }
         }
-        .or_else(|| {
-            if let AgentMessage::Custom(custom) = message {
-                tracing::warn!(
-                    "skipping non-serializable CustomMessage in session {session_id}: {:?}",
-                    custom
-                );
-            }
-            None
-        })
     }
 
     const fn state(state: serde_json::Value) -> Self {

--- a/memory/src/lib.rs
+++ b/memory/src/lib.rs
@@ -26,6 +26,7 @@
 //! store.save(&id, &meta, &messages)?;
 //! ```
 
+pub mod codec;
 pub mod compaction;
 pub mod entry;
 pub mod interrupt;

--- a/memory/src/sqlite.rs
+++ b/memory/src/sqlite.rs
@@ -14,10 +14,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Mutex, PoisonError};
 
 use rusqlite::{Connection, params};
-use swink_agent::{
-    AgentMessage, CustomMessageRegistry, LlmMessage, deserialize_custom_message,
-    serialize_custom_message,
-};
+use swink_agent::{AgentMessage, CustomMessageRegistry, LlmMessage};
 
 use crate::entry::SessionEntry;
 use crate::interrupt::InterruptState;
@@ -198,49 +195,6 @@ impl SqliteSessionStore {
     }
 }
 
-/// Serialize an [`AgentMessage`] to a `(kind, json_data)` pair for storage.
-fn serialize_agent_message(msg: &AgentMessage, session_id: &str) -> io::Result<(String, String)> {
-    match msg {
-        AgentMessage::Llm(llm) => {
-            let json = serde_json::to_string(llm).map_err(to_io)?;
-            Ok(("llm".to_string(), json))
-        }
-        AgentMessage::Custom(custom) => {
-            if let Some(envelope) = serialize_custom_message(custom.as_ref()) {
-                let json = serde_json::to_string(&envelope).map_err(to_io)?;
-                Ok(("custom".to_string(), json))
-            } else {
-                tracing::warn!(
-                    "skipping non-serializable CustomMessage in session {session_id}: {:?}",
-                    custom
-                );
-                Err(io::Error::other("non-serializable custom message"))
-            }
-        }
-    }
-}
-
-/// Deserialize a stored entry back to [`AgentMessage`].
-fn deserialize_entry(
-    kind: &str,
-    data: &str,
-    registry: Option<&CustomMessageRegistry>,
-) -> Option<AgentMessage> {
-    match kind {
-        "llm" => serde_json::from_str::<LlmMessage>(data)
-            .ok()
-            .map(AgentMessage::Llm),
-        "custom" => {
-            let envelope: serde_json::Value = serde_json::from_str(data).ok()?;
-            registry.and_then(|reg| {
-                deserialize_custom_message(reg, &envelope)
-                    .ok()
-                    .map(AgentMessage::Custom)
-            })
-        }
-        _ => None,
-    }
-}
 
 #[allow(clippy::significant_drop_tightening)]
 impl SessionStore for SqliteSessionStore {
@@ -279,8 +233,9 @@ impl SessionStore for SqliteSessionStore {
 
         let mut pos = 0i64;
         for msg in messages {
-            if let Ok((kind, data)) = serialize_agent_message(msg, id) {
-                stmt.execute(params![id, pos, kind, data]).map_err(to_io)?;
+            if let Some((kind, data)) = crate::codec::encode(msg, id) {
+                stmt.execute(params![id, pos, kind.as_str(), data])
+                    .map_err(to_io)?;
                 pos += 1;
             }
         }
@@ -317,8 +272,9 @@ impl SessionStore for SqliteSessionStore {
 
         let mut pos = max_pos + 1;
         for msg in messages {
-            if let Ok((kind, data)) = serialize_agent_message(msg, id) {
-                stmt.execute(params![id, pos, kind, data]).map_err(to_io)?;
+            if let Some((kind, data)) = crate::codec::encode(msg, id) {
+                stmt.execute(params![id, pos, kind.as_str(), data])
+                    .map_err(to_io)?;
                 pos += 1;
             }
         }
@@ -368,8 +324,9 @@ impl SessionStore for SqliteSessionStore {
             })
             .map_err(to_io)?
             .filter_map(|row| {
-                let (kind, data) = row.ok()?;
-                deserialize_entry(&kind, &data, registry)
+                let (kind_str, data) = row.ok()?;
+                let kind = crate::codec::MessageKind::parse(&kind_str)?;
+                crate::codec::decode(kind, &data, registry).ok().flatten()
             })
             .collect();
 

--- a/memory/src/store_async.rs
+++ b/memory/src/store_async.rs
@@ -43,13 +43,12 @@ pub trait AsyncSessionStore: Send + Sync {
 
     /// Load a session by ID asynchronously.
     ///
-    /// If `registry` is `Some`, custom messages are deserialized using the
-    /// provided registry. If `None`, custom messages are skipped.
-    fn load(
-        &self,
-        id: &str,
-        registry: Option<&CustomMessageRegistry>,
-    ) -> SessionStoreFuture<'_, (SessionMeta, Vec<AgentMessage>)>;
+    /// Custom messages are deserialized using the registry configured at
+    /// construction time (e.g. via [`BlockingSessionStore::with_registry`]).
+    /// To restore custom messages, provide the registry at construction rather
+    /// than per-call: a per-call registry cannot cross `spawn_blocking`
+    /// boundaries reliably.
+    fn load(&self, id: &str) -> SessionStoreFuture<'_, (SessionMeta, Vec<AgentMessage>)>;
 
     /// List all saved sessions asynchronously.
     fn list(&self) -> SessionStoreFuture<'_, Vec<SessionMeta>>;
@@ -111,10 +110,8 @@ impl<S: crate::store::SessionStore + 'static> BlockingSessionStore<S> {
 
     /// Attach a [`CustomMessageRegistry`] for deserializing custom messages on load.
     ///
-    /// Without a registry, the per-call `registry` argument to [`AsyncSessionStore::load`]
-    /// is ignored because `&CustomMessageRegistry` cannot cross `spawn_blocking`
-    /// boundaries. Providing a registry here ensures custom messages survive the
-    /// blocking adapter round-trip.
+    /// Because `&CustomMessageRegistry` cannot cross `spawn_blocking` boundaries,
+    /// the registry must be provided once at construction rather than per call.
     #[must_use]
     pub fn with_registry(mut self, registry: Arc<CustomMessageRegistry>) -> Self {
         self.registry = Some(registry);
@@ -152,17 +149,9 @@ impl<S: crate::store::SessionStore + 'static> AsyncSessionStore for BlockingSess
         spawn_store_call(move || inner.append(&id, &messages))
     }
 
-    fn load(
-        &self,
-        id: &str,
-        _registry: Option<&CustomMessageRegistry>,
-    ) -> SessionStoreFuture<'_, (SessionMeta, Vec<AgentMessage>)> {
+    fn load(&self, id: &str) -> SessionStoreFuture<'_, (SessionMeta, Vec<AgentMessage>)> {
         let inner = Arc::clone(&self.inner);
         let id = id.to_string();
-        // Use the stored registry (set via `with_registry`) because a bare
-        // `&CustomMessageRegistry` reference cannot cross `spawn_blocking`.
-        // The per-call `_registry` parameter is accepted for trait conformance
-        // but the stored `Arc` takes precedence.
         let registry = self.registry.clone();
         spawn_store_call(move || inner.load(&id, registry.as_deref()))
     }
@@ -260,7 +249,7 @@ mod tests {
         assert_eq!(sessions[0].title, "Async test");
 
         // Load via async adapter.
-        let (loaded_meta, loaded_messages) = async_store.load("test_async", None).await.unwrap();
+        let (loaded_meta, loaded_messages) = async_store.load("test_async").await.unwrap();
         assert_eq!(loaded_meta.id, "test_async");
         assert!(loaded_messages.is_empty());
 
@@ -382,7 +371,7 @@ mod tests {
             .unwrap();
 
         // Load back through the blocking adapter — custom messages must survive.
-        let (_, loaded) = async_store.load("custom_save", None).await.unwrap();
+        let (_, loaded) = async_store.load("custom_save").await.unwrap();
         assert_eq!(loaded.len(), 3, "all three messages must be loaded");
         assert!(matches!(loaded[0], AgentMessage::Llm(_)));
         assert!(matches!(loaded[1], AgentMessage::Custom(_)));
@@ -410,7 +399,7 @@ mod tests {
         // Load through the blocking adapter with a registry — must restore the custom message.
         let jsonl_store = JsonlSessionStore::new(dir.path().to_path_buf()).unwrap();
         let async_store = BlockingSessionStore::new(jsonl_store).with_registry(registry);
-        let (_, loaded) = async_store.load("reg_load", None).await.unwrap();
+        let (_, loaded) = async_store.load("reg_load").await.unwrap();
         assert_eq!(loaded.len(), 1);
         assert!(matches!(loaded[0], AgentMessage::Custom(_)));
         let custom = loaded[0].downcast_ref::<TestCustomMsg>().unwrap();
@@ -452,7 +441,7 @@ mod tests {
             .unwrap();
 
         // Reload and verify the custom message survived.
-        let (_, loaded) = async_store.load("custom_append", None).await.unwrap();
+        let (_, loaded) = async_store.load("custom_append").await.unwrap();
         assert_eq!(loaded.len(), 2);
         assert!(matches!(loaded[0], AgentMessage::Llm(_)));
         assert!(matches!(loaded[1], AgentMessage::Custom(_)));

--- a/memory/tests/async_store.rs
+++ b/memory/tests/async_store.rs
@@ -17,7 +17,7 @@ async fn async_save_and_load_roundtrip() {
 
     store.save("async_rt", &meta, &messages).await.unwrap();
 
-    let (loaded_meta, loaded_msgs) = store.load("async_rt", None).await.unwrap();
+    let (loaded_meta, loaded_msgs) = store.load("async_rt").await.unwrap();
     assert_eq!(loaded_meta.id, meta.id);
     assert_eq!(loaded_meta.title, meta.title);
     assert_eq!(loaded_meta.sequence, 1); // incremented on save
@@ -38,7 +38,7 @@ async fn concurrent_async_operations_on_different_sessions() {
             let meta = sample_meta(&id, &format!("Session {i}"));
             let messages = vec![user_message(&format!("message from {i}"))];
             store.save(&id, &meta, &messages).await.unwrap();
-            let (loaded_meta, loaded_msgs) = store.load(&id, None).await.unwrap();
+            let (loaded_meta, loaded_msgs) = store.load(&id).await.unwrap();
             assert_eq!(loaded_meta.id, id);
             assert_eq!(loaded_msgs.len(), 1);
         });


### PR DESCRIPTION
## Summary

- Introduces `memory/src/codec.rs` — a shared `AgentMessage` encode/decode module used by both JSONL and `SQLite` backends, eliminating the duplicate `serialize_agent_message` / `deserialize_entry` functions each backend owned independently
- Removes the silently-ignored per-call `registry: Option<&CustomMessageRegistry>` parameter from `AsyncSessionStore::load` — it was accepted by the trait but `BlockingSessionStore` could not honour it (a `&CustomMessageRegistry` reference cannot cross `spawn_blocking`), so callers got no custom message restoration even when they passed a registry
- Simplifies `SessionRecord::from_message` in `jsonl.rs` using `let-else`, inlining the warn-and-skip logic directly in the `Custom` match arm

## What changed

| File | Change |
|------|--------|
| `memory/src/codec.rs` | New: `MessageKind` enum, `encode` / `decode` functions, 4 unit tests |
| `memory/src/sqlite.rs` | Removes 43-line private codec; `save`, `append`, `load` delegate to `crate::codec` |
| `memory/src/jsonl.rs` | `from_message` simplified with `let-else`; warn-and-skip moved inline |
| `memory/src/store_async.rs` | `AsyncSessionStore::load` drops per-call `registry` param; `BlockingSessionStore::load` simplified |
| `memory/tests/async_store.rs` | Updated load call-sites |

## Breaking change

`AsyncSessionStore::load` signature is narrowed — the `registry` parameter is removed. Any downstream crate that **implements** (not just calls) this trait must drop the parameter. Within this workspace `BlockingSessionStore` is the only implementor and is updated here. Callers that need custom-message restoration should use `with_registry` at construction time.

## Test plan

- [x] `cargo clippy -p swink-agent-memory -- -D warnings` clean
- [x] `cargo test -p swink-agent-memory` — 29 tests pass
- [x] `cargo test -p swink-agent-memory --features sqlite` — 94 tests pass (includes SQLite encode/decode path)
- [x] `cargo test -p swink-agent --no-default-features` — 309 tests pass
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] Pre-existing `bash_output_truncation` and `MockPlugin` failures are unrelated to this change

Part of #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)