### PR TITLE
fix: cancel active loop and bump generation on Agent::reset

### DIFF
--- a/src/agent/control.rs
+++ b/src/agent/control.rs
@@ -16,7 +16,21 @@ impl Agent {
     }
 
     /// Reset the agent to its initial state, clearing messages, queues, and error.
+    ///
+    /// If a loop is currently active, the abort token is cancelled and the
+    /// generation counter is bumped so the stale [`LoopGuardStream`] cannot
+    /// clear `loop_active` for any future run.
     pub fn reset(&mut self) {
+        // Cancel the running loop *before* dropping the token, so the spawned
+        // stream observes cancellation rather than continuing to emit events.
+        if let Some(ref token) = self.abort_controller {
+            token.cancel();
+        }
+
+        // Bump the generation counter so the old LoopGuardStream's Drop impl
+        // sees a mismatched generation and skips clearing loop_active.
+        self.loop_generation.fetch_add(1, Ordering::AcqRel);
+
         self.state.messages.clear();
         self.state.is_running = false;
         self.loop_active.store(false, Ordering::Release);

--- a/tests/agent.rs
+++ b/tests/agent.rs
@@ -381,3 +381,40 @@ async fn wait_for_idle_multiple_waiters() {
     let ((), ()) = tokio::join!(agent.wait_for_idle(), agent.wait_for_idle(),);
     assert!(!agent.state().is_running);
 }
+
+// ─── Regression: reset cancels active loop and bumps generation (#266) ──
+
+#[tokio::test]
+async fn reset_cancels_active_loop_and_allows_new_run() {
+    // Two scripted responses: one for the first (interrupted) run, one for the
+    // second (post-reset) run.
+    let stream_fn = Arc::new(MockStreamFn::new(vec![
+        text_only_events("first"),
+        text_only_events("second"),
+    ]));
+    let mut agent = make_agent(stream_fn);
+
+    // Start a streaming run but do NOT drain it — simulate an active loop.
+    let mut stream = agent.prompt_stream(vec![user_msg("go")]).unwrap();
+
+    // Pull at least one event so the stream is actively being consumed.
+    let _first_event = stream.next().await;
+    assert!(agent.state().is_running, "agent should be running mid-stream");
+
+    // Reset while the loop is still active. Before the fix this would not
+    // cancel the abort token and would not bump the generation counter,
+    // letting the stale LoopGuardStream corrupt state on drop.
+    agent.reset();
+
+    // Drop the old stream — its LoopGuardStream::drop should be a no-op
+    // because reset() bumped the generation counter.
+    drop(stream);
+
+    // Agent should be idle after reset.
+    assert!(!agent.state().is_running, "agent should be idle after reset");
+
+    // A new run should succeed without AlreadyRunning error.
+    let result = agent.prompt_async(vec![user_msg("go again")]).await.unwrap();
+    assert_eq!(result.stop_reason, StopReason::Stop);
+    assert!(!agent.state().is_running);
+}


### PR DESCRIPTION
## Summary
- Fixes #266: `reset()` now cancels the abort token before dropping it and bumps the generation counter, preventing a stale `LoopGuardStream` from clearing `loop_active` for a subsequent run
- Adds regression test `reset_cancels_active_loop_and_allows_new_run`

## Tasks completed
- Cancel abort token in `reset()` before clearing it
- Bump `loop_generation` so old `LoopGuardStream::Drop` is a no-op
- Regression test: start stream, reset mid-flight, verify new run succeeds

## Test plan
- [x] `cargo test -p swink-agent --features testkit --test agent reset_cancels_active_loop_and_allows_new_run` passes
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] Pre-existing `max_tokens_recovery` failure (issue #293) is unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)