### PR TITLE
[codex] Fix macros crate workspace proc-macro deps

### DIFF
--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -11,9 +11,9 @@ repository = "https://github.com/SuperSwinkAI/Swink-Agent"
 proc-macro = true
 
 [dependencies]
-syn = { version = "2", features = ["full", "extra-traits"] }
-quote = "1"
-proc-macro2 = "1"
+syn = { workspace = true, features = ["full", "extra-traits"] }
+quote.workspace = true
+proc-macro2.workspace = true
 
 [dev-dependencies]
 swink-agent = { path = "..", default-features = false }


### PR DESCRIPTION
## Summary
- switch `swink-agent-macros` proc-macro dependencies to workspace-managed versions
- keep the existing `syn` feature set while removing direct version pins
- align the macros crate with the repo's centralized dependency policy

## Root cause
The macros crate pinned `syn`, `quote`, and `proc-macro2` directly even though those versions are already managed in the workspace root.

## Validation
- `cargo test --workspace` 
  - fails in existing unrelated test: `tests/ac_tools.rs::concurrent_tool_execution` due a timing assertion
