### PR TITLE
fix: stop tool batches after transfer

### DIFF
--- a/src/loop_/tool_dispatch.rs
+++ b/src/loop_/tool_dispatch.rs
@@ -116,6 +116,8 @@ pub async fn execute_tools_concurrently(
         Arc::new(Mutex::new(Vec::new()));
     let steering_detected: Arc<std::sync::atomic::AtomicBool> =
         Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let transfer_detected: Arc<std::sync::atomic::AtomicBool> =
+        Arc::new(std::sync::atomic::AtomicBool::new(false));
     let transfer_signal: Arc<Mutex<Option<crate::transfer::TransferSignal>>> =
         Arc::new(Mutex::new(None));
 
@@ -273,6 +275,7 @@ pub async fn execute_tools_concurrently(
                 &results,
                 &tool_timings,
                 &steering_detected,
+                &transfer_detected,
                 &transfer_signal,
                 tx,
             )
@@ -290,6 +293,7 @@ pub async fn execute_tools_concurrently(
             handles,
             &results,
             &steering_detected,
+            &transfer_detected,
             &batch_token,
         )
         .await;
@@ -302,6 +306,16 @@ pub async fn execute_tools_concurrently(
                     tool_calls,
                     results,
                     tool_timings,
+                    injected_messages,
+                )
+                .await;
+            }
+            GroupOutcome::TransferInterrupt => {
+                return build_transfer_outcome(
+                    tool_calls,
+                    results,
+                    tool_timings,
+                    transfer_signal,
                     injected_messages,
                 )
                 .await;
@@ -412,6 +426,8 @@ enum GroupOutcome {
     Continue,
     /// Steering interrupt detected; abort remaining groups.
     SteeringInterrupt,
+    /// Transfer detected; abort remaining groups and end the turn.
+    TransferInterrupt,
 }
 
 /// Collect results for a single execution group's spawned handles.
@@ -420,6 +436,7 @@ async fn collect_group_results(
     handles: Vec<(usize, tokio::task::JoinHandle<()>)>,
     results: &Arc<tokio::sync::Mutex<Vec<(usize, ToolResultMessage)>>>,
     steering_detected: &Arc<std::sync::atomic::AtomicBool>,
+    transfer_detected: &Arc<std::sync::atomic::AtomicBool>,
     batch_token: &CancellationToken,
 ) -> GroupOutcome {
     let abort_handles: Vec<_> = handles
@@ -475,6 +492,15 @@ async fn collect_group_results(
             while futs.next().await.is_some() {}
             return GroupOutcome::SteeringInterrupt;
         }
+
+        if transfer_detected.load(std::sync::atomic::Ordering::SeqCst) {
+            batch_token.cancel();
+            for handle in &abort_handles {
+                handle.abort();
+            }
+            while futs.next().await.is_some() {}
+            return GroupOutcome::TransferInterrupt;
+        }
     }
 
     GroupOutcome::Continue
@@ -524,6 +550,48 @@ async fn build_steering_outcome(
         cancelled,
         steering_messages,
         tool_metrics: collected_timings,
+        injected_messages,
+    }
+}
+
+/// Build a completed outcome after a transfer signal cancels the remaining batch.
+async fn build_transfer_outcome(
+    tool_calls: &[ToolCallInfo],
+    results: Arc<tokio::sync::Mutex<Vec<(usize, ToolResultMessage)>>>,
+    tool_timings: Arc<tokio::sync::Mutex<Vec<crate::metrics::ToolExecMetrics>>>,
+    transfer_signal: Arc<tokio::sync::Mutex<Option<crate::transfer::TransferSignal>>>,
+    injected_messages: Vec<AgentMessage>,
+) -> ToolExecOutcome {
+    let all_results = std::mem::take(&mut *results.lock().await);
+    let result_map: HashMap<&str, &ToolResultMessage> = all_results
+        .iter()
+        .map(|(_, result)| (result.tool_call_id.as_str(), result))
+        .collect();
+    let mut ordered: Vec<ToolResultMessage> = Vec::with_capacity(tool_calls.len());
+
+    for tc in tool_calls {
+        if let Some(result) = result_map.get(tc.id.as_str()) {
+            ordered.push((*result).clone());
+        } else {
+            ordered.push(ToolResultMessage {
+                tool_call_id: tc.id.clone(),
+                content: vec![ContentBlock::Text {
+                    text: "tool call cancelled: transfer initiated".to_string(),
+                }],
+                is_error: true,
+                timestamp: now_timestamp(),
+                details: serde_json::Value::Null,
+                cache_hint: None,
+            });
+        }
+    }
+
+    let collected_timings = std::mem::take(&mut *tool_timings.lock().await);
+    let captured_transfer = transfer_signal.lock().await.take();
+    ToolExecOutcome::Completed {
+        results: ordered,
+        tool_metrics: collected_timings,
+        transfer_signal: captured_transfer,
         injected_messages,
     }
 }
