### PR TITLE
fix: evaluate post-turn policies before TurnEnd emission

### DIFF
--- a/src/loop_/mod.rs
+++ b/src/loop_/mod.rs
@@ -171,48 +171,11 @@ async fn run_loop_inner(
                     TurnOutcome::Return => return,
                 };
 
-                // Post-turn policies: invoke after each completed turn
-                if let Some(ref msg) = state.last_assistant_message {
-                    use crate::policy::{
-                        PolicyContext, PolicyVerdict, TurnPolicyContext, run_post_turn_policies,
-                    };
-
-                    let state_snapshot = {
-                        let guard = config
-                            .session_state
-                            .read()
-                            .unwrap_or_else(std::sync::PoisonError::into_inner);
-                        guard.clone()
-                    };
-                    let policy_ctx = PolicyContext {
-                        turn_index: state.turn_index,
-                        accumulated_usage: &state.accumulated_usage,
-                        accumulated_cost: &state.accumulated_cost,
-                        message_count: state.context_messages.len(),
-                        overflow_signal: state.overflow_signal,
-                        new_messages: &[], // current-turn data is in TurnPolicyContext
-                        state: &state_snapshot,
-                    };
-                    let turn_ctx = TurnPolicyContext {
-                        assistant_message: msg,
-                        tool_results: &state.last_tool_results,
-                        stop_reason: msg.stop_reason,
-                        system_prompt: &system_prompt,
-                        model_spec: &config.model,
-                        context_messages: &state.context_messages,
-                    };
-                    match run_post_turn_policies(&config.post_turn_policies, &policy_ctx, &turn_ctx)
-                    {
-                        PolicyVerdict::Continue => {}
-                        PolicyVerdict::Stop(reason) => {
-                            info!("post-turn policy stopped agent: {reason}");
-                            break 'inner;
-                        }
-                        PolicyVerdict::Inject(msgs) => {
-                            state.pending_messages.extend(msgs);
-                        }
-                    }
-                }
+                // Post-turn policies are now evaluated inside the turn handlers
+                // (handle_no_tool_calls / handle_tool_calls) BEFORE the assistant
+                // message is committed to context and TurnEnd is emitted. This
+                // ensures Inject verdicts (e.g. PII redaction) can replace the
+                // assistant message before it is observed by listeners.
 
                 if should_break {
                     break 'inner;

--- a/src/loop_/turn.rs
+++ b/src/loop_/turn.rs
@@ -5,6 +5,7 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info_span};
 
