### PR TITLE
fix: preserve TUI session metadata across saves

### DIFF
--- a/adapters/src/lib.rs
+++ b/adapters/src/lib.rs
@@ -73,7 +73,7 @@ pub mod sse;
 
 pub use remote_presets::{
     RemoteModelConnectionError, RemotePresetKey, build_remote_connection,
-    build_remote_connection_for_model, preset, remote_preset_keys, remote_presets,
+    build_remote_connection_for_model, preset, remote_presets,
 };
 
 // ── Provider adapters (feature-gated) ─────────────────────────────────────

--- a/tui/src/app/agent_bridge.rs
+++ b/tui/src/app/agent_bridge.rs
@@ -174,7 +174,9 @@ impl App {
             AgentEvent::AgentEnd { .. } => {
                 self.status = AgentStatus::Idle;
                 self.retry_attempt = None;
-                self.auto_save_session();
+                if let Err(error) = self.auto_save_session() {
+                    self.push_system_message(format!("Failed to save session: {error}"));
+                }
                 self.trim_messages_to_recent_turns();
             }
             AgentEvent::ToolApprovalRequested {

--- a/tui/src/app/lifecycle.rs
+++ b/tui/src/app/lifecycle.rs
@@ -9,15 +9,33 @@ use tokio::sync::{mpsc, oneshot};
 use swink_agent::{Agent, ToolApproval, ToolApprovalRequest};
 
 use crate::config::TuiConfig;
-use crate::session::JsonlSessionStore;
+use crate::session::{JsonlSessionStore, SessionMeta};
 use crate::theme;
 use crate::ui::conversation::ConversationView;
 use crate::ui::help_panel::HelpPanel;
 use crate::ui::input::InputEditor;
 use crate::ui::tool_panel::ToolPanel;
+use swink_agent_memory::now_utc;
 
 use super::state::{AgentStatus, App, DisplayMessage, Focus, MessageRole, OperatingMode};
 use super::{AUTO_COLLAPSE_SECS, MAX_VISIBLE_TURNS};
+
+/// Construct a fresh `SessionMeta` for a brand-new session.
+///
+/// Used when the TUI does not yet have persisted metadata (initial launch or
+/// `with_session_store` override). After load or save, the existing meta is
+/// preserved so `created_at` and `sequence` advance correctly.
+pub(super) fn new_session_meta(session_id: &str, title: &str) -> SessionMeta {
+    let now = now_utc();
+    SessionMeta {
+        id: session_id.to_string(),
+        title: title.to_string(),
+        created_at: now,
+        updated_at: now,
+        version: 1,
+        sequence: 0,
+    }
+}
 
 impl App {
     pub fn new(config: TuiConfig) -> Self {
@@ -30,6 +48,7 @@ impl App {
         } else {
             "unnamed".to_string()
         };
+        let session_meta = new_session_meta(&session_id, &config.default_model);
 
         // Apply configured color mode.
         let mode = match config.color_mode.as_str() {
@@ -63,6 +82,7 @@ impl App {
             retry_attempt: None,
             session_store,
             session_id,
+            session_meta,
             approval_rx,
             approval_tx,
             pending_approval: None,
@@ -93,6 +113,7 @@ impl App {
     #[must_use]
     pub fn with_session_store(mut self, store: JsonlSessionStore, id: String) -> Self {
         self.session_store = Some(store);
+        self.session_meta = new_session_meta(&id, &self.model_name);
         self.session_id = id;
         self
     }

--- a/tui/src/app/persistence.rs
+++ b/tui/src/app/persistence.rs
@@ -7,36 +7,55 @@ use swink_agent_memory::now_utc;
 use tracing::{info, warn};
 
 use crate::credentials;
-use crate::session::{SessionMeta, SessionStore};
+use crate::session::SessionStore;
 use crate::ui::conversation::ConversationView;
 
 use super::state::{App, DisplayMessage, MessageRole};
 
 impl App {
-    pub(super) fn auto_save_session(&self) {
+    /// Persist the current agent state to the session store.
+    ///
+    /// Returns `Ok(())` when there is no store/agent attached (nothing to do)
+    /// or after a successful save. On failure, the local `session_meta` is
+    /// left untouched so the next save retries with the same sequence.
+    pub(super) fn auto_save_session(&mut self) -> io::Result<()> {
         let Some(ref store) = self.session_store else {
-            return;
+            return Ok(());
         };
         let Some(ref agent) = self.agent else {
-            return;
+            return Ok(());
         };
         let state = agent.state();
-        let now = now_utc();
-        let meta = SessionMeta {
-            id: self.session_id.clone(),
-            title: self.model_name.clone(),
-            created_at: now,
-            updated_at: now,
-            version: 1,
-            sequence: 0,
-        };
-        let _ = store.save(&self.session_id, &meta, &state.messages);
+        // Refresh mutable fields, but preserve created_at + sequence so the
+        // JSONL store's optimistic-concurrency check accepts repeated writes.
+        self.session_meta.id.clone_from(&self.session_id);
+        self.session_meta.title.clone_from(&self.model_name);
+        self.session_meta.updated_at = now_utc();
+
+        match store.save(&self.session_id, &self.session_meta, &state.messages) {
+            Ok(()) => {
+                // The store increments stored sequence on write; mirror that
+                // locally so the next save passes `check_sequence`.
+                self.session_meta.sequence += 1;
+                Ok(())
+            }
+            Err(error) => {
+                warn!(session_id = %self.session_id, error = %error, "failed to save session");
+                Err(error)
+            }
+        }
     }
 
     pub(super) fn save_session(&mut self) {
         info!(session_id = %self.session_id, "saving session");
-        self.auto_save_session();
-        self.push_system_message(format!("Session saved: {}", self.session_id));
+        match self.auto_save_session() {
+            Ok(()) => {
+                self.push_system_message(format!("Session saved: {}", self.session_id));
+            }
+            Err(error) => {
+                self.push_system_message(format!("Failed to save session: {error}"));
+            }
+        }
     }
 
     pub(super) fn load_session(&mut self, id: &str) -> io::Result<()> {
@@ -88,6 +107,7 @@ impl App {
                 }
                 self.session_id = id.to_string();
                 self.model_name.clone_from(&meta.title);
+                self.session_meta = meta;
                 self.conversation = ConversationView::new();
                 self.trim_messages_to_recent_turns();
                 if let Some(agent) = &mut self.agent {

--- a/tui/src/app/state.rs
+++ b/tui/src/app/state.rs
@@ -12,7 +12,7 @@ use swink_agent::{
 };
 
 use crate::config::TuiConfig;
-use crate::session::JsonlSessionStore;
+use crate::session::{JsonlSessionStore, SessionMeta};
 use crate::ui::conversation::ConversationView;
 use crate::ui::help_panel::HelpPanel;
 use crate::ui::input::InputEditor;
@@ -145,6 +145,10 @@ pub struct App {
     pub(crate) session_store: Option<JsonlSessionStore>,
     /// Current session ID.
     pub(crate) session_id: String,
+    /// Persisted session metadata. Carries `created_at` and the optimistic-
+    /// concurrency `sequence` forward across saves so the JSONL store does not
+    /// reject subsequent writes from the same TUI session.
+    pub(crate) session_meta: SessionMeta,
     /// Receiver for tool approval requests from the agent callback.
     pub(crate) approval_rx: mpsc::Receiver<(ToolApprovalRequest, oneshot::Sender<ToolApproval>)>,
     /// Sender for tool approval requests (cloned into the approval callback).

--- a/tui/src/app/tests/input_ui.rs
+++ b/tui/src/app/tests/input_ui.rs
@@ -357,6 +357,88 @@ async fn resume_into_loads_existing_session() {
 }
 
 #[tokio::test]
+async fn repeated_auto_save_advances_sequence_and_preserves_created_at() {
+    // Regression for #196: rebuilding `SessionMeta` on every save with
+    // `sequence: 0` made the second save fail the JSONL store's optimistic
+    // concurrency check, and the failure was silently dropped.
+    let tempdir = tempdir().unwrap();
+    let store = JsonlSessionStore::new(tempdir.path().to_path_buf()).unwrap();
+
+    let stream_fn = Arc::new(ScriptedStreamFn::new(vec![]));
+    let agent = make_test_agent(stream_fn);
+    let mut app =
+        App::new(TuiConfig::default()).with_session_store(store, "regression-196".to_string());
+    app.set_agent(agent);
+
+    let created_at_before = app.session_meta.created_at;
+
+    app.auto_save_session().expect("first save should succeed");
+    assert_eq!(app.session_meta.sequence, 1);
+
+    app.auto_save_session()
+        .expect("second save must not fail with sequence conflict");
+    assert_eq!(app.session_meta.sequence, 2);
+
+    app.auto_save_session().expect("third save should succeed");
+    assert_eq!(app.session_meta.sequence, 3);
+
+    assert_eq!(
+        app.session_meta.created_at, created_at_before,
+        "created_at must be preserved across saves"
+    );
+
+    // Verify what we wrote round-trips and reflects the latest sequence.
+    let store2 = JsonlSessionStore::new(tempdir.path().to_path_buf()).unwrap();
+    let (loaded_meta, _) = store2.load("regression-196", None).unwrap();
+    assert_eq!(loaded_meta.sequence, 3);
+    assert_eq!(loaded_meta.created_at, created_at_before);
+}
+
+#[tokio::test]
+async fn save_after_load_preserves_created_at_and_continues_sequence() {
+    // Regression for #196: after loading an existing session, the next save
+    // must reuse the loaded `created_at` and `sequence`, not reset them.
+    let tempdir = tempdir().unwrap();
+    let store = JsonlSessionStore::new(tempdir.path().to_path_buf()).unwrap();
+
+    let session_id = "regression-196-load";
+    let original_created = swink_agent_memory::now_utc();
+    let meta = SessionMeta {
+        id: session_id.to_string(),
+        title: "mock-model".to_string(),
+        created_at: original_created,
+        updated_at: original_created,
+        version: 1,
+        sequence: 5,
+    };
+    // Seed the file at sequence 5 so a fresh save would have to round-trip
+    // through the same value.
+    store
+        .save(session_id, &meta, &[make_user_agent_message("seed")])
+        .unwrap();
+    // After save, the stored sequence is 6.
+
+    let stream_fn = Arc::new(ScriptedStreamFn::new(vec![]));
+    let agent = make_test_agent(stream_fn);
+    let store2 = JsonlSessionStore::new(tempdir.path().to_path_buf()).unwrap();
+    let mut app =
+        App::new(TuiConfig::default()).with_session_store(store2, "placeholder".to_string());
+    app.set_agent(agent);
+
+    app.load_session(session_id).unwrap();
+    assert_eq!(app.session_meta.sequence, 6);
+    assert_eq!(app.session_meta.created_at, original_created);
+
+    app.auto_save_session()
+        .expect("save after load must not conflict");
+    assert_eq!(app.session_meta.sequence, 7);
+    assert_eq!(
+        app.session_meta.created_at, original_created,
+        "created_at must survive load → save"
+    );
+}
+
+#[tokio::test]
 async fn resume_into_errors_on_missing_session() {
     let tempdir = tempdir().unwrap();
     let store = JsonlSessionStore::new(tempdir.path().to_path_buf()).unwrap();


### PR DESCRIPTION
## Summary
- Make `SessionMeta` first-class TUI state so `created_at` and `sequence` are preserved across saves instead of being rebuilt from scratch.
- `auto_save_session` now mirrors the JSONL store's sequence increment locally and returns the `io::Result`; both call sites surface failures (system message + `tracing::warn`) instead of dropping them.
- Drop a stale `remote_preset_keys` re-export in `adapters/src/lib.rs` that was breaking the workspace build on `main`.

## Regression tests
- `repeated_auto_save_advances_sequence_and_preserves_created_at` — three back-to-back saves succeed, sequence advances 1 → 2 → 3, `created_at` stable, round-trips through a fresh store.
- `save_after_load_preserves_created_at_and_continues_sequence` — seed a session at sequence 5, load it, save again, assert no conflict and `created_at` survives.

## Test plan
- [x] `cargo test -p swink-agent-tui` (274 tests pass)
- [x] `cargo clippy -p swink-agent-tui -p swink-agent-adapters -- -D warnings` clean
- [x] `cargo fmt`

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)