### PR TITLE
fix(tools): BashTool cross-platform shell dispatch (#202)

### DIFF
--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -14,13 +14,16 @@ use crate::tool::{AgentTool, AgentToolResult, ToolFuture, validated_schema_for};
 /// Default timeout in milliseconds.
 const DEFAULT_TIMEOUT_MS: u64 = 30_000;
 
-/// Built-in tool that executes a shell command via `sh -c`.
+/// Built-in tool that executes a shell command.
+///
+/// On Unix-like targets the command is passed to `sh -c`. On Windows the
+/// command is passed to `cmd /C`, matching the platform's native shell.
 ///
 /// # Security
 ///
-/// This tool executes arbitrary shell commands via `sh -c`. It should only
-/// be used with trusted input. It is NOT suitable for production agents
-/// exposed to untrusted users.
+/// This tool executes arbitrary shell commands via the platform shell. It
+/// should only be used with trusted input. It is NOT suitable for production
+/// agents exposed to untrusted users.
 pub struct BashTool {
     schema: Value,
 }
@@ -93,9 +96,7 @@ impl AgentTool for BashTool {
 
             let timeout = Duration::from_millis(parsed.timeout_ms.unwrap_or(DEFAULT_TIMEOUT_MS));
 
-            let mut child = match Command::new("sh")
-                .arg("-c")
-                .arg(&parsed.command)
+            let mut child = match shell_command(&parsed.command)
                 .stdout(std::process::Stdio::piped())
                 .stderr(std::process::Stdio::piped())
                 .spawn()
@@ -139,6 +140,24 @@ impl AgentTool for BashTool {
                 }
             }
         })
+    }
+}
+
+/// Build a platform-appropriate shell `Command` that executes `command`.
+///
+/// Unix: `sh -c <command>`. Windows: `cmd /C <command>`.
+fn shell_command(command: &str) -> Command {
+    #[cfg(windows)]
+    {
+        let mut cmd = Command::new("cmd");
+        cmd.arg("/C").arg(command);
+        cmd
+    }
+    #[cfg(not(windows))]
+    {
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c").arg(command);
+        cmd
     }
 }
 

--- a/tests/tools.rs
+++ b/tests/tools.rs
@@ -206,6 +206,8 @@ async fn bash_timeout() {
     );
 }
 
+// Unix-only: uses `cat` and `>&2` which are not available in `cmd /C`.
+#[cfg(unix)]
 #[tokio::test]
 async fn bash_output_truncation() {
     let tool = BashTool::new();

--- a/tests/tools.rs
+++ b/tests/tools.rs
@@ -7,6 +7,16 @@ use swink_agent::ContentBlock;
 use swink_agent::tool::AgentTool;
 use swink_agent::tools::{BashTool, ReadFileTool, WriteFileTool};
 
+// Cross-platform `sleep N seconds` command string for BashTool tests.
+fn sleep_command(seconds: u32) -> String {
+    if cfg!(windows) {
+        // `ping -n K 127.0.0.1` waits ~(K-1) seconds. Add 1 for the target duration.
+        format!("ping -n {} 127.0.0.1 > NUL", seconds + 1)
+    } else {
+        format!("sleep {seconds}")
+    }
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 // BashTool
 // ═══════════════════════════════════════════════════════════════════════════
@@ -53,6 +63,36 @@ async fn bash_echo_success() {
     assert!(
         text.contains("hello"),
         "expected 'hello' in output, got: {text}"
+    );
+}
+
+// Regression for #202: BashTool used to hardcode `sh -c`, which does not exist
+// on Windows. This test spawns a command via the platform shell — on Windows
+// that means `cmd /C`, on Unix `sh -c`. Failure here indicates the dispatch
+// regressed.
+#[tokio::test]
+async fn bash_uses_platform_shell() {
+    let tool = BashTool::new();
+    let token = CancellationToken::new();
+    let result = tool
+        .execute(
+            "tc_platform",
+            json!({"command": "echo platform-ok"}),
+            token,
+            None,
+            std::sync::Arc::new(std::sync::RwLock::new(swink_agent::SessionState::new())),
+            None,
+        )
+        .await;
+    assert!(
+        !result.is_error,
+        "spawning platform shell must succeed, got: {:?}",
+        result.content
+    );
+    let text = ContentBlock::extract_text(&result.content);
+    assert!(
+        text.contains("Exit code: 0") && text.contains("platform-ok"),
+        "expected successful platform-shell dispatch, got: {text}"
     );
 }
 
@@ -152,7 +192,7 @@ async fn bash_timeout() {
     let result = tool
         .execute(
             "tc_6",
-            json!({"command": "sleep 30", "timeout_ms": 100}),
+            json!({"command": sleep_command(30), "timeout_ms": 100}),
             token,
             None,
             std::sync::Arc::new(std::sync::RwLock::new(swink_agent::SessionState::new())),
@@ -203,6 +243,9 @@ async fn bash_output_truncation() {
     );
 }
 
+// Uses Unix-only utilities (`head`, `tr`, `/dev/zero`); skipped on Windows
+// where the platform shell is `cmd /C` and cannot interpret them.
+#[cfg(unix)]
 #[tokio::test]
 async fn bash_large_stdout_does_not_deadlock() {
     let tool = BashTool::new();
@@ -228,6 +271,8 @@ async fn bash_large_stdout_does_not_deadlock() {
     );
 }
 
+// Unix-only: uses `head`, `tr`, `/dev/zero`, `&`, and `wait`.
+#[cfg(unix)]
 #[tokio::test]
 async fn bash_large_stdout_and_stderr_do_not_deadlock() {
     let tool = BashTool::new();
@@ -261,6 +306,8 @@ async fn bash_large_stdout_and_stderr_do_not_deadlock() {
     );
 }
 
+// Unix-only: `yes` is not available on Windows `cmd`.
+#[cfg(unix)]
 #[tokio::test]
 async fn bash_noisy_timeout_does_not_deadlock() {
     let tool = BashTool::new();


### PR DESCRIPTION
## Summary
- BashTool hardcoded `sh -c`, which does not exist on stock Windows. Route through `cmd /C` on Windows, keep `sh -c` elsewhere via a `shell_command` helper.
- Gate Unix-only deadlock/`yes`/`/dev/zero` tests to `cfg(unix)`.
- Cross-platform sleep helper so `bash_timeout` works on Windows (`ping -n` fallback).
- New `bash_uses_platform_shell` regression test.

Closes #202.

## Tasks completed
- Platform-aware shell dispatch in `src/tools/bash.rs`.
- Regression + cross-platform test updates in `tests/tools.rs`.

## Test plan
- [x] \`cargo test -p swink-agent --features testkit --test tools\` (Windows, 20/20 passing)
- [x] \`cargo clippy -p swink-agent --lib -- -D warnings\` clean
- [ ] Workspace-wide clippy: pre-existing warnings in \`tests/transfer.rs\` unrelated to this PR
- [x] No public API changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)