### PR TITLE
fix: replace panicking unwraps in xtask report

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -44,8 +44,10 @@ async fn run_verify_catalog(provider: Option<&str>, github: bool) {
     let tasks = catalog::build_verify_tasks(provider);
     let rows = verifier::verify_all(tasks).await;
     report::print_table(&rows);
-    if write_summary {
-        report::write_github_summary(&rows);
+    if write_summary
+        && let Err(e) = report::write_github_summary(&rows)
+    {
+        eprintln!("warning: failed to write GitHub summary: {e}");
     }
     let has_fail = rows
         .iter()

--- a/xtask/src/report.rs
+++ b/xtask/src/report.rs
@@ -63,10 +63,10 @@ fn result_label(result: &PresetResult) -> String {
     }
 }
 
-pub fn write_github_summary(rows: &[VerifyRow]) {
+pub fn write_github_summary(rows: &[VerifyRow]) -> std::io::Result<()> {
     let Ok(summary_path) = std::env::var("GITHUB_STEP_SUMMARY") else {
         eprintln!("GITHUB_STEP_SUMMARY not set; skipping summary write");
-        return;
+        return Ok(());
     };
     let mut md = String::from("## Catalog Verification\n\n");
     md.push_str("| Provider | Preset | Model ID | Result |\n");
@@ -76,13 +76,13 @@ pub fn write_github_summary(rows: &[VerifyRow]) {
         let preset = &row.task.preset_display;
         let model = &row.task.model_id;
         let result = result_label(&row.result);
-        writeln!(md, "| {key} | {preset} | {model} | {result} |").unwrap();
+        writeln!(md, "| {key} | {preset} | {model} | {result} |")
+            .map_err(std::io::Error::other)?;
     }
     let mut file = std::fs::OpenOptions::new()
         .append(true)
         .create(true)
-        .open(summary_path)
-        .expect("failed to open GITHUB_STEP_SUMMARY");
-    file.write_all(md.as_bytes())
-        .expect("failed to write to GITHUB_STEP_SUMMARY");
+        .open(&summary_path)?;
+    file.write_all(md.as_bytes())?;
+    Ok(())
 }


### PR DESCRIPTION
## Summary
- Replace unwrap() calls in xtask/src/report.rs with proper error propagation via `io::Result`
- Summary I/O failures now return errors instead of panicking
- Caller in main.rs logs warnings on failure instead of crashing

## Test plan
- [x] cargo clippy --workspace -- -D warnings clean
- [x] cargo test -p xtask passes
- [x] cargo test -p swink-agent --no-default-features passes
- [x] No public API changes

Closes #288
🤖 Generated with [Claude Code](https://claude.com/claude-code)