### PR TITLE
fix(tui): gate internal modules behind cli feature (#211)

### DIFF
--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/lib.rs"
 [[bin]]
 name = "swink"
 path = "src/main.rs"
+required-features = ["cli"]
 
 [dependencies]
 swink-agent = { path = ".." }
@@ -41,8 +42,9 @@ dotenvy.workspace = true
 thiserror.workspace = true
 
 [features]
-default = []
-full = ["local"]
+default = ["cli"]
+cli = []
+full = ["local", "cli"]
 local = ["dep:swink-agent-local-llm"]
 
 [dev-dependencies]

--- a/tui/src/lib.rs
+++ b/tui/src/lib.rs
@@ -15,10 +15,17 @@ pub mod app;
 pub mod config;
 pub mod error;
 
-#[doc(hidden)]
+#[cfg(feature = "cli")]
 pub mod credentials;
-#[doc(hidden)]
+#[cfg(not(feature = "cli"))]
+#[allow(dead_code)]
+mod credentials;
+
+#[cfg(feature = "cli")]
 pub mod wizard;
+#[cfg(not(feature = "cli"))]
+#[allow(dead_code)]
+mod wizard;
 
 use crossterm::{
     event::{DisableMouseCapture, EnableMouseCapture},

--- a/tui/tests/ac_tui.rs
+++ b/tui/tests/ac_tui.rs
@@ -13,6 +13,24 @@ use swink_agent_tui::app::{AgentStatus, DisplayMessage, MessageRole, OperatingMo
 use swink_agent_tui::config::TuiConfig;
 
 // ---------------------------------------------------------------------------
+// Regression: credentials and wizard modules are gated behind `cli` feature
+// (issue #211). With default features (which include `cli`), these modules
+// should be publicly accessible.
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "cli")]
+#[test]
+fn credentials_module_accessible_with_cli_feature() {
+    // Verify the module is reachable — calling `providers()` exercises the
+    // public re-export without side effects (no keychain access required).
+    let providers = swink_agent_tui::credentials::providers();
+    assert!(
+        !providers.is_empty(),
+        "providers() should return at least one entry"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Gates `credentials` and `wizard` modules behind a new default-enabled `cli` feature, replacing `#[doc(hidden)] pub` with proper conditional compilation
- Library consumers using `default-features = false` now get a clean public API surface without internal types leaking
- Binary target (`swink`) requires the `cli` feature via `required-features`

Closes #211

## Test plan
- [x] `cargo test -p swink-agent-tui` — all 302 tests pass
- [x] `cargo clippy -p swink-agent-tui -- -D warnings` clean
- [x] `cargo check -p swink-agent-tui --no-default-features` — lib compiles without cli feature
- [x] `cargo clippy -p swink-agent-tui --no-default-features -- -D warnings` clean
- [x] Regression test verifies credentials module is accessible with cli feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)