### PR TITLE
fix(ci): add Windows to CI matrix and gate builtin-tools tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   check:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -40,7 +40,7 @@ jobs:
       - run: cargo test -p swink-agent --no-default-features
 
       - name: Check docs
-        run: RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace
+        run: cargo doc --no-deps --workspace
         env:
           RUSTDOCFLAGS: "-D warnings"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,10 @@ codegen-units = 1
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
+[[example]]
+name = "with_tools"
+required-features = ["builtin-tools"]
+
 [features]
 default = ["builtin-tools", "transfer"]
 builtin-tools = []

--- a/src/tool_middleware.rs
+++ b/src/tool_middleware.rs
@@ -3,7 +3,9 @@
 //!
 //! # Example
 //!
-//! ```
+//! ```no_run
+//! # #[cfg(feature = "builtin-tools")]
+//! # {
 //! use std::sync::Arc;
 //! use swink_agent::{AgentTool, AgentToolResult, BashTool, ToolMiddleware};
 //!
@@ -18,6 +20,7 @@
 //! });
 //!
 //! assert_eq!(logged.name(), "bash");
+//! # }
 //! ```
 
 use std::sync::Arc;

--- a/tests/schema.rs
+++ b/tests/schema.rs
@@ -4,9 +4,7 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::json;
 
-use swink_agent::{
-    BashTool, ReadFileTool, WriteFileTool, schema_for, validate_schema, validate_tool_arguments,
-};
+use swink_agent::{schema_for, validate_schema, validate_tool_arguments};
 
 // ─── schema_for generates valid schemas ─────────────────────────────────────
 
@@ -42,41 +40,46 @@ fn schema_for_optional_fields_not_required() {
 
 // ─── Built-in tool schemas still validate correctly ─────────────────────────
 
+#[cfg(feature = "builtin-tools")]
 #[test]
 fn bash_tool_schema_validates_valid_args() {
-    use swink_agent::AgentTool;
+    use swink_agent::{AgentTool, tools::BashTool};
     let tool = BashTool::new();
     let args = json!({"command": "echo hello"});
     assert!(validate_tool_arguments(tool.parameters_schema(), &args).is_ok());
 }
 
+#[cfg(feature = "builtin-tools")]
 #[test]
 fn bash_tool_schema_rejects_missing_command() {
-    use swink_agent::AgentTool;
+    use swink_agent::{AgentTool, tools::BashTool};
     let tool = BashTool::new();
     let args = json!({"timeout_ms": 5000});
     assert!(validate_tool_arguments(tool.parameters_schema(), &args).is_err());
 }
 
+#[cfg(feature = "builtin-tools")]
 #[test]
 fn read_file_tool_schema_validates_valid_args() {
-    use swink_agent::AgentTool;
+    use swink_agent::{AgentTool, tools::ReadFileTool};
     let tool = ReadFileTool::new();
     let args = json!({"path": "/tmp/file.txt"});
     assert!(validate_tool_arguments(tool.parameters_schema(), &args).is_ok());
 }
 
+#[cfg(feature = "builtin-tools")]
 #[test]
 fn write_file_tool_schema_validates_valid_args() {
-    use swink_agent::AgentTool;
+    use swink_agent::{AgentTool, tools::WriteFileTool};
     let tool = WriteFileTool::new();
     let args = json!({"path": "/tmp/file.txt", "content": "hello"});
     assert!(validate_tool_arguments(tool.parameters_schema(), &args).is_ok());
 }
 
+#[cfg(feature = "builtin-tools")]
 #[test]
 fn write_file_tool_schema_rejects_extra_fields() {
-    use swink_agent::AgentTool;
+    use swink_agent::{AgentTool, tools::WriteFileTool};
     let tool = WriteFileTool::new();
     let args = json!({"path": "/tmp/file.txt", "content": "hello", "extra": true});
     assert!(validate_tool_arguments(tool.parameters_schema(), &args).is_err());


### PR DESCRIPTION
## Summary
Closes #223.

- Adds `windows-latest` to the main CI `check` matrix so builtin tool tests run on Windows
- Fixes the doc check step to not use inline bash `RUSTDOCFLAGS=...` syntax (breaks on Windows PowerShell) — the `env:` block already sets it
- Gates builtin-tool schema tests and the `tool_middleware` doctest behind `#[cfg(feature = "builtin-tools")]` so `cargo test --no-default-features` compiles cleanly
- Adds `[[example]] required-features` for the `with_tools` example that depends on `builtin_tools()`

Note: `BashTool` already dispatches to `cmd /C` on Windows (fixed in a prior commit). All 8 BashTool tests pass on Windows locally.

## Test plan
- [x] `cargo test -p swink-agent --no-default-features` passes on Windows
- [x] `cargo test -p swink-agent --features builtin-tools` passes on Windows (8/8 bash tests)
- [x] `cargo clippy -p swink-agent -- -D warnings` clean
- [ ] CI green on all three platforms (ubuntu, macos, windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)