### PR TITLE
[codex] Avoid lost wakeups in wait_for_idle

### DIFF
--- a/src/agent/control.rs
+++ b/src/agent/control.rs
@@ -2,9 +2,30 @@ use std::future::Future;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
 
+use tokio::sync::Notify;
 use tracing::info;
 
 use super::Agent;
+
+fn wait_for_idle_future<F>(
+    notify: Arc<Notify>,
+    active: Arc<std::sync::atomic::AtomicBool>,
+    after_register: F,
+) -> impl Future<Output = ()> + Send
+where
+    F: Fn() + Send + Sync + 'static,
+{
+    async move {
+        loop {
+            let notified = notify.notified();
+            after_register();
+            if !active.load(Ordering::Acquire) {
+                return;
+            }
+            notified.await;
+        }
+    }
+}
 
 impl Agent {
     /// Cancel the currently running loop, if any.
@@ -33,16 +54,56 @@ impl Agent {
     /// Uses the shared `loop_active` flag so the future correctly resolves even
     /// when the event stream is dropped without being drained to `AgentEnd`.
     pub fn wait_for_idle(&self) -> impl Future<Output = ()> + Send + '_ {
-        let notify = Arc::clone(&self.idle_notify);
-        let active = Arc::clone(&self.loop_active);
-        async move {
-            loop {
-                let notified = notify.notified();
-                if !active.load(Ordering::Acquire) {
-                    return;
-                }
-                notified.await;
-            }
-        }
+        wait_for_idle_future(
+            Arc::clone(&self.idle_notify),
+            Arc::clone(&self.loop_active),
+            || {},
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::task::Poll;
+
+    use futures::pin_mut;
+    use tokio::sync::Notify;
+
+    use super::wait_for_idle_future;
+
+    #[tokio::test]
+    async fn wait_for_idle_returns_when_idle_transition_happens_after_registration() {
+        let notify = Arc::new(Notify::new());
+        let active = Arc::new(AtomicBool::new(true));
+        let active_for_hook = Arc::clone(&active);
+        let notify_for_hook = Arc::clone(&notify);
+
+        let wait_for_idle = wait_for_idle_future(notify, active, move || {
+            active_for_hook.store(false, Ordering::Release);
+            notify_for_hook.notify_waiters();
+        });
+        pin_mut!(wait_for_idle);
+
+        assert!(matches!(futures::poll!(wait_for_idle.as_mut()), Poll::Ready(())));
+    }
+
+    #[tokio::test]
+    async fn wait_for_idle_stays_pending_until_idle_notification() {
+        let notify = Arc::new(Notify::new());
+        let active = Arc::new(AtomicBool::new(true));
+        let active_for_assert = Arc::clone(&active);
+
+        let wait_for_idle = wait_for_idle_future(Arc::clone(&notify), Arc::clone(&active), || {});
+        pin_mut!(wait_for_idle);
+
+        assert!(matches!(futures::poll!(wait_for_idle.as_mut()), Poll::Pending));
+        assert!(active_for_assert.load(Ordering::Acquire));
+
+        active.store(false, Ordering::Release);
+        notify.notify_waiters();
+
+        assert!(matches!(futures::poll!(wait_for_idle.as_mut()), Poll::Ready(())));
     }
 }

--- a/src/agent/control.rs
+++ b/src/agent/control.rs
@@ -36,10 +36,13 @@ impl Agent {
         let notify = Arc::clone(&self.idle_notify);
         let active = Arc::clone(&self.loop_active);
         async move {
-            if !active.load(Ordering::Acquire) {
-                return;
+            loop {
+                let notified = notify.notified();
+                if !active.load(Ordering::Acquire) {
+                    return;
+                }
+                notified.await;
             }
-            notify.notified().await;
         }
     }
 }


### PR DESCRIPTION
## Summary
- register the idle notification waiter before checking the active flag
- re-check the active flag in a loop so the idle transition cannot be missed
- keep the public `wait_for_idle` behavior unchanged for callers

## Root cause
`wait_for_idle()` checked `loop_active` before registering `Notify::notified()`, so the idle transition could be observed and notified in the gap, leaving the waiter blocked forever.

## Validation
- `CARGO_TARGET_DIR=/Users/wes/Development/SuperSwinkAI/codex-target cargo test --workspace`
  - fails in existing unrelated test: `tests/agent_loop.rs::max_tokens_recovery`
