### PR TITLE
fix(local-llm): emit error event on cancellation (#208)

### DIFF
--- a/local-llm/src/stream.rs
+++ b/local-llm/src/stream.rs
@@ -752,11 +752,15 @@ impl StreamState {
     fn finalize_cancelled(mut self) -> Vec<AssistantMessageEvent> {
         self.close_thinking_block();
         self.close_text_block();
-        self.events.push(AssistantMessageEvent::Done {
-            stop_reason: StopReason::Stop,
-            usage: build_usage(self.accumulated_usage.as_ref()),
-            cost: Cost::default(),
-        });
+        for (id, tc_content_index) in &self.active_tool_calls {
+            if !id.is_empty() {
+                self.events.push(AssistantMessageEvent::ToolCallEnd {
+                    content_index: *tc_content_index,
+                });
+            }
+        }
+        self.events
+            .push(AssistantMessageEvent::error("local inference cancelled"));
         self.events
     }
 }
@@ -784,11 +788,7 @@ fn local_stream<'a>(
         if cancellation_token.is_cancelled() {
             return stream::iter(vec![
                 AssistantMessageEvent::Start,
-                AssistantMessageEvent::Done {
-                    stop_reason: StopReason::Stop,
-                    usage: Usage::default(),
-                    cost: Cost::default(),
-                },
+                AssistantMessageEvent::error("local inference cancelled"),
             ]);
         }
 
@@ -972,6 +972,33 @@ mod tests {
         let (thinking, text) = extract_thinking_delta(input);
         assert!(thinking.is_none());
         assert_eq!(text, "<think>unclosed thinking");
+    }
+
+    #[test]
+    fn finalize_cancelled_emits_error_terminal() {
+        let mut state = StreamState::new(false);
+        // Simulate having started a text block.
+        state.events.push(AssistantMessageEvent::TextStart {
+            content_index: 0,
+        });
+        state.text_started = true;
+
+        let events = state.finalize_cancelled();
+        let terminal = events.last().expect("at least one event");
+        match terminal {
+            AssistantMessageEvent::Error { error_message, .. } => {
+                assert!(
+                    error_message.contains("cancelled"),
+                    "expected cancellation message, got: {error_message}"
+                );
+            }
+            other => panic!("expected Error terminal, got {other:?}"),
+        }
+        // Open text block must be closed before the terminal error.
+        assert!(events.iter().any(|e| matches!(
+            e,
+            AssistantMessageEvent::TextEnd { .. }
+        )));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Cancelling a local LLM stream previously terminated with `Done { stop_reason: Stop }`, which is indistinguishable from a normal completion. Both cancellation paths in `local-llm/src/stream.rs` now emit `AssistantMessageEvent::error("local inference cancelled")` instead, so callers can detect cancellation via the standard error channel used by the other adapters (Anthropic, Bedrock, etc.).

`finalize_cancelled` also now closes any active tool-call blocks before pushing the terminal error, preserving the accumulator's strict ordering invariant.

Closes #208.

## Tasks completed
- Replace early-cancel `Done { Stop }` with error terminal in `local_stream` (`local-llm/src/stream.rs:784`)
- Replace mid-stream `finalize_cancelled` `Done { Stop }` with error terminal, closing open tool-call blocks first (`local-llm/src/stream.rs:752`)
- Regression test `finalize_cancelled_emits_error_terminal`

## Test plan
- [x] `cargo test -p swink-agent-local-llm --lib stream::` (8 passed)
- [x] `cargo clippy -p swink-agent-local-llm --lib -- -D warnings` clean
- [x] No public API changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)