### PR TITLE
[codex] Collapse memory persistence codecs

### DIFF
--- a/memory/src/codec.rs
+++ b/memory/src/codec.rs
@@ -1,10 +1,12 @@
-//! Canonical [`AgentMessage`] encode / decode used by all storage backends.
+//! Canonical persistence codecs used by all storage backends.
 //!
-//! Both the `JSONL` and `SQLite` backends previously duplicated the logic for
-//! serializing / deserializing [`AgentMessage`] values (calling
-//! [`serialize_custom_message`] / [`deserialize_custom_message`] inline,
-//! each with its own warn-and-skip pattern). This module centralises that
-//! shared concern so backends only deal with their own storage format.
+//! This module centralises the shared encode / decode rules for:
+//! - plain [`AgentMessage`] persistence
+//! - JSONL message lines, including legacy `_custom` and `_state` records
+//! - rich [`SessionEntry`] persistence used by filtered/history-aware loading
+//!
+//! Backends should only deal with their transport shape (line-based JSONL,
+//! `(kind, data)` rows in `SQLite`, etc.), not reimplement message codecs.
 
 use std::io;
 
@@ -12,6 +14,8 @@ use swink_agent::{
     AgentMessage, CustomMessageRegistry, LlmMessage, restore_single_custom,
     serialize_custom_message,
 };
+
+use crate::entry::SessionEntry;
 
 /// Discriminator tag for an encoded agent message.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -93,6 +97,95 @@ pub fn decode(
     }
 }
 
