### PR TITLE
impl(189): migrate GeminiStreamState to shared BlockAccumulator

### DIFF
--- a/adapters/src/azure.rs
+++ b/adapters/src/azure.rs
@@ -139,7 +139,10 @@ impl AzureStreamFn {
     ) -> Result<String, String> {
         // Check cache first
         {
-            let cache = self.token_cache.read().unwrap_or_else(PoisonError::into_inner);
+            let cache = self
+                .token_cache
+                .read()
+                .unwrap_or_else(PoisonError::into_inner);
             if let Some(cached) = cache.as_ref()
                 && Instant::now() + REFRESH_MARGIN < cached.expires_at
             {

--- a/adapters/src/block_accumulator.rs
+++ b/adapters/src/block_accumulator.rs
@@ -35,7 +35,7 @@ use crate::finalize::{OpenBlock, StreamFinalize};
 /// The accumulator implements [`StreamFinalize`]: call
 /// `finalize_blocks(accumulator)` (from [`crate::finalize`]) to close every
 /// block that the provider left open.
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct BlockAccumulator {
     /// Next content index to hand out.
     next_index: usize,
@@ -53,6 +53,7 @@ pub struct BlockAccumulator {
 #[allow(clippy::missing_const_for_fn)]
 impl BlockAccumulator {
     /// Create a new accumulator starting at content index 0.
+    #[allow(dead_code)]
     #[inline]
     pub fn new() -> Self {
         Self::default()
@@ -215,6 +216,7 @@ impl BlockAccumulator {
     ///
     /// Returns a `ToolCallEnd` event, or `None` if no open block with that
     /// index exists.
+    #[allow(dead_code)]
     pub fn close_tool_call(&mut self, content_index: usize) -> Option<AssistantMessageEvent> {
         if let Some(pos) = self
             .open_tool_calls

--- a/adapters/src/google.rs
+++ b/adapters/src/google.rs
@@ -187,20 +187,18 @@ struct GeminiUsageMetadata {
 
 #[derive(Debug)]
 struct GeminiToolCallState {
-    id: String,
-    name: String,
+    /// Harness-side content index returned by [`BlockAccumulator::open_tool_call`].
     content_index: usize,
+    /// Accumulated JSON arguments for incremental delta diffing.
     arguments: String,
 }
 
 #[derive(Debug, Default)]
 struct GeminiStreamState {
-    text_started: bool,
-    text_content_index: Option<usize>,
-    thinking_started: bool,
-    thinking_content_index: Option<usize>,
-    thinking_signature: Option<String>,
-    next_content_index: usize,
+    /// Shared block lifecycle accumulator (index allocation, open/close, drain).
+    blocks: crate::block_accumulator::BlockAccumulator,
+    /// Provider-part-index → harness state.  Kept for argument diffing and
+    /// delta event emission; block lifecycle is owned by `blocks`.
     tool_calls: HashMap<usize, GeminiToolCallState>,
     saw_tool_call: bool,
     usage: Usage,
@@ -633,31 +631,25 @@ fn process_chunk(
     if let Some(content) = candidate.content {
         for (part_index, part) in content.parts.into_iter().enumerate() {
             if part.thought.unwrap_or(false) {
-                close_text_block(state, events);
-                if !state.thinking_started {
-                    let content_index = state.next_content_index;
-                    state.next_content_index += 1;
-                    state.thinking_started = true;
-                    state.thinking_content_index = Some(content_index);
-                    events.push(AssistantMessageEvent::ThinkingStart { content_index });
+                events.extend(state.blocks.close_text());
+                if let Some(ev) = state.blocks.ensure_thinking_open() {
+                    events.push(ev);
                 }
                 if let Some(text) = part.text
                     && !text.is_empty()
+                    && let Some(ev) = state.blocks.thinking_delta(text)
                 {
-                    events.push(AssistantMessageEvent::ThinkingDelta {
-                        content_index: state.thinking_content_index.expect("thinking index set"),
-                        delta: text,
-                    });
+                    events.push(ev);
                 }
                 if let Some(signature) = part.thought_signature {
-                    state.thinking_signature = Some(signature);
+                    state.blocks.set_thinking_signature(signature);
                 }
                 continue;
             }
 
             if let Some(function_call) = part.function_call {
-                close_text_block(state, events);
-                close_thinking_block(state, events);
+                events.extend(state.blocks.close_text());
+                events.extend(state.blocks.close_thinking(None));
                 process_function_call(part_index, function_call, state, events);
                 continue;
             }
@@ -665,18 +657,13 @@ fn process_chunk(
             if let Some(text) = part.text
                 && !text.is_empty()
             {
-                close_thinking_block(state, events);
-                if !state.text_started {
-                    let content_index = state.next_content_index;
-                    state.next_content_index += 1;
-                    state.text_started = true;
-                    state.text_content_index = Some(content_index);
-                    events.push(AssistantMessageEvent::TextStart { content_index });
+                events.extend(state.blocks.close_thinking(None));
+                if let Some(ev) = state.blocks.ensure_text_open() {
+                    events.push(ev);
                 }
-                events.push(AssistantMessageEvent::TextDelta {
-                    content_index: state.text_content_index.expect("text index set"),
-                    delta: text,
-                });
+                if let Some(ev) = state.blocks.text_delta(text) {
+                    events.push(ev);
+                }
             }
         }
     }
@@ -684,8 +671,8 @@ fn process_chunk(
     if let Some(ref finish_reason) = candidate.finish_reason {
         if finish_reason == "SAFETY" {
             warn!("Google Gemini response blocked by safety filter");
-            close_text_block(state, events);
-            close_thinking_block(state, events);
+            events.extend(state.blocks.close_text());
+            events.extend(state.blocks.close_thinking(None));
             events.push(AssistantMessageEvent::error_content_filtered(
                 "Google Gemini: response blocked by safety filter",
             ));
@@ -701,28 +688,28 @@ fn process_function_call(
     state: &mut GeminiStreamState,
     events: &mut Vec<AssistantMessageEvent>,
 ) {
-    let entry = state.tool_calls.entry(part_index).or_insert_with(|| {
+    // Open a new tool-call block the first time we see this part_index.
+    if !state.tool_calls.contains_key(&part_index) {
         state.saw_tool_call = true;
-        let content_index = state.next_content_index;
-        state.next_content_index += 1;
-        GeminiToolCallState {
-            id: function_call
-                .id
-                .clone()
-                .unwrap_or_else(|| format!("gemini-tool-{part_index}")),
-            name: function_call.name.clone(),
-            content_index,
-            arguments: String::new(),
-        }
-    });
-
-    if entry.arguments.is_empty() {
-        events.push(AssistantMessageEvent::ToolCallStart {
-            content_index: entry.content_index,
-            id: entry.id.clone(),
-            name: entry.name.clone(),
-        });
+        let id = function_call
+            .id
+            .clone()
+            .unwrap_or_else(|| format!("gemini-tool-{part_index}"));
+        let (content_index, start_ev) = state.blocks.open_tool_call(id, function_call.name.clone());
+        events.push(start_ev);
+        state.tool_calls.insert(
+            part_index,
+            GeminiToolCallState {
+                content_index,
+                arguments: String::new(),
+            },
+        );
     }
+
+    let entry = state
+        .tool_calls
+        .get_mut(&part_index)
+        .expect("just inserted or already present");
 
     let serialized_args = match function_call.args {
         Value::Null => String::new(),
@@ -759,50 +746,11 @@ fn map_finish_reason(finish_reason: &str, saw_tool_call: bool) -> StopReason {
     }
 }
 
-fn close_text_block(state: &mut GeminiStreamState, events: &mut Vec<AssistantMessageEvent>) {
-    if let Some(content_index) = state.text_content_index.take() {
-        events.push(AssistantMessageEvent::TextEnd { content_index });
-        state.text_started = false;
-    }
-}
-
-fn close_thinking_block(state: &mut GeminiStreamState, events: &mut Vec<AssistantMessageEvent>) {
-    if let Some(content_index) = state.thinking_content_index.take() {
-        events.push(AssistantMessageEvent::ThinkingEnd {
-            content_index,
-            signature: state.thinking_signature.take(),
-        });
-        state.thinking_started = false;
-    }
-}
-
 impl crate::finalize::StreamFinalize for GeminiStreamState {
     fn drain_open_blocks(&mut self) -> Vec<crate::finalize::OpenBlock> {
-        let mut blocks = Vec::new();
-
-        if let Some(content_index) = self.text_content_index.take() {
-            blocks.push(crate::finalize::OpenBlock::Text { content_index });
-            self.text_started = false;
-        }
-
-        if let Some(content_index) = self.thinking_content_index.take() {
-            blocks.push(crate::finalize::OpenBlock::Thinking {
-                content_index,
-                signature: self.thinking_signature.take(),
-            });
-            self.thinking_started = false;
-        }
-
-        let mut tool_calls: Vec<_> = self.tool_calls.values().collect();
-        tool_calls.sort_by_key(|tool_call| tool_call.content_index);
-        for tool_call in tool_calls {
-            blocks.push(crate::finalize::OpenBlock::ToolCall {
-                content_index: tool_call.content_index,
-            });
-        }
+        // Clear per-chunk bookkeeping; block lifecycle is owned by `blocks`.
         self.tool_calls.clear();
-
-        blocks
+        crate::finalize::StreamFinalize::drain_open_blocks(&mut self.blocks)
     }
 }
 

--- a/adapters/tests/google.rs
+++ b/adapters/tests/google.rs
@@ -411,3 +411,136 @@ async fn google_safety_finish_reason_emits_error() {
         "error message should mention safety: {msg}"
     );
 }
+
+// ── BlockAccumulator regression tests ─────────────────────────────────────────
+//
+// These tests verify the content-index ordering contract introduced when
+// GeminiStreamState migrated from its own block-tracking fields to the shared
+// BlockAccumulator.  The key invariant: each block (thinking, text, tool-call)
+// receives a globally-sequential, unique content index regardless of how many
+// chunks arrive or how the blocks interleave.
+
+/// Thinking block (index 0) followed by text block (index 1): indices must be
+/// sequential and non-overlapping across block types.
+#[tokio::test]
+async fn gemini_thinking_then_text_content_indices_are_sequential() {
+    let body = [
+        r#"data: {"candidates":[{"content":{"parts":[{"text":"thinking…","thought":true}]}}]}"#,
+        "",
+        r#"data: {"candidates":[{"content":{"parts":[{"text":"answer"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":3,"totalTokenCount":8}}"#,
+        "",
+        "data: [DONE]",
+        "",
+    ]
+    .join("\n");
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(sse_response(&body))
+        .mount(&server)
+        .await;
+
+    let stream_fn = GeminiStreamFn::new(server.uri(), "test-key", ApiVersion::V1beta);
+    let events = collect_events(&stream_fn).await;
+
+    let thinking_start_ci = events.iter().find_map(|ev| match ev {
+        AssistantMessageEvent::ThinkingStart { content_index } => Some(*content_index),
+        _ => None,
+    });
+    let text_start_ci = events.iter().find_map(|ev| match ev {
+        AssistantMessageEvent::TextStart { content_index } => Some(*content_index),
+        _ => None,
+    });
+
+    let thinking_ci = thinking_start_ci.expect("expected ThinkingStart");
+    let text_ci = text_start_ci.expect("expected TextStart");
+    assert_ne!(
+        thinking_ci, text_ci,
+        "thinking and text must have different content indices"
+    );
+    assert!(
+        thinking_ci < text_ci,
+        "thinking block opened first must have a lower content index"
+    );
+    assert_eq!(
+        text_ci,
+        thinking_ci + 1,
+        "content indices must be strictly sequential"
+    );
+}
+
+/// Two tool calls in one response must receive distinct, ascending content
+/// indices (regression for the `next_content_index` removal).
+#[tokio::test]
+async fn gemini_two_tool_calls_have_sequential_content_indices() {
+    let body = [
+        r#"data: {"candidates":[{"content":{"parts":[{"functionCall":{"id":"c1","name":"get_weather","args":{"city":"Paris"}}},{"functionCall":{"id":"c2","name":"get_time","args":{"tz":"UTC"}}}]}}]}"#,
+        "",
+        r#"data: {"candidates":[{"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":12,"totalTokenCount":22}}"#,
+        "",
+        "data: [DONE]",
+        "",
+    ]
+    .join("\n");
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(sse_response(&body))
+        .mount(&server)
+        .await;
+
+    let stream_fn = GeminiStreamFn::new(server.uri(), "test-key", ApiVersion::V1beta);
+    let events = collect_events(&stream_fn).await;
+
+    let cis: Vec<usize> = events
+        .iter()
+        .filter_map(|ev| match ev {
+            AssistantMessageEvent::ToolCallStart { content_index, .. } => Some(*content_index),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(cis.len(), 2, "expected 2 ToolCallStart events: {cis:?}");
+    assert_ne!(
+        cis[0], cis[1],
+        "tool calls must have different content indices"
+    );
+    assert!(
+        cis[0] < cis[1],
+        "first tool call must have a lower content index"
+    );
+    assert_eq!(cis[1], cis[0] + 1, "content indices must be sequential");
+}
+
+/// When the stream ends without an explicit finish reason the open text block
+/// must be closed by the finalization path (not silently dropped).
+#[tokio::test]
+async fn gemini_abrupt_stream_end_closes_open_text_block() {
+    // No finishReason, no [DONE] — simulates an abrupt disconnect.
+    let body = [
+        r#"data: {"candidates":[{"content":{"parts":[{"text":"partial"}]}}]}"#,
+        "",
+    ]
+    .join("\n");
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(sse_response(&body))
+        .mount(&server)
+        .await;
+
+    let stream_fn = GeminiStreamFn::new(server.uri(), "test-key", ApiVersion::V1beta);
+    let events = collect_events(&stream_fn).await;
+
+    let types: Vec<_> = events.iter().map(event_name).collect();
+    // The text block must have been opened…
+    assert!(
+        types.contains(&"TextStart"),
+        "expected TextStart: {types:?}"
+    );
+    // …and must be closed, even on abrupt termination.
+    assert!(
+        types.contains(&"TextEnd"),
+        "expected TextEnd from finalization: {types:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- Removes 6 hand-coded block-tracking fields from `GeminiStreamState` (`text_started`, `text_content_index`, `thinking_started`, `thinking_content_index`, `thinking_signature`, `next_content_index`) and the two `close_text_block()`/`close_thinking_block()` helper functions.
- Delegates block lifecycle (index allocation, open/close transitions, stream-end draining) to the shared `BlockAccumulator` introduced in #194, which already covers the OAI-compatible and Ollama adapters.
- Simplifies `GeminiToolCallState` to only `content_index` + `arguments` (provider-specific fields removed; id/name are passed directly to `BlockAccumulator::open_tool_call`).
- Reduces `StreamFinalize` impl to a 2-line delegate to `BlockAccumulator::drain_open_blocks()`.

## Regression tests added (`adapters/tests/google.rs`)

- `gemini_thinking_then_text_content_indices_are_sequential` — thinking block gets index 0, text block gets index 1; strictly sequential and non-overlapping (regression for `next_content_index` removal).
- `gemini_two_tool_calls_have_sequential_content_indices` — parallel tool calls in one response receive distinct ascending indices.
- `gemini_abrupt_stream_end_closes_open_text_block` — open text block is closed via the finalization path even when the stream ends without an explicit `finishReason`.

## Test plan

- [x] `cargo fmt --check -p swink-agent-adapters` passes
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo test -p swink-agent-adapters --features gemini` — 14 tests pass (3 new)
- [x] `cargo test --workspace --features testkit` — all pass except pre-existing `bash_output_truncation` failure (confirmed on `main`, unrelated to this change)
- [x] No public API breakage — changes are internal to `google.rs`; `GeminiStreamFn` public interface unchanged

Part of #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)