### PR TITLE
fix: add testkit feature coverage to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
 
       - run: cargo nextest run --workspace
 
+      - name: Test (testkit features)
+        run: cargo test --workspace --features testkit
+
       - run: cargo build --examples --workspace
 
       - run: cargo test --workspace --doc


### PR DESCRIPTION
## Summary
Adds a dedicated `cargo test --workspace --features testkit` step to CI so that testkit-gated integration tests are validated on every push, matching the project's recommended test command.

## Test plan
- [x] YAML syntax is valid
- [x] Only ci.yml modified

Closes #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)