+/// Encode an [`AgentMessage`] as a JSONL line.
+///
+/// LLM messages are stored as raw `LlmMessage` JSON for backward
+/// compatibility. Custom messages are stored as their serialized envelope with
+/// a `_custom: true` marker so `JSONL` can distinguish them from plain JSON
+/// objects.
+pub fn encode_jsonl_message_line(msg: &AgentMessage, session_id: &str) -> Option<String> {
+    match msg {
+        AgentMessage::Llm(llm) => serde_json::to_string(llm).ok(),
+        AgentMessage::Custom(custom) => {
+            let Some(envelope) = serialize_custom_message(custom.as_ref()) else {
+                tracing::warn!(
+                    session_id,
+                    "skipping non-serializable CustomMessage: {custom:?}"
+                );
+                return None;
+            };
+
+            let mut envelope = envelope;
+            envelope
+                .as_object_mut()
+                .expect("custom message envelope must be an object")
+                .insert("_custom".to_string(), serde_json::Value::Bool(true));
+
+            serde_json::to_string(&envelope).ok()
+        }
+    }
+}
+
+/// Decode one JSONL line back into an [`AgentMessage`].
+///
+/// Returns `Ok(None)` for state records, for entry-tagged records that are not
+/// messages, and when a custom message cannot be restored because no registry
+/// was supplied.
+pub fn decode_jsonl_message_line(
+    line: &str,
+    registry: Option<&CustomMessageRegistry>,
+) -> io::Result<Option<AgentMessage>> {
+    let value: serde_json::Value = serde_json::from_str(line).map_err(io::Error::other)?;
+    if value.get("_state").and_then(serde_json::Value::as_bool) == Some(true) {
+        return Ok(None);
+    }
+
+    if value.get("_custom").and_then(serde_json::Value::as_bool) == Some(true) {
+        return decode(MessageKind::Custom, line, registry);
+    }
+
+    if let Ok(message) = serde_json::from_value::<LlmMessage>(value.clone()) {
+        return Ok(Some(AgentMessage::Llm(message)));
+    }
+
+    match SessionEntry::parse(line).map_err(io::Error::other)? {
+        SessionEntry::Message(message) => Ok(Some(AgentMessage::Llm(message))),
+        _ => Ok(None),
+    }
+}
+
+/// Encode a rich [`SessionEntry`] for row-based backends such as `SQLite`.
+///
+/// The returned `kind` is a lightweight discriminator column, while `data`
+/// contains the canonical JSON payload. Message entries keep their
+/// `entry_type = "message"` tagged representation for compatibility with
+/// existing rich-entry storage.
+pub fn encode_session_entry(entry: &SessionEntry) -> io::Result<(String, String)> {
+    let kind = entry.entry_type_name().to_string();
+    let data = serde_json::to_string(entry).map_err(io::Error::other)?;
+    Ok((kind, data))
+}
+
+/// Decode a rich [`SessionEntry`] from a row-based backend.
+///
+/// Returns `Ok(None)` for stored custom-agent-message rows (`kind = "custom"`),
+/// which are not representable as `SessionEntry`.
+pub fn decode_session_entry(kind: &str, data: &str) -> io::Result<Option<SessionEntry>> {
+    match MessageKind::parse(kind) {
+        Some(MessageKind::Llm) => serde_json::from_str::<LlmMessage>(data)
+            .map(SessionEntry::Message)
+            .map(Some)
+            .map_err(io::Error::other),
+        Some(MessageKind::Custom) => match serde_json::from_str::<SessionEntry>(data) {
+            Ok(entry) => Ok(Some(entry)),
+            Err(_) => Ok(None),
+        },
+        None => serde_json::from_str::<SessionEntry>(data)
+            .map(Some)
+            .map_err(io::Error::other),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -145,5 +238,68 @@ mod tests {
         let json = serde_json::to_string(&envelope).unwrap();
         let result = decode(MessageKind::Custom, &json, None).expect("no io error");
         assert!(result.is_none(), "no registry → None, not an error");
+    }
+
+    #[test]
+    fn decode_jsonl_message_line_reads_tagged_message_entry() {
+        let entry = SessionEntry::Message(LlmMessage::User(UserMessage {
+            content: vec![ContentBlock::Text {
+                text: "from-entry".to_string(),
+            }],
+            timestamp: 7,
+            cache_hint: None,
+        }));
+        let line = serde_json::to_string(&entry).unwrap();
+
+        let decoded = decode_jsonl_message_line(&line, None)
+            .expect("parse succeeds")
+            .expect("message preserved");
+        assert!(matches!(decoded, AgentMessage::Llm(LlmMessage::User(_))));
+    }
+
+    #[test]
+    fn decode_jsonl_message_line_skips_state_records() {
+        let line = serde_json::json!({
+            "_state": true,
+            "data": { "cursor": 42 }
+        })
+        .to_string();
+
+        let decoded = decode_jsonl_message_line(&line, None).expect("parse succeeds");
+        assert!(decoded.is_none());
+    }
+
+    #[test]
+    fn session_entry_codec_roundtrips_message_entries() {
+        let entry = SessionEntry::Message(LlmMessage::User(UserMessage {
+            content: vec![ContentBlock::Text {
+                text: "hello".to_string(),
+            }],
+            timestamp: 1,
+            cache_hint: None,
+        }));
+
+        let (kind, data) = encode_session_entry(&entry).unwrap();
+        let decoded = decode_session_entry(&kind, &data)
+            .expect("decode succeeds")
+            .expect("entry preserved");
+
+        assert!(matches!(decoded, SessionEntry::Message(LlmMessage::User(_))));
+    }
+
+    #[test]
+    fn session_entry_codec_preserves_custom_entries_despite_custom_kind_overlap() {
+        let entry = SessionEntry::Custom {
+            type_name: "audit".to_string(),
+            data: serde_json::json!({"ok": true}),
+            timestamp: 11,
+        };
+
+        let (kind, data) = encode_session_entry(&entry).unwrap();
+        let decoded = decode_session_entry(&kind, &data)
+            .expect("decode succeeds")
+            .expect("entry preserved");
+
+        assert!(matches!(decoded, SessionEntry::Custom { .. }));
     }
 }

--- a/memory/src/jsonl.rs
+++ b/memory/src/jsonl.rs
@@ -9,10 +9,7 @@
 use std::io::{self, BufRead, Seek, Write};
 use std::path::{Path, PathBuf};
 
-use swink_agent::{
-    AgentMessage, CustomMessageRegistry, LlmMessage, restore_single_custom,
-    serialize_custom_message,
-};
+use swink_agent::{AgentMessage, CustomMessageRegistry, LlmMessage};
 
 use crate::entry::SessionEntry;
 use crate::interrupt::InterruptState;
@@ -30,22 +27,11 @@ enum SessionRecord {
 
 impl SessionRecord {
     fn from_message(message: &AgentMessage, session_id: &str) -> Option<Self> {
-        match message {
-            AgentMessage::Llm(llm) => Some(Self::Llm(Box::new(llm.clone()))),
-            AgentMessage::Custom(custom) => {
-                let Some(mut envelope) = serialize_custom_message(custom.as_ref()) else {
-                    tracing::warn!(
-                        session_id,
-                        "skipping non-serializable CustomMessage: {custom:?}"
-                    );
-                    return None;
-                };
-                envelope
-                    .as_object_mut()
-                    .expect("custom message envelope must be an object")
-                    .insert("_custom".to_string(), serde_json::Value::Bool(true));
-                Some(Self::Custom(envelope))
-            }
+        let line = crate::codec::encode_jsonl_message_line(message, session_id)?;
+        match Self::parse(&line).ok()? {
+            Self::Llm(llm) => Some(Self::Llm(llm)),
+            Self::Custom(envelope) => Some(Self::Custom(envelope)),
+            Self::State(_) => None,
         }
     }
 
@@ -248,28 +234,13 @@ fn parse_message_record(
     id: &str,
     registry: Option<&CustomMessageRegistry>,
 ) -> Option<AgentMessage> {
-    match SessionRecord::parse(line) {
-        Ok(SessionRecord::Llm(message)) => Some(AgentMessage::Llm(*message)),
-        Ok(SessionRecord::Custom(envelope)) => {
-            match restore_single_custom(registry, &envelope) {
-                Ok(Some(custom)) => Some(AgentMessage::Custom(custom)),
-                Ok(None) => None, // no registry provided
-                Err(error) => {
-                    tracing::warn!(
-                        line = line_num,
-                        error = %error,
-                        "skipping unrestorable custom message in session {id}"
-                    );
-                    None
-                }
-            }
-        }
-        Ok(SessionRecord::State(_)) => None,
+    match crate::codec::decode_jsonl_message_line(line, registry) {
+        Ok(message) => message,
         Err(error) => {
             tracing::warn!(
                 line = line_num,
                 error = %error,
-                "skipping unparseable line in session {id}"
+                "skipping unparseable message line in session {id}"
             );
             None
         }
@@ -853,5 +824,50 @@ mod tests {
 
         let (_, messages) = store.load("test-state", None).unwrap();
         assert_eq!(messages.len(), 2);
+    }
+
+    #[test]
+    fn load_reads_message_entries_saved_via_save_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = JsonlSessionStore::new(dir.path().to_path_buf()).unwrap();
+
+        let now = now_utc();
+        let meta = SessionMeta {
+            id: "entry-messages".to_string(),
+            title: "Entry messages".to_string(),
+            created_at: now,
+            updated_at: now,
+            version: 1,
+            sequence: 0,
+        };
+
+        let entries = vec![
+            SessionEntry::Message(LlmMessage::User(swink_agent::UserMessage {
+                content: vec![swink_agent::ContentBlock::Text {
+                    text: "hello".to_string(),
+                }],
+                timestamp: 1,
+                cache_hint: None,
+            })),
+            SessionEntry::Label {
+                text: "bookmark".to_string(),
+                message_index: 0,
+                timestamp: 2,
+            },
+            SessionEntry::Message(LlmMessage::User(swink_agent::UserMessage {
+                content: vec![swink_agent::ContentBlock::Text {
+                    text: "world".to_string(),
+                }],
+                timestamp: 3,
+                cache_hint: None,
+            })),
+        ];
+
+        store.save_entries("entry-messages", &meta, &entries).unwrap();
+
+        let (_, messages) = store.load("entry-messages", None).unwrap();
+        assert_eq!(messages.len(), 2);
+        assert!(matches!(messages[0], AgentMessage::Llm(LlmMessage::User(_))));
+        assert!(matches!(messages[1], AgentMessage::Llm(LlmMessage::User(_))));
     }
 }

--- a/memory/src/sqlite.rs
+++ b/memory/src/sqlite.rs
@@ -14,7 +14,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Mutex, PoisonError};
 
 use rusqlite::{Connection, params};
-use swink_agent::{AgentMessage, CustomMessageRegistry, LlmMessage};
+use swink_agent::{AgentMessage, CustomMessageRegistry};
 
 use crate::entry::SessionEntry;
 use crate::interrupt::InterruptState;
@@ -489,7 +489,9 @@ impl SessionStore for SqliteSessionStore {
             .map_err(to_io)?
             .filter_map(|row| {
                 let (kind, data) = row.ok()?;
-                deserialize_session_entry(&kind, &data)
+                crate::codec::decode_session_entry(&kind, &data)
+                    .ok()
+                    .flatten()
             })
             .collect();
 
@@ -554,7 +556,7 @@ impl SqliteSessionStore {
             .map_err(to_io)?;
 
         for (i, entry) in entries.iter().enumerate() {
-            let (kind, data) = serialize_session_entry(entry)?;
+            let (kind, data) = crate::codec::encode_session_entry(entry)?;
             let pos = i64::try_from(i).map_err(to_io)?;
             stmt.execute(params![id, pos, kind, data]).map_err(to_io)?;
         }
@@ -584,32 +586,13 @@ impl SqliteSessionStore {
             .map_err(to_io)?
             .filter_map(|row| {
                 let (kind, data) = row.ok()?;
-                deserialize_session_entry(&kind, &data)
+                crate::codec::decode_session_entry(&kind, &data)
+                    .ok()
+                    .flatten()
             })
             .collect();
 
         Ok((meta, entries))
-    }
-}
-
-fn serialize_session_entry(entry: &SessionEntry) -> io::Result<(String, String)> {
-    let kind = entry.entry_type_name().to_string();
-    let data = serde_json::to_string(entry).map_err(to_io)?;
-    Ok((kind, data))
-}
-
-fn deserialize_session_entry(kind: &str, data: &str) -> Option<SessionEntry> {
-    match kind {
-        "llm" => {
-            // Stored via save() as AgentMessage — unwrap to SessionEntry::Message
-            serde_json::from_str::<LlmMessage>(data)
-                .ok()
-                .map(SessionEntry::Message)
-        }
-        _ => {
-            // Stored via save_entries() as tagged SessionEntry
-            serde_json::from_str::<SessionEntry>(data).ok()
-        }
     }
 }
 
@@ -1087,5 +1070,22 @@ mod tests {
         assert!(matches!(loaded[1], AgentMessage::Custom(_)));
         let custom = loaded[1].downcast_ref::<TestCustom>().unwrap();
         assert_eq!(custom.data, "payload");
+    }
+
+    #[test]
+    fn load_entries_reads_sessions_saved_via_message_api() {
+        let store = SqliteSessionStore::in_memory().unwrap();
+        let m = meta("entry-compat", "Entry compatibility");
+        let messages = vec![user_msg("hello"), assistant_msg("world")];
+
+        store.save("entry-compat", &m, &messages).unwrap();
+
+        let (_, entries) = store.load_entries("entry-compat").unwrap();
+        assert_eq!(entries.len(), 2);
+        assert!(matches!(entries[0], SessionEntry::Message(LlmMessage::User(_))));
+        assert!(matches!(
+            entries[1],
+            SessionEntry::Message(LlmMessage::Assistant(_))
+        ));
     }
 }


### PR DESCRIPTION
## Summary
- centralize JSONL message-line and SQLite session-entry persistence rules in `memory/src/codec.rs`
- switch both backends to the shared codec instead of keeping backend-local encode/decode paths
- add regression coverage for JSONL/SQLite compatibility edges, including the overlapping `custom` discriminator case

## Why
Issue #165 called out that persistence behavior was split across multiple backends with duplicated codecs and surprising contracts. The async trait mismatch had already been removed, so the remaining actionable overlap was the duplicated message and rich-entry serialization logic in JSONL and SQLite.

## Impact
This narrows the persistence contract around one shared codec surface while preserving existing on-disk and row-based compatibility paths.

## Validation
- `cargo test -p swink-agent-memory`
- `cargo test -p swink-agent-memory --features sqlite`

Closes #165