### PR TITLE
fix(tui): use event tool ID for concurrent completion tracking

### DIFF
--- a/src/loop_/event.rs
+++ b/src/loop_/event.rs
@@ -102,6 +102,7 @@ pub enum AgentEvent {
 
     /// Emitted when a tool call completes.
     ToolExecutionEnd {
+        id: String,
         result: AgentToolResult,
         is_error: bool,
     },

--- a/src/loop_/tool_dispatch.rs
+++ b/src/loop_/tool_dispatch.rs
@@ -41,6 +41,7 @@ async fn emit_error_result(
     let _ = emit(
         tx,
         AgentEvent::ToolExecutionEnd {
+            id: tool_call_id.to_string(),
             result: error_result.clone(),
             is_error: true,
         },
@@ -691,6 +692,7 @@ async fn dispatch_single_tool(
             let _ = emit(
                 &tx_clone,
                 AgentEvent::ToolExecutionEnd {
+                    id: tool_call_id.clone(),
                     result: result.clone(),
                     is_error,
                 },

--- a/tests/agent_event_serde.rs
+++ b/tests/agent_event_serde.rs
@@ -142,6 +142,7 @@ fn all_agent_event_variants_serialize_to_json() {
         (
             "ToolExecutionEnd",
             AgentEvent::ToolExecutionEnd {
+                id: "tc1".into(),
                 result: AgentToolResult::text("done"),
                 is_error: false,
             },
@@ -426,6 +427,7 @@ fn agent_event_roundtrip_all_variants() {
         (
             "ToolExecutionEnd",
             AgentEvent::ToolExecutionEnd {
+                id: "tc1".into(),
                 result: AgentToolResult::text("done"),
                 is_error: false,
             },

--- a/tui/src/app/agent_bridge.rs
+++ b/tui/src/app/agent_bridge.rs
@@ -138,11 +138,8 @@ impl App {
             AgentEvent::ToolExecutionStart { id, name, .. } => {
                 self.tool_panel.start_tool(id, name);
             }
-            AgentEvent::ToolExecutionEnd { is_error, .. } => {
-                if let Some(tool) = self.tool_panel.active.last() {
-                    let id = tool.id.clone();
-                    self.tool_panel.end_tool(&id, is_error);
-                }
+            AgentEvent::ToolExecutionEnd { id, is_error, .. } => {
+                self.tool_panel.end_tool(&id, is_error);
             }
             AgentEvent::TurnEnd { tool_results, .. } => {
                 for result in &tool_results {

--- a/tui/src/ui/tool_panel.rs
+++ b/tui/src/ui/tool_panel.rs
@@ -411,6 +411,41 @@ mod tests {
     }
 
     #[test]
+    fn end_tool_out_of_order_concurrent() {
+        let mut panel = ToolPanel::new();
+        panel.start_tool("t1".into(), "bash".into());
+        panel.start_tool("t2".into(), "read_file".into());
+        panel.start_tool("t3".into(), "write_file".into());
+
+        // Complete in reverse order (t3, t1, t2)
+        panel.end_tool("t3", false);
+        assert_eq!(panel.active.len(), 2);
+        assert_eq!(panel.completed.len(), 1);
+        assert_eq!(panel.completed[0].id, "t3");
+        assert_eq!(panel.completed[0].name, "write_file");
+
+        panel.end_tool("t1", true);
+        assert_eq!(panel.active.len(), 1);
+        assert_eq!(panel.completed.len(), 2);
+        assert_eq!(panel.completed[1].id, "t1");
+        assert!(panel.completed[1].is_error);
+
+        panel.end_tool("t2", false);
+        assert!(panel.active.is_empty());
+        assert_eq!(panel.completed.len(), 3);
+        assert_eq!(panel.completed[2].id, "t2");
+    }
+
+    #[test]
+    fn end_tool_unknown_id_is_noop() {
+        let mut panel = ToolPanel::new();
+        panel.start_tool("t1".into(), "bash".into());
+        panel.end_tool("nonexistent", false);
+        assert_eq!(panel.active.len(), 1);
+        assert!(panel.completed.is_empty());
+    }
+
+    #[test]
     fn height_capped_at_max() {
         let mut panel = ToolPanel::new();
         for i in 0..20 {


### PR DESCRIPTION
## Summary
- Add missing `id` field to `ToolExecutionEnd` event variant (aligning with the spec's `call_id` contract)
- Thread tool call ID through both emit sites in `tool_dispatch.rs`
- Fix TUI bridge to use the event's `id` instead of `active.last()`, which misattributed completions during concurrent tool execution

## Test plan
- [x] `cargo test -p swink-agent-tui` passes (21 tests including 2 new regression tests)
- [x] `cargo test -p swink-agent --test agent_event_serde --features testkit` passes (13 tests)
- [x] `cargo clippy -p swink-agent -p swink-agent-tui -p swink-agent-adapters -- -D warnings` clean
- [x] Pre-existing `max_tokens_recovery` failure (issue #221 / PR #244) is unrelated

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)