### PR TITLE
fix: surface transport errors from SSE and Ollama stream loops

### DIFF
--- a/adapters/src/anthropic.rs
+++ b/adapters/src/anthropic.rs
@@ -466,6 +466,15 @@ fn parse_sse_stream(
                 ));
                 SseAction::Done(events)
             }
+            Some(SseEvent { event_type, data })
+                if event_type == crate::sse::SSE_TRANSPORT_ERROR_EVENT =>
+            {
+                let mut events = crate::finalize::finalize_blocks(state);
+                events.push(AssistantMessageEvent::error_network(format!(
+                    "Anthropic {data}",
+                )));
+                SseAction::Done(events)
+            }
             Some(SseEvent { event_type, data }) => {
                 let mut done = false;
                 let events = process_sse_event(&event_type, &data, state, &mut done);

--- a/adapters/src/google.rs
+++ b/adapters/src/google.rs
@@ -605,6 +605,13 @@ fn parse_sse_stream(
                     }
                 }
             }
+            Some(SseLine::TransportError(message)) => {
+                let mut events = crate::finalize::finalize_blocks(state);
+                events.push(AssistantMessageEvent::error_network(format!(
+                    "Google {message}",
+                )));
+                SseAction::Done(events)
+            }
             Some(_) => SseAction::Skip,
         },
     )

--- a/adapters/src/ollama.rs
+++ b/adapters/src/ollama.rs
@@ -406,7 +406,18 @@ fn parse_ndjson_stream(
                             events.push(AssistantMessageEvent::error_network("Ollama stream ended unexpectedly"));
                             Some((events, (lines, token, state, done, false)))
                         }
