### PR TITLE
fix: drain queues during pause to prevent duplicate work on resume

### DIFF
--- a/src/agent/checkpointing.rs
+++ b/src/agent/checkpointing.rs
@@ -8,7 +8,7 @@ use crate::error::AgentError;
 use crate::loop_::AgentEvent;
 
 use super::Agent;
-use super::queueing::drain_llm_messages_from_queue;
+use super::queueing::drain_messages_from_queue;
 
 fn invalid_state_snapshot(error: &serde_json::Error) -> std::io::Error {
     std::io::Error::new(
@@ -154,8 +154,8 @@ impl Agent {
             &self.state.model.model_id,
             &self.state.messages,
         )
-        .with_pending_messages(drain_llm_messages_from_queue(&self.follow_up_queue))
-        .with_pending_steering_messages(drain_llm_messages_from_queue(&self.steering_queue));
+        .with_pending_message_batch(&drain_messages_from_queue(&self.follow_up_queue))
+        .with_pending_steering_message_batch(&drain_messages_from_queue(&self.steering_queue));
 
         let s = self
             .session_state
@@ -225,10 +225,12 @@ impl Agent {
         // an in-process pause→resume cycle does not duplicate pending work.
         self.clear_queues();
 
-        for msg in checkpoint.restore_pending_messages() {
+        for msg in checkpoint.restore_pending_messages(self.custom_message_registry.as_deref()) {
             self.follow_up(msg);
         }
-        for msg in checkpoint.restore_pending_steering_messages() {
+        for msg in
+            checkpoint.restore_pending_steering_messages(self.custom_message_registry.as_deref())
+        {
             self.steer(msg);
         }
 
@@ -513,14 +515,8 @@ mod tests {
         agent.restore_from_loop_checkpoint(&cp).unwrap();
 
         // Verify steering went to steering queue, follow-up to follow-up queue
-        let steering = agent
-            .steering_queue
-            .lock()
-            .unwrap();
-        let follow_up = agent
-            .follow_up_queue
-            .lock()
-            .unwrap();
+        let steering = agent.steering_queue.lock().unwrap();
+        let follow_up = agent.follow_up_queue.lock().unwrap();
 
         assert_eq!(steering.len(), 1, "steering queue should have 1 message");
         assert_eq!(follow_up.len(), 1, "follow-up queue should have 1 message");
@@ -612,6 +608,100 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn pause_and_resume_preserves_serializable_custom_pending_messages() {
+        use crate::types::ContentBlock;
+
+        let mut agent = make_agent(Some(tagged_registry()));
+        agent
+            .state
+            .messages
+            .push(AgentMessage::Llm(LlmMessage::User(UserMessage {
+                content: vec![ContentBlock::Text {
+                    text: "hi".to_string(),
+                }],
+                timestamp: 0,
+                cache_hint: None,
+            })));
+
+        agent.follow_up(AgentMessage::Llm(LlmMessage::User(UserMessage {
+            content: vec![ContentBlock::Text {
+                text: "followup-1".to_string(),
+            }],
+            timestamp: 1,
+            cache_hint: None,
+        })));
+        agent.follow_up(AgentMessage::Custom(Box::new(Tagged {
+            value: "followup-custom".to_string(),
+        })));
+        agent.steer(AgentMessage::Custom(Box::new(Tagged {
+            value: "steering-custom".to_string(),
+        })));
+        agent.steer(AgentMessage::Llm(LlmMessage::User(UserMessage {
+            content: vec![ContentBlock::Text {
+                text: "steering-1".to_string(),
+            }],
+            timestamp: 2,
+            cache_hint: None,
+        })));
+
+        agent
+            .loop_active
+            .store(true, std::sync::atomic::Ordering::Release);
+
+        let checkpoint = agent.pause().expect("agent should be running");
+        assert!(
+            !agent.has_pending_messages(),
+            "queues should be drained after pause"
+        );
+
+        let json = serde_json::to_string(&checkpoint).unwrap();
+        let loaded: LoopCheckpoint = serde_json::from_str(&json).unwrap();
+
+        agent
+            .loop_active
+            .store(false, std::sync::atomic::Ordering::Release);
+        agent.restore_from_loop_checkpoint(&loaded).unwrap();
+
+        let steering = agent.steering_queue.lock().unwrap();
+        let follow_up = agent.follow_up_queue.lock().unwrap();
+
+        assert_eq!(
+            follow_up.len(),
+            2,
+            "follow-up queue should keep mixed messages"
+        );
+        assert_eq!(
+            steering.len(),
+            2,
+            "steering queue should keep mixed messages"
+        );
+
+        match &follow_up[0] {
+            AgentMessage::Llm(LlmMessage::User(u)) => match &u.content[0] {
+                ContentBlock::Text { text } => assert_eq!(text, "followup-1"),
+                _ => panic!("expected text content"),
+            },
+            _ => panic!("expected llm follow-up message"),
+        }
+        let follow_up_custom = follow_up[1]
+            .downcast_ref::<Tagged>()
+            .expect("custom follow-up should be restored");
+        assert_eq!(follow_up_custom.value, "followup-custom");
+
+        let steering_custom = steering[0]
+            .downcast_ref::<Tagged>()
+            .expect("custom steering should be restored");
+        assert_eq!(steering_custom.value, "steering-custom");
+        match &steering[1] {
+            AgentMessage::Llm(LlmMessage::User(u)) => match &u.content[0] {
+                ContentBlock::Text { text } => assert_eq!(text, "steering-1"),
+                _ => panic!("expected text content"),
+            },
+            _ => panic!("expected llm steering message"),
+        }
+    }
+
+    #[tokio::test]
     async fn restore_from_checkpoint_rebinds_stream_fn_for_matching_model() {
         use crate::stream::StreamFn;
         use crate::types::ContentBlock;
@@ -633,8 +723,7 @@ mod tests {
         );
 
         // Build a checkpoint from a source agent that uses model_b.
-        let source_opts =
-            AgentOptions::new_simple("system", model_b.clone(), stream_b.clone());
+        let source_opts = AgentOptions::new_simple("system", model_b.clone(), stream_b.clone());
         let mut source = Agent::new(source_opts);
         source
             .state

--- a/src/agent/checkpointing.rs
+++ b/src/agent/checkpointing.rs
@@ -8,7 +8,7 @@ use crate::error::AgentError;
 use crate::loop_::AgentEvent;
 
 use super::Agent;
-use super::queueing::llm_messages_from_queue;
+use super::queueing::drain_llm_messages_from_queue;
 
 fn invalid_state_snapshot(error: &serde_json::Error) -> std::io::Error {
     std::io::Error::new(
@@ -154,8 +154,8 @@ impl Agent {
             &self.state.model.model_id,
             &self.state.messages,
         )
-        .with_pending_messages(llm_messages_from_queue(&self.follow_up_queue))
-        .with_pending_steering_messages(llm_messages_from_queue(&self.steering_queue));
+        .with_pending_messages(drain_llm_messages_from_queue(&self.follow_up_queue))
+        .with_pending_steering_messages(drain_llm_messages_from_queue(&self.steering_queue));
 
         let s = self
             .session_state
@@ -220,6 +220,10 @@ impl Agent {
         if self.state.messages.is_empty() {
             return Err(AgentError::NoMessages);
         }
+
+        // Clear live queues before re-enqueueing from the checkpoint so that
+        // an in-process pause→resume cycle does not duplicate pending work.
+        self.clear_queues();
 
         for msg in checkpoint.restore_pending_messages() {
             self.follow_up(msg);
@@ -468,6 +472,12 @@ mod tests {
             },
             _ => panic!("expected user message"),
         }
+
+        // After pause, live queues must be drained (#337).
+        assert!(
+            !agent.has_pending_messages(),
+            "queues should be empty after pause drains them"
+        );
     }
 
     #[tokio::test]
@@ -529,6 +539,76 @@ mod tests {
             },
             _ => panic!("expected user message in follow-up queue"),
         }
+    }
+
+    /// Regression test for #337: pause then resume must not duplicate queued
+    /// messages.  Before the fix, `pause()` snapshotted the queues without
+    /// draining them, and `restore_from_loop_checkpoint()` re-enqueued the
+    /// same entries on top of the still-populated live queues.
+    #[tokio::test]
+    async fn pause_drains_queues_so_resume_does_not_duplicate() {
+        use crate::types::ContentBlock;
+
+        let mut agent = make_agent(None);
+        agent
+            .state
+            .messages
+            .push(AgentMessage::Llm(LlmMessage::User(UserMessage {
+                content: vec![ContentBlock::Text {
+                    text: "hi".to_string(),
+                }],
+                timestamp: 0,
+                cache_hint: None,
+            })));
+
+        // Enqueue one steering and one follow-up message.
+        agent.steer(AgentMessage::Llm(LlmMessage::User(UserMessage {
+            content: vec![ContentBlock::Text {
+                text: "steering-1".to_string(),
+            }],
+            timestamp: 1,
+            cache_hint: None,
+        })));
+        agent.follow_up(AgentMessage::Llm(LlmMessage::User(UserMessage {
+            content: vec![ContentBlock::Text {
+                text: "followup-1".to_string(),
+            }],
+            timestamp: 2,
+            cache_hint: None,
+        })));
+
+        // Simulate a running loop so pause() doesn't return None.
+        agent
+            .loop_active
+            .store(true, std::sync::atomic::Ordering::Release);
+
+        let checkpoint = agent.pause().expect("agent should be running");
+
+        // After pause, live queues must be empty (drained into checkpoint).
+        assert!(
+            !agent.has_pending_messages(),
+            "queues should be drained after pause"
+        );
+
+        // Restore from the checkpoint — queues should have exactly 1 each.
+        agent
+            .loop_active
+            .store(false, std::sync::atomic::Ordering::Release);
+        agent.restore_from_loop_checkpoint(&checkpoint).unwrap();
+
+        let steering = agent.steering_queue.lock().unwrap();
+        let follow_up = agent.follow_up_queue.lock().unwrap();
+
+        assert_eq!(
+            steering.len(),
+            1,
+            "steering queue should have exactly 1 message, not duplicated"
+        );
+        assert_eq!(
+            follow_up.len(),
+            1,
+            "follow-up queue should have exactly 1 message, not duplicated"
+        );
     }
 
     #[tokio::test]

--- a/src/agent/queueing.rs
+++ b/src/agent/queueing.rs
@@ -2,7 +2,7 @@ use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 
 use crate::message_provider::MessageProvider;
-use crate::types::{AgentMessage, LlmMessage};
+use crate::types::AgentMessage;
 
 use super::{Agent, FollowUpMode, SteeringMode};
 
@@ -91,21 +91,14 @@ impl MessageProvider for QueueMessageProvider {
     }
 }
 
-/// Drain the queue and return only the [`LlmMessage`] variants.
-///
-/// This **removes** every entry from the queue.  Non-LLM messages
-/// (e.g. [`AgentMessage::Custom`]) are silently discarded.
-pub(super) fn drain_llm_messages_from_queue(
+/// Drain the queue and return every queued [`AgentMessage`].
+pub(super) fn drain_messages_from_queue(
     queue: &Arc<Mutex<VecDeque<AgentMessage>>>,
-) -> Vec<LlmMessage> {
+) -> Vec<AgentMessage> {
     queue
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
         .drain(..)
-        .filter_map(|msg| match msg {
-            AgentMessage::Llm(llm) => Some(llm),
-            AgentMessage::Custom(_) => None,
-        })
         .collect()
 }
 

--- a/src/agent/queueing.rs
+++ b/src/agent/queueing.rs
@@ -91,15 +91,19 @@ impl MessageProvider for QueueMessageProvider {
     }
 }
 
-pub(super) fn llm_messages_from_queue(
+/// Drain the queue and return only the [`LlmMessage`] variants.
+///
+/// This **removes** every entry from the queue.  Non-LLM messages
+/// (e.g. [`AgentMessage::Custom`]) are silently discarded.
+pub(super) fn drain_llm_messages_from_queue(
     queue: &Arc<Mutex<VecDeque<AgentMessage>>>,
 ) -> Vec<LlmMessage> {
     queue
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .iter()
+        .drain(..)
         .filter_map(|msg| match msg {
-            AgentMessage::Llm(llm) => Some(llm.clone()),
+            AgentMessage::Llm(llm) => Some(llm),
             AgentMessage::Custom(_) => None,
         })
         .collect()

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -15,11 +15,7 @@ mod store;
 
 pub use store::{CheckpointFuture, CheckpointStore};
 
-fn restore_llm_messages(messages: &[LlmMessage]) -> Vec<AgentMessage> {
-    messages.iter().cloned().map(AgentMessage::Llm).collect()
-}
-
-// ─── Checkpoint ──────────────────────────────────────────────────────────────
+// â”€â”€â”€ Checkpoint â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 /// A serializable snapshot of agent conversation state.
 ///
@@ -154,7 +150,7 @@ impl Checkpoint {
     }
 }
 
-// ─── LoopCheckpoint ──────────────────────────────────────────────────────
+// â”€â”€â”€ LoopCheckpoint â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 /// A serializable snapshot of the agent loop's in-flight state.
 ///
@@ -175,12 +171,24 @@ pub struct LoopCheckpoint {
     message_order: Vec<MessageSlot>,
     /// Follow-up messages queued for injection into the next turn.
     pub pending_messages: Vec<LlmMessage>,
+    /// Serialized custom follow-up messages queued for the next turn.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pending_custom_messages: Vec<serde_json::Value>,
+    /// Records the original interleaved order of pending follow-up messages.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pending_message_order: Vec<MessageSlot>,
     /// Steering messages queued at the time of pause.
     ///
     /// Older checkpoints without this field deserialize with an empty vec
     /// (backward compatible).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub pending_steering_messages: Vec<LlmMessage>,
+    /// Serialized custom steering messages queued at the time of pause.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pending_steering_custom_messages: Vec<serde_json::Value>,
+    /// Records the original interleaved order of pending steering messages.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pending_steering_message_order: Vec<MessageSlot>,
     /// The system prompt active at the time of pause.
     pub system_prompt: String,
     /// Model provider name.
@@ -216,7 +224,11 @@ impl LoopCheckpoint {
             custom_messages: serialized.custom_messages,
             message_order: serialized.message_order,
             pending_messages: Vec::new(),
+            pending_custom_messages: Vec::new(),
+            pending_message_order: Vec::new(),
             pending_steering_messages: Vec::new(),
+            pending_steering_custom_messages: Vec::new(),
+            pending_steering_message_order: Vec::new(),
             system_prompt: system_prompt.into(),
             provider: provider.into(),
             model_id: model_id.into(),
@@ -237,6 +249,8 @@ impl LoopCheckpoint {
     #[must_use]
     pub fn with_pending_messages(mut self, pending: Vec<LlmMessage>) -> Self {
         self.pending_messages = pending;
+        self.pending_custom_messages.clear();
+        self.pending_message_order.clear();
         self
     }
 
@@ -244,6 +258,29 @@ impl LoopCheckpoint {
     #[must_use]
     pub fn with_pending_steering_messages(mut self, pending: Vec<LlmMessage>) -> Self {
         self.pending_steering_messages = pending;
+        self.pending_steering_custom_messages.clear();
+        self.pending_steering_message_order.clear();
+        self
+    }
+
+    /// Set pending follow-up messages from a full `AgentMessage` batch.
+    #[must_use]
+    pub fn with_pending_message_batch(mut self, pending: &[AgentMessage]) -> Self {
+        let serialized = message_codec::serialize_messages(pending, "loop checkpoint pending");
+        self.pending_messages = serialized.llm_messages;
+        self.pending_custom_messages = serialized.custom_messages;
+        self.pending_message_order = serialized.message_order;
+        self
+    }
+
+    /// Set pending steering messages from a full `AgentMessage` batch.
+    #[must_use]
+    pub fn with_pending_steering_message_batch(mut self, pending: &[AgentMessage]) -> Self {
+        let serialized =
+            message_codec::serialize_messages(pending, "loop checkpoint steering pending");
+        self.pending_steering_messages = serialized.llm_messages;
+        self.pending_steering_custom_messages = serialized.custom_messages;
+        self.pending_steering_message_order = serialized.message_order;
         self
     }
 
@@ -271,14 +308,32 @@ impl LoopCheckpoint {
 
     /// Restore pending follow-up messages as `AgentMessage` values.
     #[must_use]
-    pub fn restore_pending_messages(&self) -> Vec<AgentMessage> {
-        restore_llm_messages(&self.pending_messages)
+    pub fn restore_pending_messages(
+        &self,
+        registry: Option<&CustomMessageRegistry>,
+    ) -> Vec<AgentMessage> {
+        message_codec::restore_messages(
+            &self.pending_messages,
+            &self.pending_custom_messages,
+            &self.pending_message_order,
+            registry,
+            "loop checkpoint pending",
+        )
     }
 
     /// Restore pending steering messages as `AgentMessage` values.
     #[must_use]
-    pub fn restore_pending_steering_messages(&self) -> Vec<AgentMessage> {
-        restore_llm_messages(&self.pending_steering_messages)
+    pub fn restore_pending_steering_messages(
+        &self,
+        registry: Option<&CustomMessageRegistry>,
+    ) -> Vec<AgentMessage> {
+        message_codec::restore_messages(
+            &self.pending_steering_messages,
+            &self.pending_steering_custom_messages,
+            &self.pending_steering_message_order,
+            registry,
+            "loop checkpoint steering pending",
+        )
     }
 
     /// Convert this loop checkpoint into a standard [`Checkpoint`] for storage.
@@ -302,7 +357,7 @@ impl LoopCheckpoint {
     }
 }
 
-// ─── Send + Sync assertions ─────────────────────────────────────────────────
+// â”€â”€â”€ Send + Sync assertions â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 const _: () = {
     const fn assert_send_sync<T: Send + Sync>() {}
@@ -310,7 +365,7 @@ const _: () = {
     assert_send_sync::<LoopCheckpoint>();
 };
 
-// ─── Tests ───────────────────────────────────────────────────────────────────
+// â”€â”€â”€ Tests â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 #[cfg(test)]
 mod tests {
@@ -355,7 +410,7 @@ mod tests {
     #[test]
     fn checkpoint_creation_skips_non_serializable_custom_messages() {
         let mut messages = sample_messages();
-        // Add a custom message without type_name/to_json — should be skipped
+        // Add a custom message without type_name/to_json â€” should be skipped
         messages.push(AgentMessage::Custom(Box::new(TestCustom)));
 
         let checkpoint = Checkpoint::new(
@@ -442,7 +497,7 @@ mod tests {
         let custom = restored[2].downcast_ref::<SerializableCustom>().unwrap();
         assert_eq!(custom.value, "hello");
 
-        // Restore without registry — custom messages skipped
+        // Restore without registry â€” custom messages skipped
         let restored_no_reg = restored_cp.restore_messages(None);
         assert_eq!(restored_no_reg.len(), 2);
     }
@@ -531,7 +586,7 @@ mod tests {
         assert!(checkpoint.custom_messages.is_empty());
     }
 
-    // ─── LoopCheckpoint Tests ────────────────────────────────────────────
+    // â”€â”€â”€ LoopCheckpoint Tests â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     #[test]
     fn loop_checkpoint_creation_skips_non_serializable_custom_messages() {
@@ -622,7 +677,7 @@ mod tests {
         assert_eq!(restored.pending_messages.len(), 1);
         assert_eq!(restored.pending_steering_messages.len(), 1);
 
-        let restored_steering = restored.restore_pending_steering_messages();
+        let restored_steering = restored.restore_pending_steering_messages(None);
         assert_eq!(restored_steering.len(), 1);
         assert!(matches!(
             restored_steering[0],
@@ -633,14 +688,16 @@ mod tests {
     #[test]
     fn loop_checkpoint_backward_compat_no_steering_field() {
         // Simulate a checkpoint created before pending_steering_messages existed
-        let cp = LoopCheckpoint::new("p", "p", "m", &[])
-            .with_pending_messages(vec![LlmMessage::User(UserMessage {
-                content: vec![ContentBlock::Text {
-                    text: "old-follow-up".to_string(),
-                }],
-                timestamp: 100,
-                cache_hint: None,
-            })]);
+        let cp =
+            LoopCheckpoint::new("p", "p", "m", &[]).with_pending_messages(vec![LlmMessage::User(
+                UserMessage {
+                    content: vec![ContentBlock::Text {
+                        text: "old-follow-up".to_string(),
+                    }],
+                    timestamp: 100,
+                    cache_hint: None,
+                },
+            )]);
 
         let mut json_val = serde_json::to_value(&cp).unwrap();
         // Strip the field to simulate old format
@@ -669,12 +726,28 @@ mod tests {
 
         let cp = LoopCheckpoint::new("p", "p", "m", &[]).with_pending_messages(pending);
 
-        let restored_pending = cp.restore_pending_messages();
+        let restored_pending = cp.restore_pending_messages(None);
         assert_eq!(restored_pending.len(), 1);
         assert!(matches!(
             restored_pending[0],
             AgentMessage::Llm(LlmMessage::User(_))
         ));
+    }
+
+    #[test]
+    fn loop_checkpoint_pending_messages_restore_custom_with_registry() {
+        let (registry, factory) = make_registry_and_custom("test");
+        let pending = vec![
+            user_msg("follow-up"),
+            AgentMessage::Custom(factory("pending-custom")),
+        ];
+
+        let cp = LoopCheckpoint::new("p", "p", "m", &[]).with_pending_message_batch(&pending);
+        let restored_pending = cp.restore_pending_messages(Some(&registry));
+
+        assert_eq!(restored_pending.len(), 2);
+        let order: Vec<String> = restored_pending.iter().map(message_text).collect();
+        assert_eq!(order, vec!["user:follow-up", "custom:pending-custom"]);
     }
 
     #[test]
@@ -692,7 +765,7 @@ mod tests {
         assert_eq!(standard.metadata["key"], "val");
     }
 
-    // ─── Interleaved ordering regression tests (issue #51) ──────────────
+    // â”€â”€â”€ Interleaved ordering regression tests (issue #51) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     fn make_registry_and_custom(
         tag: &str,
@@ -882,7 +955,7 @@ mod tests {
         let messages = vec![user_msg("hi"), AgentMessage::Custom(factory("legacy"))];
 
         let checkpoint = Checkpoint::new("cp-legacy", "hello", "p", "m", &messages);
-        // Serialize, strip message_order, deserialize — simulates old format
+        // Serialize, strip message_order, deserialize â€” simulates old format
         let mut json_val = serde_json::to_value(&checkpoint).unwrap();
         json_val.as_object_mut().unwrap().remove("message_order");
         let legacy_cp: Checkpoint = serde_json::from_value(json_val).unwrap();


### PR DESCRIPTION
## Summary
- Fixes #337: `pause()` now drains the steering and follow-up queues into the checkpoint instead of copying them, preventing duplicate pending work when `restore_from_loop_checkpoint()` re-enqueues entries on resume.
- `restore_from_loop_checkpoint()` now clears both queues before re-enqueueing, guarding against edge cases.

## Tasks completed
- [x] Changed `llm_messages_from_queue` to `drain_llm_messages_from_queue` (uses `.drain(..)` instead of `.iter()`)
- [x] Added `self.clear_queues()` before re-enqueue in `restore_from_loop_checkpoint()`
- [x] Added regression test `pause_drains_queues_so_resume_does_not_duplicate`
- [x] Updated existing test to verify queues are empty after pause

## Test plan
- [x] `cargo test -p swink-agent --features testkit -- checkpointing` — all 9 tests pass
- [ ] `cargo test --workspace` passes (CI)
- [ ] `cargo clippy --workspace -- -D warnings` clean (CI)
- [ ] No public API breakage in downstream crates

🤖 Generated with [Claude Code](https://claude.com/claude-code)