### PR TITLE
fix: Gemini finishReason loses MAX_TOKENS after tool use

### DIFF
--- a/adapters/src/google.rs
+++ b/adapters/src/google.rs
@@ -743,12 +743,9 @@ fn process_function_call(
 }
 
 fn map_finish_reason(finish_reason: &str, saw_tool_call: bool) -> StopReason {
-    if saw_tool_call {
-        return StopReason::ToolUse;
-    }
-
     match finish_reason {
         "MAX_TOKENS" => StopReason::Length,
+        _ if saw_tool_call => StopReason::ToolUse,
         _ => StopReason::Stop,
     }
 }

--- a/adapters/tests/google.rs
+++ b/adapters/tests/google.rs
@@ -512,6 +512,52 @@ async fn gemini_two_tool_calls_have_sequential_content_indices() {
     assert_eq!(cis[1], cis[0] + 1, "content indices must be sequential");
 }
 
+/// When a tool call is emitted but finishReason is MAX_TOKENS, the stop reason
+/// must be Length — not ToolUse. Regression test for #273.
+#[tokio::test]
+async fn gemini_max_tokens_after_tool_call_reports_length() {
+    let body = [
+        r#"data: {"candidates":[{"content":{"parts":[{"functionCall":{"id":"c1","name":"get_weather","args":{"city":"Paris"}}}]}}]}"#,
+        "",
+        r#"data: {"candidates":[{"finishReason":"MAX_TOKENS"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":50,"totalTokenCount":60}}"#,
+        "",
+        "data: [DONE]",
+        "",
+    ]
+    .join("\n");
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path(
+            "/v1beta/models/gemini-3-flash-preview:streamGenerateContent",
+        ))
+        .and(query_param("alt", "sse"))
+        .respond_with(sse_response(&body))
+        .mount(&server)
+        .await;
+
+    let stream_fn = GeminiStreamFn::new(server.uri(), "test-key", ApiVersion::V1beta);
+    let events = collect_events(&stream_fn).await;
+
+    // Tool call events should still be present
+    let types: Vec<_> = events.iter().map(event_name).collect();
+    assert!(
+        types.contains(&"ToolCallStart"),
+        "missing ToolCallStart: {types:?}"
+    );
+
+    // Stop reason must be Length, not ToolUse
+    let stop_reason = events.iter().find_map(|event| match event {
+        AssistantMessageEvent::Done { stop_reason, .. } => Some(*stop_reason),
+        _ => None,
+    });
+    assert_eq!(
+        stop_reason,
+        Some(StopReason::Length),
+        "MAX_TOKENS must map to Length even when tool calls were emitted"
+    );
+}
+
 /// When the stream ends without an explicit finish reason the open text block
 /// must be closed by the finalization path (not silently dropped).
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Fixes `map_finish_reason` in `google.rs` to check the explicit `finishReason` (e.g. `MAX_TOKENS`) **before** falling back to `ToolUse` based on `saw_tool_call`
- Previously, any stream containing a tool call would always report `StopReason::ToolUse`, even when the provider terminated with `MAX_TOKENS` — causing the loop to miss the real length stop and skip the recovery path

## Tasks completed
- [x] Reorder match arms in `map_finish_reason` so `MAX_TOKENS → Length` takes priority over `saw_tool_call → ToolUse`
- [x] Add regression test `gemini_max_tokens_after_tool_call_reports_length`

## Test plan
- [x] `cargo test -p swink-agent-adapters --features gemini --test google` — all 15 tests pass
- [ ] `cargo clippy --workspace -- -D warnings` clean (could not run full workspace clippy due to build env memory constraint; scoped test run passed)
- [ ] No public API breakage in downstream crates

Closes #273