### PR TITLE
release: bump version to 0.6.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,10 @@ MSRV **1.88** (edition 2024). Workspace deps centralized in root `Cargo.toml`.
 - Adapter SSE parsing should go through `adapters/src/sse.rs` helpers when possible; the proxy adapter no longer uses its own `eventsource-stream` path.
 - `adapters/src/sse.rs` is the shared byte-to-SSE-line parser for both generic data-only adapters and Anthropic's event+data pairing logic; avoid reintroducing custom chunk splitters in provider modules.
 
+### Local LLM Streaming (`local-llm/src/stream.rs`)
+
+- Gemma 4 delimiter scanners must only slice `&str` at UTF-8 character boundaries. For partial `<|channel>thought\n` and `<tool_call|>` matches, use the shared UTF-8-safe suffix helper instead of raw byte-offset suffix slicing.
+
 ### Context (`src/context.rs`)
 
 - Sliding window: anchor (first N) + tail (recent), middle removed to fit budget.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,10 @@ MSRV **1.88** (edition 2024). Workspace deps centralized in root `Cargo.toml`.
 - `partial_json` consumed on `ToolCallEnd` — parsed once. Empty string → `{}`, not null.
 - `AssistantMessageEvent::error()` is the canonical error constructor — adapters must use it.
 
