### PR TITLE
fix: preserve TUI session metadata across saves and surface failures

### DIFF
--- a/adapters/src/lib.rs
+++ b/adapters/src/lib.rs
@@ -73,7 +73,7 @@ pub mod sse;
 
 pub use remote_presets::{
     RemoteModelConnectionError, RemotePresetKey, build_remote_connection,
-    build_remote_connection_for_model, preset, remote_preset_keys, remote_presets,
+    build_remote_connection_for_model, preset, remote_presets,
 };
 
 // ── Provider adapters (feature-gated) ─────────────────────────────────────

--- a/tui/src/app/agent_bridge.rs
+++ b/tui/src/app/agent_bridge.rs
@@ -174,7 +174,9 @@ impl App {
             AgentEvent::AgentEnd { .. } => {
                 self.status = AgentStatus::Idle;
                 self.retry_attempt = None;
-                self.auto_save_session();
+                if let Err(error) = self.auto_save_session() {
+                    tracing::warn!(error = %error, "auto-save failed");
+                }
                 self.trim_messages_to_recent_turns();
             }
             AgentEvent::ToolApprovalRequested {

--- a/tui/src/app/lifecycle.rs
+++ b/tui/src/app/lifecycle.rs
@@ -63,6 +63,7 @@ impl App {
             retry_attempt: None,
             session_store,
             session_id,
+            session_meta: None,
             approval_rx,
             approval_tx,
             pending_approval: None,
@@ -94,6 +95,7 @@ impl App {
     pub fn with_session_store(mut self, store: JsonlSessionStore, id: String) -> Self {
         self.session_store = Some(store);
         self.session_id = id;
+        self.session_meta = None;
         self
     }
 

--- a/tui/src/app/persistence.rs
+++ b/tui/src/app/persistence.rs
@@ -13,30 +13,62 @@ use crate::ui::conversation::ConversationView;
 use super::state::{App, DisplayMessage, MessageRole};
 
 impl App {
-    pub(super) fn auto_save_session(&self) {
+    /// Persist the current session. Returns an error if the save failed so that
+    /// callers can surface it to the user instead of silently dropping failures.
+    pub(super) fn auto_save_session(&mut self) -> io::Result<()> {
         let Some(ref store) = self.session_store else {
-            return;
+            return Ok(());
         };
         let Some(ref agent) = self.agent else {
-            return;
+            return Ok(());
         };
         let state = agent.state();
         let now = now_utc();
-        let meta = SessionMeta {
-            id: self.session_id.clone(),
-            title: self.model_name.clone(),
-            created_at: now,
-            updated_at: now,
-            version: 1,
-            sequence: 0,
+
+        // Build the meta to send to the store. Preserve `created_at` and the
+        // optimistic-concurrency `sequence` from the last successful save.
+        let mut meta = match self.session_meta.clone() {
+            Some(mut existing) => {
+                existing.id.clone_from(&self.session_id);
+                existing.title.clone_from(&self.model_name);
+                existing.updated_at = now;
+                existing
+            }
+            None => SessionMeta {
+                id: self.session_id.clone(),
+                title: self.model_name.clone(),
+                created_at: now,
+                updated_at: now,
+                version: 1,
+                sequence: 0,
+            },
         };
-        let _ = store.save(&self.session_id, &meta, &state.messages);
+
+        match store.save(&self.session_id, &meta, &state.messages) {
+            Ok(()) => {
+                // Store increments sequence by 1 on successful write — mirror that
+                // locally so the next save doesn't race on a stale sequence.
+                meta.sequence += 1;
+                self.session_meta = Some(meta);
+                Ok(())
+            }
+            Err(error) => {
+                warn!(session_id = %self.session_id, error = %error, "failed to save session");
+                Err(error)
+            }
+        }
     }
 
     pub(super) fn save_session(&mut self) {
         info!(session_id = %self.session_id, "saving session");
-        self.auto_save_session();
-        self.push_system_message(format!("Session saved: {}", self.session_id));
+        match self.auto_save_session() {
+            Ok(()) => {
+                self.push_system_message(format!("Session saved: {}", self.session_id));
+            }
+            Err(error) => {
+                self.push_system_message(format!("Failed to save session: {error}"));
+            }
+        }
     }
 
     pub(super) fn load_session(&mut self, id: &str) -> io::Result<()> {
@@ -88,6 +120,7 @@ impl App {
                 }
                 self.session_id = id.to_string();
                 self.model_name.clone_from(&meta.title);
+                self.session_meta = Some(meta.clone());
                 self.conversation = ConversationView::new();
                 self.trim_messages_to_recent_turns();
                 if let Some(agent) = &mut self.agent {

--- a/tui/src/app/state.rs
+++ b/tui/src/app/state.rs
@@ -145,6 +145,10 @@ pub struct App {
     pub(crate) session_store: Option<JsonlSessionStore>,
     /// Current session ID.
     pub(crate) session_id: String,
+    /// Current persisted session metadata. `None` until the first successful save
+    /// or until a session is loaded. Owns `created_at` and the optimistic-concurrency
+    /// `sequence` counter so subsequent saves don't race against the store.
+    pub(crate) session_meta: Option<crate::session::SessionMeta>,
     /// Receiver for tool approval requests from the agent callback.
     pub(crate) approval_rx: mpsc::Receiver<(ToolApprovalRequest, oneshot::Sender<ToolApproval>)>,
     /// Sender for tool approval requests (cloned into the approval callback).

--- a/tui/src/app/tests/input_ui.rs
+++ b/tui/src/app/tests/input_ui.rs
@@ -357,6 +357,115 @@ async fn resume_into_loads_existing_session() {
 }
 
 #[tokio::test]
+async fn repeated_auto_save_preserves_created_at_and_advances_sequence() {
+    // Regression for #196: the TUI rebuilt SessionMeta from scratch on every
+    // save, sending sequence=0 each time, which tripped the JSONL store's
+    // optimistic-concurrency check and silently dropped every save after the
+    // first. `created_at` was also regenerated on each write.
+    let tempdir = tempdir().unwrap();
+    let store = JsonlSessionStore::new(tempdir.path().to_path_buf()).unwrap();
+    let session_id = "session-repeated-save";
+
+    let stream_fn = Arc::new(ScriptedStreamFn::new(vec![]));
+    let agent = make_test_agent(stream_fn);
+    let mut app = App::new(TuiConfig::default()).with_session_store(store, session_id.to_string());
+    app.set_agent(agent);
+
+    // Populate at least one message so the save has content to persist.
+    if let Some(ref mut agent) = app.agent {
+        agent.set_messages(vec![make_user_agent_message("hello")]);
+    }
+
+    // First save: creates the file, sequence goes 0 -> 1 in the store.
+    app.auto_save_session().expect("first save should succeed");
+    let first_meta = app.session_meta.clone().expect("meta set after save");
+    let created_at = first_meta.created_at;
+    assert_eq!(first_meta.sequence, 1, "local sequence mirrors the store");
+
+    // Second save: previously failed silently with a sequence conflict.
+    if let Some(ref mut agent) = app.agent {
+        agent.set_messages(vec![
+            make_user_agent_message("hello"),
+            make_assistant_agent_message("world"),
+        ]);
+    }
+    app.auto_save_session()
+        .expect("second save should succeed without sequence conflict");
+    let second_meta = app.session_meta.clone().unwrap();
+    assert_eq!(second_meta.sequence, 2, "sequence advanced on second save");
+    assert_eq!(
+        second_meta.created_at, created_at,
+        "created_at is preserved across saves"
+    );
+
+    // Third save — make sure advancement keeps working.
+    app.auto_save_session().expect("third save should succeed");
+    assert_eq!(app.session_meta.as_ref().unwrap().sequence, 3);
+
+    // Reload from disk and confirm the persisted state matches what we expected.
+    let reload_store = JsonlSessionStore::new(tempdir.path().to_path_buf()).unwrap();
+    let (persisted_meta, persisted_messages) = reload_store.load(session_id, None).unwrap();
+    assert_eq!(persisted_meta.sequence, 3);
+    assert_eq!(persisted_meta.created_at, created_at);
+    assert_eq!(
+        persisted_messages.len(),
+        2,
+        "latest messages were persisted"
+    );
+}
+
+#[tokio::test]
+async fn auto_save_after_load_preserves_created_at_and_continues_sequence() {
+    // Regression for #196: after loading an existing session, saves should
+    // carry the loaded meta forward rather than starting at sequence 0.
+    let tempdir = tempdir().unwrap();
+    let store = JsonlSessionStore::new(tempdir.path().to_path_buf()).unwrap();
+    let session_id = "session-load-then-save";
+
+    let original_created = swink_agent_memory::now_utc();
+    let meta = SessionMeta {
+        id: session_id.to_string(),
+        title: "mock-model".to_string(),
+        created_at: original_created,
+        updated_at: original_created,
+        version: 1,
+        sequence: 0,
+    };
+    store
+        .save(session_id, &meta, &[make_user_agent_message("hi")])
+        .unwrap();
+    // After that save the stored sequence is 1.
+
+    let stream_fn = Arc::new(ScriptedStreamFn::new(vec![]));
+    let agent = make_test_agent(stream_fn);
+    let store2 = JsonlSessionStore::new(tempdir.path().to_path_buf()).unwrap();
+    let mut app =
+        App::new(TuiConfig::default()).with_session_store(store2, "placeholder".to_string());
+    app.set_agent(agent);
+    app.load_session(session_id).unwrap();
+
+    let loaded_meta = app.session_meta.clone().expect("meta set after load");
+    assert_eq!(loaded_meta.sequence, 1);
+    assert_eq!(loaded_meta.created_at, original_created);
+
+    // Mutate and save — should succeed and advance sequence to 2.
+    if let Some(ref mut agent) = app.agent {
+        agent.set_messages(vec![
+            make_user_agent_message("hi"),
+            make_assistant_agent_message("there"),
+        ]);
+    }
+    app.auto_save_session()
+        .expect("save after load should succeed");
+    assert_eq!(app.session_meta.as_ref().unwrap().sequence, 2);
+    assert_eq!(
+        app.session_meta.as_ref().unwrap().created_at,
+        original_created,
+        "loaded created_at is preserved on subsequent saves"
+    );
+}
+
+#[tokio::test]
 async fn resume_into_errors_on_missing_session() {
     let tempdir = tempdir().unwrap();
     let store = JsonlSessionStore::new(tempdir.path().to_path_buf()).unwrap();


### PR DESCRIPTION
## Summary

The TUI rebuilt `SessionMeta` from scratch on every save, sending `sequence: 0` each time. After the first successful write, the JSONL store's optimistic-concurrency check (`memory/src/jsonl.rs:96-104`) rejected every subsequent save — and the error was discarded silently because `auto_save_session` ignored the result. `created_at` was also regenerated on each save.

This means session persistence quietly stopped advancing after the first write, while the TUI continued to behave as if everything was fine.

## Changes

- Added `session_meta: Option<SessionMeta>` to `App` state — tracks the persisted metadata as first-class app state instead of reconstructing it inside the save helper.
- `auto_save_session` now:
  - Preserves `created_at` (and `version`) from the loaded/last-saved metadata.
  - Sends the current `sequence` so the optimistic-concurrency check passes.
  - Mirrors the store's internal `sequence += 1` locally on success.
  - Returns `io::Result<()>` so callers can surface failures.
- `save_session` (manual `#save`) reports failures to the user instead of swallowing them.
- `agent_bridge::AgentEnd` auto-save logs failures via `tracing::warn` instead of silently dropping them.
- `load_session` populates `session_meta` from the loaded metadata so subsequent saves carry the loaded sequence forward.

## Drive-by fix

`adapters/src/lib.rs` re-exported `remote_preset_keys` from `remote_presets`, but commit 2b92662 (#198) removed that function. The workspace currently does not build on `main` without this — removed the stale re-export so this PR can compile.

## Tasks

- Track session metadata as first-class TUI state (`tui/src/app/state.rs`)
- Preserve `created_at` and `sequence` across saves (`tui/src/app/persistence.rs`)
- Surface save failures to the user
- Initialize `session_meta` on `load_session`
- Add regression coverage

## Test plan

- [x] `cargo test -p swink-agent-tui` — all 274 tests pass, including two new regression tests:
  - `repeated_auto_save_preserves_created_at_and_advances_sequence`
  - `auto_save_after_load_preserves_created_at_and_continues_sequence`
- [x] `cargo clippy -p swink-agent-tui -p swink-agent-adapters -- -D warnings` clean
- [x] `cargo fmt --all`
- [ ] `cargo test --workspace` — pre-existing unrelated failure in `swink-agent::tests::tools::bash_output_truncation` (Windows bash truncation test, not touched by this change)
- [ ] No public API changes in core; downstream crates unaffected.

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)