### PR TITLE
release: bump version to 0.6.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ aws-smithy-runtime-api = { version = "1.11.6", features = ["client"] }
 
 [package]
 name = "swink-agent"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 rust-version = "1.88"
 description = "Core scaffolding for running LLM-powered agentic loops"

--- a/adapters/Cargo.toml
+++ b/adapters/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swink-agent-adapters"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 rust-version = "1.88"
 description = "LLM provider adapters for swink-agent"

--- a/artifacts/Cargo.toml
+++ b/artifacts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swink-agent-artifacts"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 rust-version = "1.88"
 description = "Versioned artifact storage for swink-agent sessions"

--- a/auth/Cargo.toml
+++ b/auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swink-agent-auth"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 rust-version = "1.88"
 description = "Credential management and OAuth2 support for swink-agent"

--- a/eval/Cargo.toml
+++ b/eval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swink-agent-eval"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 rust-version = "1.88"
 description = "Evaluation framework for swink-agent: trajectory tracing, golden path verification, and cost governance"

--- a/local-llm/Cargo.toml
+++ b/local-llm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swink-agent-local-llm"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 rust-version = "1.88"
 description = "Local on-device LLM inference for swink-agent using mistral.rs"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swink-agent-macros"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 rust-version = "1.88"
 description = "Proc macros for swink-agent: #[derive(ToolSchema)] and #[tool]"

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swink-agent-mcp"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 rust-version = "1.88"
 description = "MCP (Model Context Protocol) integration for swink-agent"

--- a/memory/Cargo.toml
+++ b/memory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swink-agent-memory"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 rust-version = "1.88"
 description = "Session persistence and memory management for swink-agent"

--- a/patterns/Cargo.toml
+++ b/patterns/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swink-agent-patterns"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 rust-version = "1.88"
 description = "Multi-agent pipeline patterns for swink-agent"

--- a/policies/Cargo.toml
+++ b/policies/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swink-agent-policies"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 rust-version = "1.88"
 description = "Policy implementations for swink-agent"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 rust-version = "1.88"
 publish = false


### PR DESCRIPTION
Bumps root + 11 subcrates from 0.6.1 to 0.6.2 for the v0.6.2 release.

tui stays at 0.7.0 (already ahead from #191).

## Why

SuperSwink-Core needs a release tag it can pin against so tests build on non-sibling checkouts (currently path dep, which fails on CI and other dev machines). Tagging current main as v0.6.2 gives Core a fetchable pin.

## Test plan

- [x] All 12 \`version = "0.6.1"\` lines in Cargo.toml files bumped to 0.6.2
- [x] tui/Cargo.toml unchanged (already 0.7.0)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)