### PR TITLE
fix: defer Gemini tool-call delta emission to finalization

### DIFF
--- a/adapters/src/google.rs
+++ b/adapters/src/google.rs
@@ -189,7 +189,10 @@ struct GeminiUsageMetadata {
 struct GeminiToolCallState {
     /// Harness-side content index returned by [`BlockAccumulator::open_tool_call`].
     content_index: usize,
-    /// Accumulated JSON arguments for incremental delta diffing.
+    /// Latest full arguments snapshot from Gemini.  Updated on every chunk but
+    /// only emitted as a single [`AssistantMessageEvent::ToolCallDelta`] at
+    /// finalization to avoid corrupted concatenation when Gemini rewrites
+    /// (non-prefix-extends) the snapshot between chunks.
     arguments: String,
 }
 
@@ -560,7 +563,8 @@ fn parse_sse_stream(
         "Google request cancelled",
         |item, state| match item {
             None => {
-                let mut events = crate::finalize::finalize_blocks(state);
+                let mut events = state.emit_final_tool_deltas();
+                events.extend(crate::finalize::finalize_blocks(state));
                 if state.stop_reason.is_none() {
                     events.push(AssistantMessageEvent::error_network(
                         "Google stream ended unexpectedly",
@@ -575,7 +579,8 @@ fn parse_sse_stream(
                 SseAction::Done(events)
             }
             Some(SseLine::Done) => {
-                let mut events = crate::finalize::finalize_blocks(state);
+                let mut events = state.emit_final_tool_deltas();
+                events.extend(crate::finalize::finalize_blocks(state));
                 events.push(AssistantMessageEvent::Done {
                     stop_reason: state.stop_reason.unwrap_or({
                         if state.saw_tool_call {
@@ -606,7 +611,8 @@ fn parse_sse_stream(
                 }
             }
             Some(SseLine::TransportError(message)) => {
-                let mut events = crate::finalize::finalize_blocks(state);
+                let mut events = state.emit_final_tool_deltas();
+                events.extend(crate::finalize::finalize_blocks(state));
                 events.push(AssistantMessageEvent::error_network(format!(
                     "Google {message}",
                 )));
@@ -718,26 +724,16 @@ fn process_function_call(
         .get_mut(&part_index)
         .expect("just inserted or already present");
 
+    // Gemini sends full argument snapshots, not deltas.  We buffer the latest
+    // snapshot and defer delta emission to finalization.  Emitting deltas
+    // inline corrupts `accumulate_message` when Gemini rewrites the snapshot
+    // (non-prefix change) between chunks, because `partial_json` is
+    // append-only.  See issue #271.
     let serialized_args = match function_call.args {
         Value::Null => String::new(),
         value => value.to_string(),
     };
-    if serialized_args.len() > entry.arguments.len()
-        && serialized_args.starts_with(&entry.arguments)
-    {
-        let delta = serialized_args[entry.arguments.len()..].to_string();
-        if !delta.is_empty() {
-            events.push(AssistantMessageEvent::ToolCallDelta {
-                content_index: entry.content_index,
-                delta: delta.clone(),
-            });
-            entry.arguments.push_str(&delta);
-        }
-    } else if !serialized_args.is_empty() && serialized_args != entry.arguments {
-        events.push(AssistantMessageEvent::ToolCallDelta {
-            content_index: entry.content_index,
-            delta: serialized_args.clone(),
-        });
+    if !serialized_args.is_empty() {
         entry.arguments = serialized_args;
     }
 }
@@ -747,6 +743,23 @@ fn map_finish_reason(finish_reason: &str, saw_tool_call: bool) -> StopReason {
         "MAX_TOKENS" => StopReason::Length,
         _ if saw_tool_call => StopReason::ToolUse,
         _ => StopReason::Stop,
+    }
+}
+
+impl GeminiStreamState {
+    /// Emit a single [`AssistantMessageEvent::ToolCallDelta`] per buffered tool
+    /// call carrying the complete final arguments snapshot.  Must be called
+    /// **before** [`finalize_blocks`](crate::finalize::finalize_blocks) (which
+    /// drains and clears the tool-call map).
+    fn emit_final_tool_deltas(&self) -> Vec<AssistantMessageEvent> {
+        self.tool_calls
+            .values()
+            .filter(|tc| !tc.arguments.is_empty())
+            .map(|tc| AssistantMessageEvent::ToolCallDelta {
+                content_index: tc.content_index,
+                delta: tc.arguments.clone(),
+            })
+            .collect()
     }
 }
 

--- a/adapters/tests/google.rs
+++ b/adapters/tests/google.rs
@@ -558,6 +558,108 @@ async fn gemini_max_tokens_after_tool_call_reports_length() {
     );
 }
 
+/// Regression test for #271: when Gemini rewrites `function_call.args` between
+/// chunks (non-prefix change), the concatenated `ToolCallDelta` events must
+/// produce the correct final JSON, not a corrupted `old + new` concatenation.
+#[tokio::test]
+async fn gemini_non_prefix_arg_rewrite_produces_correct_json() {
+    // Chunk 1: initial args snapshot with key "a"
+    // Chunk 2: rewritten args snapshot with key "b" (NOT a prefix extension)
+    // Chunk 3: finish
+    let body = [
+        r#"data: {"candidates":[{"content":{"parts":[{"functionCall":{"id":"c1","name":"do_stuff","args":{"a":1}}}]}}]}"#,
+        "",
+        r#"data: {"candidates":[{"content":{"parts":[{"functionCall":{"id":"c1","name":"do_stuff","args":{"b":2}}}]}}]}"#,
+        "",
+        r#"data: {"candidates":[{"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":5,"totalTokenCount":10}}"#,
+        "",
+        "data: [DONE]",
+        "",
+    ]
+    .join("\n");
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path(
+            "/v1beta/models/gemini-3-flash-preview:streamGenerateContent",
+        ))
+        .and(query_param("alt", "sse"))
+        .respond_with(sse_response(&body))
+        .mount(&server)
+        .await;
+
+    let stream_fn = GeminiStreamFn::new(server.uri(), "test-key", ApiVersion::V1beta);
+    let events = collect_events(&stream_fn).await;
+
+    let arguments: String = events
+        .iter()
+        .filter_map(|event| match event {
+            AssistantMessageEvent::ToolCallDelta { delta, .. } => Some(delta.as_str()),
+            _ => None,
+        })
+        .collect();
+
+    // The concatenation of all deltas must be valid JSON matching the LAST
+    // snapshot — not a corrupted merge of old + new.
+    let parsed: serde_json::Value =
+        serde_json::from_str(&arguments).expect("concatenated deltas must be valid JSON");
+    assert_eq!(
+        parsed,
+        serde_json::json!({"b": 2}),
+        "final args must match the last Gemini snapshot, got: {arguments}"
+    );
+}
+
+/// Verify that monotonic prefix-growth of `function_call.args` across multiple
+/// chunks still produces the correct concatenated JSON after the deferred-delta
+/// change for #271.
+#[tokio::test]
+async fn gemini_prefix_growth_args_produce_correct_json() {
+    // Chunk 1: partial args  {"city":"Pa
+    // Chunk 2: extended args {"city":"Paris"}
+    // Chunk 3: finish
+    let body = [
+        r#"data: {"candidates":[{"content":{"parts":[{"functionCall":{"id":"c1","name":"get_weather","args":{"city":"Paris"}}}]}}]}"#,
+        "",
+        r#"data: {"candidates":[{"content":{"parts":[{"functionCall":{"id":"c1","name":"get_weather","args":{"city":"Paris","unit":"C"}}}]}}]}"#,
+        "",
+        r#"data: {"candidates":[{"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":5,"totalTokenCount":10}}"#,
+        "",
+        "data: [DONE]",
+        "",
+    ]
+    .join("\n");
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path(
+            "/v1beta/models/gemini-3-flash-preview:streamGenerateContent",
+        ))
+        .and(query_param("alt", "sse"))
+        .respond_with(sse_response(&body))
+        .mount(&server)
+        .await;
+
+    let stream_fn = GeminiStreamFn::new(server.uri(), "test-key", ApiVersion::V1beta);
+    let events = collect_events(&stream_fn).await;
+
+    let arguments: String = events
+        .iter()
+        .filter_map(|event| match event {
+            AssistantMessageEvent::ToolCallDelta { delta, .. } => Some(delta.as_str()),
+            _ => None,
+        })
+        .collect();
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(&arguments).expect("concatenated deltas must be valid JSON");
+    assert_eq!(
+        parsed,
+        serde_json::json!({"city": "Paris", "unit": "C"}),
+        "final args must match the last snapshot, got: {arguments}"
+    );
+}
+
 /// When the stream ends without an explicit finish reason the open text block
 /// must be closed by the finalization path (not silently dropped).
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Fixes #271: Gemini tool-call delta emission corrupts non-prefix arg rewrites
- Defers `ToolCallDelta` emission from inline (per-chunk) to finalization (single emission per tool call)
- Adds `emit_final_tool_deltas()` helper on `GeminiStreamState` called before `finalize_blocks()` at all 3 finalization sites

## Why
Gemini sends full argument snapshots, not deltas. The old code emitted the entire new snapshot as a `ToolCallDelta` when it wasn't a prefix extension of the previous snapshot. Since `accumulate_message` concatenates all deltas (`partial_json.push_str(&delta)`), this produced corrupted JSON like `{"a":1{"b":2}` instead of `{"b":2}`.

## Approach
Buffer the latest args snapshot in `GeminiToolCallState.arguments` without emitting deltas during streaming. At finalization, emit one `ToolCallDelta` per tool call with the complete final snapshot, then `ToolCallEnd`. This ensures the concatenated result always equals the correct final args.

## Tasks completed
- [x] Removed inline delta emission from `process_function_call`
- [x] Added `emit_final_tool_deltas()` method to `GeminiStreamState`
- [x] Updated all 3 finalization sites (stream end, Done, TransportError)
- [x] Added regression test for non-prefix arg rewrite
- [x] Added test for prefix-growth args (common case still works)

## Test plan
- [x] `cargo test -p swink-agent-adapters --test google --features gemini` — 17 tests pass
- [x] `cargo clippy -p swink-agent-adapters --features gemini` — no new warnings
- [x] No public API changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)