### PR TITLE
fix: remove duplicate crate-root forbid attributes

### DIFF
--- a/mcp/src/lib.rs
+++ b/mcp/src/lib.rs
@@ -25,8 +25,6 @@
 //! mcp.connect_all().await?;
 //! let tools = mcp.tools();
 //! ```
-#![forbid(unsafe_code)]
-
 mod config;
 mod connection;
 pub mod convert;

--- a/policies/src/lib.rs
+++ b/policies/src/lib.rs
@@ -18,8 +18,6 @@
 //! - **`pii`**: `PiiRedactor` — redacts personally identifiable information from assistant responses
 //! - **`content-filter`**: `ContentFilter` — keyword/regex blocklist for assistant output
 //! - **`audit`**: `AuditLogger` — records every turn to a pluggable sink
-#![forbid(unsafe_code)]
-
 #[cfg(any(feature = "prompt-guard", feature = "pii", feature = "content-filter"))]
 mod patterns;
 


### PR DESCRIPTION
## Summary
- Remove duplicate `#![forbid(unsafe_code)]` attributes in `policies/src/lib.rs` and `mcp/src/lib.rs`
- Both crates already declare `unsafe_code = "forbid"` in their `Cargo.toml` `[lints.rust]` section, so the source-level attributes were redundant and triggered clippy's `duplicated_attributes` warning
- Each crate root now has the lint declared exactly once (via Cargo.toml), fixing the clippy warnings

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo test -p swink-agent-policies` passes
- [x] `cargo test -p swink-agent-mcp` passes
- [x] `cargo test -p swink-agent --no-default-features` passes
- [x] No public API changes

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)