+### Local LLM Streaming (`local-llm/src/stream.rs`)
+
+- Gemma 4 delimiter scanners must only slice `&str` at UTF-8 character boundaries. For partial `<|channel>thought\n` and `<tool_call|>` matches, use the shared UTF-8-safe suffix helper instead of raw byte-offset suffix slicing.
+
 ### Context (`src/context.rs`)
 
 - Sliding window: anchor (first N) + tail (recent), middle removed to fit budget.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7291,7 +7291,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swink-agent"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -7330,7 +7330,7 @@ dependencies = [
 
 [[package]]
 name = "swink-agent-adapters"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -7357,7 +7357,7 @@ dependencies = [
 
 [[package]]
 name = "swink-agent-artifacts"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -7373,7 +7373,7 @@ dependencies = [
 
 [[package]]
 name = "swink-agent-auth"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "chrono",
  "futures",
@@ -7391,7 +7391,7 @@ dependencies = [
 
 [[package]]
 name = "swink-agent-eval"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "futures",
  "pretty_assertions",
@@ -7411,7 +7411,7 @@ dependencies = [
 
 [[package]]
 name = "swink-agent-local-llm"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "futures",
  "hf-hub 0.5.0",
@@ -7430,7 +7430,7 @@ dependencies = [
 
 [[package]]
 name = "swink-agent-macros"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7444,7 +7444,7 @@ dependencies = [
 
 [[package]]
 name = "swink-agent-mcp"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "reqwest 0.13.2",
  "rmcp",
@@ -7460,7 +7460,7 @@ dependencies = [
 
 [[package]]
 name = "swink-agent-memory"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "chrono",
  "dirs",
@@ -7476,7 +7476,7 @@ dependencies = [
 
 [[package]]
 name = "swink-agent-patterns"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "regex",
  "schemars 1.2.1",
@@ -7514,7 +7514,7 @@ dependencies = [
 
 [[package]]
 name = "swink-agent-policies"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "chrono",
  "futures",
@@ -7531,7 +7531,7 @@ dependencies = [
 
 [[package]]
 name = "swink-agent-tui"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "arboard",
  "crossterm 0.29.0",
@@ -10024,7 +10024,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "clap",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ rusqlite = { version = "0.35", features = ["bundled"] }
 
 [package]
 name = "swink-agent"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 rust-version = "1.88"
 description = "Core scaffolding for running LLM-powered agentic loops"

--- a/adapters/Cargo.toml
+++ b/adapters/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swink-agent-adapters"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 rust-version = "1.88"
 description = "LLM provider adapters for swink-agent"

--- a/adapters/src/remote_presets.rs
+++ b/adapters/src/remote_presets.rs
@@ -36,7 +36,7 @@ impl RemotePresetKey {
     }
 }
 
-#[allow(unused_imports)]
+#[allow(dead_code, unused_imports)]
 pub mod remote_preset_keys {
     use super::RemotePresetKey;
 

--- a/adapters/src/remote_presets.rs
+++ b/adapters/src/remote_presets.rs
@@ -491,7 +491,10 @@ mod tests {
     #[test]
     fn remote_preset_requires_key() {
         let preset = preset("gpt-4o").unwrap();
-        let err = build_connection_from_preset(&preset, None, None).unwrap_err();
+        let err = match build_connection_from_preset(&preset, None, None) {
+            Ok(_) => panic!("expected missing credential error"),
+            Err(err) => err,
+        };
         assert_eq!(
             err,
             RemoteModelConnectionError::MissingCredential {

--- a/artifacts/Cargo.toml
+++ b/artifacts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swink-agent-artifacts"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 rust-version = "1.88"
 description = "Versioned artifact storage for swink-agent sessions"

--- a/auth/Cargo.toml
+++ b/auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swink-agent-auth"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 rust-version = "1.88"
 description = "Credential management and OAuth2 support for swink-agent"

--- a/eval/Cargo.toml
+++ b/eval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swink-agent-eval"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 rust-version = "1.88"
 description = "Evaluation framework for swink-agent: trajectory tracing, golden path verification, and cost governance"

--- a/local-llm/CLAUDE.md
+++ b/local-llm/CLAUDE.md
@@ -28,6 +28,7 @@
 - **Gemma 4 thinking mode** — `<|think|>\n` prepended to system prompt in `convert.rs` when `config.is_gemma4() && thinking_enabled`. mistralrs has no `think: true` API for direct inference.
 - **Gemma 4 thinking output** — `ChannelThoughtParser` in `stream.rs` handles cross-chunk `<|channel>thought\n...<channel|>` delimiters. Stateful 4-state machine (Normal → PartialOpen → InThinking → PartialClose).
 - **Gemma 4 tool calls** — `ToolCallParser` in `stream.rs` handles cross-chunk `<|tool_call>call:{name}{args}<tool_call|>` format. IDs are generated as UUIDs. `Gemma4LocalConverter` wraps tool results as `<|tool_result>{tool_call_id}\n{text}<tool_result|>`.
+- **Gemma 4 partial delimiter matching must be UTF-8 safe** — when scanning for split `<|channel>thought\n` and `<tool_call|>` delimiters, only slice `&str` values at character boundaries. Reuse the shared suffix helper in `stream.rs`; raw byte-offset suffix slicing can panic on multibyte output.
 - **Two converter types** — `LocalConverter` (SmolLM3) and `Gemma4LocalConverter` (Gemma 4) both implement `MessageConverter`. `convert_context_messages` dispatches based on `config.is_gemma4()`.
 
 ## Design Decisions

--- a/local-llm/Cargo.toml
+++ b/local-llm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swink-agent-local-llm"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 rust-version = "1.88"
 description = "Local on-device LLM inference for swink-agent using mistral.rs"

--- a/local-llm/src/stream.rs
+++ b/local-llm/src/stream.rs
@@ -68,7 +68,44 @@ impl StreamFn for LocalStreamFn {
 // ─── ChannelThoughtParser (Gemma 4) ────────────────────────────────────────
 
 #[cfg(feature = "gemma4")]
+mod gemma4 {
+    /// Find the longest suffix of `haystack` that is also a prefix of `needle`.
+    ///
+    /// The returned length is a byte length into `haystack`, but matching is
+    /// only attempted at valid UTF-8 character boundaries so callers can safely
+    /// slice the original `&str`.
+    pub(super) fn partial_prefix_at_end(haystack: &str, needle: &str) -> Option<usize> {
+        if needle.len() <= 1 || haystack.is_empty() {
+            return None;
+        }
+
+        let min_start = haystack
+            .len()
+            .saturating_sub(needle.len().saturating_sub(1));
+
+        for (start, _) in haystack.char_indices() {
+            if start < min_start {
+                continue;
+            }
+
+            let suffix = &haystack[start..];
+            if needle.starts_with(suffix) {
+                return Some(haystack.len() - start);
+            }
+        }
+
+        if needle.starts_with(haystack) && haystack.len() < needle.len() {
+            Some(haystack.len())
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(feature = "gemma4")]
 mod channel_thought {
+    use super::gemma4::partial_prefix_at_end;
+
     /// Opening delimiter for Gemma 4 thinking blocks.
     const OPEN_DELIM: &str = "<|channel>thought\n";
     /// Closing delimiter for Gemma 4 thinking blocks.
@@ -231,25 +268,14 @@ mod channel_thought {
             None => *target = Some(s.to_string()),
         }
     }
-
-    /// Find the longest suffix of `haystack` that is a prefix of `needle`.
-    /// Returns the length of the partial match, or `None` if no partial match.
-    fn partial_prefix_at_end(haystack: &str, needle: &str) -> Option<usize> {
-        let max_check = haystack.len().min(needle.len() - 1);
-        for len in (1..=max_check).rev() {
-            let suffix = &haystack[haystack.len() - len..];
-            if needle.starts_with(suffix) {
-                return Some(len);
-            }
-        }
-        None
-    }
 }
 
 // ─── ToolCallParser (Gemma 4) ─────────────────────────────────────────────
 
 #[cfg(feature = "gemma4")]
 mod tool_call {
+    use super::gemma4::partial_prefix_at_end;
+
     /// Opening delimiter for Gemma 4 tool calls.
     const OPEN_DELIM: &str = "<|tool_call>call:";
     /// Closing delimiter for Gemma 4 tool calls.
@@ -429,17 +455,6 @@ mod tool_call {
             Some(existing) => existing.push_str(s),
             None => *target = Some(s.to_string()),
         }
-    }
-
-    fn partial_prefix_at_end(haystack: &str, needle: &str) -> Option<usize> {
-        let max_check = haystack.len().min(needle.len() - 1);
-        for len in (1..=max_check).rev() {
-            let suffix = &haystack[haystack.len() - len..];
-            if needle.starts_with(suffix) {
-                return Some(len);
-            }
-        }
-        None
     }
 }
 
@@ -991,6 +1006,7 @@ mod tests {
     #[cfg(feature = "gemma4")]
     mod gemma4_tests {
         use super::super::channel_thought::ChannelThoughtParser;
+        use super::super::gemma4::partial_prefix_at_end;
 
         #[test]
         fn channel_thought_single_chunk() {
@@ -1025,6 +1041,21 @@ mod tests {
             let (t2, txt2) = parser.process("nel|>after text");
             assert!(t2.is_none());
             assert_eq!(txt2.as_deref(), Some("after text"));
+        }
+
+        #[test]
+        fn channel_thought_partial_match_is_utf8_safe() {
+            let haystack = "alpha🙂<|chan";
+            assert_eq!(partial_prefix_at_end(haystack, "<|channel>thought\n"), Some(6));
+
+            let mut parser = ChannelThoughtParser::new();
+            let (t1, txt1) = parser.process("alpha🙂<|chan");
+            assert!(t1.is_none());
+            assert_eq!(txt1.as_deref(), Some("alpha🙂"));
+
+            let (t2, txt2) = parser.process("nel>thought\nreasoning<channel|>");
+            assert_eq!(t2.as_deref(), Some("reasoning"));
+            assert!(txt2.is_none());
         }
 
         #[test]
@@ -1087,6 +1118,26 @@ mod tests {
             assert!(text1.is_none());
 
             let (calls2, text2) = parser.process("|>");
+            assert_eq!(calls2.len(), 1);
+            assert_eq!(calls2[0].name, "read_file");
+            assert_eq!(calls2[0].args, r#"{"path":"foo.rs"}"#);
+            assert!(text2.is_none());
+        }
+
+        #[test]
+        fn tool_call_partial_match_is_utf8_safe() {
+            use super::super::tool_call::ToolCallParser;
+
+            let haystack = r#"prefix🙂<tool_cal"#;
+            assert_eq!(partial_prefix_at_end(haystack, "<tool_call|>"), Some(9));
+
+            let mut parser = ToolCallParser::new();
+            let (calls1, text1) =
+                parser.process(r#"prefix🙂<|tool_call>call:read_file{"path":"foo.rs"}<tool_cal"#);
+            assert!(calls1.is_empty());
+            assert_eq!(text1.as_deref(), Some("prefix🙂"));
+
+            let (calls2, text2) = parser.process("l|>");
             assert_eq!(calls2.len(), 1);
             assert_eq!(calls2[0].name, "read_file");
             assert_eq!(calls2[0].args, r#"{"path":"foo.rs"}"#);

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swink-agent-macros"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 rust-version = "1.88"
 description = "Proc macros for swink-agent: #[derive(ToolSchema)] and #[tool]"

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swink-agent-mcp"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 rust-version = "1.88"
 description = "MCP (Model Context Protocol) integration for swink-agent"

--- a/memory/Cargo.toml
+++ b/memory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swink-agent-memory"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 rust-version = "1.88"
 description = "Session persistence and memory management for swink-agent"

--- a/memory/src/codec.rs
+++ b/memory/src/codec.rs
@@ -22,7 +22,7 @@ use crate::entry::SessionEntry;
 pub enum MessageKind {
     /// An [`LlmMessage`] (user, assistant, tool result).
     Llm,
-    /// A custom message serialised via [`CustomMessage::to_json`].
+    /// A custom message serialised via `swink_agent::CustomMessage::to_json`.
     Custom,
 }
 
@@ -49,7 +49,8 @@ impl MessageKind {
 /// Encode an [`AgentMessage`] to a `(kind, json)` pair.
 ///
 /// Returns `None` and emits a `tracing::warn` for custom messages that cannot
-/// be serialised (i.e. their [`CustomMessage::to_json`] / [`CustomMessage::type_name`]
+/// be serialised (i.e. their `swink_agent::CustomMessage::to_json` /
+/// `swink_agent::CustomMessage::type_name`
 /// implementations return `None`). LLM messages always succeed unless
 /// `serde_json` itself errors, which should not happen in practice.
 pub fn encode(msg: &AgentMessage, session_id: &str) -> Option<(MessageKind, String)> {

--- a/memory/src/codec.rs
+++ b/memory/src/codec.rs
@@ -145,7 +145,7 @@ pub fn decode_jsonl_message_line(
         return decode(MessageKind::Custom, line, registry);
     }
 
-    if let Ok(message) = serde_json::from_value::<LlmMessage>(value.clone()) {
+    if let Ok(message) = serde_json::from_value::<LlmMessage>(value) {
         return Ok(Some(AgentMessage::Llm(message)));
     }
 
@@ -177,10 +177,9 @@ pub fn decode_session_entry(kind: &str, data: &str) -> io::Result<Option<Session
             .map(SessionEntry::Message)
             .map(Some)
             .map_err(io::Error::other),
-        Some(MessageKind::Custom) => match serde_json::from_str::<SessionEntry>(data) {
-            Ok(entry) => Ok(Some(entry)),
-            Err(_) => Ok(None),
-        },
+        Some(MessageKind::Custom) => {
+            serde_json::from_str::<SessionEntry>(data).map_or_else(|_| Ok(None), |entry| Ok(Some(entry)))
+        }
         None => serde_json::from_str::<SessionEntry>(data)
             .map(Some)
             .map_err(io::Error::other),

--- a/memory/src/migrate.rs
+++ b/memory/src/migrate.rs
@@ -2,7 +2,7 @@
 //!
 //! [`SessionMigrator`] implementations transform session entries from one
 //! schema version to the next. The migration runner in
-//! [`JsonlSessionStore::load`] applies applicable migrators in order.
+//! [`crate::store::SessionStore::load`] applies applicable migrators in order.
 
 use std::io;
 

--- a/patterns/Cargo.toml
+++ b/patterns/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swink-agent-patterns"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 rust-version = "1.88"
 description = "Multi-agent pipeline patterns for swink-agent"

--- a/plugins/web/tests/search_test.rs
+++ b/plugins/web/tests/search_test.rs
@@ -11,8 +11,6 @@ use tokio_util::sync::CancellationToken;
 
 #[cfg(feature = "duckduckgo")]
 mod duckduckgo_parsing {
-    use swink_agent_plugin_web::search::SearchResult;
-
     // We call the public `parse_results` directly, avoiding any HTTP calls.
     use swink_agent_plugin_web::search::DuckDuckGoProvider;
 

--- a/policies/Cargo.toml
+++ b/policies/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swink-agent-policies"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 rust-version = "1.88"
 description = "Policy implementations for swink-agent"

--- a/src/context.rs
+++ b/src/context.rs
@@ -79,7 +79,7 @@ pub struct CompactionReport {
     /// The LLM messages that were dropped during this compaction pass.
     ///
     /// Only `LlmMessage` variants are included; `CustomMessage` values are
-    /// filtered out. Populated by [`compact_sliding_window_with`]; empty for
+    /// filtered out. Populated by the sliding-window compaction routine; empty for
     /// bare-closure transformers that don't have access to the dropped slice.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub dropped_messages: Vec<LlmMessage>,

--- a/tests/ac_context.rs
+++ b/tests/ac_context.rs
@@ -19,8 +19,8 @@ use common::{
 };
 
 use swink_agent::{
-    Agent, AgentMessage, AgentOptions, AssistantMessageEvent, ContentBlock, DefaultRetryStrategy,
-    LlmMessage, sliding_window,
+    Agent, AgentMessage, AgentOptions, AssistantMessageEvent, ContentBlock, ContextTransformer,
+    DefaultRetryStrategy, LlmMessage, SlidingWindowTransformer,
 };
 
 // ─── Helpers ─────────────────────────────────────────────────────────────
@@ -38,7 +38,11 @@ fn make_agent_with_small_context(
             stream_fn,
             default_convert,
         )
-        .with_transform_context_fn(sliding_window(normal_budget, overflow_budget, anchor))
+        .with_transform_context(SlidingWindowTransformer::new(
+            normal_budget,
+            overflow_budget,
+            anchor,
+        ))
         .with_retry_strategy(Box::new(
             DefaultRetryStrategy::default()
                 .with_jitter(false)
@@ -265,7 +269,7 @@ async fn tool_result_pairs_kept_together() {
         )
         .with_tools(vec![tool])
         // Very small budget to force compaction after a few rounds.
-        .with_transform_context_fn(sliding_window(300, 150, 1))
+        .with_transform_context(SlidingWindowTransformer::new(300, 150, 1))
         .with_retry_strategy(Box::new(
             DefaultRetryStrategy::default()
                 .with_jitter(false)
@@ -341,8 +345,8 @@ async fn transform_context_callback_on_overflow() {
                     overflow_seen_clone.store(true, Ordering::SeqCst);
                 }
                 // Apply basic sliding window to avoid infinite loops.
-                let compact = sliding_window(10_000, 200, 1);
-                compact(msgs, overflow);
+                let compact = SlidingWindowTransformer::new(10_000, 200, 1);
+                compact.transform(msgs, overflow);
             })
             .with_retry_strategy(Box::new(
                 DefaultRetryStrategy::default()

--- a/tests/context_compaction.rs
+++ b/tests/context_compaction.rs
@@ -18,8 +18,8 @@ use tokio_util::sync::CancellationToken;
 
 use swink_agent::{
     AgentContext, AgentEvent, AgentLoopConfig, AgentMessage, AssistantMessageEvent, ContentBlock,
-    DefaultRetryStrategy, LlmMessage, ModelSpec, StopReason, StreamFn, StreamOptions, UserMessage,
-    agent_loop, sliding_window,
+    ContextTransformer, DefaultRetryStrategy, LlmMessage, ModelSpec, SlidingWindowTransformer,
+    StopReason, StreamFn, StreamOptions, UserMessage, agent_loop,
 };
 
 // ─── MockMessageCapturingStreamFn ────────────────────────────────────────────
@@ -152,11 +152,11 @@ async fn overflow_triggers_compaction() {
     let mut config = default_config(stream_fn);
     // Use sliding_window with a budget that forces compaction on overflow.
     // Normal budget: 10000 (generous), overflow budget: 200 (tight).
-    let compact = sliding_window(10_000, 200, 1);
+    let compact = SlidingWindowTransformer::new(10_000, 200, 1);
     config.transform_context = Some(Arc::new(
         move |msgs: &mut Vec<AgentMessage>, overflow: bool| {
             flags_clone.lock().unwrap().push(overflow);
-            compact(msgs, overflow);
+            compact.transform(msgs, overflow);
         },
     ));
 
@@ -212,12 +212,12 @@ async fn compacted_context_preserves_anchors() {
     });
 
     let anchor_count = 2;
-    let compact = sliding_window(10_000, 300, anchor_count);
+    let compact = SlidingWindowTransformer::new(10_000, 300, anchor_count);
 
     let mut config = default_config(stream_fn as Arc<dyn StreamFn>);
     config.transform_context = Some(Arc::new(
         move |msgs: &mut Vec<AgentMessage>, overflow: bool| {
-            compact(msgs, overflow);
+            compact.transform(msgs, overflow);
         },
     ));
 
@@ -299,13 +299,13 @@ async fn compacted_context_preserves_tool_pairs() {
     let tool = Arc::new(MockTool::new("mock_tool"));
     // Budget: overflow_budget tight enough to trigger compaction but large enough
     // to keep the tool pair (tool call + result are relatively small).
-    let compact = sliding_window(10_000, 500, 1);
+    let compact = SlidingWindowTransformer::new(10_000, 500, 1);
 
     let mut config = default_config(stream_fn as Arc<dyn StreamFn>);
     config.tools = vec![tool];
     config.transform_context = Some(Arc::new(
         move |msgs: &mut Vec<AgentMessage>, overflow: bool| {
-            compact(msgs, overflow);
+            compact.transform(msgs, overflow);
         },
     ));
 
@@ -446,12 +446,12 @@ async fn overflow_with_no_compaction_surfaces_error() {
     // Very tight overflow budget that a single large message exceeds.
     // sliding_window with anchor=1 and budget=10 on a single message cannot
     // remove anything (the anchor IS the only message), so it returns None.
-    let compact = sliding_window(10_000, 10, 1);
+    let compact = SlidingWindowTransformer::new(10_000, 10, 1);
 
     let mut config = default_config(stream_fn);
     config.transform_context = Some(Arc::new(
         move |msgs: &mut Vec<AgentMessage>, overflow: bool| {
-            compact(msgs, overflow);
+            compact.transform(msgs, overflow);
         },
     ));
 

--- a/tests/property.rs
+++ b/tests/property.rs
@@ -3,9 +3,9 @@
 use proptest::prelude::*;
 use std::time::Duration;
 use swink_agent::{
-    AgentMessage, AssistantMessageEvent, ContentBlock, Cost, DefaultRetryStrategy, LlmMessage,
-    RetryStrategy, StopReason, Usage, UserMessage, accumulate_message, estimate_tokens,
-    sliding_window,
+    AgentMessage, AssistantMessageEvent, ContentBlock, ContextTransformer, Cost,
+    DefaultRetryStrategy, LlmMessage, RetryStrategy, SlidingWindowTransformer, StopReason, Usage,
+    UserMessage, accumulate_message, estimate_tokens,
 };
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
@@ -44,10 +44,10 @@ proptest! {
         budget in 50_usize..5000,
         anchor in 0_usize..5,
     ) {
-        let compact = sliding_window(budget, budget / 2, anchor);
+        let compact = SlidingWindowTransformer::new(budget, budget / 2, anchor);
         let mut msgs = lengths_to_messages(&lengths);
         let total_before: usize = msgs.iter().map(estimate_tokens).sum();
-        compact(&mut msgs, false);
+        compact.transform(&mut msgs, false);
         let total_after: usize = msgs.iter().map(estimate_tokens).sum();
 
         // After compaction, tokens should be ≤ budget, unless:
@@ -66,12 +66,12 @@ proptest! {
         budget in 10_usize..2000,
         anchor in 1_usize..4,
     ) {
-        let compact = sliding_window(budget, budget / 2, anchor);
+        let compact = SlidingWindowTransformer::new(budget, budget / 2, anchor);
         let original = lengths_to_messages(&lengths);
         let mut msgs = lengths_to_messages(&lengths);
         let effective_anchor = anchor.min(msgs.len());
 
-        compact(&mut msgs, false);
+        compact.transform(&mut msgs, false);
 
         // Anchor messages must always be preserved at the front.
         prop_assert!(msgs.len() >= effective_anchor);
@@ -88,10 +88,10 @@ proptest! {
         budget in 10_usize..5000,
         anchor in 0_usize..5,
     ) {
-        let compact = sliding_window(budget, budget / 2, anchor);
+        let compact = SlidingWindowTransformer::new(budget, budget / 2, anchor);
         let original_len = lengths.len();
         let mut msgs = lengths_to_messages(&lengths);
-        compact(&mut msgs, false);
+        compact.transform(&mut msgs, false);
         prop_assert!(msgs.len() <= original_len);
     }
 }

--- a/tests/transfer.rs
+++ b/tests/transfer.rs
@@ -15,7 +15,7 @@ use serde_json::json;
 
 use swink_agent::testing::SimpleMockStreamFn;
 use swink_agent::{
-    Agent, AgentEvent, AgentMessage, AgentOptions, AgentRegistry, AgentTool, AgentToolResult,
+    Agent, AgentMessage, AgentOptions, AgentRegistry, AgentTool, AgentToolResult,
     ContentBlock, DefaultRetryStrategy, LlmMessage, ModelSpec, StopReason, TransferToAgentTool,
 };
 

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swink-agent-tui"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 rust-version = "1.88"
 description = "Interactive terminal UI for swink-agent"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 rust-version = "1.88"
 publish = false


### PR DESCRIPTION
## Summary
- bump workspace crate versions from `0.6.0` to `0.6.1`
- refresh `Cargo.lock` for the release version updates

## Verification
- cargo check --workspace