### PR TITLE
fix(core): keep agent running until loop stream is dropped or drained

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -26,6 +26,7 @@ mod state_updates;
 mod structured_output;
 
 use std::collections::{HashSet, VecDeque};
+use std::sync::atomic::{AtomicBool, AtomicU64};
 use std::sync::{Arc, Mutex};
 
 use tokio::sync::Notify;
@@ -189,6 +190,15 @@ pub struct Agent {
     cache_config: Option<crate::context_cache::CacheConfig>,
     /// Optional dynamic system prompt.
     dynamic_system_prompt: Option<Arc<dyn Fn() -> String + Send + Sync>>,
+    /// Shared flag: true while a spawned loop task is active. Set to false by
+    /// the `LoopGuardStream` wrapper on drop or by `collect_stream`/`AgentEnd`.
+    /// Used by `check_not_running` and `wait_for_idle` as the ground truth for
+    /// whether a loop is still in progress (instead of `state.is_running` which
+    /// may lag on the stream-drop path).
+    loop_active: Arc<AtomicBool>,
+    /// Monotonically increasing counter bumped on each `start_loop`. Prevents a
+    /// stale `LoopGuardStream` from clearing `loop_active` for a newer run.
+    loop_generation: Arc<AtomicU64>,
     /// Registered plugins retained for runtime introspection (priority-sorted).
     #[cfg(feature = "plugins")]
     plugins: Vec<Arc<dyn crate::plugin::Plugin>>,
@@ -282,6 +292,8 @@ impl Agent {
             credential_resolver: options.credential_resolver,
             cache_config: options.cache_config,
             dynamic_system_prompt: options.dynamic_system_prompt.map(Arc::from),
+            loop_active: Arc::new(AtomicBool::new(false)),
+            loop_generation: Arc::new(AtomicU64::new(0)),
             #[cfg(feature = "plugins")]
             plugins: options.plugins,
         };
@@ -318,9 +330,23 @@ impl Agent {
     }
 
     /// Access the current agent state.
+    ///
+    /// Note: [`AgentState::is_running`] may lag behind the true loop lifecycle
+    /// after a stream is dropped. Use [`Agent::is_running`] for an accurate
+    /// real-time check.
     #[must_use]
     pub const fn state(&self) -> &AgentState {
         &self.state
+    }
+
+    /// Returns whether a loop is currently active.
+    ///
+    /// This reads an atomic flag that is cleared immediately when the event
+    /// stream is dropped or drained to `AgentEnd`, making it accurate even in
+    /// the window between dropping a stream and the next `&mut self` call.
+    #[must_use]
+    pub fn is_running(&self) -> bool {
+        self.loop_active.load(std::sync::atomic::Ordering::Acquire)
     }
 
     /// Access the session key-value state (thread-safe, shared reference).

--- a/src/agent/checkpointing.rs
+++ b/src/agent/checkpointing.rs
@@ -1,5 +1,7 @@
-use futures::Stream;
 use std::pin::Pin;
+use std::sync::atomic::Ordering;
+
+use futures::Stream;
 
 use crate::checkpoint::{Checkpoint, CheckpointStore};
 use crate::error::AgentError;
@@ -103,9 +105,14 @@ impl Agent {
     /// checkpoint. The checkpoint can later be passed to [`resume`](Self::resume)
     /// to continue the loop from where it left off.
     ///
+    /// The agent remains in the *running* state after this call. It becomes idle
+    /// when the caller either drains the event stream to completion or drops the
+    /// stream returned by [`prompt_stream`](Self::prompt_stream). This prevents a
+    /// new run from starting while the previous loop is still tearing down.
+    ///
     /// Returns `None` if the agent is not currently running.
     pub fn pause(&mut self) -> Option<crate::checkpoint::LoopCheckpoint> {
-        if !self.state.is_running {
+        if !self.loop_active.load(Ordering::Acquire) {
             return None;
         }
 
@@ -131,9 +138,10 @@ impl Agent {
         }
         drop(s);
 
-        self.state.is_running = false;
-        self.abort_controller = None;
-        self.idle_notify.notify_waiters();
+        // Do NOT clear is_running / abort_controller / notify idle here.
+        // The agent stays "running" until the LoopGuardStream is dropped or
+        // the stream is drained to AgentEnd, which guarantees the spawned loop
+        // task has finished using the channel before a new run can start.
 
         Some(checkpoint)
     }

--- a/src/agent/control.rs
+++ b/src/agent/control.rs
@@ -1,5 +1,6 @@
 use std::future::Future;
 use std::sync::Arc;
+use std::sync::atomic::Ordering;
 
 use tracing::info;
 
@@ -18,6 +19,7 @@ impl Agent {
     pub fn reset(&mut self) {
         self.state.messages.clear();
         self.state.is_running = false;
+        self.loop_active.store(false, Ordering::Release);
         self.state.stream_message = None;
         self.state.pending_tool_calls.clear();
         self.state.error = None;
@@ -27,10 +29,14 @@ impl Agent {
     }
 
     /// Returns a future that resolves when the agent is no longer running.
+    ///
+    /// Uses the shared `loop_active` flag so the future correctly resolves even
+    /// when the event stream is dropped without being drained to `AgentEnd`.
     pub fn wait_for_idle(&self) -> impl Future<Output = ()> + Send + '_ {
         let notify = Arc::clone(&self.idle_notify);
+        let active = Arc::clone(&self.loop_active);
         async move {
-            if !self.state.is_running {
+            if !active.load(Ordering::Acquire) {
                 return;
             }
             notify.notified().await;

--- a/src/agent/invoke.rs
+++ b/src/agent/invoke.rs
@@ -1,7 +1,10 @@
 use std::pin::Pin;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::task::{Context, Poll};
 
 use futures::Stream;
+use tokio::sync::Notify;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
@@ -14,6 +17,41 @@ use crate::util::now_timestamp;
 
 use super::queueing::QueueMessageProvider;
 use super::{Agent, SharedRetryStrategy};
+
+// ─── LoopGuardStream ────────────────────────────────────────────────────────
+
+/// Wrapper stream that clears the agent's `loop_active` flag when dropped.
+///
+/// This ensures the agent becomes idle even if the caller drops the stream
+/// without draining it to `AgentEnd`. A generation counter prevents a stale
+/// guard from clearing the flag for a newer run.
+struct LoopGuardStream {
+    inner: Pin<Box<dyn Stream<Item = AgentEvent> + Send>>,
+    loop_active: Arc<AtomicBool>,
+    idle_notify: Arc<Notify>,
+    generation: u64,
+    expected_generation: Arc<AtomicU64>,
+}
+
+impl Stream for LoopGuardStream {
+    type Item = AgentEvent;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.inner.as_mut().poll_next(cx)
+    }
+}
+
+impl Drop for LoopGuardStream {
+    fn drop(&mut self) {
+        // Only clear loop_active if this guard belongs to the current run.
+        // A newer start_loop will have incremented loop_generation, making
+        // this guard's generation stale.
+        if self.expected_generation.load(Ordering::Acquire) == self.generation {
+            self.loop_active.store(false, Ordering::Release);
+            self.idle_notify.notify_waiters();
+        }
+    }
+}
 
 impl Agent {
     /// Start a new loop with input messages, returning an event stream.
@@ -157,8 +195,12 @@ impl Agent {
         })
     }
 
-    pub(super) const fn check_not_running(&self) -> Result<(), AgentError> {
-        if self.state.is_running {
+    pub(super) fn check_not_running(&mut self) -> Result<(), AgentError> {
+        // Synchronise the observable `state.is_running` from the atomic ground
+        // truth so callers that inspect `agent.state()` see an up-to-date value.
+        let active = self.loop_active.load(Ordering::Acquire);
+        self.state.is_running = active;
+        if active {
             return Err(AgentError::AlreadyRunning);
         }
         Ok(())
@@ -185,6 +227,8 @@ impl Agent {
     ) -> Result<Pin<Box<dyn Stream<Item = AgentEvent> + Send>>, AgentError> {
         self.state.is_running = true;
         self.state.error = None;
+        self.loop_active.store(true, Ordering::Release);
+        let generation = self.loop_generation.fetch_add(1, Ordering::AcqRel) + 1;
 
         let token = CancellationToken::new();
         self.abort_controller = Some(token.clone());
@@ -219,7 +263,15 @@ impl Agent {
 
         self.in_flight_llm_messages = Some(in_flight_llm_messages);
 
-        Ok(raw_stream)
+        let guarded: Pin<Box<dyn Stream<Item = AgentEvent> + Send>> =
+            Box::pin(LoopGuardStream {
+                inner: raw_stream,
+                loop_active: Arc::clone(&self.loop_active),
+                idle_notify: Arc::clone(&self.idle_notify),
+                generation,
+                expected_generation: Arc::clone(&self.loop_generation),
+            });
+        Ok(guarded)
     }
 
     #[allow(clippy::type_complexity)]

--- a/src/agent/state_updates.rs
+++ b/src/agent/state_updates.rs
@@ -1,6 +1,8 @@
-use futures::{Stream, StreamExt};
 use std::pin::Pin;
 use std::sync::Arc;
+use std::sync::atomic::Ordering;
+
+use futures::{Stream, StreamExt};
 
 use crate::error::AgentError;
 use crate::loop_::AgentEvent;
@@ -72,6 +74,7 @@ impl Agent {
             self.state.messages = state_messages;
         }
         self.state.is_running = false;
+        self.loop_active.store(false, Ordering::Release);
         self.state.error.clone_from(&error);
         self.idle_notify.notify_waiters();
 
@@ -136,6 +139,7 @@ impl Agent {
             }
             AgentEvent::AgentEnd { .. } => {
                 self.state.is_running = false;
+                self.loop_active.store(false, Ordering::Release);
                 self.state.pending_tool_calls.clear();
                 self.state.stream_message = None;
             }

--- a/tests/pause_resume.rs
+++ b/tests/pause_resume.rs
@@ -183,6 +183,67 @@ fn loop_checkpoint_serde_stable() {
     assert_eq!(restored.metadata["session"], "sess-abc");
 }
 
+/// After `pause()`, the agent remains running until the event stream is
+/// dropped. Attempting a new `prompt_stream` before dropping returns
+/// `AlreadyRunning`. Dropping the stream makes the agent idle again.
+#[tokio::test]
+async fn pause_keeps_running_until_stream_dropped() {
+    use futures::StreamExt;
+
+    let mut agent = simple_agent(vec![text_only_events("hello"), text_only_events("world")]);
+
+    // Start a run and get the stream.
+    let stream = agent.prompt_stream(vec![user_msg("hi")]).unwrap();
+
+    // Pause cancels the token but the agent stays running.
+    let checkpoint = agent.pause().expect("should return checkpoint");
+    assert!(agent.is_running(), "agent should remain running after pause");
+
+    // Trying to start a new run should fail — loop is still active.
+    let err = agent.prompt_stream(vec![user_msg("again")]);
+    assert!(
+        matches!(err, Err(swink_agent::AgentError::AlreadyRunning)),
+        "expected AlreadyRunning while stream is alive"
+    );
+
+    // Drop the stream — this triggers cleanup via LoopGuardStream.
+    drop(stream);
+
+    // Now the agent should be idle and a new run should succeed.
+    assert!(
+        !agent.is_running(),
+        "agent should be idle after stream is dropped"
+    );
+    let _checkpoint = checkpoint; // keep checkpoint alive for the assertion above
+    let new_stream = agent.prompt_stream(vec![user_msg("new run")]);
+    assert!(new_stream.is_ok(), "new run should succeed after stream drop");
+
+    // Clean up: drain the new stream.
+    let mut s = new_stream.unwrap();
+    while s.next().await.is_some() {}
+}
+
+/// Regression test for the PR #252 blocking finding: pausing a
+/// `prompt_stream()` run and dropping the stream without draining it must
+/// not leave the agent permanently stuck in `AlreadyRunning`.
+#[tokio::test]
+async fn pause_then_drop_stream_becomes_idle() {
+    let mut agent = simple_agent(vec![text_only_events("hello")]);
+
+    let stream = agent.prompt_stream(vec![user_msg("hi")]).unwrap();
+    let _checkpoint = agent.pause().expect("should return checkpoint");
+
+    // Drop stream without consuming any events.
+    drop(stream);
+
+    // wait_for_idle must resolve (not hang forever).
+    tokio::time::timeout(std::time::Duration::from_secs(2), agent.wait_for_idle())
+        .await
+        .expect("wait_for_idle should resolve after stream drop, not hang");
+
+    assert!(!agent.is_running());
+}
+
 #[test]
 fn loop_checkpoint_to_standard_checkpoint_integration() {
     let msgs = vec![user_msg("hello")];


### PR DESCRIPTION
## Summary
- `pause()` previously set `is_running=false` immediately, before the spawned loop task finished. This allowed starting a new run while the old loop was still draining, creating a state race.
- Introduces a shared `loop_active: Arc<AtomicBool>` flag with a `LoopGuardStream` wrapper that clears the flag when the event stream is dropped or drained to `AgentEnd`. A generation counter prevents stale streams from clearing a newer run's flag.
- `pause()` now only cancels the cancellation token — cleanup happens automatically via stream lifecycle. This fixes the original race AND the PR #252 blocking finding (stream dropped without draining no longer leaves agent stuck in `AlreadyRunning`).
- Adds `Agent::is_running()` public method that reads the atomic flag for accurate real-time state.

Supersedes #252.
Closes #228

## Tasks completed
- Removed premature `is_running = false`, `abort_controller = None`, and `idle_notify.notify_waiters()` from `pause()`
- Added `loop_active: Arc<AtomicBool>` and `loop_generation: Arc<AtomicU64>` to Agent
- Added `LoopGuardStream` wrapper with generation-guarded cleanup on drop
- Updated `check_not_running()` to use `loop_active` (syncs `state.is_running`)
- Updated `wait_for_idle()`, `reset()`, `collect_stream()`, `update_state_from_event()` to maintain `loop_active`
- Added `Agent::is_running()` public accessor
- Added 2 regression tests

## Test plan
- [x] `cargo test -p swink-agent --test pause_resume --features testkit` — all 10 tests pass
- [x] `cargo test --workspace --features testkit` — passes (only pre-existing `max_tokens_recovery` failure)
- [x] `cargo clippy -p swink-agent -- -D warnings` — clean
- [x] `cargo test -p swink-agent --no-default-features --lib` — 319 tests pass
- [x] No public API breakage — `check_not_running` is `pub(super)`, all other changes are additive
- [x] Minor additive API: new `Agent::is_running()` method

🤖 Generated with [Claude Code](https://claude.com/claude-code)