### PR TITLE
refactor: unify atomic file-write helper across memory and artifacts

### DIFF
--- a/artifacts/src/fs_store.rs
+++ b/artifacts/src/fs_store.rs
@@ -97,26 +97,22 @@ impl FileArtifactStore {
         }
     }
 
-    /// Write meta.json atomically via temp file + rename.
+    /// Write meta.json atomically via the shared atomic-write helper.
     async fn write_meta(
         &self,
         session_id: &str,
         name: &str,
         meta: &MetaFile,
     ) -> Result<(), ArtifactError> {
-        let dir = self.artifact_dir(session_id, name);
-        let meta_path = dir.join("meta.json");
-        let tmp_path = dir.join("meta.json.tmp");
-
+        let meta_path = self.meta_path(session_id, name);
         let json = serde_json::to_string_pretty(meta).map_err(storage_err)?;
-        tokio::fs::write(&tmp_path, json.as_bytes())
-            .await
-            .map_err(storage_err)?;
-        tokio::fs::rename(&tmp_path, &meta_path)
-            .await
-            .map_err(storage_err)?;
-
-        Ok(())
+        let bytes = json.into_bytes();
+        tokio::task::spawn_blocking(move || {
+            swink_agent::atomic_fs::atomic_write_bytes(&meta_path, &bytes)
+        })
+        .await
+        .map_err(|e| storage_err(std::io::Error::other(e)))?
+        .map_err(storage_err)
     }
 
     /// Scan a session directory to find all artifact names.
@@ -188,15 +184,16 @@ impl ArtifactStore for FileArtifactStore {
             metadata: data.metadata.clone(),
         };
 
-        // Write content via temp file + atomic rename
+        // Write content atomically via the shared helper.
         let content_path = self.version_path(session_id, name, next_version);