+use crate::policy::{PolicyContext, PolicyVerdict, TurnPolicyContext, run_post_turn_policies};
 use crate::types::{
     AgentContext, AgentMessage, AssistantMessage, ContentBlock, LlmMessage, StopReason,
     ToolResultMessage, TurnSnapshot,
@@ -287,6 +288,7 @@ pub async fn run_single_turn(
             assistant_message,
             state,
             config,
+            system_prompt,
             llm_call_duration,
             turn_start,
             tx,
@@ -300,6 +302,7 @@ pub async fn run_single_turn(
         state,
         assistant_message,
         tool_calls,
+        system_prompt,
         llm_call_duration,
         turn_start,
         cancellation_token,
@@ -595,12 +598,80 @@ fn extract_tool_calls(message: &AssistantMessage) -> Vec<ToolCallInfo> {
         .collect()
 }
 
-/// Handle the case where no tool calls are present: emit `TurnEnd`, break inner.
+/// Run post-turn policies and return the (possibly replaced) assistant message.
+///
+/// If a policy returns `Inject` with an `AssistantMessage`, it replaces the
+/// original — the replacement is what gets committed to context and emitted in
+/// `TurnEnd`. Non-assistant injected messages go to `pending_messages`.
+///
+/// Returns `(final_assistant_message, Option<stop_reason>)`.
+fn run_post_turn_policy_check(
+    assistant_message: &AssistantMessage,
+    tool_results: &[ToolResultMessage],
+    state: &mut LoopState,
+    config: &Arc<AgentLoopConfig>,
+    system_prompt: &str,
+) -> (AssistantMessage, Option<String>) {
+    if config.post_turn_policies.is_empty() {
+        return (assistant_message.clone(), None);
+    }
+
+    let state_snapshot = {
+        let guard = config
+            .session_state
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        guard.clone()
+    };
+    let policy_ctx = PolicyContext {
+        turn_index: state.turn_index,
+        accumulated_usage: &state.accumulated_usage,
+        accumulated_cost: &state.accumulated_cost,
+        message_count: state.context_messages.len(),
+        overflow_signal: state.overflow_signal,
+        new_messages: &[], // current-turn data is in TurnPolicyContext
+        state: &state_snapshot,
+    };
+    let turn_ctx = TurnPolicyContext {
+        assistant_message,
+        tool_results,
+        stop_reason: assistant_message.stop_reason,
+        system_prompt,
+        model_spec: &config.model,
+        context_messages: &state.context_messages,
+    };
+    match run_post_turn_policies(&config.post_turn_policies, &policy_ctx, &turn_ctx) {
+        PolicyVerdict::Continue => (assistant_message.clone(), None),
+        PolicyVerdict::Stop(reason) => (assistant_message.clone(), Some(reason)),
+        PolicyVerdict::Inject(msgs) => {
+            // If the injection includes an assistant message, use the last one
+            // as a replacement. All other injected messages go to pending.
+            let mut replaced = assistant_message.clone();
+            for msg in msgs {
+                match msg {
+                    AgentMessage::Llm(LlmMessage::Assistant(new_msg)) => {
+                        replaced = new_msg;
+                    }
+                    other => {
+                        state.pending_messages.push(other);
+                    }
+                }
+            }
+            // Update last_assistant_message to reflect the replacement.
+            state.last_assistant_message = Some(replaced.clone());
+            (replaced, None)
+        }
+    }
+}
+
+/// Handle the case where no tool calls are present: run post-turn policies,
+/// commit the (possibly replaced) message, emit `TurnEnd`, break inner.
 #[allow(clippy::too_many_arguments)]
 async fn handle_no_tool_calls(
     assistant_message: AssistantMessage,
     state: &mut LoopState,
     config: &Arc<AgentLoopConfig>,
+    system_prompt: &str,
     llm_call_duration: Duration,
     turn_start: Instant,
     tx: &mpsc::Sender<AgentEvent>,
@@ -618,17 +689,25 @@ async fn handle_no_tool_calls(
     )
     .await;
 
-    let msg_for_event = assistant_message.clone();
+    // Run post-turn policies BEFORE committing to context or emitting TurnEnd.
+    let (assistant_message, policy_stop) = run_post_turn_policy_check(
+        &assistant_message,
+        &[],
+        state,
+        config,
+        system_prompt,
+    );
+
     let stop = assistant_message.stop_reason;
     state
         .context_messages
-        .push(AgentMessage::Llm(LlmMessage::Assistant(assistant_message)));
+        .push(AgentMessage::Llm(LlmMessage::Assistant(assistant_message.clone())));
     let state_delta = flush_state_delta(config, tx).await;
     let snapshot = build_snapshot(state, stop, state_delta);
     if !emit(
         tx,
         AgentEvent::TurnEnd {
-            assistant_message: msg_for_event,
+            assistant_message,
             tool_results: vec![],
             reason: TurnEndReason::Complete,
             snapshot,
@@ -638,17 +717,23 @@ async fn handle_no_tool_calls(
     {
         return TurnOutcome::Return;
     }
+
+    if let Some(reason) = policy_stop {
+        tracing::info!("post-turn policy stopped agent: {reason}");
+    }
+
     TurnOutcome::BreakInner
 }
 
 /// Handle tool calls: separate incomplete ones, execute the rest, collect results,
-/// emit `TurnEnd`, and poll steering.
+/// run post-turn policies, emit `TurnEnd`, and poll steering.
 #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 async fn handle_tool_calls(
     config: &Arc<AgentLoopConfig>,
     state: &mut LoopState,
     assistant_message: AssistantMessage,
     mut tool_call_data: Vec<ToolCallInfo>,
+    system_prompt: &str,
     llm_call_duration: Duration,
     turn_start: Instant,
     cancellation_token: &CancellationToken,
@@ -656,10 +741,13 @@ async fn handle_tool_calls(
 ) -> TurnOutcome {
     accumulate_turn_state(state, &assistant_message);
 
-    let msg_for_turn_end = assistant_message.clone();
+    // Record the index where we insert the assistant message so we can replace
+    // it later if a post-turn policy returns a mutated version.
+    let assistant_ctx_index = state.context_messages.len();
     state
         .context_messages
-        .push(AgentMessage::Llm(LlmMessage::Assistant(assistant_message)));
+        .push(AgentMessage::Llm(LlmMessage::Assistant(assistant_message.clone())));
+    let msg_for_turn_end = assistant_message;
 
     // Max tokens recovery: replace incomplete tool calls with error results
     let max_token_results =
@@ -774,7 +862,21 @@ async fn handle_tool_calls(
         .await;
     }
 
-    // xiii. Emit TurnEnd
+    // xiii. Run post-turn policies BEFORE emitting TurnEnd so Inject can
+    //       replace the assistant message before it is observed by listeners.
+    let (msg_for_turn_end, policy_stop) = run_post_turn_policy_check(
+        &msg_for_turn_end,
+        &tool_results,
+        state,
+        config,
+        system_prompt,
+    );
+
+    // Update the assistant message in context in case a policy replaced it.
+    state.context_messages[assistant_ctx_index] =
+        AgentMessage::Llm(LlmMessage::Assistant(msg_for_turn_end.clone()));
+
+    // xiv. Emit TurnEnd
     let state_delta = flush_state_delta(config, tx).await;
     let snapshot = build_snapshot(state, msg_for_turn_end.stop_reason, state_delta);
     if !emit(
@@ -793,6 +895,11 @@ async fn handle_tool_calls(
     .await
     {
         return TurnOutcome::Return;
+    }
+
+    if let Some(reason) = policy_stop {
+        tracing::info!("post-turn policy stopped agent: {reason}");
+        return TurnOutcome::BreakInner;
     }
 
     // Poll steering if not already interrupted

--- a/tests/agent_loop.rs
+++ b/tests/agent_loop.rs
@@ -17,9 +17,10 @@ use serde_json::json;
 use tokio_util::sync::CancellationToken;
 
 use swink_agent::{
-    AgentEvent, AgentLoopConfig, AgentMessage, AgentTool, AgentToolResult, AssistantMessageEvent,
-    ContentBlock, Cost, CustomMessage, DefaultRetryStrategy, LlmMessage, MessageProvider,
-    StopReason, StreamFn, StreamOptions, ToolResultMessage, TurnSnapshot, Usage, UserMessage,
+    AgentEvent, AgentLoopConfig, AgentMessage, AgentTool, AgentToolResult, AssistantMessage,
+    AssistantMessageEvent, ContentBlock, Cost, CustomMessage, DefaultRetryStrategy, LlmMessage,
+    MessageProvider, PolicyContext, PolicyVerdict, PostTurnPolicy, StopReason, StreamFn,
+    StreamOptions, ToolResultMessage, TurnPolicyContext, TurnSnapshot, Usage, UserMessage,
     agent_loop,
 };
 
@@ -1253,4 +1254,130 @@ async fn turn_snapshot_serializes_to_json() {
     assert!((parsed.cost.total - 0.05).abs() < f64::EPSILON);
     assert_eq!(parsed.stop_reason, StopReason::Stop);
     assert!(parsed.messages.is_empty());
+}
+
+// ─── Post-turn policy replaces assistant message before TurnEnd ──────────
+
+/// A post-turn policy that replaces the assistant message text.
+/// Simulates what PiiRedactor does: returns Inject with a modified
+/// AssistantMessage to replace the original.
+struct ReplacingPostTurnPolicy {
+    replacement_text: String,
+}
+
+impl PostTurnPolicy for ReplacingPostTurnPolicy {
+    fn name(&self) -> &str {
+        "replacing-post-turn"
+    }
+
+    fn evaluate(&self, _ctx: &PolicyContext<'_>, turn: &TurnPolicyContext<'_>) -> PolicyVerdict {
+        let orig = turn.assistant_message;
+        let msg = AssistantMessage {
+            content: vec![ContentBlock::Text {
+                text: self.replacement_text.clone(),
+            }],
+            provider: orig.provider.clone(),
+            model_id: orig.model_id.clone(),
+            usage: orig.usage.clone(),
+            cost: orig.cost.clone(),
+            stop_reason: orig.stop_reason,
+            error_message: orig.error_message.clone(),
+            error_kind: orig.error_kind,
+            timestamp: orig.timestamp,
+            cache_hint: None,
+        };
+        PolicyVerdict::Inject(vec![AgentMessage::Llm(LlmMessage::Assistant(msg))])
+    }
+}
+
+/// Regression test for #313: post-turn Inject verdicts must replace the
+/// assistant message in TurnEnd and context BEFORE the event is emitted.
+#[tokio::test]
+async fn post_turn_inject_replaces_assistant_message_in_turn_end() {
+    let stream_fn = Arc::new(MockStreamFn::new(vec![text_only_events(
+        "secret SSN 123-45-6789",
+    )]));
+
+    let policy: Arc<dyn PostTurnPolicy> = Arc::new(ReplacingPostTurnPolicy {
+        replacement_text: "secret SSN [REDACTED]".to_string(),
+    });
+
+    let mut config = default_config(stream_fn);
+    config.post_turn_policies = vec![policy];
+
+    let events = collect_events(agent_loop(
+        vec![],
+        "system".to_string(),
+        config,
+        CancellationToken::new(),
+    ))
+    .await;
+
+    // Find the TurnEnd event and verify the assistant message was replaced.
+    let turn_end = events.iter().find_map(|e| match e {
+        AgentEvent::TurnEnd {
+            assistant_message, ..
+        } => Some(assistant_message),
+        _ => None,
+    });
+
+    let msg = turn_end.expect("should have TurnEnd event");
+    let text = ContentBlock::extract_text(&msg.content);
+    assert_eq!(
+        text, "secret SSN [REDACTED]",
+        "TurnEnd must contain the replaced assistant message, not the original"
+    );
+
+    // Verify the AgentEnd snapshot also contains the replaced message.
+    let agent_end_messages = events.iter().find_map(|e| match e {
+        AgentEvent::AgentEnd { messages } => Some(messages.clone()),
+        _ => None,
+    });
+    let msgs = agent_end_messages.expect("should have AgentEnd");
+    let last_assistant = msgs.iter().rev().find_map(|m| match m {
+        AgentMessage::Llm(LlmMessage::Assistant(a)) => Some(a),
+        _ => None,
+    });
+    let a = last_assistant.expect("should have assistant message in AgentEnd");
+    let final_text = ContentBlock::extract_text(&a.content);
+    assert_eq!(
+        final_text, "secret SSN [REDACTED]",
+        "AgentEnd context_messages must contain the replaced assistant message"
+    );
+}
+
+/// Regression test: post-turn Stop verdict still emits TurnEnd before stopping.
+#[tokio::test]
+async fn post_turn_stop_still_emits_turn_end() {
+    struct StoppingPostTurnPolicy;
+
+    impl PostTurnPolicy for StoppingPostTurnPolicy {
+        fn name(&self) -> &str {
+            "stopping-post-turn"
+        }
+
+        fn evaluate(
+            &self,
+            _ctx: &PolicyContext<'_>,
+            _turn: &TurnPolicyContext<'_>,
+        ) -> PolicyVerdict {
+            PolicyVerdict::Stop("budget exceeded".to_string())
+        }
+    }
+
+    let stream_fn = Arc::new(MockStreamFn::new(vec![text_only_events("Hello!")]));
+    let mut config = default_config(stream_fn);
+    config.post_turn_policies = vec![Arc::new(StoppingPostTurnPolicy)];
+
+    let events = collect_events(agent_loop(
+        vec![],
+        "system".to_string(),
+        config,
+        CancellationToken::new(),
+    ))
+    .await;
+
+    // TurnEnd should still be emitted even when the policy stops the loop.
+    assert!(has_event(&events, "TurnEnd"));
+    assert!(has_event(&events, "AgentEnd"));
 }


### PR DESCRIPTION
## Summary
- Moves post-turn policy evaluation from the outer loop (`mod.rs`) into the turn handlers (`turn.rs`), running policies **before** the assistant message is committed to `context_messages` and before `TurnEnd` is emitted
- `Inject` verdicts (e.g. PII redaction) now actually replace the assistant message that listeners and checkpoints observe, instead of silently appending a second message for the next turn
- Adds `run_post_turn_policy_check()` helper that handles `Continue`, `Stop`, and `Inject` (with assistant message replacement) semantics

## Tasks completed
- [x] Move post-turn policy evaluation into `handle_no_tool_calls` and `handle_tool_calls`
- [x] Handle `Inject` with assistant message replacement (last injected assistant message wins)
- [x] Handle `Stop` verdict (emit TurnEnd, then break inner loop)
- [x] Remove stale post-turn block from `mod.rs`
- [x] Add regression test: `post_turn_inject_replaces_assistant_message_in_turn_end`
- [x] Add regression test: `post_turn_stop_still_emits_turn_end`

## Test plan
- [x] `cargo test -p swink-agent --features testkit --lib` — 359 tests pass
- [x] `cargo test -p swink-agent --features testkit --test agent_loop` — 25 tests pass (including 2 new)
- [x] `cargo test -p swink-agent-policies` — 71 tests pass
- [x] `cargo test -p swink-agent --features testkit,plugins --test plugin_integration` — 20 tests pass
- [ ] `cargo clippy --workspace -- -D warnings` clean (pre-existing clippy warning in `checkpointing.rs` unrelated to this PR)
- [ ] No public API breakage in downstream crates

Closes #313