### PR TITLE
fix: preserve CustomMessage in stream-driven state rebuild

### DIFF
--- a/src/agent/state_updates.rs
+++ b/src/agent/state_updates.rs
@@ -62,7 +62,7 @@ impl Agent {
                         received_full_context = true;
                     }
                     Err(messages) => {
-                        self.state.messages = clone_llm_messages(messages.as_ref());
+                        self.state.messages = clone_messages(messages.as_ref());
                         received_full_context = true;
                     }
                 },
@@ -112,7 +112,7 @@ impl Agent {
                 }
             }
             AgentEvent::AgentEnd { messages } => {
-                self.state.messages = clone_llm_messages(messages.as_ref());
+                self.state.messages = clone_messages(messages.as_ref());
                 self.in_flight_llm_messages = None;
                 // Preserve terminal error — do not clear self.state.error.
                 self.idle_notify.notify_waiters();
@@ -148,12 +148,21 @@ impl Agent {
     }
 }
 
-fn clone_llm_messages(messages: &[AgentMessage]) -> Vec<AgentMessage> {
+fn clone_messages(messages: &[AgentMessage]) -> Vec<AgentMessage> {
     messages
         .iter()
         .filter_map(|message| match message {
             AgentMessage::Llm(llm) => Some(AgentMessage::Llm(llm.clone())),
-            AgentMessage::Custom(_) => None,
+            AgentMessage::Custom(cm) => cm.clone_box().map_or_else(
+                || {
+                    tracing::warn!(
+                        "CustomMessage {:?} does not support clone_box — dropped during state rebuild",
+                        cm
+                    );
+                    None
+                },
+                |cloned| Some(AgentMessage::Custom(cloned)),
+            ),
         })
         .collect()
 }

--- a/src/types/custom_message.rs
+++ b/src/types/custom_message.rs
@@ -37,6 +37,15 @@ pub trait CustomMessage: Send + Sync + fmt::Debug + std::any::Any {
     fn to_json(&self) -> Option<serde_json::Value> {
         None
     }
+
+    /// Clone this custom message into a new boxed trait object.
+    ///
+    /// Returns `None` if the underlying type does not support cloning
+    /// (the default). Implement this to preserve custom messages across
+    /// stream-driven state rebuilds (e.g. `handle_stream_event`).
+    fn clone_box(&self) -> Option<Box<dyn CustomMessage>> {
+        None
+    }
 }
 
 /// A function that deserializes a JSON value into a boxed [`CustomMessage`].

--- a/src/types/message_codec.rs
+++ b/src/types/message_codec.rs
@@ -236,6 +236,9 @@ impl super::CustomMessage for SerializedCustomMessage {
     fn to_json(&self) -> Option<serde_json::Value> {
         Some(self.json.clone())
     }
+    fn clone_box(&self) -> Option<Box<dyn super::CustomMessage>> {
+        Some(Box::new(self.clone()))
+    }
 }
 
 // ─── clone_messages_for_send ────────────────────────────────────────────────

--- a/tests/agent_structured.rs
+++ b/tests/agent_structured.rs
@@ -14,7 +14,10 @@ use common::{
 use futures::stream::StreamExt;
 use serde_json::json;
 
-use swink_agent::{Agent, AgentError, AgentOptions, DefaultRetryStrategy, StopReason, StreamFn};
+use swink_agent::{
+    Agent, AgentError, AgentMessage, AgentOptions, CustomMessage, DefaultRetryStrategy, StopReason,
+    StreamFn,
+};
 
 // ─── Helpers ─────────────────────────────────────────────────────────────
 
@@ -388,4 +391,72 @@ async fn handle_stream_event_preserves_terminal_error_through_agent_end() {
         Some("stream error: fatal error"),
         "terminal error must survive through AgentEnd"
     );
+}
+
+// ─── Regression test for #269: CustomMessage preservation ──────────────
+
+/// A cloneable custom message for testing state rebuild preservation.
+#[derive(Debug, Clone)]
+struct CloneableCustomMsg {
+    label: String,
+}
+
+impl CustomMessage for CloneableCustomMsg {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn clone_box(&self) -> Option<Box<dyn CustomMessage>> {
+        Some(Box::new(self.clone()))
+    }
+}
+
+/// Regression test for #269: stream-driven state rebuild via `handle_stream_event`
+/// must preserve `AgentMessage::Custom` entries that implement `clone_box`.
+#[tokio::test]
+async fn handle_stream_event_preserves_custom_messages() {
+    let stream_fn = Arc::new(MockStreamFn::new(vec![text_only_events("response")]));
+    let mut agent = make_agent(stream_fn);
+
+    // Inject a custom message alongside the user message.
+    let input = vec![
+        user_msg("hello"),
+        AgentMessage::Custom(Box::new(CloneableCustomMsg {
+            label: "my-custom".to_string(),
+        })),
+    ];
+
+    let stream = agent.prompt_stream(input).unwrap();
+    let mut stream = std::pin::pin!(stream);
+    while let Some(event) = stream.next().await {
+        agent.handle_stream_event(&event);
+    }
+
+    assert!(!agent.state().is_running, "agent should be idle");
+
+    // Count custom messages in the rebuilt state.
+    let custom_count = agent
+        .state()
+        .messages
+        .iter()
+        .filter(|m| matches!(m, AgentMessage::Custom(_)))
+        .count();
+
+    assert_eq!(
+        custom_count, 1,
+        "custom message must survive stream-driven state rebuild (got {custom_count})"
+    );
+
+    // Verify it's the right custom message by downcasting.
+    let custom = agent
+        .state()
+        .messages
+        .iter()
+        .find_map(|m| match m {
+            AgentMessage::Custom(cm) => cm.as_any().downcast_ref::<CloneableCustomMsg>(),
+            _ => None,
+        })
+        .expect("should find CloneableCustomMsg in rebuilt state");
+
+    assert_eq!(custom.label, "my-custom");
 }


### PR DESCRIPTION
## Summary
- Add `clone_box()` default method to `CustomMessage` trait so custom messages can opt into cloning
- Fix `clone_llm_messages` → `clone_messages` in `state_updates.rs` to preserve `Custom` variants during `AgentEnd` state restoration
- Implement `clone_box` on `SerializedCustomMessage` (already `Clone`)
- Logs a warning for custom messages that don't support cloning (backward compatible — old behavior was silent drop)

Fixes #269

## Test plan
- [x] New regression test `handle_stream_event_preserves_custom_messages` verifies custom messages survive stream-driven rebuild
- [x] `cargo test --features testkit --test agent_structured` — all 11 tests pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo test -p swink-agent --no-default-features` — passes
- [x] No public API breakage (additive change: new default method on trait)