### PR TITLE
fix: restore custom messages through checkpoint resume paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7252,7 +7252,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swink-agent"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "bytes",
  "chrono",
@@ -7291,7 +7291,7 @@ dependencies = [
 
 [[package]]
 name = "swink-agent-adapters"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -7318,7 +7318,7 @@ dependencies = [
 
 [[package]]
 name = "swink-agent-artifacts"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "bytes",
  "chrono",
@@ -7334,7 +7334,7 @@ dependencies = [
 
 [[package]]
 name = "swink-agent-auth"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "chrono",
  "futures",
@@ -7352,7 +7352,7 @@ dependencies = [
 
 [[package]]
 name = "swink-agent-eval"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "futures",
  "pretty_assertions",
@@ -7372,7 +7372,7 @@ dependencies = [
 
 [[package]]
 name = "swink-agent-local-llm"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "futures",
  "hf-hub 0.5.0",
@@ -7391,7 +7391,7 @@ dependencies = [
 
 [[package]]
 name = "swink-agent-macros"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7406,7 +7406,7 @@ dependencies = [
 
 [[package]]
 name = "swink-agent-mcp"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "reqwest 0.13.2",
  "rmcp",
@@ -7422,7 +7422,7 @@ dependencies = [
 
 [[package]]
 name = "swink-agent-memory"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "chrono",
  "dirs",
@@ -7437,7 +7437,7 @@ dependencies = [
 
 [[package]]
 name = "swink-agent-patterns"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "regex",
  "schemars 1.2.1",
@@ -7475,7 +7475,7 @@ dependencies = [
 
 [[package]]
 name = "swink-agent-policies"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "chrono",
  "futures",
@@ -9985,7 +9985,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "clap",
  "futures",

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -169,6 +169,8 @@ pub struct Agent {
     async_transform_context: Option<AsyncTransformContextArc>,
     /// Optional checkpoint store.
     checkpoint_store: Option<CheckpointStoreArc>,
+    /// Optional registry for decoding persisted custom messages on restore.
+    pub(crate) custom_message_registry: Option<Arc<crate::types::CustomMessageRegistry>>,
     /// Optional metrics collector.
     metrics_collector: Option<Arc<dyn crate::metrics::MetricsCollector>>,
     /// Optional model fallback chain.
@@ -268,6 +270,7 @@ impl Agent {
             event_forwarders: options.event_forwarders,
             async_transform_context: options.async_transform_context,
             checkpoint_store: options.checkpoint_store,
+            custom_message_registry: options.custom_message_registry,
             metrics_collector: options.metrics_collector,
             fallback: options.fallback,
             external_message_provider: options.external_message_provider,

--- a/src/agent/checkpointing.rs
+++ b/src/agent/checkpointing.rs
@@ -47,11 +47,13 @@ impl Agent {
     /// Restore agent message history from a checkpoint.
     ///
     /// Replaces the current messages with those from the checkpoint and
-    /// updates the system prompt to match. Custom messages are not restored
-    /// by this method; use `restore_messages(Some(registry))` directly for
-    /// full restoration including custom messages.
+    /// updates the system prompt to match. Persisted custom messages are
+    /// restored when a [`CustomMessageRegistry`](crate::types::CustomMessageRegistry)
+    /// has been configured on [`AgentOptions`](crate::AgentOptions) via
+    /// [`with_custom_message_registry`](crate::AgentOptions::with_custom_message_registry);
+    /// otherwise they are dropped.
     pub fn restore_from_checkpoint(&mut self, checkpoint: &Checkpoint) {
-        self.state.messages = checkpoint.restore_messages(None);
+        self.state.messages = checkpoint.restore_messages(self.custom_message_registry.as_deref());
         self.state
             .system_prompt
             .clone_from(&checkpoint.system_prompt);
@@ -160,7 +162,7 @@ impl Agent {
         &mut self,
         checkpoint: &crate::checkpoint::LoopCheckpoint,
     ) -> Result<(), AgentError> {
-        self.state.messages = checkpoint.restore_messages(None);
+        self.state.messages = checkpoint.restore_messages(self.custom_message_registry.as_deref());
         self.state
             .system_prompt
             .clone_from(&checkpoint.system_prompt);
@@ -190,5 +192,131 @@ impl Agent {
         );
 
         Ok(())
+    }
+}
+
+#[cfg(all(test, feature = "testkit"))]
+mod tests {
+    use std::sync::Arc;
+
+    use crate::agent::Agent;
+    use crate::agent_options::AgentOptions;
+    use crate::testing::SimpleMockStreamFn;
+    use crate::types::{
+        AgentMessage, CustomMessage, CustomMessageRegistry, LlmMessage, ModelSpec, UserMessage,
+    };
+
+    #[derive(Debug, Clone, PartialEq)]
+    struct Tagged {
+        value: String,
+    }
+
+    impl CustomMessage for Tagged {
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+        fn type_name(&self) -> Option<&str> {
+            Some("Tagged")
+        }
+        fn to_json(&self) -> Option<serde_json::Value> {
+            Some(serde_json::json!({ "value": self.value }))
+        }
+    }
+
+    fn tagged_registry() -> CustomMessageRegistry {
+        let mut reg = CustomMessageRegistry::new();
+        reg.register(
+            "Tagged",
+            Box::new(|val: serde_json::Value| {
+                let value = val
+                    .get("value")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| "missing value".to_string())?;
+                Ok(Box::new(Tagged {
+                    value: value.to_string(),
+                }) as Box<dyn CustomMessage>)
+            }),
+        );
+        reg
+    }
+
+    fn make_agent(registry: Option<CustomMessageRegistry>) -> Agent {
+        let stream_fn = Arc::new(SimpleMockStreamFn::from_text("ok"));
+        let mut opts =
+            AgentOptions::new_simple("system", ModelSpec::new("mock", "mock-model"), stream_fn);
+        if let Some(reg) = registry {
+            opts = opts.with_custom_message_registry(reg);
+        }
+        Agent::new(opts)
+    }
+
+    #[tokio::test]
+    async fn restore_from_checkpoint_rehydrates_custom_messages_via_registry() {
+        let mut source = make_agent(None);
+        source
+            .state
+            .messages
+            .push(AgentMessage::Llm(LlmMessage::User(UserMessage {
+                content: vec![crate::types::ContentBlock::Text {
+                    text: "hi".to_string(),
+                }],
+                timestamp: 0,
+                cache_hint: None,
+            })));
+        source
+            .state
+            .messages
+            .push(AgentMessage::Custom(Box::new(Tagged {
+                value: "preserved".to_string(),
+            })));
+
+        let checkpoint = source.save_checkpoint("cp-1").await.unwrap();
+        let json = serde_json::to_string(&checkpoint).unwrap();
+        let loaded: crate::checkpoint::Checkpoint = serde_json::from_str(&json).unwrap();
+        assert_eq!(loaded.custom_messages.len(), 1);
+
+        // Without a registry the custom message is dropped (legacy behavior).
+        let mut no_reg = make_agent(None);
+        no_reg.restore_from_checkpoint(&loaded);
+        assert_eq!(no_reg.state.messages.len(), 1);
+
+        // With a registry configured on AgentOptions, the custom message
+        // survives restoration through the public API.
+        let mut with_reg = make_agent(Some(tagged_registry()));
+        with_reg.restore_from_checkpoint(&loaded);
+        assert_eq!(with_reg.state.messages.len(), 2);
+        let restored = with_reg.state.messages[1]
+            .downcast_ref::<Tagged>()
+            .expect("custom message should be restored via registry");
+        assert_eq!(restored.value, "preserved");
+    }
+
+    #[tokio::test]
+    async fn loop_checkpoint_resume_rehydrates_custom_messages_via_registry() {
+        use crate::checkpoint::LoopCheckpoint;
+
+        let messages = vec![
+            AgentMessage::Llm(LlmMessage::User(UserMessage {
+                content: vec![crate::types::ContentBlock::Text {
+                    text: "hi".to_string(),
+                }],
+                timestamp: 0,
+                cache_hint: None,
+            })),
+            AgentMessage::Custom(Box::new(Tagged {
+                value: "resumed".to_string(),
+            })),
+        ];
+        let cp = LoopCheckpoint::new("system", "mock", "mock-model", &messages);
+        let json = serde_json::to_string(&cp).unwrap();
+        let loaded: LoopCheckpoint = serde_json::from_str(&json).unwrap();
+
+        let mut agent = make_agent(Some(tagged_registry()));
+        agent.restore_from_loop_checkpoint(&loaded).unwrap();
+        assert_eq!(agent.state.messages.len(), 2);
+        let restored = agent.state.messages[1]
+            .downcast_ref::<Tagged>()
+            .expect("custom message should be restored via registry");
+        assert_eq!(restored.value, "resumed");
     }
 }

--- a/src/agent_options.rs
+++ b/src/agent_options.rs
@@ -15,7 +15,7 @@ use crate::message_provider::MessageProvider;
 use crate::retry::{DefaultRetryStrategy, RetryStrategy};
 use crate::stream::{StreamFn, StreamOptions};
 use crate::tool::{AgentTool, ApprovalMode, ToolApproval, ToolApprovalRequest};
-use crate::types::{AgentMessage, LlmMessage, ModelSpec};
+use crate::types::{AgentMessage, CustomMessageRegistry, LlmMessage, ModelSpec};
 
 // ─── Type aliases (module-local) ─────────────────────────────────────────────
 
@@ -93,6 +93,16 @@ pub struct AgentOptions {
     pub async_transform_context: Option<AsyncTransformContextArc>,
     /// Optional checkpoint store for persisting agent state.
     pub checkpoint_store: Option<CheckpointStoreArc>,
+    /// Optional registry used to deserialize persisted [`CustomMessage`](crate::types::CustomMessage)
+    /// values when restoring from a [`Checkpoint`](crate::checkpoint::Checkpoint) or
+    /// [`LoopCheckpoint`](crate::checkpoint::LoopCheckpoint).
+    ///
+    /// When set, the agent's `restore_from_checkpoint` / `load_and_restore_checkpoint`
+    /// / `resume` / `resume_stream` paths thread this registry into
+    /// [`Checkpoint::restore_messages`] so that custom messages survive a round
+    /// trip through the checkpoint store. When `None`, persisted custom messages
+    /// are silently dropped on restore (legacy behavior).
+    pub custom_message_registry: Option<Arc<CustomMessageRegistry>>,
     /// Optional metrics collector for per-turn observability.
     pub metrics_collector: Option<Arc<dyn crate::metrics::MetricsCollector>>,
     /// Optional custom token counter for context compaction.
@@ -177,6 +187,7 @@ impl AgentOptions {
             event_forwarders: Vec::new(),
             async_transform_context: None,
             checkpoint_store: None,
+            custom_message_registry: None,
             metrics_collector: None,
             token_counter: None,
             fallback: None,
@@ -407,6 +418,31 @@ impl AgentOptions {
     #[must_use]
     pub fn with_checkpoint_store(mut self, store: impl CheckpointStore + 'static) -> Self {
         self.checkpoint_store = Some(Arc::new(store));
+        self
+    }
+
+    /// Set the [`CustomMessageRegistry`] used to decode persisted custom
+    /// messages when restoring from a checkpoint.
+    ///
+    /// Without this, [`Checkpoint::restore_messages`](crate::checkpoint::Checkpoint::restore_messages)
+    /// and [`LoopCheckpoint::restore_messages`](crate::checkpoint::LoopCheckpoint::restore_messages)
+    /// are called with `None` in the public agent restore/resume APIs, and any
+    /// persisted [`CustomMessage`](crate::types::CustomMessage) values are
+    /// silently dropped.
+    #[must_use]
+    pub fn with_custom_message_registry(mut self, registry: CustomMessageRegistry) -> Self {
+        self.custom_message_registry = Some(Arc::new(registry));
+        self
+    }
+
+    /// Set the [`CustomMessageRegistry`] from a shared [`Arc`], for sharing a
+    /// single registry across multiple agents.
+    #[must_use]
+    pub fn with_custom_message_registry_arc(
+        mut self,
+        registry: Arc<CustomMessageRegistry>,
+    ) -> Self {
+        self.custom_message_registry = Some(registry);
         self
     }
 


### PR DESCRIPTION
## Summary
- `Agent::restore_from_checkpoint`, `load_and_restore_checkpoint`, `resume`, and `resume_stream` all called `Checkpoint::restore_messages(None)`, silently dropping every persisted `CustomMessage` on restore despite the codec serializing them.
- Adds an optional `CustomMessageRegistry` slot on `AgentOptions` (threaded into `Agent`) with `with_custom_message_registry` / `with_custom_message_registry_arc` builders. The restore paths now pass this registry into `restore_messages`, so consumers that wire one up recover custom messages automatically. Call sites that do not set a registry keep the legacy behavior, so the change is purely additive.
- Updates the `restore_from_checkpoint` doc comment to describe the new behavior.

## Public API change
Additive only:
- New field `AgentOptions::custom_message_registry: Option<Arc<CustomMessageRegistry>>`
- New builders `AgentOptions::with_custom_message_registry` and `with_custom_message_registry_arc`

No existing signatures or traits change.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace -- -D warnings` (project-standard command)
- [x] `cargo test -p swink-agent --features testkit` (includes two new regression tests covering `Checkpoint` and `LoopCheckpoint` restore paths)
- [x] `cargo test -p swink-agent --no-default-features`
- [ ] `cargo test --workspace --features testkit` — one pre-existing unrelated failure in `swink-agent-adapters::ollama_duplicate_tool_calls_deduped` (Ollama dedup test, unrelated to checkpointing); everything else green.

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)