### PR TITLE
[codex] Preserve OpenAI-compatible usage details

### DIFF
--- a/adapters/src/openai_compat.rs
+++ b/adapters/src/openai_compat.rs
@@ -147,6 +147,46 @@ pub struct OaiUsage {
     pub prompt_tokens: u64,
     #[serde(default)]
     pub completion_tokens: u64,
+    #[serde(default)]
+    pub total_tokens: Option<u64>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+impl OaiUsage {
+    fn to_usage(&self) -> Usage {
+        let mut extra = HashMap::new();
+        for (key, value) in &self.extra {
+            collect_numeric_usage_fields(key.clone(), value, &mut extra);
+        }
+
+        Usage {
+            input: self.prompt_tokens,
+            output: self.completion_tokens,
+            cache_read: 0,
+            cache_write: 0,
+            total: self
+                .total_tokens
+                .unwrap_or(self.prompt_tokens + self.completion_tokens),
+            extra,
+        }
+    }
+}
+
+fn collect_numeric_usage_fields(key: String, value: &Value, extra: &mut HashMap<String, u64>) {
+    match value {
+        Value::Number(number) => {
+            if let Some(value) = number.as_u64() {
+                extra.insert(key, value);
+            }
+        }
+        Value::Object(fields) => {
+            for (child_key, child_value) in fields {
+                collect_numeric_usage_fields(format!("{key}.{child_key}"), child_value, extra);
+            }
+        }
+        _ => {}
+    }
 }
 
 // ─── Tool call state tracking ───────────────────────────────────────────────
@@ -311,14 +351,7 @@ pub fn process_oai_chunk(
     provider: &str,
 ) {
     if let Some(u) = &chunk.usage {
-        state.usage = Some(Usage {
-            input: u.prompt_tokens,
-            output: u.completion_tokens,
-            cache_read: 0,
-            cache_write: 0,
-            total: u.prompt_tokens + u.completion_tokens,
-            extra: HashMap::new(),
-        });
+        state.usage = Some(u.to_usage());
     }
 
     for choice in &chunk.choices {

--- a/adapters/tests/openai.rs
+++ b/adapters/tests/openai.rs
@@ -250,6 +250,51 @@ async fn openai_usage_in_separate_chunk() {
 }
 
 #[tokio::test]
+async fn openai_usage_preserves_provider_total_and_breakdowns() {
+    let body = [
+        r#"data: {"choices":[{"delta":{"content":"hi"},"index":0}]}"#,
+        "",
+        r#"data: {"choices":[],"usage":{"prompt_tokens":42,"completion_tokens":17,"total_tokens":80,"prompt_tokens_details":{"cached_tokens":9},"completion_tokens_details":{"reasoning_tokens":7,"accepted_prediction_tokens":3},"provider_batch_tokens":11}}"#,
+        "",
+        r#"data: {"choices":[{"delta":{},"finish_reason":"stop","index":0}]}"#,
+        "",
+        "data: [DONE]",
+        "",
+        "",
+    ]
+    .join("\n");
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(sse_response(&body))
+        .mount(&server)
+        .await;
+
+    let sf = OpenAiStreamFn::new(server.uri(), "test-key");
+    let events = collect_events(&sf).await;
+
+    let usage = events
+        .iter()
+        .find_map(|e| match e {
+            AssistantMessageEvent::Done { usage, .. } => Some(usage.clone()),
+            _ => None,
+        })
+        .expect("missing Done event");
+
+    assert_eq!(usage.input, 42);
+    assert_eq!(usage.output, 17);
+    assert_eq!(usage.total, 80, "expected provider-reported total");
+    assert_eq!(usage.extra["prompt_tokens_details.cached_tokens"], 9);
+    assert_eq!(usage.extra["completion_tokens_details.reasoning_tokens"], 7);
+    assert_eq!(
+        usage.extra["completion_tokens_details.accepted_prediction_tokens"],
+        3
+    );
+    assert_eq!(usage.extra["provider_batch_tokens"], 11);
+}
+
+#[tokio::test]
 async fn openai_http_401() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))


### PR DESCRIPTION
## What changed
- preserve provider-reported `total_tokens` in the shared OpenAI-compatible usage parser instead of always recomputing `prompt + completion`
- flatten numeric usage breakdown fields into `Usage.extra` so nested usage detail objects survive the adapter boundary
- add focused regression coverage for totals plus nested breakdown preservation in the OpenAI-compatible stream path

## Why it changed
OpenAI-compatible providers can report an authoritative total and richer token breakdowns. The previous parser dropped that information, which made usage and cost accounting less trustworthy.

## Issue slice completed
- completed issue #345 by preserving provider totals and numeric breakdown fields in the shared OpenAI-compatible parser

## Validation
- `rustfmt adapters/src/openai_compat.rs adapters/tests/openai.rs`
- `cargo test -p swink-agent-adapters --test openai openai_usage_preserves_provider_total_and_breakdowns` *(blocked by the existing unrelated borrow-check failure in `src/agent/checkpointing.rs` already present on `main`)*

Closes #345