### PR TITLE
fix(credential): make credential module private (#210)

### DIFF
--- a/auth/src/in_memory.rs
+++ b/auth/src/in_memory.rs
@@ -3,8 +3,7 @@
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
-use swink_agent::credential::CredentialFuture;
-use swink_agent::{Credential, CredentialStore};
+use swink_agent::{Credential, CredentialFuture, CredentialStore};
 
 /// Thread-safe in-memory credential store.
 ///

--- a/auth/src/resolver.rs
+++ b/auth/src/resolver.rs
@@ -11,9 +11,9 @@ use futures::future::{BoxFuture, Shared};
 use tokio::sync::Mutex;
 use tracing::{debug, info};
 
-use swink_agent::credential::CredentialFuture;
 use swink_agent::{
-    Credential, CredentialError, CredentialResolver, CredentialStore, ResolvedCredential,
+    Credential, CredentialError, CredentialFuture, CredentialResolver, CredentialStore,
+    ResolvedCredential,
 };
 
 use crate::oauth2;

--- a/macros/src/tool_attr.rs
+++ b/macros/src/tool_attr.rs
@@ -83,7 +83,7 @@ pub fn tool_attr_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
                 cancellation_token: tokio_util::sync::CancellationToken,
                 _on_update: Option<Box<dyn Fn(swink_agent::AgentToolResult) + Send + Sync>>,
                 _state: std::sync::Arc<std::sync::RwLock<swink_agent::SessionState>>,
-                _credential: Option<swink_agent::credential::ResolvedCredential>,
+                _credential: Option<swink_agent::ResolvedCredential>,
             ) -> std::pin::Pin<Box<dyn std::future::Future<Output = swink_agent::AgentToolResult> + Send + '_>> {
                 Box::pin(async move {
                     #[allow(unused_variables)]

--- a/mcp/src/tool.rs
+++ b/mcp/src/tool.rs
@@ -8,8 +8,8 @@ use std::sync::Arc;
 use serde_json::Value;
 use tokio_util::sync::CancellationToken;
 
+use swink_agent::ResolvedCredential;
 use swink_agent::SessionState;
-use swink_agent::credential::ResolvedCredential;
 use swink_agent::tool::{AgentTool, AgentToolResult, ToolFuture, ToolMetadata};
 
 use crate::connection::McpConnection;

--- a/patterns/src/pipeline/tool.rs
+++ b/patterns/src/pipeline/tool.rs
@@ -86,7 +86,7 @@ impl AgentTool for PipelineTool {
         cancellation_token: CancellationToken,
         _on_update: Option<Box<dyn Fn(AgentToolResult) + Send + Sync>>,
         _state: Arc<std::sync::RwLock<swink_agent::SessionState>>,
-        _credential: Option<swink_agent::credential::ResolvedCredential>,
+        _credential: Option<swink_agent::ResolvedCredential>,
     ) -> ToolFuture<'_> {
         Box::pin(async move {
             let parsed: PipelineToolParams = match serde_json::from_value(params) {

--- a/plugins/web/src/tools/extract.rs
+++ b/plugins/web/src/tools/extract.rs
@@ -81,7 +81,7 @@ impl AgentTool for ExtractTool {
         cancellation_token: tokio_util::sync::CancellationToken,
         _on_update: Option<Box<dyn Fn(AgentToolResult) + Send + Sync>>,
         _state: Arc<std::sync::RwLock<swink_agent::SessionState>>,
-        _credential: Option<swink_agent::credential::ResolvedCredential>,
+        _credential: Option<swink_agent::ResolvedCredential>,
     ) -> ToolFuture<'_> {
         Box::pin(async move {
             // Extract URL from params.

--- a/plugins/web/src/tools/fetch.rs
+++ b/plugins/web/src/tools/fetch.rs
@@ -71,7 +71,7 @@ impl AgentTool for FetchTool {
         cancellation_token: tokio_util::sync::CancellationToken,
         _on_update: Option<Box<dyn Fn(AgentToolResult) + Send + Sync>>,
         _state: Arc<std::sync::RwLock<swink_agent::SessionState>>,
-        _credential: Option<swink_agent::credential::ResolvedCredential>,
+        _credential: Option<swink_agent::ResolvedCredential>,
     ) -> ToolFuture<'_> {
         Box::pin(async move {
             // Extract URL from params.

--- a/plugins/web/src/tools/screenshot.rs
+++ b/plugins/web/src/tools/screenshot.rs
@@ -89,7 +89,7 @@ impl AgentTool for ScreenshotTool {
         cancellation_token: CancellationToken,
         _on_update: Option<Box<dyn Fn(AgentToolResult) + Send + Sync>>,
         _state: Arc<std::sync::RwLock<swink_agent::SessionState>>,
-        _credential: Option<swink_agent::credential::ResolvedCredential>,
+        _credential: Option<swink_agent::ResolvedCredential>,
     ) -> ToolFuture<'_> {
         Box::pin(async move {
             if cancellation_token.is_cancelled() {

--- a/plugins/web/src/tools/search.rs
+++ b/plugins/web/src/tools/search.rs
@@ -81,7 +81,7 @@ impl AgentTool for SearchTool {
         _cancellation_token: CancellationToken,
         _on_update: Option<Box<dyn Fn(AgentToolResult) + Send + Sync>>,
         _state: Arc<std::sync::RwLock<swink_agent::SessionState>>,
-        _credential: Option<swink_agent::credential::ResolvedCredential>,
+        _credential: Option<swink_agent::ResolvedCredential>,
     ) -> ToolFuture<'_> {
         let query = params
             .get("query")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,12 @@
 #![forbid(unsafe_code)]
+//! # Encapsulation regression
+//!
+//! The `credential` module is private; consumers must use the canonical
+//! re-exports at the crate root rather than reaching into submodule paths.
+//!
+//! ```compile_fail
+//! use swink_agent::credential::ResolvedCredential;
+//! ```
 mod agent;
 mod agent_id;
 pub mod agent_options;
@@ -13,7 +21,7 @@ pub mod context_cache;
 mod context_transformer;
 mod context_version;
 pub mod convert;
-pub mod credential;
+mod credential;
 pub mod display;
 mod emit;
 mod error;
@@ -82,8 +90,8 @@ pub use context_version::{
 };
 pub use convert::{MessageConverter, ToolSchema, convert_messages, extract_tool_schemas};
 pub use credential::{
-    AuthConfig, AuthScheme, Credential, CredentialError, CredentialResolver, CredentialStore,
-    CredentialType, ResolvedCredential,
+    AuthConfig, AuthScheme, Credential, CredentialError, CredentialFuture, CredentialResolver,
+    CredentialStore, CredentialType, ResolvedCredential,
 };
 pub use emit::Emission;
 pub use error::{AgentError, DowncastError};


### PR DESCRIPTION
## Summary
- Make `swink_agent::credential` a private module so consumers can no longer reach internal items via the submodule path.
- Re-export `CredentialFuture` from the crate root alongside the existing credential types.
- Update workspace consumers (`auth`, `mcp`, `plugins/web/*`, `patterns`) and the `#[tool]` macro to use the canonical `swink_agent::*` paths.
- Add a `compile_fail` doctest in `src/lib.rs` pinning the encapsulation as a regression guard.

Closes #210.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo test -p swink-agent --features testkit --doc` (compile_fail doctest passes)
- [x] `cargo test --workspace --features testkit` (only pre-existing `max_tokens_recovery` failure from #221, unrelated)
- [ ] `cargo clippy --workspace -- -D warnings` — pre-existing rust 1.94 lint failures unrelated to this change

## Notes
No public API removal: all `credential::*` items previously re-exported at the crate root remain re-exported, plus the newly re-exported `CredentialFuture`. Downstream code that imported via `swink_agent::credential::X` will need to switch to `swink_agent::X` (a flag for SuperSwink-Core).