### PR TITLE
fix(loop): apply PreDispatch policy Inject verdict (#204)

### DIFF
--- a/src/loop_/tool_dispatch.rs
+++ b/src/loop_/tool_dispatch.rs
@@ -11,7 +11,7 @@ use crate::tool::{
     validate_tool_arguments, validation_error_result,
 };
 use crate::tool_execution_policy::{ToolCallSummary, ToolExecutionPolicy};
-use crate::types::{ContentBlock, ToolResultMessage};
+use crate::types::{AgentMessage, ContentBlock, ToolResultMessage};
 use crate::util::now_timestamp;
 
 use crate::agent_options::ApproveToolFn;
@@ -122,6 +122,9 @@ pub async fn execute_tools_concurrently(
 
     // Phase 1: Pre-process all tool calls (approval, transform, validate).
     let mut prepared: Vec<PreparedToolCall> = Vec::new();
+    // Messages injected by PreDispatch policies (Inject verdict). These are
+    // propagated via the outcome so the loop can append them to pending_messages.
+    let mut injected_messages: Vec<AgentMessage> = Vec::new();
 
     for (idx, tc) in tool_calls.iter().enumerate() {
         // Emit ToolExecutionStart
@@ -159,7 +162,10 @@ pub async fn execute_tools_concurrently(
                 state: &state_snapshot,
             };
             match run_pre_dispatch_policies(&config.pre_dispatch_policies, &mut dispatch_ctx) {
-                PreDispatchVerdict::Continue | PreDispatchVerdict::Inject(_) => {}
+                PreDispatchVerdict::Continue => {}
+                PreDispatchVerdict::Inject(msgs) => {
+                    injected_messages.extend(msgs);
+                }
                 PreDispatchVerdict::Stop(reason) => {
                     let error_result = AgentToolResult {
                         content: vec![ContentBlock::Text {
@@ -178,6 +184,7 @@ pub async fn execute_tools_concurrently(
                         results: ordered,
                         tool_metrics: collected_timings,
                         transfer_signal: None,
+                        injected_messages,
                     };
                 }
                 PreDispatchVerdict::Skip(error_text) => {
@@ -273,7 +280,14 @@ pub async fn execute_tools_concurrently(
         match group_outcome {
             GroupOutcome::Continue => {}
             GroupOutcome::SteeringInterrupt => {
-                return build_steering_outcome(config, tool_calls, results, tool_timings).await;
+                return build_steering_outcome(
+                    config,
+                    tool_calls,
+                    results,
+                    tool_timings,
+                    injected_messages,
+                )
+                .await;
             }
         }
     }
@@ -288,6 +302,7 @@ pub async fn execute_tools_concurrently(
         results: ordered,
         tool_metrics: collected_timings,
         transfer_signal: captured_transfer,
+        injected_messages,
     }
 }
 
@@ -446,6 +461,7 @@ async fn build_steering_outcome(
     tool_calls: &[ToolCallInfo],
     results: Arc<tokio::sync::Mutex<Vec<(usize, ToolResultMessage)>>>,
     tool_timings: Arc<tokio::sync::Mutex<Vec<crate::metrics::ToolExecMetrics>>>,
+    injected_messages: Vec<AgentMessage>,
 ) -> ToolExecOutcome {
     let all_results = std::mem::take(&mut *results.lock().await);
     let result_map: HashMap<&str, &ToolResultMessage> = all_results
@@ -483,6 +499,7 @@ async fn build_steering_outcome(
         cancelled,
         steering_messages,
         tool_metrics: collected_timings,
+        injected_messages,
     }
 }
 

--- a/src/loop_/turn.rs
+++ b/src/loop_/turn.rs
@@ -687,21 +687,25 @@ async fn handle_tool_calls(
                 results,
                 tool_metrics,
                 transfer_signal,
+                injected_messages,
             } => {
                 tool_results.extend(results);
                 collected_tool_metrics = tool_metrics;
                 detected_transfer_signal = transfer_signal;
+                state.pending_messages.extend(injected_messages);
             }
             ToolExecOutcome::SteeringInterrupt {
                 completed,
                 cancelled,
                 steering_messages,
                 tool_metrics,
+                injected_messages,
             } => {
                 tool_results.extend(completed);
                 tool_results.extend(cancelled);
                 steering_interrupted = true;
                 collected_tool_metrics = tool_metrics;
+                state.pending_messages.extend(injected_messages);
                 state.pending_messages.extend(steering_messages);
             }
             ToolExecOutcome::ChannelClosed => return TurnOutcome::Return,

--- a/src/loop_/types.rs
+++ b/src/loop_/types.rs
@@ -68,12 +68,17 @@ pub enum ToolExecOutcome {
         tool_metrics: Vec<crate::metrics::ToolExecMetrics>,
         /// Transfer signal detected during tool execution (first one wins).
         transfer_signal: Option<crate::transfer::TransferSignal>,
+        /// Messages injected by `PreDispatch` policies via `Inject` verdict,
+        /// to be appended to `pending_messages` for the next turn.
+        injected_messages: Vec<AgentMessage>,
     },
     SteeringInterrupt {
         completed: Vec<ToolResultMessage>,
         cancelled: Vec<ToolResultMessage>,
         steering_messages: Vec<AgentMessage>,
         tool_metrics: Vec<crate::metrics::ToolExecMetrics>,
+        /// Messages injected by `PreDispatch` policies before the steering interrupt.
+        injected_messages: Vec<AgentMessage>,
     },
     ChannelClosed,
 }

--- a/tests/ac_tools.rs
+++ b/tests/ac_tools.rs
@@ -458,3 +458,60 @@ async fn tool_validator_rejects_call() {
         "should have an error tool result when policy skips"
     );
 }
+
+// ─── Regression (#204): PreDispatch Inject verdict must be applied ───────────
+
+/// A `PreDispatch` policy that injects a user message before the tool runs.
+struct InjectMessagePolicy;
+
+impl swink_agent::PreDispatchPolicy for InjectMessagePolicy {
+    fn name(&self) -> &'static str {
+        "inject_message"
+    }
+
+    fn evaluate(
+        &self,
+        _ctx: &mut swink_agent::ToolDispatchContext<'_>,
+    ) -> swink_agent::PreDispatchVerdict {
+        swink_agent::PreDispatchVerdict::Inject(vec![user_msg("pre_dispatch_injected")])
+    }
+}
+
+#[tokio::test]
+async fn pre_dispatch_inject_is_applied() {
+    // Regression for #204: injected messages were silently dropped.
+    //
+    // Without the fix, the second stream call sees: [user, assistant(tool_call), tool_result] = 3.
+    // With the fix, it also sees the injected user message = 4.
+    let tool = Arc::new(MockTool::new("noop"));
+
+    let stream_fn = Arc::new(MockContextCapturingStreamFn::new(vec![
+        tool_call_events("call_1", "noop", "{}"),
+        text_only_events("done"),
+    ]));
+
+    let mut agent = Agent::new(
+        AgentOptions::new("test", default_model(), stream_fn.clone(), default_convert)
+            .with_tools(vec![tool.clone()])
+            .with_pre_dispatch_policy(InjectMessagePolicy)
+            .with_retry_strategy(fast_retry()),
+    );
+
+    let _ = agent.prompt_async(vec![user_msg("go")]).await.unwrap();
+
+    let counts = stream_fn.captured_message_counts.lock().unwrap().clone();
+    assert_eq!(
+        counts.len(),
+        2,
+        "stream should be called twice (tool-call turn + follow-up turn): {counts:?}"
+    );
+    assert_eq!(
+        counts[0], 1,
+        "first call sees only the initial user message: {counts:?}"
+    );
+    assert_eq!(
+        counts[1], 4,
+        "second call must include the PreDispatch-injected message \
+         (expected 4: user + assistant + tool_result + injected; got {counts:?})"
+    );
+}


### PR DESCRIPTION
## Summary
- `PreDispatchVerdict::Inject(msgs)` was matched together with `Continue` and the injected messages silently dropped in `src/loop_/tool_dispatch.rs`.
- Collect injected messages during phase 1 of tool dispatch, propagate them through both `ToolExecOutcome::Completed` and `ToolExecOutcome::SteeringInterrupt`, and append them to `state.pending_messages` in `turn.rs` so the next turn consumes them (matching how PostTurn/PostLoop Inject is handled).

Closes #204.

## Tasks completed
- Fix pre-dispatch Inject handling in `src/loop_/tool_dispatch.rs`
- Thread `injected_messages` through `ToolExecOutcome` variants (`src/loop_/types.rs`)
- Apply injected messages to `state.pending_messages` in `src/loop_/turn.rs`
- Regression test `pre_dispatch_inject_is_applied` in `tests/ac_tools.rs`

## Test plan
- [x] `cargo test -p swink-agent --features testkit --test ac_tools` — 9 passed including new regression test
- [ ] `cargo test --workspace`
- [ ] `cargo clippy --workspace -- -D warnings` (note: pre-existing clippy errors in `src/types/message_codec.rs` unrelated to this change)
- [x] No public API breakage — `ToolExecOutcome` is an internal `pub(crate)`-scoped type in `loop_` submodule