### PR TITLE
safety: forbid(unsafe_code) on policies, mcp, web plugin roots

### DIFF
--- a/mcp/src/lib.rs
+++ b/mcp/src/lib.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 //! MCP (Model Context Protocol) integration for swink-agent.
 //!
 //! Provides connection management, tool discovery, and tool execution for

--- a/plugins/web/src/lib.rs
+++ b/plugins/web/src/lib.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 //! Web browsing plugin for swink-agent.
 //!
 //! Provides tools for fetching web pages, searching the web, capturing screenshots,

--- a/policies/src/lib.rs
+++ b/policies/src/lib.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 //! Policy implementations for [`swink_agent`].
 //!
 //! This crate provides all policy implementations built against `swink-agent`'s


### PR DESCRIPTION
## Summary
Adds the workspace-standard \`#![forbid(unsafe_code)]\` attribute to the three crate roots flagged in #236:
- \`plugins/web/src/lib.rs\`
- \`policies/src/lib.rs\`
- \`mcp/src/lib.rs\`

This hardens the project's no-unsafe guarantee at the crate boundary — any future \`unsafe\` block in these crates will now be a hard compile error, matching the other workspace crates.

Closes #236

## Test plan
- [x] \`cargo check -p swink-agent-policies -p swink-agent-mcp -p swink-agent-plugin-web\` passes
- [ ] CI: \`cargo test --workspace\`
- [ ] CI: \`cargo clippy --workspace -- -D warnings\`
- No public API changes.