### PR TITLE
fix: preserve steering queue semantics in pause/resume checkpoints

### DIFF
--- a/src/agent/checkpointing.rs
+++ b/src/agent/checkpointing.rs
@@ -127,7 +127,8 @@ impl Agent {
             &self.state.model.model_id,
             &self.state.messages,
         )
-        .with_pending_messages(llm_messages_from_queue(&self.follow_up_queue));
+        .with_pending_messages(llm_messages_from_queue(&self.follow_up_queue))
+        .with_pending_steering_messages(llm_messages_from_queue(&self.steering_queue));
 
         let s = self
             .session_state
@@ -192,6 +193,9 @@ impl Agent {
 
         for msg in checkpoint.restore_pending_messages() {
             self.follow_up(msg);
+        }
+        for msg in checkpoint.restore_pending_steering_messages() {
+            self.steer(msg);
         }
 
         tracing::info!(
@@ -297,6 +301,136 @@ mod tests {
             .downcast_ref::<Tagged>()
             .expect("custom message should be restored via registry");
         assert_eq!(restored.value, "preserved");
+    }
+
+    #[tokio::test]
+    async fn pause_captures_both_steering_and_follow_up_queues() {
+        use crate::types::ContentBlock;
+
+        let mut agent = make_agent(None);
+        // Give the agent a message so it's valid to resume
+        agent
+            .state
+            .messages
+            .push(AgentMessage::Llm(LlmMessage::User(UserMessage {
+                content: vec![ContentBlock::Text {
+                    text: "hi".to_string(),
+                }],
+                timestamp: 0,
+                cache_hint: None,
+            })));
+
+        // Queue a steering message and a follow-up message
+        agent.steer(AgentMessage::Llm(LlmMessage::User(UserMessage {
+            content: vec![ContentBlock::Text {
+                text: "steering-msg".to_string(),
+            }],
+            timestamp: 1,
+            cache_hint: None,
+        })));
+        agent.follow_up(AgentMessage::Llm(LlmMessage::User(UserMessage {
+            content: vec![ContentBlock::Text {
+                text: "followup-msg".to_string(),
+            }],
+            timestamp: 2,
+            cache_hint: None,
+        })));
+
+        // Simulate a running loop so pause() doesn't return None
+        agent
+            .loop_active
+            .store(true, std::sync::atomic::Ordering::Release);
+
+        let checkpoint = agent.pause().expect("agent should be running");
+
+        // Verify both queues are captured separately
+        assert_eq!(
+            checkpoint.pending_messages.len(),
+            1,
+            "follow-up queue should be captured"
+        );
+        assert_eq!(
+            checkpoint.pending_steering_messages.len(),
+            1,
+            "steering queue should be captured"
+        );
+
+        // Verify the content is correct
+        match &checkpoint.pending_messages[0] {
+            LlmMessage::User(u) => match &u.content[0] {
+                ContentBlock::Text { text } => assert_eq!(text, "followup-msg"),
+                _ => panic!("expected text content"),
+            },
+            _ => panic!("expected user message"),
+        }
+        match &checkpoint.pending_steering_messages[0] {
+            LlmMessage::User(u) => match &u.content[0] {
+                ContentBlock::Text { text } => assert_eq!(text, "steering-msg"),
+                _ => panic!("expected text content"),
+            },
+            _ => panic!("expected user message"),
+        }
+    }
+
+    #[tokio::test]
+    async fn restore_from_loop_checkpoint_routes_steering_to_steering_queue() {
+        use crate::checkpoint::LoopCheckpoint;
+        use crate::types::ContentBlock;
+
+        let messages = vec![AgentMessage::Llm(LlmMessage::User(UserMessage {
+            content: vec![ContentBlock::Text {
+                text: "hi".to_string(),
+            }],
+            timestamp: 0,
+            cache_hint: None,
+        }))];
+
+        let cp = LoopCheckpoint::new("system", "mock", "mock-model", &messages)
+            .with_pending_messages(vec![LlmMessage::User(UserMessage {
+                content: vec![ContentBlock::Text {
+                    text: "followup".to_string(),
+                }],
+                timestamp: 1,
+                cache_hint: None,
+            })])
+            .with_pending_steering_messages(vec![LlmMessage::User(UserMessage {
+                content: vec![ContentBlock::Text {
+                    text: "steering".to_string(),
+                }],
+                timestamp: 2,
+                cache_hint: None,
+            })]);
+
+        let mut agent = make_agent(None);
+        agent.restore_from_loop_checkpoint(&cp).unwrap();
+
+        // Verify steering went to steering queue, follow-up to follow-up queue
+        let steering = agent
+            .steering_queue
+            .lock()
+            .unwrap();
+        let follow_up = agent
+            .follow_up_queue
+            .lock()
+            .unwrap();
+
+        assert_eq!(steering.len(), 1, "steering queue should have 1 message");
+        assert_eq!(follow_up.len(), 1, "follow-up queue should have 1 message");
+
+        match &steering[0] {
+            AgentMessage::Llm(LlmMessage::User(u)) => match &u.content[0] {
+                ContentBlock::Text { text } => assert_eq!(text, "steering"),
+                _ => panic!("expected text"),
+            },
+            _ => panic!("expected user message in steering queue"),
+        }
+        match &follow_up[0] {
+            AgentMessage::Llm(LlmMessage::User(u)) => match &u.content[0] {
+                ContentBlock::Text { text } => assert_eq!(text, "followup"),
+                _ => panic!("expected text"),
+            },
+            _ => panic!("expected user message in follow-up queue"),
+        }
     }
 
     #[tokio::test]

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -173,8 +173,14 @@ pub struct LoopCheckpoint {
     /// Records the original interleaved order of LLM and custom messages.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     message_order: Vec<MessageSlot>,
-    /// Messages queued for injection into the next turn.
+    /// Follow-up messages queued for injection into the next turn.
     pub pending_messages: Vec<LlmMessage>,
+    /// Steering messages queued at the time of pause.
+    ///
+    /// Older checkpoints without this field deserialize with an empty vec
+    /// (backward compatible).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub pending_steering_messages: Vec<LlmMessage>,
     /// The system prompt active at the time of pause.
     pub system_prompt: String,
     /// Model provider name.
@@ -210,6 +216,7 @@ impl LoopCheckpoint {
             custom_messages: serialized.custom_messages,
             message_order: serialized.message_order,
             pending_messages: Vec::new(),
+            pending_steering_messages: Vec::new(),
             system_prompt: system_prompt.into(),
             provider: provider.into(),
             model_id: model_id.into(),
@@ -226,10 +233,17 @@ impl LoopCheckpoint {
         self
     }
 
-    /// Set pending messages.
+    /// Set pending follow-up messages.
     #[must_use]
     pub fn with_pending_messages(mut self, pending: Vec<LlmMessage>) -> Self {
         self.pending_messages = pending;
+        self
+    }
+
+    /// Set pending steering messages.
+    #[must_use]
+    pub fn with_pending_steering_messages(mut self, pending: Vec<LlmMessage>) -> Self {
+        self.pending_steering_messages = pending;
         self
     }
 
@@ -255,10 +269,16 @@ impl LoopCheckpoint {
         )
     }
 
-    /// Restore pending messages as `AgentMessage` values.
+    /// Restore pending follow-up messages as `AgentMessage` values.
     #[must_use]
     pub fn restore_pending_messages(&self) -> Vec<AgentMessage> {
         restore_llm_messages(&self.pending_messages)
+    }
+
+    /// Restore pending steering messages as `AgentMessage` values.
+    #[must_use]
+    pub fn restore_pending_steering_messages(&self) -> Vec<AgentMessage> {
+        restore_llm_messages(&self.pending_steering_messages)
     }
 
     /// Convert this loop checkpoint into a standard [`Checkpoint`] for storage.
@@ -572,6 +592,69 @@ mod tests {
             restored[1],
             AgentMessage::Llm(LlmMessage::Assistant(_))
         ));
+    }
+
+    #[test]
+    fn loop_checkpoint_steering_messages_roundtrip() {
+        let steering = vec![LlmMessage::User(UserMessage {
+            content: vec![ContentBlock::Text {
+                text: "steer-me".to_string(),
+            }],
+            timestamp: 300,
+            cache_hint: None,
+        })];
+        let follow_up = vec![LlmMessage::User(UserMessage {
+            content: vec![ContentBlock::Text {
+                text: "follow-up".to_string(),
+            }],
+            timestamp: 301,
+            cache_hint: None,
+        })];
+
+        let cp = LoopCheckpoint::new("p", "p", "m", &[])
+            .with_pending_messages(follow_up)
+            .with_pending_steering_messages(steering);
+
+        // Serde roundtrip
+        let json = serde_json::to_string(&cp).unwrap();
+        let restored: LoopCheckpoint = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(restored.pending_messages.len(), 1);
+        assert_eq!(restored.pending_steering_messages.len(), 1);
+
+        let restored_steering = restored.restore_pending_steering_messages();
+        assert_eq!(restored_steering.len(), 1);
+        assert!(matches!(
+            restored_steering[0],
+            AgentMessage::Llm(LlmMessage::User(_))
+        ));
+    }
+
+    #[test]
+    fn loop_checkpoint_backward_compat_no_steering_field() {
+        // Simulate a checkpoint created before pending_steering_messages existed
+        let cp = LoopCheckpoint::new("p", "p", "m", &[])
+            .with_pending_messages(vec![LlmMessage::User(UserMessage {
+                content: vec![ContentBlock::Text {
+                    text: "old-follow-up".to_string(),
+                }],
+                timestamp: 100,
+                cache_hint: None,
+            })]);
+
+        let mut json_val = serde_json::to_value(&cp).unwrap();
+        // Strip the field to simulate old format
+        json_val
+            .as_object_mut()
+            .unwrap()
+            .remove("pending_steering_messages");
+        let legacy: LoopCheckpoint = serde_json::from_value(json_val).unwrap();
+
+        assert!(
+            legacy.pending_steering_messages.is_empty(),
+            "missing steering field should default to empty"
+        );
+        assert_eq!(legacy.pending_messages.len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds `pending_steering_messages` field to `LoopCheckpoint` so steering and follow-up queues are persisted separately
- Updates `pause()` to capture both queues instead of only `follow_up_queue`
- Updates `restore_from_loop_checkpoint()` to route steering messages back to `steer()` instead of `follow_up()`
- Backward compatible: old checkpoints without `pending_steering_messages` deserialize with an empty vec (`#[serde(default)]`)

Closes #267

## Test plan
- [x] `cargo test -p swink-agent --features testkit -- checkpoint` — all 23 tests pass (4 new)
- [x] `cargo clippy -p swink-agent -- -D warnings` — clean
- [x] Backward compat test: old checkpoints without `pending_steering_messages` field deserialize correctly
- [x] No public API breakage — new field and methods are additive

🤖 Generated with [Claude Code](https://claude.com/claude-code)