### PR TITLE
fix(core): keep agent running until loop drains after pause()

### DIFF
--- a/src/agent/checkpointing.rs
+++ b/src/agent/checkpointing.rs
@@ -103,6 +103,12 @@ impl Agent {
     /// checkpoint. The checkpoint can later be passed to [`resume`](Self::resume)
     /// to continue the loop from where it left off.
     ///
+    /// The agent remains in the **running** state until the loop fully drains
+    /// and emits `AgentEnd`. Callers should either consume the remaining stream
+    /// events (via [`handle_stream_event`](Self::handle_stream_event) or by
+    /// awaiting the `prompt_async` future) or call [`wait_for_idle`](Self::wait_for_idle)
+    /// before starting a new run.
+    ///
     /// Returns `None` if the agent is not currently running.
     pub fn pause(&mut self) -> Option<crate::checkpoint::LoopCheckpoint> {
         if !self.state.is_running {
@@ -131,9 +137,11 @@ impl Agent {
         }
         drop(s);
 
-        self.state.is_running = false;
-        self.abort_controller = None;
-        self.idle_notify.notify_waiters();
+        // Do NOT mark idle here. The spawned loop task is still running
+        // asynchronously and may emit events until it reaches `AgentEnd`.
+        // The `is_running` flag and idle notification are handled by the
+        // normal loop-completion paths (`collect_stream`, `handle_stream_event`,
+        // and `update_state_from_event`).
 
         Some(checkpoint)
     }

--- a/tests/pause_resume.rs
+++ b/tests/pause_resume.rs
@@ -195,3 +195,45 @@ fn loop_checkpoint_to_standard_checkpoint_integration() {
     assert_eq!(standard.system_prompt, "sys");
     assert_eq!(standard.messages.len(), 1);
 }
+
+#[tokio::test]
+async fn pause_keeps_running_until_loop_drains() {
+    use futures::StreamExt;
+
+    let mut agent = simple_agent(vec![text_only_events("hello")]);
+
+    let mut stream = agent.prompt_stream(vec![user_msg("hi")]).unwrap();
+    assert!(agent.state().is_running, "agent should be running after prompt_stream");
+
+    let checkpoint = agent.pause();
+    assert!(checkpoint.is_some(), "pause should return a checkpoint");
+
+    // After pause(), the agent must still report as running until the loop
+    // fully drains and emits AgentEnd.
+    assert!(
+        agent.state().is_running,
+        "agent must remain running after pause() until the loop emits AgentEnd"
+    );
+
+    // A new run must be rejected while the old loop is still draining.
+    let err = agent.prompt_stream(vec![user_msg("too early")]);
+    assert!(
+        matches!(err, Err(swink_agent::AgentError::AlreadyRunning)),
+        "starting a new run before drain completes must fail"
+    );
+
+    // Consume the remaining stream events to let the loop finish.
+    while let Some(event) = stream.next().await {
+        agent.handle_stream_event(&event);
+    }
+
+    // Now the agent should be idle.
+    assert!(
+        !agent.state().is_running,
+        "agent should be idle after stream is fully consumed"
+    );
+
+    // A new run should succeed now.
+    let result = agent.prompt_stream(vec![user_msg("after drain")]);
+    assert!(result.is_ok(), "new run should succeed after drain completes");
+}


### PR DESCRIPTION
## Summary
- `pause()` previously set `is_running=false` and notified idle waiters immediately, before the spawned loop task finished emitting events. This allowed a caller to start a new run while the old one was still draining, creating a state race.
- Removed the premature state cleanup from `pause()`. The normal loop completion paths (`collect_stream`, `handle_stream_event`, `update_state_from_event` on `AgentEnd`) already handle marking the agent idle after the loop fully terminates.

Closes #228

## Tasks completed
- Removed premature `is_running = false`, `abort_controller = None`, and `idle_notify.notify_waiters()` from `pause()`
- Updated `pause()` doc comments to explain the draining behavior
- Added regression test `pause_keeps_running_until_loop_drains`

## Test plan
- [x] `cargo test -p swink-agent --test pause_resume --features testkit` — all 9 tests pass
- [x] `cargo clippy -p swink-agent -- -D warnings` — clean
- [x] No public API breakage (method signature unchanged, behavior is now correct)
- [x] Pre-existing `max_tokens_recovery` failure in `agent_loop.rs` is unrelated (also fails on `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)