### PR TITLE
[codex] Decouple MCP shutdown from tool Arc lifetimes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,10 @@ MSRV **1.88** (edition 2024). Workspace deps centralized in root `Cargo.toml`.
 - `on_init(&self, &Agent)` dispatched in priority order, wrapped in `catch_unwind` — panicking `on_init` is logged and skipped, construction continues (plugin's other contributions remain active).
 - Entire module behind `#[cfg(feature = "plugins")]` — opt-in, not default-enabled, zero cost when disabled.
 
+### MCP Integration (`mcp/`)
+
+- `McpManager::shutdown()` must operate on shared connection-owned state, not `Arc::try_unwrap()`: exported `McpTool` handles keep `Arc<McpConnection>` clones alive, so deterministic disconnect has to clear the session/monitor even when callers still retain tool `Arc`s.
+
 ### Streaming (`src/stream.rs`)
 
 - `accumulate_message` enforces strict ordering: one Start, indexed content blocks, one terminal (Done/Error).

--- a/mcp/src/connection.rs
+++ b/mcp/src/connection.rs
@@ -27,16 +27,22 @@ use crate::error::McpError;
 pub enum McpConnectionStatus {
     /// Connected and ready to serve tool calls.
     Connected,
-    /// Disconnected — tool calls will fail immediately.
+    /// Disconnected; tool calls will fail immediately.
     Disconnected,
+}
+
+struct McpConnectionState {
+    status: McpConnectionStatus,
+    peer: Option<Peer<RoleClient>>,
+    monitor: Option<JoinHandle<()>>,
 }
 
 /// A connection to a single MCP server.
 ///
 /// Holds a cloned `Peer<RoleClient>` for making tool calls and a background
 /// monitor task that awaits the service lifecycle. When the remote transport
-/// closes the monitor transitions `status` to `Disconnected` and sends an
-/// `AgentEvent::McpServerDisconnected` on the optional event channel.
+/// closes, the monitor transitions the shared state to `Disconnected` and
+/// sends an `AgentEvent::McpServerDisconnected` on the optional event channel.
 ///
 /// Created via [`McpConnection::connect`] or [`McpConnection::from_service`].
 pub struct McpConnection {
@@ -44,13 +50,8 @@ pub struct McpConnection {
     pub config: McpServerConfig,
     /// Discovered tools from the server (raw rmcp tool definitions).
     pub discovered_tools: Vec<rmcp::model::Tool>,
-    /// Shared connection status — written by the monitor task, read by callers.
-    status: Arc<Mutex<McpConnectionStatus>>,
-    /// Cloned peer handle for forwarding tool calls.
-    peer: Option<Peer<RoleClient>>,
-    /// Background lifecycle-monitor task. Holds the `RunningService` and
-    /// resolves when the transport closes.
-    monitor: Option<JoinHandle<()>>,
+    /// Shared connection state used by callers, shutdown, and the monitor task.
+    state: Arc<Mutex<McpConnectionState>>,
 }
 
 impl std::fmt::Debug for McpConnection {
@@ -66,7 +67,10 @@ impl std::fmt::Debug for McpConnection {
 impl McpConnection {
     /// Returns the current connection status.
     pub fn status(&self) -> McpConnectionStatus {
-        *self.status.lock().unwrap_or_else(PoisonError::into_inner)
+        self.state
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .status
     }
 
     /// Create a disconnected connection placeholder.
@@ -77,9 +81,11 @@ impl McpConnection {
         Self {
             config,
             discovered_tools: Vec::new(),
-            status: Arc::new(Mutex::new(McpConnectionStatus::Disconnected)),
-            peer: None,
-            monitor: None,
+            state: Arc::new(Mutex::new(McpConnectionState {
+                status: McpConnectionStatus::Disconnected,
+                peer: None,
+                monitor: None,
+            })),
         }
     }
 
@@ -109,15 +115,18 @@ impl McpConnection {
             "MCP server connected via provided service, tools discovered"
         );
 
-        let status = Arc::new(Mutex::new(McpConnectionStatus::Connected));
-        let monitor = spawn_monitor(service, Arc::clone(&status), config.name.clone(), event_tx);
+        let state = Arc::new(Mutex::new(McpConnectionState {
+            status: McpConnectionStatus::Connected,
+            peer: Some(peer),
+            monitor: None,
+        }));
+        let monitor = spawn_monitor(service, Arc::clone(&state), config.name.clone(), event_tx);
+        state.lock().unwrap_or_else(PoisonError::into_inner).monitor = Some(monitor);
 
         Ok(Self {
             config,
             discovered_tools,
-            status,
-            peer: Some(peer),
-            monitor: Some(monitor),
+            state,
         })
     }
 
@@ -156,15 +165,18 @@ impl McpConnection {
             "MCP server connected, tools discovered"
         );
 
-        let status = Arc::new(Mutex::new(McpConnectionStatus::Connected));
-        let monitor = spawn_monitor(service, Arc::clone(&status), config.name.clone(), event_tx);
+        let state = Arc::new(Mutex::new(McpConnectionState {
+            status: McpConnectionStatus::Connected,
+            peer: Some(peer),
+            monitor: None,
+        }));
+        let monitor = spawn_monitor(service, Arc::clone(&state), config.name.clone(), event_tx);
+        state.lock().unwrap_or_else(PoisonError::into_inner).monitor = Some(monitor);
 
         Ok(Self {
             config,
             discovered_tools,
-            status,
-            peer: Some(peer),
-            monitor: Some(monitor),
+            state,
         })
     }
 
@@ -230,19 +242,22 @@ impl McpConnection {
         tool_name: &str,
         arguments: Value,
     ) -> Result<CallToolResult, McpError> {
-        if self.status() == McpConnectionStatus::Disconnected {
-            return Err(McpError::ToolCallFailed {
+        let peer = {
+            let state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+            if state.status == McpConnectionStatus::Disconnected {
+                return Err(McpError::ToolCallFailed {
+                    server: self.config.name.clone(),
+                    tool: tool_name.to_string(),
+                    reason: "server is disconnected".to_string(),
+                });
+            }
+
+            state.peer.clone().ok_or_else(|| McpError::ToolCallFailed {
                 server: self.config.name.clone(),
                 tool: tool_name.to_string(),
-                reason: "server is disconnected".to_string(),
-            });
-        }
-
-        let peer = self.peer.as_ref().ok_or_else(|| McpError::ToolCallFailed {
-            server: self.config.name.clone(),
-            tool: tool_name.to_string(),
-            reason: "no active session".to_string(),
-        })?;
+                reason: "no active session".to_string(),
+            })?
+        };
 
         let json_args = match arguments {
             Value::Object(map) => Some(map),
@@ -276,13 +291,29 @@ impl McpConnection {
     /// Aborts the monitor task (which drops the underlying `RunningService`).
     /// For stdio servers, rmcp's `ChildWithCleanup` terminates the subprocess
     /// on drop. For SSE servers, the HTTP connection is closed.
-    pub async fn shutdown(mut self) {
-        if let Some(monitor) = self.monitor.take() {
+    pub async fn shutdown(&self) {
+        let monitor = {
+            let mut state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+            state.status = McpConnectionStatus::Disconnected;
+            state.peer = None;
+            state.monitor.take()
+        };
+
+        if let Some(monitor) = monitor {
             monitor.abort();
             let _ = monitor.await;
         }
-        *self.status.lock().unwrap_or_else(PoisonError::into_inner) =
-            McpConnectionStatus::Disconnected;
+    }
+}
+
+impl Drop for McpConnection {
+    fn drop(&mut self) {
+        let mut state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+        state.status = McpConnectionStatus::Disconnected;
+        state.peer = None;
+        if let Some(monitor) = state.monitor.take() {
+            monitor.abort();
+        }
     }
 }
 
@@ -296,20 +327,24 @@ fn client_info() -> ClientInfo {
 /// Spawn a background task that awaits the service lifecycle.
 ///
 /// When the transport closes with `QuitReason::Closed` (remote disconnect or
-/// crash), the shared `status` is updated to `Disconnected` and
+/// crash), the shared state is updated to `Disconnected` and
 /// `McpServerDisconnected` is sent on `event_tx`. Voluntary cancellations
 /// (`QuitReason::Cancelled`) and join errors are silently ignored since they
 /// are initiated by the caller via `shutdown()`.
 fn spawn_monitor(
     service: RunningService<RoleClient, ClientInfo>,
-    status: Arc<Mutex<McpConnectionStatus>>,
+    state: Arc<Mutex<McpConnectionState>>,
     server_name: String,
     event_tx: Option<UnboundedSender<AgentEvent>>,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
         if let Ok(QuitReason::Closed | QuitReason::JoinError(_)) = service.waiting().await {
-            *status.lock().unwrap_or_else(PoisonError::into_inner) =
-                McpConnectionStatus::Disconnected;
+            let mut state = state.lock().unwrap_or_else(PoisonError::into_inner);
+            state.status = McpConnectionStatus::Disconnected;
+            state.peer = None;
+            state.monitor = None;
+            drop(state);
+
             if let Some(ref tx) = event_tx {
                 let _ = tx.send(crate::event::server_disconnected(
                     &server_name,
@@ -317,6 +352,6 @@ fn spawn_monitor(
                 ));
             }
         }
-        // Cancelled by shutdown() or other future variants — no event needed.
+        // Cancelled by shutdown() or other future variants; no event needed.
     })
 }

--- a/mcp/src/manager.rs
+++ b/mcp/src/manager.rs
@@ -7,8 +7,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use swink_agent::AgentEvent;
-use swink_agent::AgentTool;
+use swink_agent::{AgentEvent, AgentTool};
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::warn;
 
@@ -94,31 +93,10 @@ impl McpManager {
 
         for connection in connections {
             let conn = Arc::new(connection);
-            let config = &conn.config;
-
-            for tool_def in &conn.discovered_tools {
-                // Apply tool filter if configured. Filter on original (unprefixed) name.
-                let (original_name, _, _) = convert::tool_definition(tool_def);
-                if let Some(ref filter) = config.tool_filter
-                    && !filter.matches(&original_name)
-                {
-                    continue;
-                }
-                let mcp_tool = McpTool::new(
-                    tool_def,
-                    config.tool_prefix.as_deref(),
-                    &config.name,
-                    config.requires_approval,
-                    Arc::clone(&conn),
-                );
-                let name = mcp_tool.name().to_string();
-                all_tools.push((name, config.name.clone(), Arc::new(mcp_tool)));
-            }
-
+            all_tools.extend(build_tools_for_connection(&conn));
             arc_connections.push(conn);
         }
 
-        // Check for name collisions across all servers.
         let tools = detect_collisions_and_collect(all_tools)?;
 
         Ok(Self {
@@ -131,7 +109,7 @@ impl McpManager {
 
     /// Connect to all configured servers, discover tools.
     ///
-    /// Servers that fail to connect are logged and skipped — the remaining
+    /// Servers that fail to connect are logged and skipped; the remaining
     /// servers' tools are still available. Returns an error only if a tool
     /// name collision is detected across servers.
     pub async fn connect_all(&mut self) -> Result<(), McpError> {
@@ -141,26 +119,7 @@ impl McpManager {
             match McpConnection::connect(config.clone(), self.event_tx.clone()).await {
                 Ok(connection) => {
                     let conn = Arc::new(connection);
-
-                    for tool_def in &conn.discovered_tools {
-                        // Apply tool filter if configured. Filter on original (unprefixed) name.
-                        let (original_name, _, _) = convert::tool_definition(tool_def);
-                        if let Some(ref filter) = config.tool_filter
-                            && !filter.matches(&original_name)
-                        {
-                            continue;
-                        }
-                        let mcp_tool = McpTool::new(
-                            tool_def,
-                            config.tool_prefix.as_deref(),
-                            &config.name,
-                            config.requires_approval,
-                            Arc::clone(&conn),
-                        );
-                        let name = mcp_tool.name().to_string();
-                        all_tools.push((name, config.name.clone(), Arc::new(mcp_tool)));
-                    }
-
+                    all_tools.extend(build_tools_for_connection(&conn));
                     self.connections.push(conn);
                 }
                 Err(e) => {
@@ -186,30 +145,17 @@ impl McpManager {
 
     /// Disconnect all servers and clean up resources.
     pub async fn shutdown(&mut self) {
-        // Drop tool references first so Arc refcount decreases.
         self.tools.clear();
 
         for conn in self.connections.drain(..) {
-            match Arc::try_unwrap(conn) {
-                Ok(c) => c.shutdown().await,
-                Err(arc) => {
-                    warn!(
-                        server = %arc.config.name,
-                        "MCP connection still referenced, cannot shut down cleanly"
-                    );
-                }
-            }
+            conn.shutdown().await;
         }
     }
 }
 
 impl Drop for McpManager {
     fn drop(&mut self) {
-        // Release tool Arc references so connection refcounts can decrease.
         self.tools.clear();
-        // Dropping Arc<McpConnection> releases connections.
-        // For stdio transport, rmcp's ChildWithCleanup terminates the subprocess on drop.
-        // For SSE transport, the HTTP connection is dropped.
         self.connections.clear();
     }
 }
@@ -246,4 +192,36 @@ fn detect_collisions_and_collect(
     }
 
     Ok(all_tools.into_iter().map(|(_, _, tool)| tool).collect())
+}
+
+fn build_tools_for_connection(
+    conn: &Arc<McpConnection>,
+) -> Vec<(String, String, Arc<dyn AgentTool>)> {
+    let config = &conn.config;
+
+    conn.discovered_tools
+        .iter()
+        .filter_map(|tool_def| {
+            let (original_name, _, _) = convert::tool_definition(tool_def);
+            if let Some(ref filter) = config.tool_filter
+                && !filter.matches(&original_name)
+            {
+                return None;
+            }
+
+            let mcp_tool = McpTool::new(
+                tool_def,
+                config.tool_prefix.as_deref(),
+                &config.name,
+                config.requires_approval,
+                Arc::clone(conn),
+            );
+            let name = mcp_tool.name().to_string();
+            Some((
+                name,
+                config.name.clone(),
+                Arc::new(mcp_tool) as Arc<dyn AgentTool>,
+            ))
+        })
+        .collect()
 }

--- a/mcp/tests/lifecycle_test.rs
+++ b/mcp/tests/lifecycle_test.rs
@@ -1,4 +1,4 @@
-//! Lifecycle management tests for MCP integration (T039, T040, T042, T043).
+//! Lifecycle management tests for MCP integration (T039, T040, T041, T042, T043).
 
 mod common;
 
@@ -6,8 +6,12 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use swink_agent::AgentTool;
-use swink_agent_mcp::{McpConnection, McpManager, McpServerConfig, McpTool, McpTransport};
+use swink_agent::{AgentEvent, AgentTool, ContentBlock, SessionState};
+use swink_agent_mcp::{
+    McpConnection, McpConnectionStatus, McpManager, McpServerConfig, McpTool, McpTransport,
+};
+use tokio::sync::mpsc::unbounded_channel;
+use tokio::sync::oneshot;
 
 /// T039: Drop McpManager cleans up without hang or panic.
 ///
@@ -23,9 +27,7 @@ async fn drop_manager_cleans_up_without_panic() {
 
     assert!(!manager.tools().is_empty(), "should have tools before drop");
 
-    // Drop the manager — this exercises the Drop impl.
     drop(manager);
-    // If we reach here without hanging, cleanup succeeded.
 }
 
 /// T040: call_tool on a disconnected McpConnection returns an error immediately.
@@ -61,19 +63,59 @@ async fn call_tool_on_disconnected_connection_returns_error() {
     );
 }
 
+/// T041: `McpManager::shutdown()` disconnects shared connections even when
+/// exported tool handles are still cloned by the caller.
+#[tokio::test]
+async fn shutdown_disconnects_cloned_tool_handles() {
+    let conn = common::spawn_mock_connection("shared-shutdown-test", None, vec![]).await;
+    let mut manager =
+        McpManager::from_connections(vec![conn]).expect("manager creation should succeed");
+
+    let kept_tool = manager
+        .tools()
+        .into_iter()
+        .next()
+        .expect("manager should expose at least one tool");
+
+    tokio::time::timeout(Duration::from_secs(2), manager.shutdown())
+        .await
+        .expect("shutdown should complete even when tool handles are still alive");
+
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let state = Arc::new(std::sync::RwLock::new(SessionState::default()));
+
+    let result = kept_tool
+        .execute(
+            "call-shutdown",
+            serde_json::json!({"text": "hello"}),
+            cancel,
+            None,
+            state,
+            None,
+        )
+        .await;
+
+    assert!(
+        result.is_error,
+        "retained tool handles should fail fast after manager shutdown"
+    );
+
+    let text = ContentBlock::extract_text(&result.content);
+    assert!(
+        text.contains("disconnected") || text.contains("active session"),
+        "shutdown should disconnect shared tool handles, got: {text}"
+    );
+}
+
 /// T042: Background monitor detects transport closure, updates status to
 /// Disconnected, and emits McpServerDisconnected on the event channel.
 ///
 /// We simulate a crash by properly cancelling the server's `RunningService`,
 /// which drops its side of the duplex transport and causes the client to see
-/// EOF — triggering `QuitReason::Closed` in the monitor task.
+/// EOF, triggering `QuitReason::Closed` in the monitor task.
 #[tokio::test]
 async fn monitor_detects_transport_close_and_emits_event() {
     use rmcp::service::ServiceExt;
-    use swink_agent::AgentEvent;
-    use swink_agent_mcp::{McpConnection, McpConnectionStatus, McpServerConfig, McpTransport};
-    use tokio::sync::mpsc::unbounded_channel;
-    use tokio::sync::oneshot;
 
     let (event_tx, mut event_rx) = unbounded_channel::<AgentEvent>();
 
@@ -82,10 +124,6 @@ async fn monitor_detects_transport_close_and_emits_event() {
     let mock_cfg = common::MockServerConfig::new(vec![]);
     let server = common::MockMcpServer::from_config(&mock_cfg);
 
-    // Signal channel: test → server task, to cancel the server RunningService.
-    // Aborting the outer task only detaches rmcp's internal I/O task (dropping
-    // JoinHandle detaches, doesn't abort), so the duplex stays open. We must
-    // explicitly cancel the RunningService to drop the transport.
     let (cancel_tx, cancel_rx) = oneshot::channel::<()>();
     let server_task = tokio::spawn(async move {
         let svc = server
@@ -93,7 +131,6 @@ async fn monitor_detects_transport_close_and_emits_event() {
             .await
             .expect("server should start");
         let _ = cancel_rx.await;
-        // cancel() calls ct.cancel() → internal loop breaks → server_stream dropped
         let _ = svc.cancel().await;
     });
 
@@ -124,11 +161,9 @@ async fn monitor_detects_transport_close_and_emits_event() {
         "should start Connected"
     );
 
-    // Simulate crash: cancel the server → drops server_stream → client sees EOF.
     let _ = cancel_tx.send(());
     let _ = server_task.await;
 
-    // Poll until the monitor detects QuitReason::Closed and updates status.
     let deadline = std::time::Instant::now() + Duration::from_secs(2);
     loop {
         if conn.status() == McpConnectionStatus::Disconnected {
@@ -147,7 +182,6 @@ async fn monitor_detects_transport_close_and_emits_event() {
         "monitor should have transitioned status to Disconnected"
     );
 
-    // The disconnect event should have been emitted.
     let event = event_rx
         .try_recv()
         .expect("McpServerDisconnected event should be in channel");
@@ -165,13 +199,11 @@ async fn monitor_detects_transport_close_and_emits_event() {
 /// returning an error AgentToolResult, not panicking or hanging.
 #[tokio::test]
 async fn mcp_tool_execute_on_disconnected_returns_error_result() {
-    // Get a real tool definition from the mock server.
     let mock_cfg = common::MockServerConfig::new(vec![]);
     let client = common::spawn_mock_server_with_client(&mock_cfg).await;
     let tools = client.peer().list_all_tools().await.unwrap();
     let echo_def = tools.iter().find(|t| t.name == "echo").unwrap();
 
-    // Create a disconnected connection.
     let config = McpServerConfig {
         name: "disconnected-server".into(),
         transport: McpTransport::Stdio {
@@ -187,7 +219,7 @@ async fn mcp_tool_execute_on_disconnected_returns_error_result() {
     let tool = McpTool::new(echo_def, None, "disconnected-server", false, conn);
 
     let cancel = tokio_util::sync::CancellationToken::new();
-    let state = Arc::new(std::sync::RwLock::new(swink_agent::SessionState::default()));
+    let state = Arc::new(std::sync::RwLock::new(SessionState::default()));
 
     let result = tool
         .execute(


### PR DESCRIPTION
## Summary
- move MCP connection shutdown onto shared connection-owned state so `McpManager::shutdown()` no longer depends on `Arc::try_unwrap()`
- reuse one helper for MCP tool wrapper construction in both manager connection paths
- add lifecycle regression coverage for cloned tool handles surviving manager shutdown

## Why
`McpTool` instances retain `Arc<McpConnection>` handles. That made `McpManager::shutdown()` degrade into a warning whenever a caller kept any exported tool alive, leaving disconnect timing to eventual drops instead of deterministic shutdown.

Closes #365.

## Issue Slice Completed
This PR completes the shutdown ownership slice from #365 by making disconnect explicit and by collapsing the duplicated tool-materialization path in `McpManager`.

## Validation
- `cargo fmt --package swink-agent-mcp`
- `cargo test -p swink-agent-mcp lifecycle_test -- --nocapture` *(blocked by a pre-existing borrow-check failure on `main` in `src/agent/checkpointing.rs:228`, `:231`, and `:236`; unrelated to this MCP change)*

## Notes
- No public MCP tool surface changes were introduced.
- Added the MCP shutdown ownership lesson to `AGENTS.md`.