### PR TITLE
fix: prove sandbox path containment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,7 @@ MSRV **1.88** (edition 2024). Workspace deps centralized in root `Cargo.toml`.
 - Two verdict enums: `PolicyVerdict` (Continue/Stop/Inject) and `PreDispatchVerdict` (+ Skip). Compile-time enforcement that Skip is only valid in PreDispatch.
 - Slot runner uses `AssertUnwindSafe` + `catch_unwind` — traits only need `Send + Sync`, not `UnwindSafe`.
 - Empty policy vecs = zero overhead, no allocation. Default is anything-goes.
+- `ToolDispatchContext.execution_root` carries the tool's working directory when known. Policies that validate relative paths must reject them when this context is absent instead of assuming lexical containment.
 - **All policy implementations live in `swink-agent-policies` crate** — core only defines traits and runners.
 - Old fields removed from `AgentLoopConfig`: `budget_guard`, `loop_policy`, `post_turn_hook`, `tool_validator`, `tool_call_transformer`. Replaced by 4 policy vecs.
 - `PolicyContext.new_messages` contains only messages added since the last evaluation for that slot. PreTurn: pending batch (tracked via `new_messages_start` index before append). PostTurn/PostLoop/PreDispatch: `&[]` (current-turn data is in `TurnPolicyContext`/`ToolPolicyContext`). This is a slice borrow (zero-copy), not a clone.
@@ -78,6 +79,7 @@ MSRV **1.88** (edition 2024). Workspace deps centralized in root `Cargo.toml`.
 - Stateful policies (e.g., `LoopDetectionPolicy`) use interior mutability (`Mutex`) — trait takes `&self`.
 - `CheckpointPolicy` bridges sync/async via `tokio::spawn` fire-and-forget. Captures `Handle::current()` at construction.
 - `SandboxPolicy` checks configured field names (default: `["path", "file_path", "file"]`) — Skip with error, no silent rewriting.
+- `SandboxPolicy` must resolve checked paths against a canonical allowed root plus the `ToolDispatchContext.execution_root`; lexical `starts_with` checks are insufficient because relative paths and symlinked parents can escape the sandbox.
 - `PromptInjectionGuard` implements both `PreTurnPolicy` and `PostTurnPolicy` — single struct, dual trait.
 - `PiiRedactor` Inject verdict constructs `AgentMessage::Llm(LlmMessage::Assistant(...))` preserving original metadata.
 - `ContentFilter` converts keywords to regex at construction time (with `` for whole-word, `(?i)` for case-insensitive).

--- a/plugins/web/tests/domain_filter_test.rs
+++ b/plugins/web/tests/domain_filter_test.rs
@@ -19,6 +19,7 @@ fn make_dispatch_ctx<'a>(
         tool_name,
         tool_call_id,
         arguments: args,
+        execution_root: None,
         state,
     }
 }

--- a/plugins/web/tests/rate_limiter_test.rs
+++ b/plugins/web/tests/rate_limiter_test.rs
@@ -25,6 +25,7 @@ fn make_dispatch_ctx<'a>(
         tool_name,
         tool_call_id,
         arguments: args,
+        execution_root: None,
         state,
     }
 }

--- a/policies/src/deny_list.rs
+++ b/policies/src/deny_list.rs
@@ -56,6 +56,7 @@ mod tests {
             tool_name,
             tool_call_id: "id1",
             arguments: args,
+            execution_root: None,
             state,
         }
     }

--- a/policies/src/sandbox.rs
+++ b/policies/src/sandbox.rs
@@ -1,7 +1,8 @@
 //! Sandbox policy — restricts file paths to an allowed root directory.
 #![forbid(unsafe_code)]
 
-use std::path::{Path, PathBuf};
+use std::ffi::OsString;
+use std::path::{Component, Path, PathBuf};
 
 use swink_agent::{PreDispatchPolicy, PreDispatchVerdict, ToolDispatchContext};
 
@@ -46,24 +47,97 @@ impl SandboxPolicy {
         self
     }
 
