### PR TITLE
fix: restore max-tokens recovery for incomplete tool calls

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -620,9 +620,19 @@ pub fn accumulate_message(
                 cost: c,
             } => {
                 if let Some(idx) = open_blocks.iter().position(|open| *open) {
-                    return Err(format!(
-                        "Done received with unterminated content block at index {idx}"
-                    ));
+                    if tolerate_truncated_tool_args {
+                        // Max-tokens truncation: leave open tool-call blocks
+                        // with `partial_json` set so the loop's
+                        // `recover_incomplete_tool_calls` path can convert
+                        // them into error tool results on the next turn.
+                        tracing::debug!(
+                            "Done(Length) with unterminated content block at index {idx} — tolerating for max-tokens recovery"
+                        );
+                    } else {
+                        return Err(format!(
+                            "Done received with unterminated content block at index {idx}"
+                        ));
+                    }
                 }
                 stop_reason = Some(sr);
                 usage = Some(u);
@@ -871,6 +881,43 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    // Regression for #293: Done(Length) with an unterminated tool-call block
+    // must NOT be rejected — the block should survive with `partial_json` set
+    // so `recover_incomplete_tool_calls` can convert it to an error result.
+    #[test]
+    fn done_length_with_unterminated_tool_call_is_tolerated() {
+        let events = vec![
+            AssistantMessageEvent::Start,
+            AssistantMessageEvent::ToolCallStart {
+                content_index: 0,
+                id: "tc_1".into(),
+                name: "read_file".into(),
+            },
+            AssistantMessageEvent::ToolCallDelta {
+                content_index: 0,
+                delta: r#"{"path": "/tmp"#.into(),
+            },
+            AssistantMessageEvent::Done {
+                stop_reason: StopReason::Length,
+                usage: Usage::default(),
+                cost: Cost::default(),
+            },
+        ];
+        let msg = accumulate_message(events, "test", "test")
+            .expect("Done(Length) with open tool-call block should succeed");
+        assert_eq!(msg.stop_reason, StopReason::Length);
+        // The tool call block should have partial_json set (incomplete)
+        match &msg.content[0] {
+            ContentBlock::ToolCall { partial_json, .. } => {
+                assert!(
+                    partial_json.is_some(),
+                    "partial_json should be Some for incomplete tool call"
+                );
+            }
+            other => panic!("expected ToolCall, got {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- When a provider hits max tokens mid-tool-call and emits `Done(Length)` without a preceding `ToolCallEnd`, `accumulate_message` was rejecting the stream with "unterminated content block" instead of preserving the incomplete block for the loop's `recover_incomplete_tool_calls` path
- Now tolerates open tool-call blocks when `tolerate_truncated_tool_args` is true (stop reason is `Length`), leaving `partial_json` set so the loop converts it into an error tool result and continues on the next turn
- Adds a regression unit test `done_length_with_unterminated_tool_call_is_tolerated`

Closes #293

## Tasks completed
- [x] Root-caused the issue in `accumulate_message` (`src/stream.rs:622`)
- [x] Applied fix to tolerate open blocks on `Done(Length)`
- [x] Added regression test in `stream::tests`
- [x] Verified `max_tokens_recovery` and `max_tokens_recovery_with_tool_call_end` integration tests pass
- [x] Verified existing `done_with_unterminated_*` tests still reject non-Length cases
- [x] `cargo clippy -p swink-agent -- -D warnings` clean

## Test plan
- [x] `cargo test -p swink-agent --features testkit max_tokens_recovery` passes (both variants)
- [x] `cargo test -p swink-agent done_with_unterminated` passes (existing rejection tests)
- [x] `cargo clippy -p swink-agent -- -D warnings` clean
- [ ] `cargo test --workspace --features testkit` passes
- [ ] No public API breakage in downstream crates

🤖 Generated with [Claude Code](https://claude.com/claude-code)