### PR TITLE
fix(tooling): pass rewritten arguments to approval gate

### DIFF
--- a/src/loop_/tool_dispatch.rs
+++ b/src/loop_/tool_dispatch.rs
@@ -210,6 +210,7 @@ pub async fn execute_tools_concurrently(
             match check_approval(
                 approve_fn,
                 tc,
+                &effective_arguments,
                 idx,
                 requires_approval,
                 &tool_map,
@@ -515,9 +516,15 @@ enum ApprovalOutcome {
 }
 
 /// Run the approval gate for a single tool call: emit events, call callback, handle rejection.
+///
+/// `effective_arguments` are the post-rewrite arguments after pre-dispatch
+/// policies have been applied. These are shown to the approval callback so the
+/// approver sees the actual arguments that will be executed.
+#[allow(clippy::too_many_arguments)]
 async fn check_approval(
     approve_fn: &ApproveToolFn,
     tc: &ToolCallInfo,
+    effective_arguments: &serde_json::Value,
     idx: usize,
     requires_approval: bool,
     tool_map: &HashMap<&str, &Arc<dyn AgentTool>>,
@@ -529,7 +536,7 @@ async fn check_approval(
         AgentEvent::ToolApprovalRequested {
             id: tc.id.clone(),
             name: tc.name.clone(),
-            arguments: tc.arguments.clone(),
+            arguments: effective_arguments.clone(),
         },
     )
     .await
@@ -540,7 +547,7 @@ async fn check_approval(
     // Resolve approval context with panic safety.
     let approval_context = tool_map.get(tc.name.as_str()).and_then(|tool| {
         std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            tool.approval_context(&tc.arguments)
+            tool.approval_context(effective_arguments)
         }))
         .unwrap_or_else(|_| {
             tracing::warn!(tool_name = %tc.name, "approval_context() panicked — using None");
@@ -551,7 +558,7 @@ async fn check_approval(
     let request = ToolApprovalRequest {
         tool_call_id: tc.id.clone(),
         tool_name: tc.name.clone(),
-        arguments: tc.arguments.clone(),
+        arguments: effective_arguments.clone(),
         requires_approval,
         context: approval_context,
     };

--- a/tests/approval.rs
+++ b/tests/approval.rs
@@ -14,7 +14,8 @@ use tokio_util::sync::CancellationToken;
 
 use swink_agent::{
     Agent, AgentEvent, AgentMessage, AgentOptions, AgentTool, AgentToolResult, ApprovalMode,
-    AssistantMessageEvent, ContentBlock, Cost, LlmMessage, StopReason, ToolApproval, Usage,
+    AssistantMessageEvent, ContentBlock, Cost, LlmMessage, PreDispatchPolicy, PreDispatchVerdict,
+    StopReason, ToolApproval, ToolApprovalRequest, ToolDispatchContext, Usage,
 };
 
 // ─── Helpers ─────────────────────────────────────────────────────────────
@@ -426,4 +427,85 @@ async fn approval_request_carries_requires_approval_field() {
     let _ = agent.prompt_async(vec![user_msg("hello")]).await.unwrap();
 
     assert_eq!(*captured.lock().unwrap(), Some(true));
+}
+
+// ─── Regression: approval sees post-rewrite arguments (#227) ────────────
+
+/// A pre-dispatch policy that rewrites tool arguments.
+struct RewriteArgsPolicy;
+
+impl PreDispatchPolicy for RewriteArgsPolicy {
+    fn name(&self) -> &str {
+        "rewrite-args"
+    }
+
+    fn evaluate(&self, ctx: &mut ToolDispatchContext<'_>) -> PreDispatchVerdict {
+        // Inject a "rewritten" key so the approval callback can detect it.
+        if let Some(obj) = ctx.arguments.as_object_mut() {
+            obj.insert("injected_by_policy".to_string(), json!(true));
+        }
+        PreDispatchVerdict::Continue
+    }
+}
+
+/// Test 14: Approval callback sees rewritten arguments after pre-dispatch policy,
+/// not the original arguments from the LLM.
+#[tokio::test]
+async fn approval_sees_post_rewrite_arguments() {
+    let tool = Arc::new(MockTool::new("test_tool"));
+    let captured_args: Arc<Mutex<Option<Value>>> = Arc::new(Mutex::new(None));
+    let cap = Arc::clone(&captured_args);
+
+    let responses = tool_call_then_stop("tc1", "test_tool", r#"{"original": true}"#);
+    let options = make_agent(responses, vec![tool])
+        .with_pre_dispatch_policy(RewriteArgsPolicy)
+        .with_approve_tool(move |req: ToolApprovalRequest| {
+            *cap.lock().unwrap() = Some(req.arguments.clone());
+            Box::pin(async { ToolApproval::Approved })
+        });
+    let mut agent = Agent::new(options);
+
+    let result = agent.prompt_async(vec![user_msg("hello")]).await.unwrap();
+    assert!(result.error.is_none());
+
+    let args = captured_args.lock().unwrap().take().expect("approval callback should have been called");
+    assert_eq!(
+        args.get("injected_by_policy"),
+        Some(&json!(true)),
+        "approval must see arguments after pre-dispatch rewrite"
+    );
+    assert_eq!(
+        args.get("original"),
+        Some(&json!(true)),
+        "original arguments should still be present"
+    );
+}
+
+/// Test 15: ToolApprovalRequested event carries rewritten arguments.
+#[tokio::test]
+async fn approval_event_carries_rewritten_arguments() {
+    let tool = Arc::new(MockTool::new("test_tool"));
+    let event_args: Arc<Mutex<Option<Value>>> = Arc::new(Mutex::new(None));
+
+    let responses = tool_call_then_stop("tc1", "test_tool", r#"{"original": true}"#);
+    let options = make_agent(responses, vec![tool])
+        .with_pre_dispatch_policy(RewriteArgsPolicy)
+        .with_approve_tool(|_req| Box::pin(async { ToolApproval::Approved }));
+    let mut agent = Agent::new(options);
+
+    let captured = Arc::clone(&event_args);
+    agent.subscribe(move |event| {
+        if let AgentEvent::ToolApprovalRequested { arguments, .. } = event {
+            *captured.lock().unwrap() = Some(arguments.clone());
+        }
+    });
+
+    let _result = agent.prompt_async(vec![user_msg("hello")]).await.unwrap();
+
+    let args = event_args.lock().unwrap().take().expect("ToolApprovalRequested event should have fired");
+    assert_eq!(
+        args.get("injected_by_policy"),
+        Some(&json!(true)),
+        "ToolApprovalRequested event must carry post-rewrite arguments"
+    );
 }


### PR DESCRIPTION
## Summary
- Pre-dispatch policies can rewrite tool-call arguments, but `check_approval()` was passing the original `tc.arguments` to the approval callback, `ToolApprovalRequested` event, and `approval_context()`. This broke the approval contract: a human could approve one argument set while execution used another.
- Thread `effective_arguments` into `check_approval()` so all three sites use the post-rewrite payload.

Fixes #227
Fixes #226 (duplicate)

## Test plan
- [x] Two new regression tests in `tests/approval.rs`:
  - `approval_sees_post_rewrite_arguments` — verifies the `ToolApprovalRequest.arguments` field contains the rewritten args
  - `approval_event_carries_rewritten_arguments` — verifies the `ToolApprovalRequested` event carries rewritten args
- [x] `cargo test -p swink-agent --test approval --features testkit` — 15/15 pass
- [x] `cargo clippy -p swink-agent --features testkit -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)