-    /// Check if a path is within the allowed root.
-    fn is_path_allowed(&self, path_str: &str) -> bool {
-        let path = Path::new(path_str);
+    fn validate_path(&self, path_str: &str, execution_root: Option<&Path>) -> Result<(), String> {
+        let allowed_root = std::fs::canonicalize(&self.allowed_root).map_err(|err| {
+            format!(
+                "sandbox allowed root '{}' is unavailable: {err}",
+                self.allowed_root.display()
+            )
+        })?;
+        let resolved_path = self.resolve_path(Path::new(path_str), execution_root)?;
 
-        // Reject paths containing `..` traversal
-        for component in path.components() {
-            if matches!(component, std::path::Component::ParentDir) {
-                return false;
-            }
-        }
-
-        // Check if the path starts with the allowed root
-        // For relative paths, they're allowed (they'll resolve within the working dir)
-        if path.is_absolute() {
-            path.starts_with(&self.allowed_root)
+        if resolved_path.starts_with(&allowed_root) {
+            Ok(())
         } else {
-            // Relative paths are allowed as long as they don't contain ..
-            true
+            Err(format!(
+                "path '{}' resolves outside allowed root '{}'",
+                resolved_path.display(),
+                allowed_root.display()
+            ))
+        }
+    }
+
+    fn resolve_path(&self, path: &Path, execution_root: Option<&Path>) -> Result<PathBuf, String> {
+        let base_path = if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            let execution_root = execution_root.ok_or_else(|| {
+                format!(
+                    "relative path '{}' cannot be validated without an execution root",
+                    path.display()
+                )
+            })?;
+            let execution_root = std::fs::canonicalize(execution_root).map_err(|err| {
+                format!(
+                    "execution root '{}' is unavailable: {err}",
+                    execution_root.display()
+                )
+            })?;
+            execution_root.join(path)
+        };
+
+        Self::resolve_existing_prefix(&base_path)
+    }
+
+    fn resolve_existing_prefix(path: &Path) -> Result<PathBuf, String> {
+        let mut unresolved_components: Vec<OsString> = Vec::new();
+        let mut probe = path;
+
+        loop {
+            match std::fs::symlink_metadata(probe) {
+                Ok(_) => {
+                    let mut resolved = std::fs::canonicalize(probe).map_err(|err| {
+                        format!("failed to canonicalize '{}': {err}", probe.display())
+                    })?;
+                    for component in unresolved_components.iter().rev() {
+                        match Path::new(component).components().next() {
+                            Some(Component::CurDir) => {}
+                            Some(Component::ParentDir) => {
+                                resolved.pop();
+                            }
+                            Some(Component::Normal(part)) => resolved.push(part),
+                            Some(Component::RootDir | Component::Prefix(_)) | None => {
+                                return Err(format!(
+                                    "path '{}' contains an unsupported component",
+                                    path.display()
+                                ));
+                            }
+                        }
+                    }
+                    return Ok(resolved);
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                    let component = probe.file_name().ok_or_else(|| {
+                        format!(
+                            "failed to resolve path '{}': no existing ancestor",
+                            path.display()
+                        )
+                    })?;
+                    unresolved_components.push(component.to_os_string());
+                    probe = probe.parent().ok_or_else(|| {
+                        format!(
+                            "failed to resolve path '{}': no existing ancestor",
+                            path.display()
+                        )
+                    })?;
+                }
+                Err(err) => {
+                    return Err(format!(
+                        "failed to inspect path '{}': {err}",
+                        probe.display()
+                    ));
+                }
+            }
         }
     }
 }
@@ -80,13 +154,14 @@ impl PreDispatchPolicy for SandboxPolicy {
 
         for field_name in &self.path_fields {
             if let Some(serde_json::Value::String(path_str)) = obj.get(field_name.as_str())
-                && !self.is_path_allowed(path_str)
+                && let Err(reason) = self.validate_path(path_str, ctx.execution_root)
             {
                 return PreDispatchVerdict::Skip(format!(
-                    "path '{}' in field '{}' is outside allowed root '{}'",
+                    "path '{}' in field '{}' is outside allowed root '{}': {}",
                     path_str,
                     field_name,
-                    self.allowed_root.display()
+                    self.allowed_root.display(),
+                    reason
                 ));
             }
         }
@@ -98,69 +173,144 @@ impl PreDispatchPolicy for SandboxPolicy {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::TempDir;
 
     fn make_dispatch_ctx<'a>(
         tool_name: &'a str,
         args: &'a mut serde_json::Value,
+        execution_root: Option<&'a Path>,
         state: &'a swink_agent::SessionState,
     ) -> ToolDispatchContext<'a> {
         ToolDispatchContext {
             tool_name,
             tool_call_id: "id1",
             arguments: args,
+            execution_root,
             state,
         }
     }
 