@@ -636,6 +704,7 @@ async fn dispatch_single_tool(
     results: &Arc<tokio::sync::Mutex<Vec<(usize, ToolResultMessage)>>>,
     tool_timings: &Arc<tokio::sync::Mutex<Vec<crate::metrics::ToolExecMetrics>>>,
     steering_flag: &Arc<std::sync::atomic::AtomicBool>,
+    transfer_flag: &Arc<std::sync::atomic::AtomicBool>,
     transfer_signal: &Arc<tokio::sync::Mutex<Option<crate::transfer::TransferSignal>>>,
     tx: &mpsc::Sender<AgentEvent>,
 ) -> DispatchResult {
@@ -657,6 +726,7 @@ async fn dispatch_single_tool(
     let results_clone = Arc::clone(results);
     let timings_clone = Arc::clone(tool_timings);
     let steering_clone = Arc::clone(steering_flag);
+    let transfer_flag_clone = Arc::clone(transfer_flag);
     let transfer_clone = Arc::clone(transfer_signal);
     let config_clone = Arc::clone(config);
     let tx_clone = tx.clone();
@@ -718,6 +788,7 @@ async fn dispatch_single_tool(
                 if guard.is_none() {
                     (*guard).clone_from(&result.transfer_signal);
                 }
+                transfer_flag_clone.store(true, std::sync::atomic::Ordering::SeqCst);
             }
 
             let _ = emit(

--- a/tests/transfer.rs
+++ b/tests/transfer.rs
@@ -8,15 +8,20 @@
 
 mod common;
 
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use serde_json::json;
+use tokio_util::sync::CancellationToken;
 
 use swink_agent::testing::SimpleMockStreamFn;
 use swink_agent::{
     Agent, AgentMessage, AgentOptions, AgentRegistry, AgentTool, AgentToolResult, ContentBlock,
-    DefaultRetryStrategy, LlmMessage, ModelSpec, StopReason, TransferToAgentTool,
+    DefaultRetryStrategy, LlmMessage, ModelSpec, StopReason, ToolExecutionPolicy,
+    TransferToAgentTool,
 };
 
 use common::{
@@ -84,6 +89,60 @@ fn make_transfer_agent(stream_fn: Arc<MockStreamFn>, registry: Arc<AgentRegistry
         .with_tools(vec![transfer_tool as Arc<dyn AgentTool>])
         .with_retry_strategy(fast_retry()),
     )
+}
+
+struct MockCancellationIgnoringTool {
+    executed: Arc<AtomicBool>,
+}
+
+impl MockCancellationIgnoringTool {
+    fn new() -> Self {
+        Self {
+            executed: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    fn was_executed(&self) -> bool {
+        self.executed.load(Ordering::SeqCst)
+    }
+}
+
+impl AgentTool for MockCancellationIgnoringTool {
+    fn name(&self) -> &str {
+        "blocking_tool"
+    }
+
+    fn label(&self) -> &str {
+        "blocking_tool"
+    }
+
+    fn description(&self) -> &'static str {
+        "A tool that ignores cancellation and never completes unless aborted"
+    }
+
+    fn parameters_schema(&self) -> &serde_json::Value {
+        static SCHEMA: std::sync::OnceLock<serde_json::Value> = std::sync::OnceLock::new();
+        SCHEMA.get_or_init(|| {
+            json!({
+                "type": "object",
+                "properties": {},
+                "additionalProperties": true
+            })
+        })
+    }
+
+    fn execute(
+        &self,
+        _tool_call_id: &str,
+        _params: serde_json::Value,
+        _cancellation_token: CancellationToken,
+        _on_update: Option<Box<dyn Fn(AgentToolResult) + Send + Sync>>,
+        _state: std::sync::Arc<std::sync::RwLock<swink_agent::SessionState>>,
+        _credential: Option<swink_agent::ResolvedCredential>,
+    ) -> Pin<Box<dyn Future<Output = AgentToolResult> + Send + '_>> {
+        self.executed.store(true, Ordering::SeqCst);
+        Box::pin(async move { std::future::pending::<AgentToolResult>().await })
+    }
 }
 
 // ─── T014: Agent loop detects transfer, terminates with Transfer ────────────
@@ -316,20 +375,21 @@ async fn cancellation_takes_precedence_over_transfer() {
     );
 }
 
-// ─── T042: Transfer alongside other tools processes all results ─────────────
+// ─── T042: Transfer cancels same-group siblings promptly ───────────────────
 
 #[tokio::test]
-async fn transfer_alongside_other_tools_processes_all_results() {
+async fn transfer_cancels_same_group_siblings() {
     let registry = registry_with_billing();
 
-    let echo_tool = Arc::new(MockTool::new("echo").with_result(AgentToolResult::text("echoed!")));
+    let blocking_tool = Arc::new(MockCancellationIgnoringTool::new());
     let transfer_tool: Arc<dyn AgentTool> =
         Arc::new(TransferToAgentTool::new(Arc::clone(&registry)));
 
-    // LLM calls both echo and transfer_to_agent in the same turn
+    // LLM calls both tools in the same concurrent group. Without prompt
+    // cancellation on transfer, the blocking tool would hang the turn forever.
     let stream_fn = Arc::new(MockStreamFn::new(vec![
         tool_call_events_multi(&[
-            ("tc_echo", "echo", "{}"),
+            ("tc_blocking", "blocking_tool", "{}"),
             (
                 "tc_transfer",
                 "transfer_to_agent",
@@ -341,7 +401,10 @@ async fn transfer_alongside_other_tools_processes_all_results() {
 
     let mut agent = Agent::new(
         AgentOptions::new("test", default_model(), stream_fn, default_convert)
-            .with_tools(vec![echo_tool.clone(), transfer_tool])
+            .with_tools(vec![
+                blocking_tool.clone() as Arc<dyn AgentTool>,
+                transfer_tool,
+            ])
             .with_retry_strategy(fast_retry()),
     );
 
@@ -355,22 +418,79 @@ async fn transfer_alongside_other_tools_processes_all_results() {
     );
     assert!(result.transfer_signal.is_some());
 
-    // The echo tool should have been executed (both tools run concurrently)
     assert!(
-        echo_tool.was_executed(),
-        "echo tool should have been executed alongside transfer"
+        blocking_tool.was_executed(),
+        "same-group sibling should have started before transfer cancellation"
     );
 
-    // Both tool results should appear in the message history
-    let tool_result_count = result
+    let blocking_result = result
         .messages
         .iter()
-        .filter(|msg| matches!(msg, AgentMessage::Llm(LlmMessage::ToolResult(_))))
-        .count();
+        .filter_map(|msg| match msg {
+            AgentMessage::Llm(LlmMessage::ToolResult(tool_result))
+                if tool_result.tool_call_id == "tc_blocking" =>
+            {
+                Some(ContentBlock::extract_text(&tool_result.content))
+            }
+            _ => None,
+        })
+        .next()
+        .expect("blocking tool result should be present");
+    assert!(
+        blocking_result.contains("transfer initiated"),
+        "blocking tool should be cancelled once transfer wins, got: {blocking_result}"
+    );
+}
+
+#[tokio::test]
+async fn transfer_skips_later_priority_groups() {
+    let registry = registry_with_billing();
+
+    let later_group_tool = Arc::new(
+        MockTool::new("low_priority_tool").with_result(AgentToolResult::text("should not run")),
+    );
+    let transfer_tool: Arc<dyn AgentTool> =
+        Arc::new(TransferToAgentTool::new(Arc::clone(&registry)));
+
+    let stream_fn = Arc::new(MockStreamFn::new(vec![
+        tool_call_events_multi(&[
+            (
+                "tc_transfer",
+                "transfer_to_agent",
+                &transfer_args("billing", "billing question"),
+            ),
+            ("tc_low", "low_priority_tool", "{}"),
+        ]),
+        text_only_events("fallback"),
+    ]));
+
+    let priority_fn = Arc::new(|summary: &swink_agent::ToolCallSummary<'_>| {
+        if summary.name == "transfer_to_agent" {
+            10
+        } else {
+            0
+        }
+    });
+
+    let mut agent = Agent::new(
+        AgentOptions::new("test", default_model(), stream_fn, default_convert)
+            .with_tools(vec![
+                transfer_tool,
+                later_group_tool.clone() as Arc<dyn AgentTool>,
+            ])
+            .with_tool_execution_policy(ToolExecutionPolicy::Priority(priority_fn))
+            .with_retry_strategy(fast_retry()),
+    );
+
+    let result = agent.prompt_async(vec![user_msg("do both")]).await.unwrap();
 
     assert!(
-        tool_result_count >= 2,
-        "should have at least 2 tool results (echo + transfer), got {tool_result_count}"
+        result.stop_reason == StopReason::Transfer,
+        "priority-group transfer should terminate the turn"
+    );
+    assert!(
+        !later_group_tool.was_executed(),
+        "later priority groups must not run after a transfer signal"
     );
 }
 


### PR DESCRIPTION
## Summary
- stop tool batch execution as soon as a transfer result lands
- cancel same-group siblings and synthesize cancelled tool results for unfinished calls
- skip later priority groups after transfer and add regression coverage for both paths

## Why
Transfer is a control-flow signal, not a normal tool result. Letting sibling or later-group tools keep running can trigger side effects after the agent has already decided to hand off.

## Issue slice completed
This PR addresses the #340 slice that promotes transfer to a batch-terminating signal inside execute_tools_concurrently, including tests for a cancellation-unaware sibling and priority-group ordering.

Closes #340.

## Validation
- cargo fmt --all
- cargo test -p swink-agent --test transfer --features testkit,transfer *(blocked by existing unrelated borrow-check errors in src/agent/checkpointing.rs: E0502 at lines 227 and 230 on current main)*
- cargo check -p swink-agent --tests --features testkit,transfer --keep-going *(same unrelated src/agent/checkpointing.rs E0502 blocker)*

## Baseline blocker
Current main does not compile because src/agent/checkpointing.rs mutably borrows self while a session_state write guard is still live. This PR does not modify that file.