### PR TITLE
fix: expand feature-matrix smoke coverage

### DIFF
--- a/tests/no_default_features.rs
+++ b/tests/no_default_features.rs
@@ -37,3 +37,93 @@ fn transfer_must_not_leak_into_no_default_features() {
          A dev-dependency is likely leaking features via Cargo unification."
     );
 }
+
+// --- artifact-store ---
+
+#[cfg(not(feature = "artifact-store"))]
+#[test]
+fn artifact_store_feature_is_off() {}
+
+#[cfg(feature = "artifact-store")]
+#[test]
+fn artifact_store_must_not_leak_into_no_default_features() {
+    panic!(
+        "artifact-store feature is enabled but should not be. \
+         A dev-dependency is likely leaking features via Cargo unification."
+    );
+}
+
+// --- artifact-tools ---
+
+#[cfg(not(feature = "artifact-tools"))]
+#[test]
+fn artifact_tools_feature_is_off() {}
+
+#[cfg(feature = "artifact-tools")]
+#[test]
+fn artifact_tools_must_not_leak_into_no_default_features() {
+    panic!(
+        "artifact-tools feature is enabled but should not be. \
+         A dev-dependency is likely leaking features via Cargo unification."
+    );
+}
+
+// --- hot-reload ---
+
+#[cfg(not(feature = "hot-reload"))]
+#[test]
+fn hot_reload_feature_is_off() {}
+
+#[cfg(feature = "hot-reload")]
+#[test]
+fn hot_reload_must_not_leak_into_no_default_features() {
+    panic!(
+        "hot-reload feature is enabled but should not be. \
+         A dev-dependency is likely leaking features via Cargo unification."
+    );
+}
+
+// --- tiktoken ---
+
+#[cfg(not(feature = "tiktoken"))]
+#[test]
+fn tiktoken_feature_is_off() {}
+
+#[cfg(feature = "tiktoken")]
+#[test]
+fn tiktoken_must_not_leak_into_no_default_features() {
+    panic!(
+        "tiktoken feature is enabled but should not be. \
+         A dev-dependency is likely leaking features via Cargo unification."
+    );
+}
+
+// --- plugins ---
+
+#[cfg(not(feature = "plugins"))]
+#[test]
+fn plugins_feature_is_off() {}
+
+#[cfg(feature = "plugins")]
+#[test]
+fn plugins_must_not_leak_into_no_default_features() {
+    panic!(
+        "plugins feature is enabled but should not be. \
+         A dev-dependency is likely leaking features via Cargo unification."
+    );
+}
+
+// --- otel ---
+
+#[cfg(not(feature = "otel"))]
+#[test]
+fn otel_feature_is_off() {}
+
+#[cfg(feature = "otel")]
+#[test]
+fn otel_must_not_leak_into_no_default_features() {
+    panic!(
+        "otel feature is enabled but should not be. \
+         A dev-dependency is likely leaking features via Cargo unification."
+    );
+}


### PR DESCRIPTION
## Summary
- Add leak-detection smoke tests for 6 optional root features: `artifact-store`, `artifact-tools`, `hot-reload`, `tiktoken`, `plugins`, `otel`
- Follows existing pattern from `builtin-tools` and `transfer` coverage
- Each feature gets both a "feature is off" test (compiles when disabled) and a "must not leak" test (panics if unexpectedly enabled)

## Test plan
- [x] `cargo test -p swink-agent --no-default-features` — all 8 smoke tests pass
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo test --workspace` passes (pre-existing `max_tokens_recovery` failure is #293, unrelated)
- [x] No public API changes

Closes #292
🤖 Generated with [Claude Code](https://claude.com/claude-code)