-        let tmp_content_path = dir.join(format!("v{next_version}.bin.tmp"));
-        tokio::fs::write(&tmp_content_path, &data.content)
-            .await
-            .map_err(storage_err)?;
-        tokio::fs::rename(&tmp_content_path, &content_path)
-            .await
-            .map_err(storage_err)?;
+        let content_bytes = data.content.clone();
+        tokio::task::spawn_blocking({
+            let content_path = content_path.clone();
+            move || swink_agent::atomic_fs::atomic_write_bytes(&content_path, &content_bytes)
+        })
+        .await
+        .map_err(|e| storage_err(std::io::Error::other(e)))?
+        .map_err(storage_err)?;
 
         // Update meta.json
         let version = ArtifactVersion {

--- a/memory/src/jsonl.rs
+++ b/memory/src/jsonl.rs
@@ -8,10 +8,8 @@
 
 use std::io::{self, BufRead, Write};
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
 
-static TMP_SEQ: AtomicU64 = AtomicU64::new(0);
-
+use swink_agent::atomic_fs::{atomic_write, atomic_write_unlocked, with_target_lock};
 use swink_agent::{AgentMessage, CustomMessageRegistry, LlmMessage};
 
 use crate::entry::SessionEntry;
@@ -158,109 +156,12 @@ fn read_meta_with_line_len(path: &Path, id: &str) -> io::Result<(SessionMeta, us
     Ok((meta, line_len))
 }
 
-/// Write `contents_fn` to a sibling temp file, fsync, then atomically rename
-/// over `target`. The temp file is removed on any error so a crash mid-write
-/// never leaves a zero-length or partial file at `target`.
-fn with_target_lock<T>(target: &Path, op: impl FnOnce() -> io::Result<T>) -> io::Result<T> {
-    let lock = lock_for_target(target);
-    let _guard = lock
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
-    op()
-}
-
-fn atomic_write_locked<F>(target: &Path, contents_fn: F) -> io::Result<()>
-where
-    F: FnOnce(&mut io::BufWriter<&std::fs::File>) -> io::Result<()>,
-{
-    let parent = target.parent().ok_or_else(|| {
-        io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "target path has no parent directory",
-        )
-    })?;
-    let file_name = target.file_name().and_then(|s| s.to_str()).ok_or_else(|| {
-        io::Error::new(io::ErrorKind::InvalidInput, "target path has no file name")
-    })?;
-    // Unique per write attempt: pid + monotonic counter. Two overlapping
-    // rewrites of the same target inside one process must not share a temp
-    // path, or they would truncate/rename each other's files.
-    let seq = TMP_SEQ.fetch_add(1, Ordering::Relaxed);
-    let tmp_path = parent.join(format!(".{file_name}.tmp.{}.{seq}", std::process::id()));
-
-    let result: io::Result<()> = (|| {
-        // `create_new` guarantees we never clobber a pre-existing temp file
-        // from another writer that happened to pick the same path.
-        let file = std::fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&tmp_path)?;
-        {
-            let mut writer = io::BufWriter::new(&file);
-            contents_fn(&mut writer)?;
-            writer.flush()?;
-        }
-        file.sync_all()?;
-        drop(file);
-        rename_replacing(&tmp_path, target)
-    })();
-
-    if result.is_err() {
-        let _ = std::fs::remove_file(&tmp_path);
-    }
-    result
-}
-
-/// Write `contents_fn` to a sibling temp file, fsync, then atomically rename
-/// over `target`. The temp file is removed on any error so a crash mid-write
-/// never leaves a zero-length or partial file at `target`.
-fn atomic_write<F>(target: &Path, contents_fn: F) -> io::Result<()>
-where
-    F: FnOnce(&mut io::BufWriter<&std::fs::File>) -> io::Result<()>,
-{
-    with_target_lock(target, || atomic_write_locked(target, contents_fn))
-}
-
-/// Rename `from` to `to`, replacing `to` if it already exists.
-///
-/// On Unix, `std::fs::rename` is an atomic replace. On Windows it fails with
-/// `ERROR_ALREADY_EXISTS` when the destination is present, so we remove it
-/// first. To keep concurrent rewrites of the same target safe on Windows,
-/// callers must serialize via [`lock_for_target`] around the whole
-/// write+rename sequence.
-fn rename_replacing(from: &Path, to: &Path) -> io::Result<()> {
-    #[cfg(windows)]
-    if to.exists() {
-        std::fs::remove_file(to)?;
-    }
-    std::fs::rename(from, to)
-}
-
-/// Per-target serialization guard. Two overlapping atomic rewrites of the
-/// same path inside one process must not race on the final rename step —
-/// on Windows this is especially important because the replace sequence is
-/// not a single kernel operation. We key a global mutex map on the target
-/// path so writes to different sessions remain fully concurrent.
-fn lock_for_target(target: &Path) -> std::sync::Arc<std::sync::Mutex<()>> {
-    use std::collections::HashMap;
-    use std::sync::{Arc, Mutex, OnceLock};
-    static LOCKS: OnceLock<Mutex<HashMap<PathBuf, Arc<Mutex<()>>>>> = OnceLock::new();
-    let map = LOCKS.get_or_init(|| Mutex::new(HashMap::new()));
-    let mut guard = map
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
-    guard
-        .entry(target.to_path_buf())
-        .or_insert_with(|| Arc::new(Mutex::new(())))
-        .clone()
-}
-
 fn rewrite_session_file_locked(
     path: &Path,
     meta: &SessionMeta,
     lines: &[String],
 ) -> io::Result<()> {
-    atomic_write_locked(path, |writer| {
+    atomic_write_unlocked(path, |writer| {
         serde_json::to_writer(&mut *writer, meta).map_err(io::Error::other)?;
         writeln!(writer)?;
 
@@ -301,7 +202,7 @@ fn write_messages_locked(
     messages: &[AgentMessage],
     id: &str,
 ) -> io::Result<()> {
-    atomic_write_locked(path, |writer| {
+    atomic_write_unlocked(path, |writer| {
         serde_json::to_writer(&mut *writer, meta).map_err(io::Error::other)?;
         writeln!(writer)?;
 
@@ -687,7 +588,7 @@ impl JsonlSessionStore {
             let mut write_meta = meta.clone();
             write_meta.sequence += 1;
 
-            atomic_write_locked(&path, |writer| {
+            atomic_write_unlocked(&path, |writer| {
                 // First line: metadata
                 serde_json::to_writer(&mut *writer, &write_meta).map_err(io::Error::other)?;
                 writeln!(writer)?;

--- a/src/agent/checkpointing.rs
+++ b/src/agent/checkpointing.rs
@@ -10,7 +10,7 @@ use crate::loop_::AgentEvent;
 use super::Agent;
 use super::queueing::llm_messages_from_queue;
 
-fn invalid_state_snapshot(error: serde_json::Error) -> std::io::Error {
+fn invalid_state_snapshot(error: &serde_json::Error) -> std::io::Error {
     std::io::Error::new(
         std::io::ErrorKind::InvalidData,
         format!("corrupted session state snapshot: {error}"),
@@ -88,7 +88,7 @@ impl Agent {
 
         if let Some(ref state_val) = checkpoint.state {
             let restored = crate::SessionState::restore_from_snapshot(state_val.clone())
-                .map_err(invalid_state_snapshot)?;
+                .map_err(|e| invalid_state_snapshot(&e))?;
             let mut s = self
                 .session_state
                 .write()
@@ -208,7 +208,7 @@ impl Agent {
 
         if let Some(ref state_val) = checkpoint.state {
             let restored = crate::SessionState::restore_from_snapshot(state_val.clone())
-                .map_err(invalid_state_snapshot)
+                .map_err(|e| invalid_state_snapshot(&e))
                 .map_err(AgentError::stream)?;
             let mut s = self
                 .session_state

--- a/src/atomic_fs.rs
+++ b/src/atomic_fs.rs
@@ -1,0 +1,210 @@
+//! Atomic file-write helpers shared across workspace crates.
+//!
+//! Provides [`atomic_write`] and [`atomic_write_bytes`] — both write to a
+//! unique temporary file, `fsync`, and atomically rename over the target.
+//! On error the temp file is removed so a crash mid-write never leaves a
+//! partial or zero-length file at the target path.
+//!
+//! Concurrent writes to the **same target** within one process are serialized
+//! via a per-path mutex.  Writes to different targets remain fully concurrent.
+
+use std::collections::HashMap;
+use std::io::{self, BufWriter, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+
+static TMP_SEQ: AtomicU64 = AtomicU64::new(0);
+
+// ── public API ───────────────────────────────────────────────────────
+
+/// Write to `target` atomically.
+///
+/// `contents_fn` receives a buffered writer backed by a unique temp file.
+/// After it returns successfully the temp file is fsynced and renamed over
+/// `target`.  If `contents_fn` fails (or panics) the temp file is cleaned up.
+///
+/// Concurrent calls targeting the same path are serialized internally;
+/// distinct paths are fully concurrent.
+pub fn atomic_write<F>(target: &Path, contents_fn: F) -> io::Result<()>
+where
+    F: FnOnce(&mut BufWriter<&std::fs::File>) -> io::Result<()>,
+{
+    with_target_lock(target, || atomic_write_inner(target, contents_fn))
+}
+
+/// Convenience wrapper: atomically write raw bytes to `target`.
+pub fn atomic_write_bytes(target: &Path, data: &[u8]) -> io::Result<()> {
+    atomic_write(target, |w| w.write_all(data))
+}
+
+/// Execute `op` while holding the per-target lock for `target`.
+///
+/// Use this when you need to perform multiple operations atomically
+/// (e.g. read-modify-write) and call [`atomic_write_unlocked`] inside.
+pub fn with_target_lock<T>(target: &Path, op: impl FnOnce() -> io::Result<T>) -> io::Result<T> {
+    let lock = lock_for_target(target);
+    let _guard = lock
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    op()
+}
+
+// ── internals ────────────────────────────────────────────────────────
+
+/// Atomic write **without** per-target locking.
+///
+/// Use this when you already hold the lock returned by [`lock_for_target`]
+/// and need to avoid double-locking.
+pub fn atomic_write_unlocked<F>(target: &Path, contents_fn: F) -> io::Result<()>
+where
+    F: FnOnce(&mut BufWriter<&std::fs::File>) -> io::Result<()>,
+{
+    atomic_write_inner(target, contents_fn)
+}
+
+fn atomic_write_inner<F>(target: &Path, contents_fn: F) -> io::Result<()>
+where
+    F: FnOnce(&mut BufWriter<&std::fs::File>) -> io::Result<()>,
+{
+    let parent = target.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "target path has no parent directory",
+        )
+    })?;
+    let file_name = target.file_name().and_then(|s| s.to_str()).ok_or_else(|| {
+        io::Error::new(io::ErrorKind::InvalidInput, "target path has no file name")
+    })?;
+
+    // Unique per write attempt: pid + monotonic counter. Two overlapping
+    // rewrites of the same target inside one process must not share a temp
+    // path, or they would truncate/rename each other's files.
+    let seq = TMP_SEQ.fetch_add(1, Ordering::Relaxed);
+    let tmp_path = parent.join(format!(".{file_name}.tmp.{}.{seq}", std::process::id()));
+
+    let result: io::Result<()> = (|| {
+        // `create_new` guarantees we never clobber a pre-existing temp file
+        // from another writer that happened to pick the same path.
+        let file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&tmp_path)?;
+        {
+            let mut writer = BufWriter::new(&file);
+            contents_fn(&mut writer)?;
+            writer.flush()?;
+        }
+        file.sync_all()?;
+        drop(file);
+        rename_replacing(&tmp_path, target)
+    })();
+
+    if result.is_err() {
+        let _ = std::fs::remove_file(&tmp_path);
+    }
+    result
+}
+
+/// Rename `from` to `to`, replacing `to` if it already exists.
+///
+/// On Unix, `std::fs::rename` is an atomic replace. On Windows it fails with
+/// `ERROR_ALREADY_EXISTS` when the destination is present, so we remove it
+/// first. To keep concurrent rewrites of the same target safe on Windows,
+/// callers must serialize via [`lock_for_target`] around the whole
+/// write-and-rename sequence.
+fn rename_replacing(from: &Path, to: &Path) -> io::Result<()> {
+    #[cfg(windows)]
+    if to.exists() {
+        std::fs::remove_file(to)?;
+    }
+    std::fs::rename(from, to)
+}
+
+/// Per-target serialization guard.
+///
+/// Two overlapping atomic rewrites of the same path inside one process must
+/// not race on the final rename step — on Windows this is especially important
+/// because the replace sequence is not a single kernel operation. We key a
+/// global mutex map on the target path so writes to different sessions remain
+/// fully concurrent.
+pub fn lock_for_target(target: &Path) -> Arc<Mutex<()>> {
+    static LOCKS: OnceLock<Mutex<HashMap<PathBuf, Arc<Mutex<()>>>>> = OnceLock::new();
+    let map = LOCKS.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut guard = map
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    guard
+        .entry(target.to_path_buf())
+        .or_insert_with(|| Arc::new(Mutex::new(())))
+        .clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn atomic_write_creates_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("test.txt");
+
+        atomic_write(&target, |w| writeln!(w, "hello")).unwrap();
+
+        assert_eq!(fs::read_to_string(&target).unwrap().trim(), "hello");
+    }
+
+    #[test]
+    fn atomic_write_replaces_existing() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("test.txt");
+        fs::write(&target, "old").unwrap();
+
+        atomic_write_bytes(&target, b"new").unwrap();
+
+        assert_eq!(fs::read_to_string(&target).unwrap(), "new");
+    }
+
+    #[test]
+    fn atomic_write_cleans_up_on_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("fail.txt");
+
+        let err = atomic_write(&target, |_w| {
+            Err(io::Error::new(io::ErrorKind::Other, "boom"))
+        });
+
+        assert!(err.is_err());
+        // No file at target
+        assert!(!target.exists());
+        // No temp files left behind
+        let entries: Vec<_> = fs::read_dir(dir.path()).unwrap().collect();
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn concurrent_writes_dont_corrupt() {
+        use std::thread;
+
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("concurrent.txt");
+
+        let handles: Vec<_> = (0..10)
+            .map(|i| {
+                let t = target.clone();
+                thread::spawn(move || {
+                    atomic_write_bytes(&t, format!("writer-{i}").as_bytes()).unwrap();
+                })
+            })
+            .collect();
+
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        // File should contain one complete writer's output (no corruption).
+        let content = fs::read_to_string(&target).unwrap();
+        assert!(content.starts_with("writer-"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ mod agent;
 mod agent_id;
 pub(crate) mod agent_options;
 pub(crate) mod agent_subscriptions;
+pub mod atomic_fs;
 #[cfg(feature = "artifact-store")]
 pub mod artifact;
 mod async_context_transformer;


### PR DESCRIPTION
## Summary
- Extracts the robust atomic-write implementation from `memory/src/jsonl.rs` into a shared `src/atomic_fs.rs` module in the core crate
- Refactors `FileArtifactStore` to use the shared helper via `spawn_blocking`, replacing its weaker bespoke temp-file protocol (fixed `.tmp` paths, no `fsync`, no Windows-safe rename)
- Refactors `JsonlSessionStore` to import from the shared module instead of defining its own copy
- Fixes pre-existing clippy warning in `src/agent/checkpointing.rs`

Closes #314

## Test plan
- [x] `cargo test -p swink-agent -- atomic_fs` — 4/4 pass (new shared module tests)
- [x] `cargo test -p swink-agent-memory` — 29/29 pass (existing tests exercise shared helper)
- [x] `cargo test -p swink-agent-artifacts` — 18/18 pass (exercises refactored write paths)
- [x] `cargo clippy -p swink-agent -p swink-agent-memory -p swink-agent-artifacts -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)