### PR TITLE
Handle Mistral finish_reason errors

### DIFF
--- a/adapters/src/openai_compat.rs
+++ b/adapters/src/openai_compat.rs
@@ -18,7 +18,7 @@ use swink_agent::AgentTool;
 use swink_agent::ContentBlock;
 use swink_agent::{
     AssistantMessage as HarnessAssistantMessage, AssistantMessageEvent, Cost, StopReason,
-    ToolResultMessage, Usage, UserMessage,
+    StreamErrorKind, ToolResultMessage, Usage, UserMessage,
 };
 
 use crate::convert::{MessageConverter, extract_tool_schemas};
@@ -286,6 +286,9 @@ pub struct OaiSseStreamState {
     pub usage: Option<Usage>,
     /// Saved stop reason from `finish_reason`; emitted with `Done` on `[DONE]`.
     pub stop_reason: Option<StopReason>,
+    /// Terminal provider error captured from a finish reason that should not
+    /// be downgraded into a normal `Done` event.
+    pub terminal_error: Option<AssistantMessageEvent>,
 }
 
 impl crate::finalize::StreamFinalize for OaiSseStreamState {
@@ -349,6 +352,17 @@ pub fn process_oai_chunk(
                 return;
             }
 
+            if provider == "Mistral" && reason == "error" {
+                events.extend(crate::finalize::finalize_blocks(state));
+                state.terminal_error = Some(AssistantMessageEvent::Error {
+                    stop_reason: StopReason::Error,
+                    error_message: "Mistral reported finish_reason=error".to_string(),
+                    usage: state.usage.clone(),
+                    error_kind: Some(StreamErrorKind::Network),
+                });
+                return;
+            }
+
             let stop_reason = match reason.as_str() {
                 "tool_calls" => StopReason::ToolUse,
                 "length" | "model_length" => StopReason::Length,
@@ -356,7 +370,6 @@ pub fn process_oai_chunk(
             };
 
             events.extend(crate::finalize::finalize_blocks(state));
-
             state.stop_reason = Some(stop_reason);
         }
     }
@@ -445,7 +458,9 @@ pub fn parse_oai_sse_stream(
         move |item, state| match item {
             None => {
                 let mut events = crate::finalize::finalize_blocks(state);
-                if let Some(stop_reason) = state.stop_reason.take() {
+                if let Some(error) = state.terminal_error.take() {
+                    events.push(error);
+                } else if let Some(stop_reason) = state.stop_reason.take() {
                     let usage = state.usage.take();
                     events.push(AssistantMessageEvent::Done {
                         stop_reason,
@@ -461,13 +476,17 @@ pub fn parse_oai_sse_stream(
             }
             Some(SseLine::Done) => {
                 let mut events = crate::finalize::finalize_blocks(state);
-                let stop_reason = state.stop_reason.take().unwrap_or(StopReason::Stop);
-                let usage = state.usage.take();
-                events.push(AssistantMessageEvent::Done {
-                    stop_reason,
-                    usage: usage.unwrap_or_default(),
-                    cost: Cost::default(),
-                });
+                if let Some(error) = state.terminal_error.take() {
+                    events.push(error);
+                } else {
+                    let stop_reason = state.stop_reason.take().unwrap_or(StopReason::Stop);
+                    let usage = state.usage.take();
+                    events.push(AssistantMessageEvent::Done {
+                        stop_reason,
+                        usage: usage.unwrap_or_default(),
+                        cost: Cost::default(),
+                    });
+                }
                 SseAction::Done(events)
             }
             Some(SseLine::Data(data)) => {
@@ -485,7 +504,12 @@ pub fn parse_oai_sse_stream(
 
                 let mut events = Vec::new();
                 process_oai_chunk(&chunk, state, &mut events, provider);
-                SseAction::Continue(events)
+                if let Some(error) = state.terminal_error.take() {
+                    events.push(error);
+                    SseAction::Done(events)
+                } else {
+                    SseAction::Continue(events)
+                }
             }
             Some(SseLine::TransportError(message)) => {
                 let mut events = crate::finalize::finalize_blocks(state);

--- a/adapters/tests/mistral.rs
+++ b/adapters/tests/mistral.rs
@@ -14,9 +14,10 @@ use tokio_util::sync::CancellationToken;
 use wiremock::matchers::{header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-use swink_agent::{AssistantMessage, ContentBlock, ToolResultMessage, UserMessage,
-    AgentContext, AgentMessage, AgentTool, AgentToolResult, AssistantMessageEvent, LlmMessage,
-    ModelSpec, StopReason, StreamFn, StreamOptions,
+use swink_agent::{
+    AgentContext, AgentMessage, AgentTool, AgentToolResult, AssistantMessage,
+    AssistantMessageEvent, ContentBlock, LlmMessage, ModelSpec, StopReason, StreamErrorKind,
+    StreamFn, StreamOptions, ToolResultMessage, UserMessage,
 };
 use swink_agent_adapters::MistralStreamFn;
 
@@ -732,8 +733,42 @@ async fn finish_reason_error() {
     let sf = MistralStreamFn::new(server.uri(), "test-key");
     let events = collect_events(&sf).await;
 
-    let stop_reason = extract_stop_reason(&events).expect("missing Done event");
-    assert_eq!(stop_reason, StopReason::Stop);
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, AssistantMessageEvent::Error { .. })),
+        "expected Error event, got: {events:?}"
+    );
+    assert!(
+        events
+            .iter()
+            .all(|event| !matches!(event, AssistantMessageEvent::Done { .. })),
+        "did not expect Done event, got: {events:?}"
+    );
+
+    let (message, usage, error_kind) = events
+        .iter()
+        .find_map(|event| match event {
+            AssistantMessageEvent::Error {
+                error_message,
+                usage,
+                error_kind,
+                ..
+            } => Some((error_message.clone(), usage.clone(), *error_kind)),
+            _ => None,
+        })
+        .expect("missing Error event");
+
+    assert!(
+        message.contains("finish_reason=error"),
+        "expected finish_reason in message, got: {message}"
+    );
+    assert_eq!(error_kind, Some(StreamErrorKind::Network));
+
+    let usage = usage.expect("expected usage on terminal error");
+    assert_eq!(usage.input, 5);
+    assert_eq!(usage.output, 2);
+    assert_eq!(usage.total, 7);
 }
 
 // ── US4: Error Handling ────────────────────────────────────────────────────


### PR DESCRIPTION
## What changed
- treat Mistral `finish_reason: error` as a terminal `Error` event in the shared OpenAI-compatible SSE parser
- classify that terminal event as retryable `StreamErrorKind::Network`
- preserve any usage payload already present on the error chunk
- update the Mistral regression test to require `Error` instead of `Done(Stop)`

## Why
Mistral provider failures were being downgraded into normal completion, which broke retry behavior and hid partial failures.

## Issue slice
This PR addresses issue #346 directly.

Closes #346.

## Validation
- `cargo fmt --all`
- `cargo test -p swink-agent-adapters --test mistral finish_reason_error` *(blocked by an existing unrelated borrow-check failure on `src/agent/checkpointing.rs` in the current `main` checkout: E0502 around lines 216/228/231/236)*

## Baseline failures
- `swink-agent` currently fails to compile from `main` because `src/agent/checkpointing.rs` holds a write guard while calling mutable methods on `self`