### PR TITLE
[codex] Preserve local length stops after tool calls

### DIFF
--- a/local-llm/src/stream.rs
+++ b/local-llm/src/stream.rs
@@ -674,13 +674,10 @@ impl StreamState {
     fn finalize(mut self) -> Vec<AssistantMessageEvent> {
         self.events.extend(finalize_blocks(&mut self.blocks));
 
-        let stop_reason = if self.has_tool_calls {
-            StopReason::ToolUse
-        } else {
-            match self.finish_reason.as_deref() {
-                Some("length") => StopReason::Length,
-                _ => StopReason::Stop,
-            }
+        let stop_reason = match self.finish_reason.as_deref() {
+            Some("length") => StopReason::Length,
+            _ if self.has_tool_calls => StopReason::ToolUse,
+            _ => StopReason::Stop,
         };
 
         self.events.push(AssistantMessageEvent::Done {
@@ -961,6 +958,37 @@ mod tests {
         assert_eq!(usage.total, 55);
         assert_eq!(usage.cache_read, 0);
         assert_eq!(usage.cache_write, 0);
+    }
+
+    #[test]
+    fn finalize_preserves_length_stop_reason_after_tool_calls() {
+        let mut state = StreamState::new(false);
+        state.has_tool_calls = true;
+        state.finish_reason = Some("length".to_string());
+
+        let events = state.finalize();
+        let terminal = events.last().expect("at least one event");
+        match terminal {
+            AssistantMessageEvent::Done { stop_reason, .. } => {
+                assert_eq!(*stop_reason, StopReason::Length);
+            }
+            other => panic!("expected Done terminal, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn finalize_keeps_tool_use_for_non_length_tool_call_turns() {
+        let mut state = StreamState::new(false);
+        state.has_tool_calls = true;
+
+        let events = state.finalize();
+        let terminal = events.last().expect("at least one event");
+        match terminal {
+            AssistantMessageEvent::Done { stop_reason, .. } => {
+                assert_eq!(*stop_reason, StopReason::ToolUse);
+            }
+            other => panic!("expected Done terminal, got {other:?}"),
+        }
     }
 
     #[cfg(feature = "gemma4")]


### PR DESCRIPTION
## Summary
- preserve `StopReason::Length` when a local model hits a length stop after starting tool calls
- keep `ToolUse` for normal non-length tool-call turns
- add unit coverage for both stop-reason cases in the local streaming state machine

## Root cause
The local-LLM stream finalizer always preferred `ToolUse` whenever any tool call appeared, which masked genuine `length` termination and skipped incomplete-tool-call recovery behavior.

## Validation
- `CARGO_TARGET_DIR=/Users/wes/Development/SuperSwinkAI/codex-target cargo test --workspace`
  - fails in existing unrelated test: `tests/agent_loop.rs::max_tokens_recovery`
