### PR TITLE
fix: preserve xAI provider labels in adapter errors

### DIFF
--- a/adapters/src/xai.rs
+++ b/adapters/src/xai.rs
@@ -8,20 +8,22 @@ use std::pin::Pin;
 
 use futures::Stream;
 use tokio_util::sync::CancellationToken;
+use tracing::debug;
 
 use swink_agent::{AgentContext, AssistantMessageEvent, ModelSpec, StreamFn, StreamOptions};
 
-use crate::openai::OpenAiStreamFn;
+use crate::base::AdapterBase;
+use crate::oai_transport::{oai_send_and_parse, prepare_oai_request};
 
 pub struct XAiStreamFn {
-    inner: OpenAiStreamFn,
+    base: AdapterBase,
 }
 
 impl XAiStreamFn {
     #[must_use]
     pub fn new(base_url: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
-            inner: OpenAiStreamFn::new(base_url, api_key),
+            base: AdapterBase::new(base_url, api_key),
         }
     }
 }
@@ -29,7 +31,8 @@ impl XAiStreamFn {
 impl std::fmt::Debug for XAiStreamFn {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("XAiStreamFn")
-            .field("inner", &self.inner)
+            .field("base_url", &self.base.base_url)
+            .field("api_key", &"[REDACTED]")
             .finish()
     }
 }
@@ -42,7 +45,24 @@ impl StreamFn for XAiStreamFn {
         options: &'a StreamOptions,
         cancellation_token: CancellationToken,
     ) -> Pin<Box<dyn Stream<Item = AssistantMessageEvent> + Send + 'a>> {
-        self.inner
-            .stream(model, context, options, cancellation_token)
+        let url = format!("{}/v1/chat/completions", self.base.base_url);
+        let api_key = options.api_key.as_deref().unwrap_or(&self.base.api_key);
+
+        debug!(
+            %url,
+            model = %model.model_id,
+            messages = context.messages.len(),
+            "sending xAI request"
+        );
+
+        let request = prepare_oai_request(&self.base.client, &url, model, context, options)
+            .header("Authorization", format!("Bearer {api_key}"));
+
+        Box::pin(oai_send_and_parse(
+            request,
+            "xAI",
+            cancellation_token,
+            |_, _| None,
+        ))
     }
 }

--- a/adapters/tests/xai.rs
+++ b/adapters/tests/xai.rs
@@ -9,6 +9,30 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 use swink_agent::{AgentContext, AssistantMessageEvent, ModelSpec, StreamFn, StreamOptions};
 use swink_agent_adapters::XAiStreamFn;
 
+mod common;
+
+use common::find_error_message;
+
+fn test_model() -> ModelSpec {
+    ModelSpec::new("xai", "grok-4-1-fast-non-reasoning")
+}
+
+async fn collect_events(stream_fn: &XAiStreamFn) -> Vec<AssistantMessageEvent> {
+    stream_fn
+        .stream(
+            &test_model(),
+            &AgentContext {
+                system_prompt: String::new(),
+                messages: Vec::new(),
+                tools: Vec::new(),
+            },
+            &StreamOptions::default(),
+            CancellationToken::new(),
+        )
+        .collect::<Vec<AssistantMessageEvent>>()
+        .await
+}
+
 #[tokio::test]
 async fn xai_wrapper_streams_chat_completions() {
     let body = [
@@ -34,23 +58,72 @@ async fn xai_wrapper_streams_chat_completions() {
         .await;
 
     let stream_fn = XAiStreamFn::new(server.uri(), "test-key");
-    let events = stream_fn
-        .stream(
-            &ModelSpec::new("xai", "grok-4-1-fast-non-reasoning"),
-            &AgentContext {
-                system_prompt: String::new(),
-                messages: Vec::new(),
-                tools: Vec::new(),
-            },
-            &StreamOptions::default(),
-            CancellationToken::new(),
-        )
-        .collect::<Vec<AssistantMessageEvent>>()
-        .await;
+    let events = collect_events(&stream_fn).await;
 
     assert!(
         events
             .iter()
             .any(|e| matches!(e, AssistantMessageEvent::TextDelta { delta, .. } if delta == "ok"))
+    );
+}
+
+#[tokio::test]
+async fn xai_http_errors_use_xai_provider_label() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(ResponseTemplate::new(401).set_body_string("Unauthorized"))
+        .mount(&server)
+        .await;
+
+    let stream_fn = XAiStreamFn::new(server.uri(), "test-key");
+    let events = collect_events(&stream_fn).await;
+    let error = find_error_message(&events).expect("expected error event");
+
+    assert!(
+        error.contains("xAI auth error"),
+        "expected xAI provider label, got: {error}"
+    );
+    assert!(
+        !error.contains("OpenAI"),
+        "xAI errors should not mention OpenAI: {error}"
+    );
+}
+
+#[tokio::test]
+async fn xai_fallback_tool_ids_use_xai_provider_label() {
+    let body = [
+        r#"data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"name":"shell","arguments":""}}]},"index":0}]}"#,
+        "",
+        r#"data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"cmd\":\"pwd\"}"}}]},"index":0}]}"#,
+        "",
+        r#"data: {"choices":[{"delta":{},"finish_reason":"tool_calls","index":0}],"usage":{"prompt_tokens":3,"completion_tokens":2}}"#,
+        "",
+        "data: [DONE]",
+        "",
+    ]
+    .join("\n");
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Content-Type", "text/event-stream")
+                .set_body_string(body),
+        )
+        .mount(&server)
+        .await;
+
+    let stream_fn = XAiStreamFn::new(server.uri(), "test-key");
+    let events = collect_events(&stream_fn).await;
+    let tool_call = events.iter().find_map(|event| match event {
+        AssistantMessageEvent::ToolCallStart { id, name, .. } => Some((id.clone(), name.clone())),
+        _ => None,
+    });
+
+    assert_eq!(
+        tool_call,
+        Some(("xAI-tool-0".to_string(), "shell".to_string()))
     );
 }


### PR DESCRIPTION
## What changed
- replaced the xAI wrapper's delegation through `OpenAiStreamFn` with a direct call into the shared OpenAI-compatible transport
- passed the `xAI` provider label through the transport path so HTTP/network errors and fallback tool-call IDs stay correctly attributed
- added xAI wiremock regression tests for provider-labeled HTTP errors and fallback tool-call IDs

## Why
`XAiStreamFn` was inheriting `OpenAI`-labeled errors and fallback IDs because it reused the OpenAI wrapper instead of supplying its own provider label.

Closes #349.

## Validation
- `cargo test -p swink-agent-adapters --test xai --features xai` *(blocked by an existing borrow-check failure in `src/agent/checkpointing.rs` on `main`: E0502 around `clear_queues`, `follow_up`, and `steer` while holding `session_state` write access)*

## Remaining work
- none for this issue once the baseline `main` compile failure is resolved and CI is green