+    fn sandbox_fixture() -> (TempDir, PathBuf) {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let allowed_root = tempdir.path().join("workspace");
+        std::fs::create_dir_all(&allowed_root).expect("workspace");
+        (tempdir, allowed_root)
+    }
+
     #[test]
     fn rejects_path_outside_root() {
-        let policy = SandboxPolicy::new("/tmp/workspace");
+        let (_tempdir, allowed_root) = sandbox_fixture();
+        let policy = SandboxPolicy::new(&allowed_root);
         let state = swink_agent::SessionState::new();
-        let mut args = serde_json::json!({"path": "/etc/passwd"});
-        let mut ctx = make_dispatch_ctx("write_file", &mut args, &state);
+        let outside = allowed_root.parent().unwrap().join("outside.txt");
+        let mut args = serde_json::json!({"path": outside});
+        let mut ctx = make_dispatch_ctx("write_file", &mut args, None, &state);
         let result = policy.evaluate(&mut ctx);
-        assert!(matches!(result, PreDispatchVerdict::Skip(ref e) if e.contains("/etc/passwd")));
+        assert!(matches!(result, PreDispatchVerdict::Skip(ref e) if e.contains("outside")));
     }
 
     #[test]
     fn allows_path_inside_root() {
-        let policy = SandboxPolicy::new("/tmp/workspace");
+        let (_tempdir, allowed_root) = sandbox_fixture();
+        let policy = SandboxPolicy::new(&allowed_root);
         let state = swink_agent::SessionState::new();
-        let mut args = serde_json::json!({"path": "/tmp/workspace/output.txt"});
-        let mut ctx = make_dispatch_ctx("write_file", &mut args, &state);
+        let mut args = serde_json::json!({"path": allowed_root.join("output.txt")});
+        let mut ctx = make_dispatch_ctx("write_file", &mut args, None, &state);
         let result = policy.evaluate(&mut ctx);
         assert!(matches!(result, PreDispatchVerdict::Continue));
     }
 
     #[test]
     fn handles_path_traversal_attack() {
-        let policy = SandboxPolicy::new("/tmp/workspace");
+        let (_tempdir, allowed_root) = sandbox_fixture();
+        let policy = SandboxPolicy::new(&allowed_root);
         let state = swink_agent::SessionState::new();
-        let mut args = serde_json::json!({"path": "/tmp/workspace/../../etc/passwd"});
-        let mut ctx = make_dispatch_ctx("write_file", &mut args, &state);
+        let mut args = serde_json::json!({"path": allowed_root.join("../outside/passwd")});
+        let mut ctx = make_dispatch_ctx("write_file", &mut args, None, &state);
         let result = policy.evaluate(&mut ctx);
         assert!(matches!(result, PreDispatchVerdict::Skip(_)));
     }
 
     #[test]
     fn only_checks_configured_fields() {
-        let policy = SandboxPolicy::new("/tmp/workspace");
+        let (_tempdir, allowed_root) = sandbox_fixture();
+        let policy = SandboxPolicy::new(&allowed_root);
         let state = swink_agent::SessionState::new();
         // "command" is not in the default path_fields, so it won't be checked
         let mut args = serde_json::json!({"command": "/etc/passwd"});
-        let mut ctx = make_dispatch_ctx("bash", &mut args, &state);
+        let mut ctx = make_dispatch_ctx("bash", &mut args, None, &state);
         let result = policy.evaluate(&mut ctx);
         assert!(matches!(result, PreDispatchVerdict::Continue));
     }
 
     #[test]
     fn custom_path_fields() {
-        let policy =
-            SandboxPolicy::new("/tmp/workspace").with_path_fields(["target_dir", "output"]);
+        let (_tempdir, allowed_root) = sandbox_fixture();
+        let policy = SandboxPolicy::new(&allowed_root).with_path_fields(["target_dir", "output"]);
         let state = swink_agent::SessionState::new();
-        let mut args = serde_json::json!({"target_dir": "/etc/shadow"});
-        let mut ctx = make_dispatch_ctx("deploy", &mut args, &state);
+        let mut args = serde_json::json!({"target_dir": allowed_root.join("../shadow")});
+        let mut ctx = make_dispatch_ctx("deploy", &mut args, None, &state);
         let result = policy.evaluate(&mut ctx);
         assert!(matches!(result, PreDispatchVerdict::Skip(_)));
+    }
+
+    #[test]
+    fn rejects_relative_path_outside_allowed_root() {
+        let (_tempdir, allowed_root) = sandbox_fixture();
+        let execution_root = allowed_root.parent().unwrap().join("different-cwd");
+        std::fs::create_dir_all(&execution_root).expect("execution root");
+        let policy = SandboxPolicy::new(&allowed_root);
+        let state = swink_agent::SessionState::new();
+        let mut args = serde_json::json!({"path": "output.txt"});
+        let mut ctx = make_dispatch_ctx("write_file", &mut args, Some(&execution_root), &state);
+        let result = policy.evaluate(&mut ctx);
+        assert!(
+            matches!(result, PreDispatchVerdict::Skip(ref e) if e.contains("resolves outside"))
+        );
+    }
+
+    #[test]
+    fn allows_relative_path_inside_allowed_root() {
+        let (_tempdir, allowed_root) = sandbox_fixture();
+        let execution_root = allowed_root.join("nested");
+        std::fs::create_dir_all(&execution_root).expect("execution root");
+        let policy = SandboxPolicy::new(&allowed_root);
+        let state = swink_agent::SessionState::new();
+        let mut args = serde_json::json!({"path": "output.txt"});
+        let mut ctx = make_dispatch_ctx("write_file", &mut args, Some(&execution_root), &state);
+        let result = policy.evaluate(&mut ctx);
+        assert!(matches!(result, PreDispatchVerdict::Continue));
+    }
+
+    #[test]
+    fn rejects_relative_path_without_execution_root() {
+        let (_tempdir, allowed_root) = sandbox_fixture();
+        let policy = SandboxPolicy::new(&allowed_root);
+        let state = swink_agent::SessionState::new();
+        let mut args = serde_json::json!({"path": "output.txt"});
+        let mut ctx = make_dispatch_ctx("write_file", &mut args, None, &state);
+        let result = policy.evaluate(&mut ctx);
+        assert!(
+            matches!(result, PreDispatchVerdict::Skip(ref e) if e.contains("cannot be validated without an execution root"))
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_symlink_escape_inside_allowed_root() {
+        let (_tempdir, allowed_root) = sandbox_fixture();
+        let outside = allowed_root.parent().unwrap().join("outside-dir");
+        std::fs::create_dir_all(&outside).expect("outside dir");
+        let link = allowed_root.join("escape-link");
+        std::os::unix::fs::symlink(&outside, &link).expect("symlink");
+
+        let policy = SandboxPolicy::new(&allowed_root);
+        let state = swink_agent::SessionState::new();
+        let mut args = serde_json::json!({"path": link.join("secret.txt")});
+        let mut ctx = make_dispatch_ctx("write_file", &mut args, None, &state);
+        let result = policy.evaluate(&mut ctx);
+        assert!(
+            matches!(result, PreDispatchVerdict::Skip(ref e) if e.contains("resolves outside"))
+        );
     }
 }

--- a/src/loop_/tool_dispatch.rs
+++ b/src/loop_/tool_dispatch.rs
@@ -151,6 +151,7 @@ pub async fn execute_tools_concurrently(
                 PreDispatchVerdict, ToolDispatchContext, run_pre_dispatch_policies,
             };
 
+            let execution_root = std::env::current_dir().ok();
             let state_snapshot = {
                 let guard = config
                     .session_state
@@ -162,6 +163,7 @@ pub async fn execute_tools_concurrently(
                 tool_name: &tc.name,
                 tool_call_id: &tc.id,
                 arguments: &mut effective_arguments,
+                execution_root: execution_root.as_deref(),
                 state: &state_snapshot,
             };
             match run_pre_dispatch_policies(&config.pre_dispatch_policies, &mut dispatch_ctx) {

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -18,6 +18,7 @@
 #![forbid(unsafe_code)]
 
 use std::panic::AssertUnwindSafe;
+use std::path::Path;
 use std::sync::Arc;
 
 use tracing::{debug, warn};
@@ -98,6 +99,8 @@ pub struct ToolDispatchContext<'a> {
     pub tool_call_id: &'a str,
     /// Mutable reference to tool call arguments (policies may rewrite them).
     pub arguments: &'a mut serde_json::Value,
+    /// Working directory the tool will resolve relative paths against, when known.
+    pub execution_root: Option<&'a Path>,
     /// Read-only access to the session state.
     pub state: &'a crate::SessionState,
 }
@@ -107,6 +110,7 @@ impl std::fmt::Debug for ToolDispatchContext<'_> {
         f.debug_struct("ToolDispatchContext")
             .field("tool_name", &self.tool_name)
             .field("tool_call_id", &self.tool_call_id)
+            .field("execution_root", &self.execution_root)
             .field("arguments", &"<redacted>")
             .finish()
     }
@@ -483,6 +487,7 @@ mod tests {
             tool_name: "test_tool",
             tool_call_id: "id1",
             arguments: args,
+            execution_root: None,
             state,
         }
     }
@@ -717,6 +722,7 @@ mod tests {
             tool_name: "write_file",
             tool_call_id: "call-123",
             arguments: &mut args,
+            execution_root: None,
             state: &state,
         };
         assert_eq!(ctx.tool_name, "write_file");


### PR DESCRIPTION
Fixes #277

## Summary
- add the execution root to `ToolDispatchContext` so pre-dispatch policies can validate relative paths against the real working directory
- make `SandboxPolicy` canonicalize the allowed root and resolve checked paths through existing ancestors so symlink and relative-path escapes are rejected
- add regressions for relative-path, traversal, and symlink escapes and update direct `ToolDispatchContext` test helpers in the web plugin

## Testing
- cargo test -p swink-agent-policies sandbox -- --nocapture
- cargo test -p swink-agent policy -- --nocapture
- cargo test -p swink-agent-plugin-web --tests
- cargo test --workspace --features testkit *(still fails on the pre-existing unrelated `tests/agent_loop.rs::max_tokens_recovery` assertion in `swink-agent`)*