### PR TITLE
fix: add explicit token permissions to bench workflow

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   bench:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary
Adds explicit `permissions: { contents: read, pull-requests: write }` to the benchmark workflow job that posts PR comments via `actions/github-script`, ensuring it works on repos with restricted default GITHUB_TOKEN permissions.

## Test plan
- [x] YAML syntax is valid
- [x] Only bench.yml modified

Closes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)