### PR TITLE
fix(core): preserve terminal error state through AgentEnd

### DIFF
--- a/src/agent/state_updates.rs
+++ b/src/agent/state_updates.rs
@@ -103,11 +103,15 @@ impl Agent {
                 for tr in tool_results {
                     msgs.push(AgentMessage::Llm(LlmMessage::ToolResult(tr.clone())));
                 }
+                // Capture terminal error so it survives through AgentEnd.
+                if let Some(ref err) = assistant_message.error_message {
+                    self.state.error = Some(err.clone());
+                }
             }
             AgentEvent::AgentEnd { messages } => {
                 self.state.messages = clone_llm_messages(messages.as_ref());
                 self.in_flight_llm_messages = None;
-                self.state.error = None;
+                // Preserve terminal error — do not clear self.state.error.
                 self.idle_notify.notify_waiters();
             }
             _ => {}

--- a/tests/agent_structured.rs
+++ b/tests/agent_structured.rs
@@ -8,7 +8,8 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use common::{
-    MockStreamFn, default_convert, default_model, text_only_events, tool_call_events, user_msg,
+    MockStreamFn, default_convert, default_model, error_events, text_only_events,
+    tool_call_events, user_msg,
 };
 use futures::stream::StreamExt;
 use serde_json::json;
@@ -359,5 +360,32 @@ async fn prompt_stream_without_handle_stream_event_stays_running() {
     assert!(
         matches!(err, Err(AgentError::AlreadyRunning)),
         "second prompt should fail with AlreadyRunning"
+    );
+}
+
+/// Regression test for #229: `handle_stream_event` must preserve terminal error
+/// state through `AgentEnd` instead of unconditionally clearing it.
+#[tokio::test]
+async fn handle_stream_event_preserves_terminal_error_through_agent_end() {
+    let stream_fn = Arc::new(MockStreamFn::new(vec![error_events(
+        "fatal error",
+        None,
+    )]));
+    let mut agent = make_agent(stream_fn);
+
+    let stream = agent.prompt_stream(vec![user_msg("trigger error")]).unwrap();
+    let mut stream = std::pin::pin!(stream);
+    while let Some(event) = stream.next().await {
+        agent.handle_stream_event(&event);
+    }
+
+    assert!(
+        !agent.state().is_running,
+        "agent should be idle after error stream completes"
+    );
+    assert_eq!(
+        agent.state().error.as_deref(),
+        Some("stream error: fatal error"),
+        "terminal error must survive through AgentEnd"
     );
 }


### PR DESCRIPTION
## Summary
- `handle_stream_event()` unconditionally cleared `state.error` on `AgentEnd`, hiding terminal errors from consumers using the event-driven API (e.g. TUI)
- Now captures `error_message` from `TurnEnd` into `state.error` and preserves it through `AgentEnd`, matching `collect_stream()` behavior
- Adds regression test verifying error survives the full event lifecycle

Closes #229

## Tasks completed
- [x] Capture `assistant_message.error_message` in `TurnEnd` handler
- [x] Remove unconditional `self.state.error = None` from `AgentEnd` handler
- [x] Add regression test `handle_stream_event_preserves_terminal_error_through_agent_end`

## Test plan
- [x] `cargo test -p swink-agent --features testkit --test agent_structured` — all 10 tests pass
- [x] `cargo clippy -p swink-agent --features testkit -- -D warnings` — zero warnings
- [ ] No public API breakage in downstream crates

🤖 Generated with [Claude Code](https://claude.com/claude-code)