### PR TITLE
fix(patterns): remove stale testkit-only warnings in parallel tests

### DIFF
--- a/patterns/src/pipeline/parallel.rs
+++ b/patterns/src/pipeline/parallel.rs
@@ -405,20 +405,8 @@ mod tests {
     use swink_agent::testing::{MockStreamFn, default_convert, default_model, text_only_events};
     use swink_agent::{Agent, AgentOptions};
 
-    use super::super::executor::{PipelineExecutor, SimpleAgentFactory};
-    use super::super::registry::PipelineRegistry;
-    use super::super::types::{MergeStrategy, Pipeline, PipelineId};
-
-    fn make_agent(response: &str) -> Agent {
-        let events = text_only_events(response);
-        let options = AgentOptions::new(
-            "test",
-            default_model(),
-            Arc::new(MockStreamFn::new(vec![events])),
-            default_convert,
-        );
-        Agent::new(options)
-    }
+    use super::super::executor::SimpleAgentFactory;
+    use super::super::types::{MergeStrategy, PipelineId};
 
     fn make_factory(agents: Vec<(&str, &str)>) -> Arc<SimpleAgentFactory> {
         let mut factory = SimpleAgentFactory::new();


### PR DESCRIPTION
## Summary
Removes unused imports (`PipelineExecutor`, `PipelineRegistry`, `Pipeline`) and the unused `make_agent` helper from `patterns/src/pipeline/parallel.rs` tests so `cargo test --workspace --features testkit` stops emitting warnings from checked-in code.

Closes #222

## Tasks completed
- Drop stale `use` imports in the `parallel` test module
- Remove dead `make_agent` helper

## Test plan
- [x] `cargo test -p swink-agent-patterns --features testkit` passes with no warnings
- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy --workspace -- -D warnings` clean
- [ ] No public API breakage in downstream crates