### PR TITLE
fix: enforce max_duration in BudgetGuard at runtime

### DIFF
--- a/adapters/src/bedrock.rs
+++ b/adapters/src/bedrock.rs
@@ -608,15 +608,7 @@ fn process_smithy_message(
         let exc_type = exception_type.as_deref().unwrap_or("unknown");
         let payload_str = std::str::from_utf8(message.payload()).unwrap_or("(binary)");
         warn!(exception_type = exc_type, "Bedrock exception frame");
-        let is_throttled = exc_type.to_lowercase().contains("throttl");
-        if is_throttled {
-            return vec![AssistantMessageEvent::error_throttled(format!(
-                "Bedrock throttled: {payload_str}"
-            ))];
-        }
-        return vec![AssistantMessageEvent::error_network(format!(
-            "Bedrock exception ({exc_type}): {payload_str}"
-        ))];
+        return vec![classify_bedrock_exception(exc_type, payload_str)];
     }
 
     // Handle normal event frames
@@ -640,6 +632,45 @@ fn process_smithy_message(
             vec![]
         })
     })
+}
+
+/// Classify a Bedrock exception frame into the correct error category.
+///
+/// Bedrock exception types map to three buckets:
+/// - **Throttled** (retryable): `throttlingException`, `tooManyRequestsException`
+/// - **Auth** (non-retryable): `accessDeniedException`, `validationException`,
+///   `resourceNotFoundException`
+/// - **Network** (retryable): `internalServerException`, `modelStreamErrorException`,
+///   `modelTimeoutException`, `serviceUnavailableException`
+///
+/// Unknown exception types fall through to a generic (unclassified) error so they
+/// are not silently treated as retryable.
+fn classify_bedrock_exception(exc_type: &str, payload: &str) -> AssistantMessageEvent {
+    let lower = exc_type.to_lowercase();
+
+    if lower.contains("throttl") || lower.contains("toomanyrequests") {
+        AssistantMessageEvent::error_throttled(format!("Bedrock throttled: {payload}"))
+    } else if lower.contains("accessdenied")
+        || lower.contains("validation")
+        || lower.contains("resourcenotfound")
+    {
+        AssistantMessageEvent::error_auth(format!(
+            "Bedrock client error ({exc_type}): {payload}"
+        ))
+    } else if lower.contains("internalserver")
+        || lower.contains("modelstreamerror")
+        || lower.contains("modeltimeout")
+        || lower.contains("serviceunavailable")
+    {
+        AssistantMessageEvent::error_network(format!(
+            "Bedrock server error ({exc_type}): {payload}"
+        ))
+    } else {
+        // Unknown exception type — do not assume retryable.
+        AssistantMessageEvent::error(format!(
+            "Bedrock exception ({exc_type}): {payload}"
+        ))
+    }
 }
 
 fn parse_event_frame(
@@ -1296,12 +1327,162 @@ mod tests {
     }
 
     #[test]
-    fn exception_frame_handling() {
+    fn exception_frame_throttling_is_throttled() {
         let mut state = BedrockStreamState::new();
         let msg = make_exception_message("throttlingException", br#"{"message":"Rate exceeded"}"#);
         let events = process_smithy_message(&msg, &mut state);
         assert_eq!(events.len(), 1);
-        assert!(matches!(events[0], AssistantMessageEvent::Error { .. }));
+        match &events[0] {
+            AssistantMessageEvent::Error { error_kind, .. } => {
+                assert_eq!(*error_kind, Some(swink_agent::StreamErrorKind::Throttled));
+            }
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn exception_frame_too_many_requests_is_throttled() {
+        let mut state = BedrockStreamState::new();
+        let msg =
+            make_exception_message("tooManyRequestsException", br#"{"message":"Slow down"}"#);
+        let events = process_smithy_message(&msg, &mut state);
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            AssistantMessageEvent::Error { error_kind, .. } => {
+                assert_eq!(*error_kind, Some(swink_agent::StreamErrorKind::Throttled));
+            }
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn exception_frame_access_denied_is_auth() {
+        let mut state = BedrockStreamState::new();
+        let msg =
+            make_exception_message("accessDeniedException", br#"{"message":"Not authorized"}"#);
+        let events = process_smithy_message(&msg, &mut state);
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            AssistantMessageEvent::Error { error_kind, .. } => {
+                assert_eq!(*error_kind, Some(swink_agent::StreamErrorKind::Auth));
+            }
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn exception_frame_validation_is_auth() {
+        let mut state = BedrockStreamState::new();
+        let msg =
+            make_exception_message("validationException", br#"{"message":"Invalid request"}"#);
+        let events = process_smithy_message(&msg, &mut state);
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            AssistantMessageEvent::Error { error_kind, .. } => {
+                assert_eq!(*error_kind, Some(swink_agent::StreamErrorKind::Auth));
+            }
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn exception_frame_resource_not_found_is_auth() {
+        let mut state = BedrockStreamState::new();
+        let msg = make_exception_message(
+            "resourceNotFoundException",
+            br#"{"message":"Model not found"}"#,
+        );
+        let events = process_smithy_message(&msg, &mut state);
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            AssistantMessageEvent::Error { error_kind, .. } => {
+                assert_eq!(*error_kind, Some(swink_agent::StreamErrorKind::Auth));
+            }
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn exception_frame_internal_server_is_network() {
+        let mut state = BedrockStreamState::new();
+        let msg = make_exception_message(
+            "internalServerException",
+            br#"{"message":"Internal error"}"#,
+        );
+        let events = process_smithy_message(&msg, &mut state);
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            AssistantMessageEvent::Error { error_kind, .. } => {
+                assert_eq!(*error_kind, Some(swink_agent::StreamErrorKind::Network));
+            }
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn exception_frame_model_stream_error_is_network() {
+        let mut state = BedrockStreamState::new();
+        let msg = make_exception_message(
+            "modelStreamErrorException",
+            br#"{"message":"Stream failed"}"#,
+        );
+        let events = process_smithy_message(&msg, &mut state);
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            AssistantMessageEvent::Error { error_kind, .. } => {
+                assert_eq!(*error_kind, Some(swink_agent::StreamErrorKind::Network));
+            }
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn exception_frame_model_timeout_is_network() {
+        let mut state = BedrockStreamState::new();
+        let msg =
+            make_exception_message("modelTimeoutException", br#"{"message":"Timeout"}"#);
+        let events = process_smithy_message(&msg, &mut state);
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            AssistantMessageEvent::Error { error_kind, .. } => {
+                assert_eq!(*error_kind, Some(swink_agent::StreamErrorKind::Network));
+            }
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn exception_frame_service_unavailable_is_network() {
+        let mut state = BedrockStreamState::new();
+        let msg = make_exception_message(
+            "serviceUnavailableException",
+            br#"{"message":"Service down"}"#,
+        );
+        let events = process_smithy_message(&msg, &mut state);
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            AssistantMessageEvent::Error { error_kind, .. } => {
+                assert_eq!(*error_kind, Some(swink_agent::StreamErrorKind::Network));
+            }
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn exception_frame_unknown_type_is_unclassified() {
+        let mut state = BedrockStreamState::new();
+        let msg = make_exception_message(
+            "someFutureException",
+            br#"{"message":"Something new"}"#,
+        );
+        let events = process_smithy_message(&msg, &mut state);
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            AssistantMessageEvent::Error { error_kind, .. } => {
+                assert_eq!(*error_kind, None, "unknown exceptions should not be classified as retryable");
+            }
+            other => panic!("expected Error, got {other:?}"),
+        }
     }
 
     #[test]

--- a/adapters/src/google.rs
+++ b/adapters/src/google.rs
@@ -743,12 +743,9 @@ fn process_function_call(
 }
 
 fn map_finish_reason(finish_reason: &str, saw_tool_call: bool) -> StopReason {
-    if saw_tool_call {
-        return StopReason::ToolUse;
-    }
-
     match finish_reason {
         "MAX_TOKENS" => StopReason::Length,
+        _ if saw_tool_call => StopReason::ToolUse,
         _ => StopReason::Stop,
     }
 }

--- a/adapters/tests/google.rs
+++ b/adapters/tests/google.rs
@@ -512,6 +512,52 @@ async fn gemini_two_tool_calls_have_sequential_content_indices() {
     assert_eq!(cis[1], cis[0] + 1, "content indices must be sequential");
 }
 
+/// When a tool call is emitted but finishReason is MAX_TOKENS, the stop reason
+/// must be Length — not ToolUse. Regression test for #273.
+#[tokio::test]
+async fn gemini_max_tokens_after_tool_call_reports_length() {
+    let body = [
+        r#"data: {"candidates":[{"content":{"parts":[{"functionCall":{"id":"c1","name":"get_weather","args":{"city":"Paris"}}}]}}]}"#,
+        "",
+        r#"data: {"candidates":[{"finishReason":"MAX_TOKENS"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":50,"totalTokenCount":60}}"#,
+        "",
+        "data: [DONE]",
+        "",
+    ]
+    .join("\n");
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path(
+            "/v1beta/models/gemini-3-flash-preview:streamGenerateContent",
+        ))
+        .and(query_param("alt", "sse"))
+        .respond_with(sse_response(&body))
+        .mount(&server)
+        .await;
+
+    let stream_fn = GeminiStreamFn::new(server.uri(), "test-key", ApiVersion::V1beta);
+    let events = collect_events(&stream_fn).await;
+
+    // Tool call events should still be present
+    let types: Vec<_> = events.iter().map(event_name).collect();
+    assert!(
+        types.contains(&"ToolCallStart"),
+        "missing ToolCallStart: {types:?}"
+    );
+
+    // Stop reason must be Length, not ToolUse
+    let stop_reason = events.iter().find_map(|event| match event {
+        AssistantMessageEvent::Done { stop_reason, .. } => Some(*stop_reason),
+        _ => None,
+    });
+    assert_eq!(
+        stop_reason,
+        Some(StopReason::Length),
+        "MAX_TOKENS must map to Length even when tool calls were emitted"
+    );
+}
+
 /// When the stream ends without an explicit finish reason the open text block
 /// must be closed by the finalization path (not silently dropped).
 #[tokio::test]

--- a/eval/src/trajectory.rs
+++ b/eval/src/trajectory.rs
@@ -12,24 +12,28 @@ use tracing::warn;
 
 use crate::types::{EvalCase, Invocation, RecordedToolCall, TurnRecord};
 
-/// Real-time budget guard that cancels an agent run when cost, token, or turn
-/// thresholds are exceeded mid-execution.
+/// Real-time budget guard that cancels an agent run when cost, token, turn,
+/// or duration thresholds are exceeded mid-execution.
 pub struct BudgetGuard {
     cancel: CancellationToken,
     max_cost: Option<f64>,
     max_tokens: Option<u64>,
     max_turns: Option<usize>,
+    max_duration: Option<Duration>,
+    start_time: Instant,
 }
 
 impl BudgetGuard {
     /// Create a guard with the given cancellation token and no thresholds.
     #[must_use]
-    pub const fn new(cancel: CancellationToken) -> Self {
+    pub fn new(cancel: CancellationToken) -> Self {
         Self {
             cancel,
             max_cost: None,
             max_tokens: None,
             max_turns: None,
+            max_duration: None,
+            start_time: Instant::now(),
         }
     }
 
@@ -54,18 +58,30 @@ impl BudgetGuard {
         self
     }
 
+    /// Set a maximum wall-clock duration threshold.
+    #[must_use]
+    pub const fn with_max_duration(mut self, max_duration: Duration) -> Self {
+        self.max_duration = Some(max_duration);
+        self
+    }
+
     /// Build a guard from an eval case's budget constraints, if any thresholds
     /// are defined.
     #[must_use]
     pub fn from_case(case: &EvalCase, cancel: CancellationToken) -> Option<Self> {
         let budget = case.budget.as_ref()?;
-        if budget.max_cost.is_none() && budget.max_tokens.is_none() && budget.max_turns.is_none() {
+        if budget.max_cost.is_none()
+            && budget.max_tokens.is_none()
+            && budget.max_turns.is_none()
+            && budget.max_duration.is_none()
+        {
             return None;
         }
         let mut guard = Self::new(cancel);
         guard.max_cost = budget.max_cost;
         guard.max_tokens = budget.max_tokens;
         guard.max_turns = budget.max_turns;
+        guard.max_duration = budget.max_duration;
         Some(guard)
     }
 }
@@ -221,6 +237,11 @@ impl TrajectoryCollector {
         {
             return true;
         }
+        if let Some(max_duration) = guard.max_duration
+            && guard.start_time.elapsed() > max_duration
+        {
+            return true;
+        }
         false
     }
 
@@ -246,6 +267,7 @@ impl TrajectoryCollector {
                     cost = collector.accumulated_cost.total,
                     tokens = collector.accumulated_usage.total,
                     turns = collector.turn_counter,
+                    elapsed_ms = g.start_time.elapsed().as_millis() as u64,
                     "budget guard triggered — cancelling agent run"
                 );
                 g.cancel.cancel();
@@ -309,5 +331,68 @@ mod tests {
             .with_max_tokens(1000)
             .with_max_turns(10);
         assert!(!c.exceeds_budget(&guard));
+    }
+
+    #[test]
+    fn exceeds_duration() {
+        let c = make_collector(1.0, 100, 2);
+        // Create a guard with a zero-duration limit — already exceeded.
+        let guard =
+            BudgetGuard::new(CancellationToken::new()).with_max_duration(Duration::ZERO);
+        assert!(c.exceeds_budget(&guard));
+    }
+
+    #[test]
+    fn within_duration() {
+        let c = make_collector(1.0, 100, 2);
+        // 1 hour should be well within bounds for this test.
+        let guard = BudgetGuard::new(CancellationToken::new())
+            .with_max_duration(Duration::from_secs(3600));
+        assert!(!c.exceeds_budget(&guard));
+    }
+
+    fn make_eval_case(budget: Option<crate::types::BudgetConstraints>) -> EvalCase {
+        EvalCase {
+            id: "test".to_string(),
+            name: "test".to_string(),
+            description: None,
+            system_prompt: String::new(),
+            user_messages: vec!["hi".to_string()],
+            expected_trajectory: None,
+            expected_response: None,
+            evaluators: vec![],
+            budget,
+            metadata: Default::default(),
+        }
+    }
+
+    #[test]
+    fn from_case_includes_duration() {
+        use crate::types::BudgetConstraints;
+
+        let case = make_eval_case(Some(BudgetConstraints {
+            max_cost: None,
+            max_tokens: None,
+            max_turns: None,
+            max_duration: Some(Duration::from_secs(30)),
+        }));
+        let guard = BudgetGuard::from_case(&case, CancellationToken::new());
+        assert!(guard.is_some());
+        let g = guard.unwrap();
+        assert_eq!(g.max_duration, Some(Duration::from_secs(30)));
+    }
+
+    #[test]
+    fn from_case_none_when_all_empty() {
+        use crate::types::BudgetConstraints;
+
+        let case = make_eval_case(Some(BudgetConstraints {
+            max_cost: None,
+            max_tokens: None,
+            max_turns: None,
+            max_duration: None,
+        }));
+        let guard = BudgetGuard::from_case(&case, CancellationToken::new());
+        assert!(guard.is_none());
     }
 }

--- a/policies/src/loop_detection.rs
+++ b/policies/src/loop_detection.rs
@@ -60,13 +60,37 @@ impl LoopDetectionPolicy {
     }
 
     /// Extract tool call fingerprints from a turn context.
+    ///
+    /// Fingerprints are derived from the assistant message's `ToolCall` content
+    /// blocks (tool name + arguments), which are stable across invocations.
+    /// Falls back to tool result content when no matching tool call is found.
     fn extract_fingerprint(turn: &TurnPolicyContext<'_>) -> Vec<(String, serde_json::Value)> {
+        // Build a lookup from tool_call_id -> (name, arguments) from assistant message
+        let tool_calls: std::collections::HashMap<&str, (&str, &serde_json::Value)> = turn
+            .assistant_message
+            .content
+            .iter()
+            .filter_map(|block| match block {
+                ContentBlock::ToolCall {
+                    id,
+                    name,
+                    arguments,
+                    ..
+                } => Some((id.as_str(), (name.as_str(), arguments))),
+                _ => None,
+            })
+            .collect();
+
         turn.tool_results
             .iter()
             .map(|tr| {
-                // Use the tool_call_id prefix (tool name) and content as fingerprint
-                // The actual tool name isn't in ToolResultMessage, so we use the content hash
-                (tr.tool_call_id.clone(), serde_json::json!(tr.content))
+                if let Some((name, args)) = tool_calls.get(tr.tool_call_id.as_str()) {
+                    // Stable fingerprint: tool name + arguments
+                    ((*name).to_string(), (*args).clone())
+                } else {
+                    // Fallback: use tool result content (still more stable than tool_call_id)
+                    ("_unknown".to_string(), serde_json::json!(tr.content))
+                }
             })
             .collect()
     }
@@ -185,9 +209,17 @@ mod tests {
         }
     }
 
-    fn dummy_msg() -> AssistantMessage {
+    fn msg_with_tool_calls(calls: &[(&str, &str, serde_json::Value)]) -> AssistantMessage {
         AssistantMessage {
-            content: vec![],
+            content: calls
+                .iter()
+                .map(|(id, name, args)| ContentBlock::ToolCall {
+                    id: id.to_string(),
+                    name: name.to_string(),
+                    arguments: args.clone(),
+                    partial_json: None,
+                })
+                .collect(),
             provider: String::new(),
             model_id: String::new(),
             usage: Usage::default(),
@@ -220,24 +252,26 @@ mod tests {
         let cost = Cost::default();
         let state = swink_agent::SessionState::new();
         let ctx = make_ctx(&usage, &cost, &state);
-        let msg = dummy_msg();
 
-        let results1 = vec![tool_result("bash_1", "output1")];
-        let turn1 = make_turn_ctx(&msg, &results1);
+        let msg1 = msg_with_tool_calls(&[("id1", "bash", serde_json::json!({"cmd": "ls"}))]);
+        let results1 = vec![tool_result("id1", "output1")];
+        let turn1 = make_turn_ctx(&msg1, &results1);
         assert!(matches!(
             policy.evaluate(&ctx, &turn1),
             PolicyVerdict::Continue
         ));
 
-        let results2 = vec![tool_result("bash_2", "output2")];
-        let turn2 = make_turn_ctx(&msg, &results2);
+        let msg2 = msg_with_tool_calls(&[("id2", "bash", serde_json::json!({"cmd": "pwd"}))]);
+        let results2 = vec![tool_result("id2", "output2")];
+        let turn2 = make_turn_ctx(&msg2, &results2);
         assert!(matches!(
             policy.evaluate(&ctx, &turn2),
             PolicyVerdict::Continue
         ));
 
-        let results3 = vec![tool_result("bash_3", "output3")];
-        let turn3 = make_turn_ctx(&msg, &results3);
+        let msg3 = msg_with_tool_calls(&[("id3", "bash", serde_json::json!({"cmd": "whoami"}))]);
+        let results3 = vec![tool_result("id3", "output3")];
+        let turn3 = make_turn_ctx(&msg3, &results3);
         assert!(matches!(
             policy.evaluate(&ctx, &turn3),
             PolicyVerdict::Continue
@@ -251,9 +285,10 @@ mod tests {
         let cost = Cost::default();
         let state = swink_agent::SessionState::new();
         let ctx = make_ctx(&usage, &cost, &state);
-        let msg = dummy_msg();
 
-        let results = vec![tool_result("bash_1", "same_output")];
+        // Same tool name + args each turn (but tool_call_id could differ)
+        let msg = msg_with_tool_calls(&[("id1", "bash", serde_json::json!({"cmd": "ls"}))]);
+        let results = vec![tool_result("id1", "same_output")];
 
         let turn = make_turn_ctx(&msg, &results);
         let r1 = policy.evaluate(&ctx, &turn);
@@ -275,9 +310,9 @@ mod tests {
         let cost = Cost::default();
         let state = swink_agent::SessionState::new();
         let ctx = make_ctx(&usage, &cost, &state);
-        let msg = dummy_msg();
 
-        let results = vec![tool_result("bash_1", "same")];
+        let msg = msg_with_tool_calls(&[("id1", "bash", serde_json::json!({"cmd": "ls"}))]);
+        let results = vec![tool_result("id1", "same")];
 
         let turn = make_turn_ctx(&msg, &results);
         let _ = policy.evaluate(&ctx, &turn); // 1st
@@ -294,14 +329,15 @@ mod tests {
         let cost = Cost::default();
         let state = swink_agent::SessionState::new();
         let ctx = make_ctx(&usage, &cost, &state);
-        let msg = dummy_msg();
 
-        let results1 = vec![tool_result("bash_1", "output_a")];
-        let turn1 = make_turn_ctx(&msg, &results1);
+        let msg1 = msg_with_tool_calls(&[("id1", "bash", serde_json::json!({"cmd": "ls"}))]);
+        let results1 = vec![tool_result("id1", "output_a")];
+        let turn1 = make_turn_ctx(&msg1, &results1);
         let _ = policy.evaluate(&ctx, &turn1);
 
-        let results2 = vec![tool_result("bash_1", "output_b")]; // different content
-        let turn2 = make_turn_ctx(&msg, &results2);
+        let msg2 = msg_with_tool_calls(&[("id2", "bash", serde_json::json!({"cmd": "pwd"}))]);
+        let results2 = vec![tool_result("id2", "output_b")];
+        let turn2 = make_turn_ctx(&msg2, &results2);
         let r = policy.evaluate(&ctx, &turn2);
         assert!(matches!(r, PolicyVerdict::Continue));
     }
@@ -313,24 +349,58 @@ mod tests {
         let cost = Cost::default();
         let state = swink_agent::SessionState::new();
         let ctx = make_ctx(&usage, &cost, &state);
-        let msg = dummy_msg();
+
+        let same_args = serde_json::json!({"cmd": "ls"});
+        let diff_args = serde_json::json!({"cmd": "pwd"});
 
         // Push 2 identical, then 1 different, then 2 identical again
         // Should not trigger because the different one breaks the streak
-        let same = vec![tool_result("bash_1", "same")];
-        let different = vec![tool_result("bash_1", "different")];
+        let same_msg = msg_with_tool_calls(&[("id1", "bash", same_args.clone())]);
+        let same_res = vec![tool_result("id1", "same")];
+        let diff_msg = msg_with_tool_calls(&[("id2", "bash", diff_args)]);
+        let diff_res = vec![tool_result("id2", "different")];
 
-        let t = make_turn_ctx(&msg, &same);
+        let t = make_turn_ctx(&same_msg, &same_res);
         let _ = policy.evaluate(&ctx, &t);
-        let t = make_turn_ctx(&msg, &same);
+        let t = make_turn_ctx(&same_msg, &same_res);
         let _ = policy.evaluate(&ctx, &t);
-        let t = make_turn_ctx(&msg, &different);
+        let t = make_turn_ctx(&diff_msg, &diff_res);
         let _ = policy.evaluate(&ctx, &t);
-        let t = make_turn_ctx(&msg, &same);
+        let t = make_turn_ctx(&same_msg, &same_res);
         let _ = policy.evaluate(&ctx, &t);
-        let t = make_turn_ctx(&msg, &same);
+        let t = make_turn_ctx(&same_msg, &same_res);
         let r = policy.evaluate(&ctx, &t);
         // Last 3: different, same, same — not all identical
         assert!(matches!(r, PolicyVerdict::Continue));
+    }
+
+    /// Regression test for #276: identical tool calls with different tool_call_ids
+    /// must still be detected as a loop.
+    #[test]
+    fn fresh_tool_call_ids_still_detected_as_loop() {
+        let policy = LoopDetectionPolicy::new(3);
+        let usage = Usage::default();
+        let cost = Cost::default();
+        let state = swink_agent::SessionState::new();
+        let ctx = make_ctx(&usage, &cost, &state);
+
+        let args = serde_json::json!({"command": "ls -la"});
+
+        // Each turn has the same tool name + args but a different tool_call_id
+        let msg1 = msg_with_tool_calls(&[("call_abc", "bash", args.clone())]);
+        let res1 = vec![tool_result("call_abc", "file1.txt")];
+        let t1 = make_turn_ctx(&msg1, &res1);
+        assert!(matches!(policy.evaluate(&ctx, &t1), PolicyVerdict::Continue));
+
+        let msg2 = msg_with_tool_calls(&[("call_def", "bash", args.clone())]);
+        let res2 = vec![tool_result("call_def", "file1.txt")];
+        let t2 = make_turn_ctx(&msg2, &res2);
+        assert!(matches!(policy.evaluate(&ctx, &t2), PolicyVerdict::Continue));
+
+        let msg3 = msg_with_tool_calls(&[("call_ghi", "bash", args.clone())]);
+        let res3 = vec![tool_result("call_ghi", "file1.txt")];
+        let t3 = make_turn_ctx(&msg3, &res3);
+        // Despite fresh IDs each time, the tool name + args are identical → loop detected
+        assert!(matches!(policy.evaluate(&ctx, &t3), PolicyVerdict::Stop(_)));
     }
 }

--- a/src/agent/checkpointing.rs
+++ b/src/agent/checkpointing.rs
@@ -11,6 +11,16 @@ use super::Agent;
 use super::queueing::llm_messages_from_queue;
 
 impl Agent {
+    /// Rebind `self.stream_fn` if the current model's `provider`/`model_id`
+    /// matches one of the registered `model_stream_fns`.
+    fn rebind_stream_fn_for_current_model(&mut self) {
+        if let Some((_, stream_fn)) = self.model_stream_fns.iter().find(|(m, _)| {
+            m.provider == self.state.model.provider && m.model_id == self.state.model.model_id
+        }) {
+            self.stream_fn = std::sync::Arc::clone(stream_fn);
+        }
+    }
+
     // ── Checkpointing ────────────────────────────────────────────────────
 
     /// Create a checkpoint of the current agent state.
@@ -49,7 +59,10 @@ impl Agent {
     /// Restore agent message history from a checkpoint.
     ///
     /// Replaces the current messages with those from the checkpoint and
-    /// updates the system prompt to match. Persisted custom messages are
+    /// updates the system prompt to match. If the checkpoint's model
+    /// matches one of the [`available_models`](crate::AgentOptions::with_available_models),
+    /// the stream function is rebound automatically; otherwise the current
+    /// stream function is left in place. Persisted custom messages are
     /// restored when a [`CustomMessageRegistry`](crate::types::CustomMessageRegistry)
     /// has been configured on [`AgentOptions`](crate::AgentOptions) via
     /// [`with_custom_message_registry`](crate::AgentOptions::with_custom_message_registry);
@@ -61,6 +74,7 @@ impl Agent {
             .clone_from(&checkpoint.system_prompt);
         self.state.model.provider.clone_from(&checkpoint.provider);
         self.state.model.model_id.clone_from(&checkpoint.model_id);
+        self.rebind_stream_fn_for_current_model();
 
         if let Some(ref state_val) = checkpoint.state {
             let restored = crate::SessionState::restore_from_snapshot(state_val.clone());
@@ -127,7 +141,8 @@ impl Agent {
             &self.state.model.model_id,
             &self.state.messages,
         )
-        .with_pending_messages(llm_messages_from_queue(&self.follow_up_queue));
+        .with_pending_messages(llm_messages_from_queue(&self.follow_up_queue))
+        .with_pending_steering_messages(llm_messages_from_queue(&self.steering_queue));
 
         let s = self
             .session_state
@@ -176,6 +191,7 @@ impl Agent {
             .clone_from(&checkpoint.system_prompt);
         self.state.model.provider.clone_from(&checkpoint.provider);
         self.state.model.model_id.clone_from(&checkpoint.model_id);
+        self.rebind_stream_fn_for_current_model();
 
         if let Some(ref state_val) = checkpoint.state {
             let restored = crate::SessionState::restore_from_snapshot(state_val.clone());
@@ -192,6 +208,9 @@ impl Agent {
 
         for msg in checkpoint.restore_pending_messages() {
             self.follow_up(msg);
+        }
+        for msg in checkpoint.restore_pending_steering_messages() {
+            self.steer(msg);
         }
 
         tracing::info!(
@@ -297,6 +316,227 @@ mod tests {
             .downcast_ref::<Tagged>()
             .expect("custom message should be restored via registry");
         assert_eq!(restored.value, "preserved");
+    }
+
+    #[tokio::test]
+    async fn pause_captures_both_steering_and_follow_up_queues() {
+        use crate::types::ContentBlock;
+
+        let mut agent = make_agent(None);
+        // Give the agent a message so it's valid to resume
+        agent
+            .state
+            .messages
+            .push(AgentMessage::Llm(LlmMessage::User(UserMessage {
+                content: vec![ContentBlock::Text {
+                    text: "hi".to_string(),
+                }],
+                timestamp: 0,
+                cache_hint: None,
+            })));
+
+        // Queue a steering message and a follow-up message
+        agent.steer(AgentMessage::Llm(LlmMessage::User(UserMessage {
+            content: vec![ContentBlock::Text {
+                text: "steering-msg".to_string(),
+            }],
+            timestamp: 1,
+            cache_hint: None,
+        })));
+        agent.follow_up(AgentMessage::Llm(LlmMessage::User(UserMessage {
+            content: vec![ContentBlock::Text {
+                text: "followup-msg".to_string(),
+            }],
+            timestamp: 2,
+            cache_hint: None,
+        })));
+
+        // Simulate a running loop so pause() doesn't return None
+        agent
+            .loop_active
+            .store(true, std::sync::atomic::Ordering::Release);
+
+        let checkpoint = agent.pause().expect("agent should be running");
+
+        // Verify both queues are captured separately
+        assert_eq!(
+            checkpoint.pending_messages.len(),
+            1,
+            "follow-up queue should be captured"
+        );
+        assert_eq!(
+            checkpoint.pending_steering_messages.len(),
+            1,
+            "steering queue should be captured"
+        );
+
+        // Verify the content is correct
+        match &checkpoint.pending_messages[0] {
+            LlmMessage::User(u) => match &u.content[0] {
+                ContentBlock::Text { text } => assert_eq!(text, "followup-msg"),
+                _ => panic!("expected text content"),
+            },
+            _ => panic!("expected user message"),
+        }
+        match &checkpoint.pending_steering_messages[0] {
+            LlmMessage::User(u) => match &u.content[0] {
+                ContentBlock::Text { text } => assert_eq!(text, "steering-msg"),
+                _ => panic!("expected text content"),
+            },
+            _ => panic!("expected user message"),
+        }
+    }
+
+    #[tokio::test]
+    async fn restore_from_loop_checkpoint_routes_steering_to_steering_queue() {
+        use crate::checkpoint::LoopCheckpoint;
+        use crate::types::ContentBlock;
+
+        let messages = vec![AgentMessage::Llm(LlmMessage::User(UserMessage {
+            content: vec![ContentBlock::Text {
+                text: "hi".to_string(),
+            }],
+            timestamp: 0,
+            cache_hint: None,
+        }))];
+
+        let cp = LoopCheckpoint::new("system", "mock", "mock-model", &messages)
+            .with_pending_messages(vec![LlmMessage::User(UserMessage {
+                content: vec![ContentBlock::Text {
+                    text: "followup".to_string(),
+                }],
+                timestamp: 1,
+                cache_hint: None,
+            })])
+            .with_pending_steering_messages(vec![LlmMessage::User(UserMessage {
+                content: vec![ContentBlock::Text {
+                    text: "steering".to_string(),
+                }],
+                timestamp: 2,
+                cache_hint: None,
+            })]);
+
+        let mut agent = make_agent(None);
+        agent.restore_from_loop_checkpoint(&cp).unwrap();
+
+        // Verify steering went to steering queue, follow-up to follow-up queue
+        let steering = agent
+            .steering_queue
+            .lock()
+            .unwrap();
+        let follow_up = agent
+            .follow_up_queue
+            .lock()
+            .unwrap();
+
+        assert_eq!(steering.len(), 1, "steering queue should have 1 message");
+        assert_eq!(follow_up.len(), 1, "follow-up queue should have 1 message");
+
+        match &steering[0] {
+            AgentMessage::Llm(LlmMessage::User(u)) => match &u.content[0] {
+                ContentBlock::Text { text } => assert_eq!(text, "steering"),
+                _ => panic!("expected text"),
+            },
+            _ => panic!("expected user message in steering queue"),
+        }
+        match &follow_up[0] {
+            AgentMessage::Llm(LlmMessage::User(u)) => match &u.content[0] {
+                ContentBlock::Text { text } => assert_eq!(text, "followup"),
+                _ => panic!("expected text"),
+            },
+            _ => panic!("expected user message in follow-up queue"),
+        }
+    }
+
+    #[tokio::test]
+    async fn restore_from_checkpoint_rebinds_stream_fn_for_matching_model() {
+        use crate::stream::StreamFn;
+        use crate::types::ContentBlock;
+
+        let model_a = ModelSpec::new("provider-a", "model-a");
+        let model_b = ModelSpec::new("provider-b", "model-b");
+        let stream_a = Arc::new(SimpleMockStreamFn::from_text("from-a"));
+        let stream_b = Arc::new(SimpleMockStreamFn::from_text("from-b"));
+
+        // Agent starts on model_a, with model_b registered as available.
+        let opts = AgentOptions::new_simple("system", model_a.clone(), stream_a.clone())
+            .with_available_models(vec![(model_b.clone(), stream_b.clone())]);
+        let mut agent = Agent::new(opts);
+
+        // Confirm initial stream_fn points to stream_a.
+        assert!(
+            Arc::ptr_eq(&agent.stream_fn, &(stream_a.clone() as Arc<dyn StreamFn>)),
+            "initial stream_fn should be stream_a"
+        );
+
+        // Build a checkpoint from a source agent that uses model_b.
+        let source_opts =
+            AgentOptions::new_simple("system", model_b.clone(), stream_b.clone());
+        let mut source = Agent::new(source_opts);
+        source
+            .state
+            .messages
+            .push(AgentMessage::Llm(LlmMessage::User(UserMessage {
+                content: vec![ContentBlock::Text {
+                    text: "hello".to_string(),
+                }],
+                timestamp: 0,
+                cache_hint: None,
+            })));
+        let checkpoint = source.save_checkpoint("cp-rebind").await.unwrap();
+
+        // Restore into agent (currently on model_a).
+        agent.restore_from_checkpoint(&checkpoint);
+
+        // Model metadata should reflect model_b.
+        assert_eq!(agent.state.model.provider, "provider-b");
+        assert_eq!(agent.state.model.model_id, "model-b");
+
+        // Stream function should now be rebound to stream_b.
+        assert!(
+            Arc::ptr_eq(&agent.stream_fn, &(stream_b.clone() as Arc<dyn StreamFn>)),
+            "stream_fn should be rebound to stream_b after checkpoint restore"
+        );
+    }
+
+    #[tokio::test]
+    async fn restore_from_loop_checkpoint_rebinds_stream_fn_for_matching_model() {
+        use crate::checkpoint::LoopCheckpoint;
+        use crate::stream::StreamFn;
+        use crate::types::ContentBlock;
+
+        let model_a = ModelSpec::new("provider-a", "model-a");
+        let model_b = ModelSpec::new("provider-b", "model-b");
+        let stream_a = Arc::new(SimpleMockStreamFn::from_text("from-a"));
+        let stream_b = Arc::new(SimpleMockStreamFn::from_text("from-b"));
+
+        let opts = AgentOptions::new_simple("system", model_a.clone(), stream_a.clone())
+            .with_available_models(vec![(model_b.clone(), stream_b.clone())]);
+        let mut agent = Agent::new(opts);
+
+        assert!(
+            Arc::ptr_eq(&agent.stream_fn, &(stream_a.clone() as Arc<dyn StreamFn>)),
+            "initial stream_fn should be stream_a"
+        );
+
+        // Build a LoopCheckpoint for model_b.
+        let messages = vec![AgentMessage::Llm(LlmMessage::User(UserMessage {
+            content: vec![ContentBlock::Text {
+                text: "hello".to_string(),
+            }],
+            timestamp: 0,
+            cache_hint: None,
+        }))];
+        let cp = LoopCheckpoint::new("system", "provider-b", "model-b", &messages);
+
+        agent.restore_from_loop_checkpoint(&cp).unwrap();
+
+        assert_eq!(agent.state.model.provider, "provider-b");
+        assert_eq!(agent.state.model.model_id, "model-b");
+        assert!(
+            Arc::ptr_eq(&agent.stream_fn, &(stream_b.clone() as Arc<dyn StreamFn>)),
+            "stream_fn should be rebound to stream_b after loop checkpoint restore"
+        );
     }
 
     #[tokio::test]

--- a/src/agent/control.rs
+++ b/src/agent/control.rs
@@ -16,7 +16,21 @@ impl Agent {
     }
 
     /// Reset the agent to its initial state, clearing messages, queues, and error.
+    ///
+    /// If a loop is currently active, the abort token is cancelled and the
+    /// generation counter is bumped so the stale [`LoopGuardStream`] cannot
+    /// clear `loop_active` for any future run.
     pub fn reset(&mut self) {
+        // Cancel the running loop *before* dropping the token, so the spawned
+        // stream observes cancellation rather than continuing to emit events.
+        if let Some(ref token) = self.abort_controller {
+            token.cancel();
+        }
+
+        // Bump the generation counter so the old LoopGuardStream's Drop impl
+        // sees a mismatched generation and skips clearing loop_active.
+        self.loop_generation.fetch_add(1, Ordering::AcqRel);
+
         self.state.messages.clear();
         self.state.is_running = false;
         self.loop_active.store(false, Ordering::Release);

--- a/src/agent/state_updates.rs
+++ b/src/agent/state_updates.rs
@@ -62,7 +62,7 @@ impl Agent {
                         received_full_context = true;
                     }
                     Err(messages) => {
-                        self.state.messages = clone_llm_messages(messages.as_ref());
+                        self.state.messages = clone_messages(messages.as_ref());
                         received_full_context = true;
                     }
                 },
@@ -112,7 +112,7 @@ impl Agent {
                 }
             }
             AgentEvent::AgentEnd { messages } => {
-                self.state.messages = clone_llm_messages(messages.as_ref());
+                self.state.messages = clone_messages(messages.as_ref());
                 self.in_flight_llm_messages = None;
                 // Preserve terminal error — do not clear self.state.error.
                 self.idle_notify.notify_waiters();
@@ -148,12 +148,21 @@ impl Agent {
     }
 }
 
-fn clone_llm_messages(messages: &[AgentMessage]) -> Vec<AgentMessage> {
+fn clone_messages(messages: &[AgentMessage]) -> Vec<AgentMessage> {
     messages
         .iter()
         .filter_map(|message| match message {
             AgentMessage::Llm(llm) => Some(AgentMessage::Llm(llm.clone())),
-            AgentMessage::Custom(_) => None,
+            AgentMessage::Custom(cm) => cm.clone_box().map_or_else(
+                || {
+                    tracing::warn!(
+                        "CustomMessage {:?} does not support clone_box — dropped during state rebuild",
+                        cm
+                    );
+                    None
+                },
+                |cloned| Some(AgentMessage::Custom(cloned)),
+            ),
         })
         .collect()
 }

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -173,8 +173,14 @@ pub struct LoopCheckpoint {
     /// Records the original interleaved order of LLM and custom messages.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     message_order: Vec<MessageSlot>,
-    /// Messages queued for injection into the next turn.
+    /// Follow-up messages queued for injection into the next turn.
     pub pending_messages: Vec<LlmMessage>,
+    /// Steering messages queued at the time of pause.
+    ///
+    /// Older checkpoints without this field deserialize with an empty vec
+    /// (backward compatible).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub pending_steering_messages: Vec<LlmMessage>,
     /// The system prompt active at the time of pause.
     pub system_prompt: String,
     /// Model provider name.
@@ -210,6 +216,7 @@ impl LoopCheckpoint {
             custom_messages: serialized.custom_messages,
             message_order: serialized.message_order,
             pending_messages: Vec::new(),
+            pending_steering_messages: Vec::new(),
             system_prompt: system_prompt.into(),
             provider: provider.into(),
             model_id: model_id.into(),
@@ -226,10 +233,17 @@ impl LoopCheckpoint {
         self
     }
 
-    /// Set pending messages.
+    /// Set pending follow-up messages.
     #[must_use]
     pub fn with_pending_messages(mut self, pending: Vec<LlmMessage>) -> Self {
         self.pending_messages = pending;
+        self
+    }
+
+    /// Set pending steering messages.
+    #[must_use]
+    pub fn with_pending_steering_messages(mut self, pending: Vec<LlmMessage>) -> Self {
+        self.pending_steering_messages = pending;
         self
     }
 
@@ -255,10 +269,16 @@ impl LoopCheckpoint {
         )
     }
 
-    /// Restore pending messages as `AgentMessage` values.
+    /// Restore pending follow-up messages as `AgentMessage` values.
     #[must_use]
     pub fn restore_pending_messages(&self) -> Vec<AgentMessage> {
         restore_llm_messages(&self.pending_messages)
+    }
+
+    /// Restore pending steering messages as `AgentMessage` values.
+    #[must_use]
+    pub fn restore_pending_steering_messages(&self) -> Vec<AgentMessage> {
+        restore_llm_messages(&self.pending_steering_messages)
     }
 
     /// Convert this loop checkpoint into a standard [`Checkpoint`] for storage.
@@ -572,6 +592,69 @@ mod tests {
             restored[1],
             AgentMessage::Llm(LlmMessage::Assistant(_))
         ));
+    }
+
+    #[test]
+    fn loop_checkpoint_steering_messages_roundtrip() {
+        let steering = vec![LlmMessage::User(UserMessage {
+            content: vec![ContentBlock::Text {
+                text: "steer-me".to_string(),
+            }],
+            timestamp: 300,
+            cache_hint: None,
+        })];
+        let follow_up = vec![LlmMessage::User(UserMessage {
+            content: vec![ContentBlock::Text {
+                text: "follow-up".to_string(),
+            }],
+            timestamp: 301,
+            cache_hint: None,
+        })];
+
+        let cp = LoopCheckpoint::new("p", "p", "m", &[])
+            .with_pending_messages(follow_up)
+            .with_pending_steering_messages(steering);
+
+        // Serde roundtrip
+        let json = serde_json::to_string(&cp).unwrap();
+        let restored: LoopCheckpoint = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(restored.pending_messages.len(), 1);
+        assert_eq!(restored.pending_steering_messages.len(), 1);
+
+        let restored_steering = restored.restore_pending_steering_messages();
+        assert_eq!(restored_steering.len(), 1);
+        assert!(matches!(
+            restored_steering[0],
+            AgentMessage::Llm(LlmMessage::User(_))
+        ));
+    }
+
+    #[test]
+    fn loop_checkpoint_backward_compat_no_steering_field() {
+        // Simulate a checkpoint created before pending_steering_messages existed
+        let cp = LoopCheckpoint::new("p", "p", "m", &[])
+            .with_pending_messages(vec![LlmMessage::User(UserMessage {
+                content: vec![ContentBlock::Text {
+                    text: "old-follow-up".to_string(),
+                }],
+                timestamp: 100,
+                cache_hint: None,
+            })]);
+
+        let mut json_val = serde_json::to_value(&cp).unwrap();
+        // Strip the field to simulate old format
+        json_val
+            .as_object_mut()
+            .unwrap()
+            .remove("pending_steering_messages");
+        let legacy: LoopCheckpoint = serde_json::from_value(json_val).unwrap();
+
+        assert!(
+            legacy.pending_steering_messages.is_empty(),
+            "missing steering field should default to empty"
+        );
+        assert_eq!(legacy.pending_messages.len(), 1);
     }
 
     #[test]

--- a/src/loop_/tool_dispatch.rs
+++ b/src/loop_/tool_dispatch.rs
@@ -210,24 +210,35 @@ pub async fn execute_tools_concurrently(
             let requires_approval = tool_map
                 .get(tc.name.as_str())
                 .is_some_and(|t| t.requires_approval());
-            match check_approval(
-                approve_fn,
-                tc,
-                &effective_arguments,
-                idx,
-                requires_approval,
-                &tool_map,
-                &results,
-                tx,
-            )
-            .await
-            {
-                ApprovalOutcome::Approved => {}
-                ApprovalOutcome::ApprovedWith(new_params) => {
-                    effective_arguments = new_params;
+
+            // In Smart mode, auto-approve tools that declare requires_approval() == false.
+            // Only Enabled mode routes every tool through the callback unconditionally.
+            let should_call_approval = match config.approval_mode {
+                ApprovalMode::Smart => requires_approval,
+                ApprovalMode::Enabled => true,
+                ApprovalMode::Bypassed => unreachable!(), // filtered above
+            };
+
+            if should_call_approval {
+                match check_approval(
+                    approve_fn,
+                    tc,
+                    &effective_arguments,
+                    idx,
+                    requires_approval,
+                    &tool_map,
+                    &results,
+                    tx,
+                )
+                .await
+                {
+                    ApprovalOutcome::Approved => {}
+                    ApprovalOutcome::ApprovedWith(new_params) => {
+                        effective_arguments = new_params;
+                    }
+                    ApprovalOutcome::Rejected => continue,
+                    ApprovalOutcome::ChannelClosed => return ToolExecOutcome::ChannelClosed,
                 }
-                ApprovalOutcome::Rejected => continue,
-                ApprovalOutcome::ChannelClosed => return ToolExecOutcome::ChannelClosed,
             }
         }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -620,9 +620,19 @@ pub fn accumulate_message(
                 cost: c,
             } => {
                 if let Some(idx) = open_blocks.iter().position(|open| *open) {
-                    return Err(format!(
-                        "Done received with unterminated content block at index {idx}"
-                    ));
+                    if tolerate_truncated_tool_args {
+                        // Max-tokens truncation: leave open tool-call blocks
+                        // with `partial_json` set so the loop's
+                        // `recover_incomplete_tool_calls` path can convert
+                        // them into error tool results on the next turn.
+                        tracing::debug!(
+                            "Done(Length) with unterminated content block at index {idx} — tolerating for max-tokens recovery"
+                        );
+                    } else {
+                        return Err(format!(
+                            "Done received with unterminated content block at index {idx}"
+                        ));
+                    }
                 }
                 stop_reason = Some(sr);
                 usage = Some(u);
@@ -871,6 +881,43 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    // Regression for #293: Done(Length) with an unterminated tool-call block
+    // must NOT be rejected — the block should survive with `partial_json` set
+    // so `recover_incomplete_tool_calls` can convert it to an error result.
+    #[test]
+    fn done_length_with_unterminated_tool_call_is_tolerated() {
+        let events = vec![
+            AssistantMessageEvent::Start,
+            AssistantMessageEvent::ToolCallStart {
+                content_index: 0,
+                id: "tc_1".into(),
+                name: "read_file".into(),
+            },
+            AssistantMessageEvent::ToolCallDelta {
+                content_index: 0,
+                delta: r#"{"path": "/tmp"#.into(),
+            },
+            AssistantMessageEvent::Done {
+                stop_reason: StopReason::Length,
+                usage: Usage::default(),
+                cost: Cost::default(),
+            },
+        ];
+        let msg = accumulate_message(events, "test", "test")
+            .expect("Done(Length) with open tool-call block should succeed");
+        assert_eq!(msg.stop_reason, StopReason::Length);
+        // The tool call block should have partial_json set (incomplete)
+        match &msg.content[0] {
+            ContentBlock::ToolCall { partial_json, .. } => {
+                assert!(
+                    partial_json.is_some(),
+                    "partial_json should be Some for incomplete tool call"
+                );
+            }
+            other => panic!("expected ToolCall, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/types/custom_message.rs
+++ b/src/types/custom_message.rs
@@ -37,6 +37,15 @@ pub trait CustomMessage: Send + Sync + fmt::Debug + std::any::Any {
     fn to_json(&self) -> Option<serde_json::Value> {
         None
     }
+
+    /// Clone this custom message into a new boxed trait object.
+    ///
+    /// Returns `None` if the underlying type does not support cloning
+    /// (the default). Implement this to preserve custom messages across
+    /// stream-driven state rebuilds (e.g. `handle_stream_event`).
+    fn clone_box(&self) -> Option<Box<dyn CustomMessage>> {
+        None
+    }
 }
 
 /// A function that deserializes a JSON value into a boxed [`CustomMessage`].

--- a/src/types/message_codec.rs
+++ b/src/types/message_codec.rs
@@ -236,6 +236,9 @@ impl super::CustomMessage for SerializedCustomMessage {
     fn to_json(&self) -> Option<serde_json::Value> {
         Some(self.json.clone())
     }
+    fn clone_box(&self) -> Option<Box<dyn super::CustomMessage>> {
+        Some(Box::new(self.clone()))
+    }
 }
 
 // ─── clone_messages_for_send ────────────────────────────────────────────────

--- a/tests/agent.rs
+++ b/tests/agent.rs
@@ -381,3 +381,40 @@ async fn wait_for_idle_multiple_waiters() {
     let ((), ()) = tokio::join!(agent.wait_for_idle(), agent.wait_for_idle(),);
     assert!(!agent.state().is_running);
 }
+
+// ─── Regression: reset cancels active loop and bumps generation (#266) ──
+
+#[tokio::test]
+async fn reset_cancels_active_loop_and_allows_new_run() {
+    // Two scripted responses: one for the first (interrupted) run, one for the
+    // second (post-reset) run.
+    let stream_fn = Arc::new(MockStreamFn::new(vec![
+        text_only_events("first"),
+        text_only_events("second"),
+    ]));
+    let mut agent = make_agent(stream_fn);
+
+    // Start a streaming run but do NOT drain it — simulate an active loop.
+    let mut stream = agent.prompt_stream(vec![user_msg("go")]).unwrap();
+
+    // Pull at least one event so the stream is actively being consumed.
+    let _first_event = stream.next().await;
+    assert!(agent.state().is_running, "agent should be running mid-stream");
+
+    // Reset while the loop is still active. Before the fix this would not
+    // cancel the abort token and would not bump the generation counter,
+    // letting the stale LoopGuardStream corrupt state on drop.
+    agent.reset();
+
+    // Drop the old stream — its LoopGuardStream::drop should be a no-op
+    // because reset() bumped the generation counter.
+    drop(stream);
+
+    // Agent should be idle after reset.
+    assert!(!agent.state().is_running, "agent should be idle after reset");
+
+    // A new run should succeed without AlreadyRunning error.
+    let result = agent.prompt_async(vec![user_msg("go again")]).await.unwrap();
+    assert_eq!(result.stop_reason, StopReason::Stop);
+    assert!(!agent.state().is_running);
+}

--- a/tests/agent_structured.rs
+++ b/tests/agent_structured.rs
@@ -14,7 +14,10 @@ use common::{
 use futures::stream::StreamExt;
 use serde_json::json;
 
-use swink_agent::{Agent, AgentError, AgentOptions, DefaultRetryStrategy, StopReason, StreamFn};
+use swink_agent::{
+    Agent, AgentError, AgentMessage, AgentOptions, CustomMessage, DefaultRetryStrategy, StopReason,
+    StreamFn,
+};
 
 // ─── Helpers ─────────────────────────────────────────────────────────────
 
@@ -388,4 +391,72 @@ async fn handle_stream_event_preserves_terminal_error_through_agent_end() {
         Some("stream error: fatal error"),
         "terminal error must survive through AgentEnd"
     );
+}
+
+// ─── Regression test for #269: CustomMessage preservation ──────────────
+
+/// A cloneable custom message for testing state rebuild preservation.
+#[derive(Debug, Clone)]
+struct CloneableCustomMsg {
+    label: String,
+}
+
+impl CustomMessage for CloneableCustomMsg {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn clone_box(&self) -> Option<Box<dyn CustomMessage>> {
+        Some(Box::new(self.clone()))
+    }
+}
+
+/// Regression test for #269: stream-driven state rebuild via `handle_stream_event`
+/// must preserve `AgentMessage::Custom` entries that implement `clone_box`.
+#[tokio::test]
+async fn handle_stream_event_preserves_custom_messages() {
+    let stream_fn = Arc::new(MockStreamFn::new(vec![text_only_events("response")]));
+    let mut agent = make_agent(stream_fn);
+
+    // Inject a custom message alongside the user message.
+    let input = vec![
+        user_msg("hello"),
+        AgentMessage::Custom(Box::new(CloneableCustomMsg {
+            label: "my-custom".to_string(),
+        })),
+    ];
+
+    let stream = agent.prompt_stream(input).unwrap();
+    let mut stream = std::pin::pin!(stream);
+    while let Some(event) = stream.next().await {
+        agent.handle_stream_event(&event);
+    }
+
+    assert!(!agent.state().is_running, "agent should be idle");
+
+    // Count custom messages in the rebuilt state.
+    let custom_count = agent
+        .state()
+        .messages
+        .iter()
+        .filter(|m| matches!(m, AgentMessage::Custom(_)))
+        .count();
+
+    assert_eq!(
+        custom_count, 1,
+        "custom message must survive stream-driven state rebuild (got {custom_count})"
+    );
+
+    // Verify it's the right custom message by downcasting.
+    let custom = agent
+        .state()
+        .messages
+        .iter()
+        .find_map(|m| match m {
+            AgentMessage::Custom(cm) => cm.as_any().downcast_ref::<CloneableCustomMsg>(),
+            _ => None,
+        })
+        .expect("should find CloneableCustomMsg in rebuilt state");
+
+    assert_eq!(custom.label, "my-custom");
 }

--- a/tests/approval.rs
+++ b/tests/approval.rs
@@ -114,7 +114,8 @@ async fn always_reject_callback_tools_not_executed() {
 
     let responses = tool_call_then_stop("tc1", "test_tool", "{}");
     let options = make_agent(responses, vec![tool])
-        .with_approve_tool(|_req| Box::pin(async { ToolApproval::Rejected }));
+        .with_approve_tool(|_req| Box::pin(async { ToolApproval::Rejected }))
+        .with_approval_mode(ApprovalMode::Enabled);
     let mut agent = Agent::new(options);
 
     let result = agent.prompt_async(vec![user_msg("hello")]).await.unwrap();
@@ -191,15 +192,17 @@ async fn selective_approval_by_tool_name() {
     ];
 
     let options =
-        make_agent(responses, vec![allowed_tool, blocked_tool]).with_approve_tool(|req| {
-            Box::pin(async move {
-                if req.tool_name == "allowed" {
-                    ToolApproval::Approved
-                } else {
-                    ToolApproval::Rejected
-                }
+        make_agent(responses, vec![allowed_tool, blocked_tool])
+            .with_approve_tool(|req| {
+                Box::pin(async move {
+                    if req.tool_name == "allowed" {
+                        ToolApproval::Approved
+                    } else {
+                        ToolApproval::Rejected
+                    }
+                })
             })
-        });
+            .with_approval_mode(ApprovalMode::Enabled);
     let mut agent = Agent::new(options);
 
     let result = agent.prompt_async(vec![user_msg("hello")]).await.unwrap();
@@ -219,7 +222,8 @@ async fn approval_events_in_correct_order() {
 
     let responses = tool_call_then_stop("tc1", "test_tool", "{}");
     let options = make_agent(responses, vec![tool])
-        .with_approve_tool(|_req| Box::pin(async { ToolApproval::Approved }));
+        .with_approve_tool(|_req| Box::pin(async { ToolApproval::Approved }))
+        .with_approval_mode(ApprovalMode::Enabled);
     let mut agent = Agent::new(options);
 
     let log = Arc::clone(&events_log);
@@ -462,7 +466,8 @@ async fn approval_sees_post_rewrite_arguments() {
         .with_approve_tool(move |req: ToolApprovalRequest| {
             *cap.lock().unwrap() = Some(req.arguments.clone());
             Box::pin(async { ToolApproval::Approved })
-        });
+        })
+        .with_approval_mode(ApprovalMode::Enabled);
     let mut agent = Agent::new(options);
 
     let result = agent.prompt_async(vec![user_msg("hello")]).await.unwrap();
@@ -481,7 +486,95 @@ async fn approval_sees_post_rewrite_arguments() {
     );
 }
 
-/// Test 15: ToolApprovalRequested event carries rewritten arguments.
+/// Test 15: Smart mode skips approval callback for read-only tools (requires_approval == false).
+/// Regression test for #270.
+#[tokio::test]
+async fn smart_mode_skips_callback_for_readonly_tools() {
+    let tool = Arc::new(MockTool::new("read_tool")); // requires_approval defaults to false
+    let tool_ref = Arc::clone(&tool);
+    let callback_called = Arc::new(AtomicBool::new(false));
+    let callback_flag = Arc::clone(&callback_called);
+
+    let responses = tool_call_then_stop("tc1", "read_tool", "{}");
+    let options = make_agent(responses, vec![tool])
+        .with_approve_tool(move |_req| {
+            callback_flag.store(true, Ordering::SeqCst);
+            Box::pin(async { ToolApproval::Rejected }) // would reject if called
+        })
+        .with_approval_mode(ApprovalMode::Smart);
+    let mut agent = Agent::new(options);
+
+    let result = agent.prompt_async(vec![user_msg("hello")]).await.unwrap();
+    assert!(result.error.is_none());
+    assert!(
+        tool_ref.was_executed(),
+        "read-only tool should execute in Smart mode without approval"
+    );
+    assert!(
+        !callback_called.load(Ordering::SeqCst),
+        "approval callback should not be called for read-only tools in Smart mode"
+    );
+}
+
+/// Test 16: Smart mode still calls approval callback for tools that require approval.
+/// Regression test for #270.
+#[tokio::test]
+async fn smart_mode_calls_callback_for_write_tools() {
+    let tool = Arc::new(MockTool::new("write_tool").with_requires_approval(true));
+    let tool_ref = Arc::clone(&tool);
+    let callback_called = Arc::new(AtomicBool::new(false));
+    let callback_flag = Arc::clone(&callback_called);
+
+    let responses = tool_call_then_stop("tc1", "write_tool", "{}");
+    let options = make_agent(responses, vec![tool])
+        .with_approve_tool(move |_req| {
+            callback_flag.store(true, Ordering::SeqCst);
+            Box::pin(async { ToolApproval::Rejected })
+        })
+        .with_approval_mode(ApprovalMode::Smart);
+    let mut agent = Agent::new(options);
+
+    let result = agent.prompt_async(vec![user_msg("hello")]).await.unwrap();
+    assert!(
+        !tool_ref.was_executed(),
+        "write tool should be rejected in Smart mode when callback rejects"
+    );
+    assert!(
+        callback_called.load(Ordering::SeqCst),
+        "approval callback must be called for tools requiring approval in Smart mode"
+    );
+}
+
+/// Test 17: Enabled mode still routes read-only tools through approval callback.
+/// Ensures Enabled mode behavior is unchanged by the Smart mode fix (#270).
+#[tokio::test]
+async fn enabled_mode_routes_readonly_tools_through_callback() {
+    let tool = Arc::new(MockTool::new("read_tool")); // requires_approval defaults to false
+    let tool_ref = Arc::clone(&tool);
+    let callback_called = Arc::new(AtomicBool::new(false));
+    let callback_flag = Arc::clone(&callback_called);
+
+    let responses = tool_call_then_stop("tc1", "read_tool", "{}");
+    let options = make_agent(responses, vec![tool])
+        .with_approve_tool(move |_req| {
+            callback_flag.store(true, Ordering::SeqCst);
+            Box::pin(async { ToolApproval::Rejected })
+        })
+        .with_approval_mode(ApprovalMode::Enabled);
+    let mut agent = Agent::new(options);
+
+    let result = agent.prompt_async(vec![user_msg("hello")]).await.unwrap();
+    assert!(
+        !tool_ref.was_executed(),
+        "Enabled mode should route ALL tools through callback, including read-only"
+    );
+    assert!(
+        callback_called.load(Ordering::SeqCst),
+        "callback must be called for all tools in Enabled mode"
+    );
+}
+
+/// Test 18: ToolApprovalRequested event carries rewritten arguments.
 #[tokio::test]
 async fn approval_event_carries_rewritten_arguments() {
     let tool = Arc::new(MockTool::new("test_tool"));
@@ -490,7 +583,8 @@ async fn approval_event_carries_rewritten_arguments() {
     let responses = tool_call_then_stop("tc1", "test_tool", r#"{"original": true}"#);
     let options = make_agent(responses, vec![tool])
         .with_pre_dispatch_policy(RewriteArgsPolicy)
-        .with_approve_tool(|_req| Box::pin(async { ToolApproval::Approved }));
+        .with_approve_tool(|_req| Box::pin(async { ToolApproval::Approved }))
+        .with_approval_mode(ApprovalMode::Enabled);
     let mut agent = Agent::new(options);
 
     let captured = Arc::clone(&event_args);


### PR DESCRIPTION
## Summary
- `BudgetGuard` now stores and enforces `max_duration` from `BudgetConstraints`, making it a real runtime budget that cancels the agent run when the wall-clock deadline is exceeded
- Previously `max_duration` was only checked post-run by `BudgetEvaluator`, allowing long-running eval cases to violate the documented budget limit

Closes #285

## Tasks completed
- Added `max_duration: Option<Duration>` and `start_time: Instant` fields to `BudgetGuard`
- Added `with_max_duration()` builder method
- Updated `from_case()` to wire `max_duration` from `BudgetConstraints`
- Updated `exceeds_budget()` to check elapsed time against the deadline
- Added elapsed_ms to the budget-guard-triggered warning log

## Test plan
- [x] `cargo test -p swink-agent-eval` — all 37 unit + all integration tests pass
- [x] New tests: `exceeds_duration`, `within_duration`, `from_case_includes_duration`, `from_case_none_when_all_empty`
- [ ] `cargo clippy --workspace -- -D warnings` — pre-existing warnings in `src/transfer.rs` (not related to this change)
- [ ] No public API breakage in downstream crates