### PR TITLE
fix: expose session store injection and public resume API in swink-agent-tui

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7509,7 +7509,7 @@ dependencies = [
 
 [[package]]
 name = "swink-agent-tui"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "arboard",
  "crossterm 0.29.0",

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swink-agent-tui"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Interactive terminal UI for swink-agent"

--- a/tui/src/app/event_loop.rs
+++ b/tui/src/app/event_loop.rs
@@ -430,7 +430,7 @@ impl App {
                 return;
             }
             CommandResult::LoadSession(id) => {
-                self.load_session(&id);
+                let _ = self.load_session(&id);
                 return;
             }
             CommandResult::ListSessions => {

--- a/tui/src/app/lifecycle.rs
+++ b/tui/src/app/lifecycle.rs
@@ -85,6 +85,18 @@ impl App {
         }
     }
 
+    /// Replace the session store and session ID assigned by [`App::new`].
+    ///
+    /// Consuming builder so it chains cleanly after `App::new(config)`. Use this
+    /// when embedding the TUI with a custom storage directory or ID prefix (e.g.
+    /// `tui_chat_<uuid>`).
+    #[must_use]
+    pub fn with_session_store(mut self, store: JsonlSessionStore, id: String) -> Self {
+        self.session_store = Some(store);
+        self.session_id = id;
+        self
+    }
+
     pub(super) fn push_system_message(&mut self, content: String) {
         self.messages
             .push(DisplayMessage::new(MessageRole::System, content));

--- a/tui/src/app/persistence.rs
+++ b/tui/src/app/persistence.rs
@@ -1,5 +1,7 @@
 //! Session persistence and credential helpers.
 
+use std::io;
+
 use swink_agent::{AgentMessage, ContentBlock, LlmMessage};
 use swink_agent_memory::now_utc;
 use tracing::{info, warn};
@@ -37,11 +39,11 @@ impl App {
         self.push_system_message(format!("Session saved: {}", self.session_id));
     }
 
-    pub(super) fn load_session(&mut self, id: &str) {
+    pub(super) fn load_session(&mut self, id: &str) -> io::Result<()> {
         let Some(ref store) = self.session_store else {
             warn!("session persistence unavailable");
             self.push_system_message("Session persistence unavailable.".to_string());
-            return;
+            return Err(io::Error::other("session persistence unavailable"));
         };
         info!(session_id = %id, "loading session");
         match store.load(id, None) {
@@ -96,12 +98,22 @@ impl App {
                     id,
                     self.messages.len()
                 ));
+                Ok(())
             }
             Err(error) => {
                 warn!(session_id = %id, error = %error, "failed to load session");
                 self.push_system_message(format!("Failed to load session: {error}"));
+                Err(error)
             }
         }
+    }
+
+    /// Load a prior session into the app before the event loop starts.
+    ///
+    /// Returns [`io::Error`] with kind [`io::ErrorKind::NotFound`] when the session
+    /// does not exist, allowing CLI callers to surface the correct exit code.
+    pub fn resume_into(&mut self, id: &str) -> io::Result<()> {
+        self.load_session(id)
     }
 
     pub(super) fn list_sessions(&mut self) {

--- a/tui/src/app/tests/input_ui.rs
+++ b/tui/src/app/tests/input_ui.rs
@@ -220,7 +220,7 @@ async fn load_session_keeps_full_agent_state_but_trims_visible_history() {
     app.session_store = Some(store);
     app.set_agent(agent);
 
-    app.load_session(session_id);
+    app.load_session(session_id).unwrap();
 
     let visible_turns = app
         .messages
@@ -310,6 +310,62 @@ fn resize_event_sets_dirty() {
     app.handle_terminal_event(&crossterm::event::Event::Resize(120, 40));
 
     assert!(app.dirty, "resize should set dirty flag");
+}
+
+#[test]
+fn with_session_store_overrides_default_store_and_id() {
+    let tempdir = tempdir().unwrap();
+    let store = JsonlSessionStore::new(tempdir.path().to_path_buf()).unwrap();
+    let app =
+        App::new(TuiConfig::default()).with_session_store(store, "tui_chat_custom-id".to_string());
+    assert_eq!(app.session_id, "tui_chat_custom-id");
+    assert!(app.session_store.is_some());
+}
+
+#[tokio::test]
+async fn resume_into_loads_existing_session() {
+    let tempdir = tempdir().unwrap();
+    let store = JsonlSessionStore::new(tempdir.path().to_path_buf()).unwrap();
+
+    let session_id = "session-resume-test";
+    let now = swink_agent_memory::now_utc();
+    let meta = SessionMeta {
+        id: session_id.to_string(),
+        title: "mock-model".to_string(),
+        created_at: now,
+        updated_at: now,
+        version: 1,
+        sequence: 0,
+    };
+    let messages = vec![
+        make_user_agent_message("hello"),
+        make_assistant_agent_message("world"),
+    ];
+    store.save(session_id, &meta, &messages).unwrap();
+
+    let store2 = JsonlSessionStore::new(tempdir.path().to_path_buf()).unwrap();
+    let mut app = App::new(TuiConfig::default()).with_session_store(store2, "new-id".to_string());
+    let result = app.resume_into(session_id);
+    assert!(
+        result.is_ok(),
+        "resume_into should succeed for existing session"
+    );
+    assert_eq!(
+        app.session_id, session_id,
+        "session_id updated after resume"
+    );
+}
+
+#[tokio::test]
+async fn resume_into_errors_on_missing_session() {
+    let tempdir = tempdir().unwrap();
+    let store = JsonlSessionStore::new(tempdir.path().to_path_buf()).unwrap();
+    let mut app = App::new(TuiConfig::default()).with_session_store(store, "new-id".to_string());
+    let result = app.resume_into("nonexistent-session");
+    assert!(
+        result.is_err(),
+        "resume_into should error for missing session"
+    );
 }
 
 #[tokio::test]

--- a/tui/src/lib.rs
+++ b/tui/src/lib.rs
@@ -34,6 +34,7 @@ use swink_agent::{Agent, ToolApproval, ToolApprovalRequest, selective_approve};
 
 pub use app::App;
 pub use config::TuiConfig;
+pub use session::JsonlSessionStore;
 pub use ui::conversation::ConversationView;
 pub use ui::input::InputEditor;
 pub use ui::markdown::markdown_to_lines;
@@ -112,6 +113,36 @@ pub async fn launch(
 ) -> Result<(), Box<dyn std::error::Error>> {
     dotenvy::dotenv().ok();
     let mut app = App::new(config);
+    let approval_tx = app.approval_sender();
+    let options = options.with_approve_tool(tui_approval_callback(&approval_tx));
+    app.set_agent(Agent::new(options));
+    app.run(terminal).await
+}
+
+/// Like [`launch`], but with an injectable session store, session ID, and optional resume.
+///
+/// Use this when embedding the TUI in a host binary that needs to control where sessions
+/// are stored (e.g. `~/.superswink/sessions/`) or resume a prior transcript before the
+/// event loop starts.
+///
+/// # Arguments
+/// - `store` — session store to use instead of the default `JsonlSessionStore` location.
+/// - `session_id` — ID for the new session (e.g. `tui_chat_<uuid-v7>`).
+/// - `resume_id` — if `Some(id)`, load that prior session before starting the event loop.
+///   Returns [`io::Error`] if the session is not found.
+pub async fn launch_with_session(
+    config: TuiConfig,
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    options: swink_agent::AgentOptions,
+    store: JsonlSessionStore,
+    session_id: String,
+    resume_id: Option<&str>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    dotenvy::dotenv().ok();
+    let mut app = App::new(config).with_session_store(store, session_id);
+    if let Some(id) = resume_id {
+        app.resume_into(id)?;
+    }
     let approval_tx = app.approval_sender();
     let options = options.with_approve_tool(tui_approval_callback(&approval_tx));
     app.set_agent(Agent::new(options));


### PR DESCRIPTION
## Summary

- Adds `App::with_session_store(store, id)` — consuming builder that overrides the session store directory and ID set by `App::new`. Enables host binaries to store sessions at custom paths (e.g. `~/.superswink/sessions/tui_chat_<uuid>`).
- Adds `App::resume_into(id) -> io::Result<()>` — public wrapper around the existing `load_session` that propagates errors (including `NotFound`) so CLI callers can surface the correct exit code.
- Refactors `load_session` to return `io::Result<()>` (maintains all existing system-message behaviour; the `#load` command in the event loop discards the result with `let _ = ...`).
- Adds `launch_with_session` in `lib.rs` — convenience entry point accepting a custom store, session ID, and optional resume ID; mirrors the existing `launch` signature.
- Re-exports `JsonlSessionStore` from `swink_agent_tui` so external callers (e.g. SuperSwink-Core) do not need a direct `swink-agent-memory` dependency.
- Bumps `swink-agent-tui` to 0.7.0 (new public API).
- Applies pre-existing `cargo fmt` fixes in adjacent files (`local-llm/src/stream.rs`, `memory/src/codec.rs`, `memory/src/jsonl.rs`, `memory/src/sqlite.rs`, `tests/transfer.rs`).

## Tasks completed

- [x] Add `App::with_session_store`
- [x] Add `App::resume_into` (with proper `io::Result` on missing session)
- [x] Add `launch_with_session` in `lib.rs`
- [x] Re-export `JsonlSessionStore` from `swink_agent_tui`
- [x] Bump `swink-agent-tui` minor version to 0.7.0

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo test -p swink-agent-tui` — all 272 tests pass (including 3 new regression tests: `with_session_store_overrides_default_store_and_id`, `resume_into_loads_existing_session`, `resume_into_errors_on_missing_session`)
- [x] `cargo test --workspace` — all tests pass except the pre-existing `bash_output_truncation` failure (confirmed on `main`, unrelated to this change)
- [x] No public API breakage in downstream crates (additive-only: new methods on `App`, new top-level function, new re-export)

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)