### PR TITLE
fix: stop workspace crates from leaking default features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7273,8 +7273,6 @@ dependencies = [
  "serde",
  "serde_json",
  "swink-agent-adapters",
- "swink-agent-local-llm",
- "swink-agent-tui",
  "tempfile",
  "thiserror 2.0.18",
  "tiktoken-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,9 +104,7 @@ name = "context"
 harness = false
 
 [dev-dependencies]
-swink-agent-adapters = { path = "adapters" }
-swink-agent-local-llm = { path = "local-llm" }
-swink-agent-tui = { path = "tui" }
+swink-agent-adapters = { path = "adapters", features = ["proxy"] }
 dotenvy.workspace = true
 pretty_assertions.workspace = true
 tempfile.workspace = true

--- a/adapters/Cargo.toml
+++ b/adapters/Cargo.toml
@@ -29,7 +29,7 @@ mistral = []
 xai = ["openai"]
 
 [dependencies]
-swink-agent = { path = ".." }
+swink-agent = { path = "..", default-features = false }
 reqwest.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true

--- a/artifacts/Cargo.toml
+++ b/artifacts/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 repository = "https://github.com/SuperSwinkAI/Swink-Agent"
 
 [dependencies]
-swink-agent = { path = "..", features = ["artifact-store"] }
+swink-agent = { path = "..", default-features = false, features = ["artifact-store"] }
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/auth/Cargo.toml
+++ b/auth/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 repository = "https://github.com/SuperSwinkAI/Swink-Agent"
 
 [dependencies]
-swink-agent = { path = ".." }
+swink-agent = { path = "..", default-features = false }
 reqwest.workspace = true
 chrono.workspace = true
 serde.workspace = true

--- a/eval/Cargo.toml
+++ b/eval/Cargo.toml
@@ -15,7 +15,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-swink-agent = { path = ".." }
+swink-agent = { path = "..", default-features = false }
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
@@ -32,7 +32,7 @@ serde_yaml = { workspace = true, optional = true }
 yaml = ["serde_yaml"]
 
 [dev-dependencies]
-swink-agent = { path = "..", features = ["testkit"] }
+swink-agent = { path = "..", default-features = false, features = ["testkit"] }
 tempfile.workspace = true
 tokio = { workspace = true, features = ["full", "test-util"] }
 pretty_assertions.workspace = true

--- a/local-llm/Cargo.toml
+++ b/local-llm/Cargo.toml
@@ -24,7 +24,7 @@ mkl = ["mistralrs/mkl"]
 accelerate = ["mistralrs/accelerate"]
 
 [dependencies]
-swink-agent = { path = ".." }
+swink-agent = { path = "..", default-features = false }
 mistralrs = "0.8"
 hf-hub = { version = "0.5", features = ["tokio"] }
 tokio.workspace = true
@@ -38,7 +38,7 @@ tracing.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
-swink-agent = { path = "..", features = ["testkit"] }
+swink-agent = { path = "..", default-features = false, features = ["testkit"] }
 tokio = { workspace = true, features = ["full", "test-util"] }
 pretty_assertions.workspace = true
 

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -16,7 +16,7 @@ quote = "1"
 proc-macro2 = "1"
 
 [dev-dependencies]
-swink-agent = { path = ".." }
+swink-agent = { path = "..", default-features = false }
 schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/SuperSwinkAI/Swink-Agent"
 keywords = ["llm", "agent", "mcp", "tools", "protocol"]
 
 [dependencies]
-swink-agent = { path = ".." }
+swink-agent = { path = "..", default-features = false }
 rmcp = { version = "1.3", features = ["client", "client-side-sse", "transport-streamable-http-client", "transport-streamable-http-client-reqwest", "transport-child-process"] }
 reqwest = { workspace = true }
 tokio.workspace = true
@@ -21,7 +21,7 @@ tracing.workspace = true
 
 [dev-dependencies]
 rmcp = { version = "1.3", features = ["client", "server", "macros", "client-side-sse", "transport-streamable-http-client", "transport-streamable-http-client-reqwest", "transport-child-process", "transport-streamable-http-server"] }
-swink-agent = { path = ".." }
+swink-agent = { path = "..", default-features = false }
 tokio = { workspace = true, features = ["full", "test-util"] }
 tokio-util = { workspace = true }
 serde.workspace = true

--- a/memory/Cargo.toml
+++ b/memory/Cargo.toml
@@ -15,7 +15,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-swink-agent = { path = ".." }
+swink-agent = { path = "..", default-features = false }
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/patterns/Cargo.toml
+++ b/patterns/Cargo.toml
@@ -11,7 +11,7 @@ pipelines = []
 testkit = ["swink-agent/testkit"]
 
 [dependencies]
-swink-agent = { path = ".." }
+swink-agent = { path = "..", default-features = false }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 serde = { workspace = true }

--- a/plugins/web/Cargo.toml
+++ b/plugins/web/Cargo.toml
@@ -15,7 +15,7 @@ all = ["duckduckgo", "brave", "tavily"]
 integration = []
 
 [dependencies]
-swink-agent = { path = "../..", features = ["plugins"] }
+swink-agent = { path = "../..", default-features = false, features = ["plugins"] }
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/policies/Cargo.toml
+++ b/policies/Cargo.toml
@@ -24,7 +24,7 @@ content-filter = ["regex"]
 audit = ["chrono", "serde", "serde_json", "unicode-truncate"]
 
 [dependencies]
-swink-agent = { path = ".." }
+swink-agent = { path = "..", default-features = false }
 regex = { version = "1", optional = true }
 chrono = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
@@ -34,7 +34,7 @@ tracing = { workspace = true }
 unicode-truncate = { version = "2", optional = true }
 
 [dev-dependencies]
-swink-agent = { path = "..", features = ["testkit"] }
+swink-agent = { path = "..", default-features = false, features = ["testkit"] }
 futures = { workspace = true }
 serde_json = { workspace = true }
 tempfile = { workspace = true }

--- a/tests/no_default_features.rs
+++ b/tests/no_default_features.rs
@@ -1,0 +1,39 @@
+//! Regression test for issue #205: `--no-default-features` must not re-enable
+//! `builtin-tools` or `transfer` through dev-dependency feature unification.
+//!
+//! This file compiles under `cargo test -p swink-agent --no-default-features`.
+//! If a dev-dependency leaks those features back in, the `#[cfg]` assertions
+//! below will fail at compile time, catching the regression immediately.
+
+/// When `builtin-tools` is genuinely disabled, `BashTool` must not exist.
+#[cfg(not(feature = "builtin-tools"))]
+#[test]
+fn builtin_tools_feature_is_off() {
+    // If this file compiles, the feature is truly absent.
+    // A leaking dev-dep would re-enable it, making this test vanish from the
+    // `--no-default-features` run and the companion assertion below fire instead.
+}
+
+/// Safety net: if `builtin-tools` IS enabled during a `--no-default-features`
+/// test run, something is leaking features.
+#[cfg(feature = "builtin-tools")]
+#[test]
+fn builtin_tools_must_not_leak_into_no_default_features() {
+    panic!(
+        "builtin-tools feature is enabled but should not be. \
+         A dev-dependency is likely leaking features via Cargo unification."
+    );
+}
+
+#[cfg(not(feature = "transfer"))]
+#[test]
+fn transfer_feature_is_off() {}
+
+#[cfg(feature = "transfer")]
+#[test]
+fn transfer_must_not_leak_into_no_default_features() {
+    panic!(
+        "transfer feature is enabled but should not be. \
+         A dev-dependency is likely leaking features via Cargo unification."
+    );
+}

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -5,7 +5,6 @@ use swink_agent::{
 #[cfg(feature = "builtin-tools")]
 use swink_agent::{BashTool, ReadFileTool, WriteFileTool};
 use swink_agent_adapters::ProxyStreamFn;
-use swink_agent_tui::{App, TuiConfig};
 
 #[test]
 fn top_level_reexports_remain_consumable() {
@@ -16,7 +15,6 @@ fn top_level_reexports_remain_consumable() {
     let _retry_type = std::any::type_name::<DefaultRetryStrategy>();
     let _retry_trait = std::any::type_name::<dyn RetryStrategy>();
     let _proxy = ProxyStreamFn::new("https://example.com", "token");
-    let _: fn(TuiConfig) -> App = App::new;
     let _tool_approval_type = std::any::type_name::<ToolApproval>();
     let _tool_request_type = std::any::type_name::<ToolApprovalRequest>();
     let _agent_error_type = std::any::type_name::<AgentError>();

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/main.rs"
 required-features = ["cli"]
 
 [dependencies]
-swink-agent = { path = ".." }
+swink-agent = { path = "..", default-features = false, features = ["builtin-tools", "transfer"] }
 swink-agent-adapters = { path = "../adapters", default-features = false, features = ["anthropic", "openai", "ollama", "proxy"] }
 swink-agent-memory = { path = "../memory" }
 swink-agent-local-llm = { path = "../local-llm", optional = true }
@@ -48,7 +48,7 @@ full = ["local", "cli"]
 local = ["dep:swink-agent-local-llm"]
 
 [dev-dependencies]
-swink-agent = { path = "..", features = ["testkit"] }
+swink-agent = { path = "..", default-features = false, features = ["testkit"] }
 tempfile.workspace = true
 tokio-util.workspace = true
 

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -47,6 +47,10 @@ cli = []
 full = ["local", "cli"]
 local = ["dep:swink-agent-local-llm"]
 
+[[example]]
+name = "custom_agent"
+required-features = ["local"]
+
 [dev-dependencies]
 swink-agent = { path = "..", default-features = false, features = ["testkit"] }
 tempfile.workspace = true

--- a/tui/examples/custom_agent.rs
+++ b/tui/examples/custom_agent.rs
@@ -4,7 +4,7 @@
 //! and `swink-agent-tui` as external crates — the same code you'd write in your
 //! own project after `cargo add`ing the three crates.
 //!
-//! Run: `cargo run --example custom_agent`
+//! Run: `cargo run -p swink-agent-tui --features local --example custom_agent`
 //! Requires: remote provider keys in `.env` or environment. The local SmolLM3-3B
 //! model is always available and is included in the F4 cycle by default.
 

--- a/tui/tests/public_api.rs
+++ b/tui/tests/public_api.rs
@@ -1,0 +1,6 @@
+use swink_agent_tui::{App, TuiConfig};
+
+#[test]
+fn tui_reexports_remain_consumable() {
+    let _: fn(TuiConfig) -> App = App::new;
+}

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.88"
 publish = false
 
 [dependencies]
-swink-agent = { path = ".." }
+swink-agent = { path = "..", default-features = false }
 clap = { version = "4", features = ["derive"] }
 futures.workspace = true
 reqwest = { workspace = true, features = ["json", "query"] }


### PR DESCRIPTION
## Summary
- All 13 workspace crates depended on `swink-agent` with default features enabled, so Cargo's feature unification re-activated `builtin-tools` and `transfer` even when `--no-default-features` was passed — making that CI check a false signal
- Added `default-features = false` to every workspace member's `swink-agent` dependency
- TUI explicitly declares the features it needs (`builtin-tools`, `transfer`); all other crates need neither

Closes #205

## Test plan
- [x] `cargo check -p swink-agent --no-default-features` — compiles without builtin-tools/transfer
- [x] `cargo check --workspace` — full workspace compiles
- [x] `cargo test -p swink-agent --no-default-features --lib` — 319 tests pass
- [x] `cargo test --workspace --features testkit` — passes (only pre-existing `max_tokens_recovery` failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)