### PR TITLE
fix: recover StopReason::Length with incomplete tool calls

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -365,6 +365,24 @@ pub fn accumulate_message(
     let mut saw_start = false;
     let mut saw_terminal = false;
 
+    // Pre-scan for a Length stop reason. Providers can emit `ToolCallEnd` with
+    // truncated JSON arguments (or omit it entirely) when hitting the max-token
+    // limit mid tool-call. We must preserve the incomplete block so the loop's
+    // `recover_incomplete_tool_calls` path can convert it into an error tool
+    // result and continue on the next turn. See issue #221.
+    let tolerate_truncated_tool_args = events.iter().any(|e| {
+        matches!(
+            e,
+            AssistantMessageEvent::Done {
+                stop_reason: StopReason::Length,
+                ..
+            } | AssistantMessageEvent::Error {
+                stop_reason: StopReason::Length,
+                ..
+            }
+        )
+    });
+
     for event in events {
         // Reject content-block events after a terminal event.
         match &event {
@@ -546,15 +564,31 @@ pub fn accumulate_message(
                         ..
                     } => {
                         let json_str = partial_json
-                            .take()
-                            .ok_or("ToolCallEnd: partial_json already consumed")?;
-                        *arguments = if json_str.is_empty() {
-                            Value::Object(serde_json::Map::new())
+                            .as_ref()
+                            .ok_or("ToolCallEnd: partial_json already consumed")?
+                            .clone();
+                        if json_str.is_empty() {
+                            *arguments = Value::Object(serde_json::Map::new());
+                            *partial_json = None;
                         } else {
-                            serde_json::from_str(&json_str).map_err(|e| {
-                                format!("ToolCallEnd: failed to parse arguments JSON: {e}")
-                            })?
-                        };
+                            match serde_json::from_str::<Value>(&json_str) {
+                                Ok(v) => {
+                                    *arguments = v;
+                                    *partial_json = None;
+                                }
+                                Err(e) => {
+                                    if tolerate_truncated_tool_args {
+                                        // Leave `partial_json` as Some so the
+                                        // block is flagged incomplete and the
+                                        // loop recovers on the next turn.
+                                    } else {
+                                        return Err(format!(
+                                            "ToolCallEnd: failed to parse arguments JSON: {e}"
+                                        ));
+                                    }
+                                }
+                            }
+                        }
                     }
                     _ => {
                         return Err(format!(

--- a/tests/agent_loop.rs
+++ b/tests/agent_loop.rs
@@ -833,6 +833,56 @@ async fn max_tokens_recovery() {
     );
 }
 
+// Regression for #221: when the provider emits `ToolCallEnd` with truncated
+// JSON alongside `StopReason::Length`, accumulation must preserve the
+// incomplete block so the loop's recovery path converts it into an error
+// tool result and continues.
+#[tokio::test]
+async fn max_tokens_recovery_with_tool_call_end() {
+    let events_with_incomplete = vec![
+        AssistantMessageEvent::Start,
+        AssistantMessageEvent::ToolCallStart {
+            content_index: 0,
+            id: "tc_1".to_string(),
+            name: "read_file".to_string(),
+        },
+        AssistantMessageEvent::ToolCallDelta {
+            content_index: 0,
+            delta: r#"{"path": "/tmp"#.to_string(),
+        },
+        AssistantMessageEvent::ToolCallEnd { content_index: 0 },
+        AssistantMessageEvent::Done {
+            stop_reason: StopReason::Length,
+            usage: Usage::default(),
+            cost: Cost::default(),
+        },
+    ];
+
+    let stream_fn = Arc::new(MockStreamFn::new(vec![
+        events_with_incomplete,
+        text_only_events("recovered"),
+    ]));
+
+    let tool = Arc::new(MockTool::new("read_file"));
+    let mut config = default_config(stream_fn);
+    config.tools = vec![tool];
+
+    let events = collect_events(agent_loop(
+        vec![],
+        "system".to_string(),
+        config,
+        CancellationToken::new(),
+    ))
+    .await;
+
+    assert!(has_event(&events, "AgentEnd"));
+    assert_eq!(
+        count_events(&events, "TurnStart"),
+        2,
+        "should recover across two turns when ToolCallEnd carries truncated JSON"
+    );
+}
+
 // ─── 3.14: convert_to_llm filter ────────────────────────────────────────
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Pre-scan stream events in `accumulate_message` for a terminal `StopReason::Length` and, when present, preserve `ToolCall` blocks with unparseable/truncated `partial_json` instead of erroring out.
- The existing `recover_incomplete_tool_calls` path in `loop_/turn.rs` then converts those blocks into error tool results and the loop continues on the next turn, matching the originally intended max-tokens recovery behavior.
- Adds a regression test (`max_tokens_recovery_with_tool_call_end`) that simulates the real-provider case where `ToolCallEnd` is emitted alongside truncated JSON.

No public API changes.

Closes #221

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace -- -D warnings` (default features)
- [x] `cargo test -p swink-agent --features testkit --test agent_loop` (new + existing max_tokens_recovery tests pass)
- [x] `cargo test -p swink-agent --no-default-features`
- [ ] Note: one pre-existing failure on this branch's base (`ollama_duplicate_tool_calls_deduped`) is unrelated and reproduces on `main` without these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)