### PR TITLE
fix(tui): decouple reusable TUI library from fixed provider set

### DIFF
--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -21,7 +21,7 @@ required-features = ["cli"]
 
 [dependencies]
 swink-agent = { path = "..", default-features = false, features = ["builtin-tools", "transfer"] }
-swink-agent-adapters = { path = "../adapters", default-features = false, features = ["anthropic", "openai", "ollama", "proxy"] }
+swink-agent-adapters = { path = "../adapters", default-features = false, features = ["anthropic", "openai", "ollama", "proxy"], optional = true }
 swink-agent-memory = { path = "../memory" }
 swink-agent-local-llm = { path = "../local-llm", optional = true }
 ratatui = "0.30"
@@ -43,7 +43,8 @@ thiserror.workspace = true
 
 [features]
 default = ["cli"]
-cli = []
+cli = ["adapters"]
+adapters = ["dep:swink-agent-adapters"]
 full = ["local", "cli"]
 local = ["dep:swink-agent-local-llm"]
 


### PR DESCRIPTION
## Summary
- Makes `swink-agent-adapters` an optional dependency in the TUI crate, gated behind a new `adapters` feature
- The `cli` feature (enabled by default) pulls in `adapters`, so the binary and default usage are unchanged
- Library consumers using `default-features = false` no longer transitively compile anthropic/openai/ollama/proxy adapters

Closes #265

## Test plan
- [x] `cargo check -p swink-agent-tui --no-default-features` compiles without adapters
- [x] `cargo check -p swink-agent-tui` compiles with default features (cli+adapters)
- [x] `cargo test -p swink-agent-tui` — 23 tests pass
- [x] `cargo test -p swink-agent-tui --no-default-features` — 22 tests pass
- [x] No public API breakage — existing consumers with default features see no change

🤖 Generated with [Claude Code](https://claude.com/claude-code)