-                        Some(line) => {
+                        Some(Err(err)) => {
+                            // Transport-level failure — surface as network error
+                            // instead of silently treating as EOF.
+                            error!(error = %err, "Ollama transport error");
+                            done = true;
+                            let mut events = crate::finalize::finalize_blocks(&mut state);
+                            events.push(AssistantMessageEvent::error_network(format!(
+                                "Ollama {err}"
+                            )));
+                            Some((events, (lines, token, state, done, false)))
+                        }
+                        Some(Ok(line)) => {
                             let chunk: OllamaChatChunk = match serde_json::from_str(&line) {
                                 Ok(c) => c,
                                 Err(e) => {
@@ -516,12 +527,20 @@ struct StreamState {
 }
 
 /// Convert a byte stream into a stream of complete NDJSON lines.
+///
+/// Yields `Ok(line)` for each complete line and `Err(message)` if the
+/// underlying `reqwest` byte stream reports a transport-level failure.
+/// A transport error is terminal — downstream consumers must stop after
+/// observing one.
 fn ndjson_lines(
     byte_stream: impl Stream<Item = Result<bytes::Bytes, reqwest::Error>> + Send + 'static,
-) -> Pin<Box<dyn Stream<Item = String> + Send + 'static>> {
+) -> Pin<Box<dyn Stream<Item = Result<String, String>> + Send + 'static>> {
     Box::pin(stream::unfold(
-        (Box::pin(byte_stream), String::new()),
-        |(mut stream, mut buf)| async move {
+        (Box::pin(byte_stream), String::new(), false),
+        |(mut stream, mut buf, mut errored)| async move {
+            if errored {
+                return None;
+            }
             loop {
                 // Check if we have a complete line in the buffer
                 if let Some(pos) = buf.find('\n') {
@@ -533,27 +552,41 @@ fn ndjson_lines(
                     let line: String = buf[..line_end].to_string();
                     buf.drain(..=pos);
                     if !line.is_empty() {
-                        return Some((line, (stream, buf)));
+                        return Some((Ok(line), (stream, buf, errored)));
                     }
                     continue;
                 }
 
                 // Need more data
-                if let Some(Ok(bytes)) = stream.next().await {
-                    // Attempt zero-copy UTF-8 conversion
-                    match std::str::from_utf8(&bytes) {
-                        Ok(s) => buf.push_str(s),
-                        Err(_) => buf.push_str(&String::from_utf8_lossy(&bytes)),
+                match stream.next().await {
+                    Some(Ok(bytes)) => {
+                        // Attempt zero-copy UTF-8 conversion
+                        match std::str::from_utf8(&bytes) {
+                            Ok(s) => buf.push_str(s),
+                            Err(_) => buf.push_str(&String::from_utf8_lossy(&bytes)),
+                        }
                     }
-                } else {
-                    // Stream ended — flush remaining buffer
-                    let trimmed = buf.trim();
-                    if !trimmed.is_empty() {
-                        let line = trimmed.to_string();
+                    Some(Err(err)) => {
+                        // Transport failure — surface immediately as a
+                        // terminal error so the adapter can emit a
+                        // classified network error instead of EOF.
+                        errored = true;
                         buf.clear();
-                        return Some((line, (stream, buf)));
+                        return Some((
+                            Err(format!("transport error: {err}")),
+                            (stream, buf, errored),
+                        ));
                     }
-                    return None;
+                    None => {
+                        // Stream ended cleanly — flush remaining buffer
+                        let trimmed = buf.trim();
+                        if !trimmed.is_empty() {
+                            let line = trimmed.to_string();
+                            buf.clear();
+                            return Some((Ok(line), (stream, buf, errored)));
+                        }
+                        return None;
+                    }
                 }
             }
         },
@@ -607,8 +640,8 @@ mod tests {
         let bytes_stream = stream::iter(vec![Ok(bytes::Bytes::from("line1\nline2\n"))]);
         let mut lines = ndjson_lines(bytes_stream);
 
-        assert_eq!(lines.next().await.unwrap(), "line1");
-        assert_eq!(lines.next().await.unwrap(), "line2");
+        assert_eq!(lines.next().await.unwrap().unwrap(), "line1");
+        assert_eq!(lines.next().await.unwrap().unwrap(), "line2");
         assert!(lines.next().await.is_none());
     }
 
@@ -617,8 +650,8 @@ mod tests {
         let bytes_stream = stream::iter(vec![Ok(bytes::Bytes::from("aaa\r\nbbb\r\n"))]);
         let mut lines = ndjson_lines(bytes_stream);
 
-        assert_eq!(lines.next().await.unwrap(), "aaa");
-        assert_eq!(lines.next().await.unwrap(), "bbb");
+        assert_eq!(lines.next().await.unwrap().unwrap(), "aaa");
+        assert_eq!(lines.next().await.unwrap().unwrap(), "bbb");
         assert!(lines.next().await.is_none());
     }
 
@@ -631,8 +664,8 @@ mod tests {
         ]);
         let mut lines = ndjson_lines(bytes_stream);
 
-        assert_eq!(lines.next().await.unwrap(), "hello");
-        assert_eq!(lines.next().await.unwrap(), "world");
+        assert_eq!(lines.next().await.unwrap().unwrap(), "hello");
+        assert_eq!(lines.next().await.unwrap().unwrap(), "world");
         assert!(lines.next().await.is_none());
     }
 
@@ -641,8 +674,50 @@ mod tests {
         let bytes_stream = stream::iter(vec![Ok(bytes::Bytes::from("no_newline"))]);
         let mut lines = ndjson_lines(bytes_stream);
 
-        assert_eq!(lines.next().await.unwrap(), "no_newline");
+        assert_eq!(lines.next().await.unwrap().unwrap(), "no_newline");
         assert!(lines.next().await.is_none());
+    }
+
+    /// Regression for issue #230 — transport errors on Ollama's NDJSON byte
+    /// stream must surface as a terminal `Err` rather than being silently
+    /// dropped as clean EOF. Uses a TCP listener that closes mid-body.
+    #[tokio::test]
+    async fn ndjson_surfaces_transport_error() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            if let Ok((mut sock, _)) = listener.accept().await {
+                let mut buf = [0u8; 1024];
+                let _ = sock.read(&mut buf).await;
+                let header = "HTTP/1.1 200 OK\r\n\
+                    Content-Type: application/x-ndjson\r\n\
+                    Transfer-Encoding: chunked\r\n\r\n\
+                    10\r\n{\"partial\":true";
+                let _ = sock.write_all(header.as_bytes()).await;
+                drop(sock);
+            }
+        });
+
+        let client = reqwest::Client::new();
+        let resp = client
+            .get(format!("http://{addr}/"))
+            .send()
+            .await
+            .expect("connect");
+        let mut lines = ndjson_lines(resp.bytes_stream());
+
+        let mut saw_err = false;
+        while let Some(item) = lines.next().await {
+            if item.is_err() {
+                saw_err = true;
+                break;
+            }
+        }
+        assert!(saw_err, "expected Err from ndjson_lines on transport error");
     }
 
     #[tokio::test]
@@ -650,8 +725,8 @@ mod tests {
         let bytes_stream = stream::iter(vec![Ok(bytes::Bytes::from("a\n\n\nb\n"))]);
         let mut lines = ndjson_lines(bytes_stream);
 
-        assert_eq!(lines.next().await.unwrap(), "a");
-        assert_eq!(lines.next().await.unwrap(), "b");
+        assert_eq!(lines.next().await.unwrap().unwrap(), "a");
+        assert_eq!(lines.next().await.unwrap().unwrap(), "b");
         assert!(lines.next().await.is_none());
     }
 

--- a/adapters/src/openai_compat.rs
+++ b/adapters/src/openai_compat.rs
@@ -488,6 +488,13 @@ pub fn parse_oai_sse_stream(
                 process_oai_chunk(&chunk, state, &mut events, provider);
                 SseAction::Continue(events)
             }
+            Some(SseLine::TransportError(message)) => {
+                let mut events = crate::finalize::finalize_blocks(state);
+                events.push(AssistantMessageEvent::error_network(format!(
+                    "{provider} {message}",
+                )));
+                SseAction::Done(events)
+            }
             Some(_) => SseAction::Skip,
         },
     )

--- a/adapters/src/proxy.rs
+++ b/adapters/src/proxy.rs
@@ -298,6 +298,12 @@ fn parse_sse_stream(
                             done = is_terminal_event(&parsed);
                             Some((parsed, (sse, token, done)))
                         }
+                        Some(SseLine::TransportError(message)) => Some((
+                            AssistantMessageEvent::error_network(format!(
+                                "network error: {message}",
+                            )),
+                            (sse, token, true),
+                        )),
                         Some(_) => Some((AssistantMessageEvent::error_network(
                             "network error: unexpected non-data SSE line",
                         ), (sse, token, true))),

--- a/adapters/src/sse.rs
+++ b/adapters/src/sse.rs
@@ -46,7 +46,17 @@ pub enum SseLine {
     Done,
     /// Empty line (event separator).
     Empty,
+    /// A transport-level error emitted when the underlying `reqwest`
+    /// byte stream yields an `Err`. Surfaces network failures so adapters
+    /// can classify them as retryable instead of misreporting them as a
+    /// clean EOF.
+    TransportError(String),
 }
+
+/// Synthetic event type that [`sse_paired_events`] emits when the upstream
+/// byte stream reports a transport error. Adapters consuming `SseEvent`
+/// should treat this as a terminal network error.
+pub const SSE_TRANSPORT_ERROR_EVENT: &str = "__swink_transport_error__";
 
 /// Streaming SSE parser that buffers bytes and yields parsed lines.
 ///
@@ -265,8 +275,20 @@ pub fn sse_lines(
                 }
 
                 if let Some(result) = stream.next().await {
-                    if let Ok(bytes) = result {
-                        pending.extend(parser.feed(&bytes));
+                    match result {
+                        Ok(bytes) => {
+                            pending.extend(parser.feed(&bytes));
+                        }
+                        Err(err) => {
+                            // Transport failure — flush any buffered content,
+                            // then append a terminal TransportError so downstream
+                            // adapters classify this as a network error instead
+                            // of a clean EOF.
+                            pending.extend(parser.flush());
+                            pending.push_back(SseLine::TransportError(format!(
+                                "SSE transport error: {err}"
+                            )));
+                        }
                     }
                     continue;
                 }
@@ -290,7 +312,10 @@ pub fn sse_data_lines_with_callback(
         |(mut stream, callback)| async move {
             loop {
                 if let Some(line) = stream.next().await {
-                    if !matches!(line, SseLine::Data(_) | SseLine::Done) {
+                    if !matches!(
+                        line,
+                        SseLine::Data(_) | SseLine::Done | SseLine::TransportError(_)
+                    ) {
                         continue;
                     }
                     if let (SseLine::Data(data), Some(cb)) = (&line, &callback) {
@@ -341,6 +366,15 @@ pub fn sse_paired_events(
                 match stream.next().await {
                     Some(SseLine::Empty | SseLine::Done) => {
                         current_event = None;
+                    }
+                    Some(SseLine::TransportError(message)) => {
+                        return Some((
+                            SseEvent {
+                                event_type: SSE_TRANSPORT_ERROR_EVENT.to_string(),
+                                data: message,
+                            },
+                            (stream, current_event),
+                        ));
                     }
                     Some(SseLine::Event(event_type)) => {
                         current_event = Some(event_type);
@@ -857,6 +891,54 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    /// Regression for issue #230 — transport errors from `reqwest::bytes_stream`
+    /// must surface as a terminal `SseLine::TransportError` rather than being
+    /// silently dropped as EOF. We spin up a TCP listener that writes a valid
+    /// HTTP/1.1 chunked-encoded response header + a partial chunk and then
+    /// closes the connection mid-body; `reqwest` surfaces that as an error on
+    /// its byte stream.
+    #[tokio::test]
+    async fn sse_lines_surfaces_transport_error() {
+        use tokio::io::AsyncWriteExt;
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            if let Ok((mut sock, _)) = listener.accept().await {
+                // Read + discard the request headers.
+                let mut buf = [0u8; 1024];
+                let _ = tokio::io::AsyncReadExt::read(&mut sock, &mut buf).await;
+                // Write a chunked response header and one partial chunk, then
+                // abruptly close the connection so reqwest's body stream errors.
+                let header = "HTTP/1.1 200 OK\r\n\
+                    Content-Type: text/event-stream\r\n\
+                    Transfer-Encoding: chunked\r\n\r\n\
+                    10\r\ndata: partial\n";
+                let _ = sock.write_all(header.as_bytes()).await;
+                // Drop the socket without finishing the chunk — reqwest will
+                // surface a transport-level error on its next byte-stream poll.
+                drop(sock);
+            }
+        });
+
+        let client = reqwest::Client::new();
+        let resp = client
+            .get(format!("http://{addr}/"))
+            .send()
+            .await
+            .expect("connect");
+        let lines: Vec<_> = sse_lines(resp.bytes_stream()).collect().await;
+
+        assert!(
+            lines
+                .iter()
+                .any(|l| matches!(l, SseLine::TransportError(_))),
+            "expected TransportError line, got {lines:?}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Shared SSE byte-stream reader (`sse_lines`) and Ollama's NDJSON reader both silently swallowed `reqwest::Error` from `bytes_stream()` and continued as if the stream had ended cleanly. Transport failures were misreported as unexpected EOF and lost their `StreamErrorKind::Network` classification, breaking retry.
- Transport failures now surface immediately as terminal, classified `AssistantMessageEvent::error_network(...)` events via the shared `classify` path.
- All SSE-backed adapters (`anthropic`, `openai_compat` → `openai`/`azure`/`mistral`/`xai`, `google`, `proxy`) and the Ollama NDJSON adapter now finalize any open blocks and emit a network error on transport failures.

## Implementation notes

- Added `SseLine::TransportError(String)` variant plus a `SSE_TRANSPORT_ERROR_EVENT` synthetic event type that `sse_paired_events` uses to forward transport errors to consumers of the paired-event API (Anthropic).
- `sse_data_lines_with_callback` passes `TransportError` through instead of filtering it out.
- `ollama::ndjson_lines` return type changed from `Stream<Item = String>` to `Stream<Item = Result<String, String>>`. `Err` is terminal; the parse loop emits a classified network error and finishes.

## API breaks

- **Adding the `SseLine::TransportError(String)` variant is a minor semver break** for any external code that matches `SseLine` exhaustively. The enum is documented as a shared internal utility with no stability contract, all internal matches use `Some(_)` wildcard fallbacks, and no external crates in this workspace consume it. Per the repo semver policy (post-0.x this would be a patch; pre-1.0 this is at most a minor bump), flagging here so the release notes can mention it.
- `ollama::ndjson_lines` is a crate-private helper — not part of the public API.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test --workspace --features testkit` (all green; also updated stale `ollama_duplicate_tool_calls_deduped` → `ollama_duplicate_tool_calls_preserved` to match commit 9a31888 / #213)
- [x] `cargo test -p swink-agent --no-default-features`
- [x] New regression tests spin up a real TCP listener that writes a partial chunked-HTTP body and drops the connection mid-response, forcing `reqwest::bytes_stream` to yield an `Err`:
  - `adapters::sse::tests::sse_lines_surfaces_transport_error`
  - `adapters::ollama::tests::ndjson_surfaces_transport_error`

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)