### PR TITLE
fix: share UTF-8-safe truncation helpers

### DIFF
--- a/eval/src/response.rs
+++ b/eval/src/response.rs
@@ -6,6 +6,7 @@
 use std::panic::{AssertUnwindSafe, catch_unwind};
 
 use regex::Regex;
+use swink_agent::prefix_chars;
 
 use crate::evaluator::Evaluator;
 use crate::score::Score;
@@ -88,10 +89,10 @@ impl Evaluator for ResponseMatcher {
 
 /// Truncate a string to at most `max_len` characters, appending "..." if truncated.
 fn truncate(s: &str, max_len: usize) -> String {
-    if s.len() <= max_len {
+    if s.chars().count() <= max_len {
         s.to_string()
     } else {
-        format!("{}...", &s[..max_len])
+        format!("{}...", prefix_chars(s, max_len))
     }
 }
 
@@ -163,6 +164,13 @@ mod tests {
         let result = truncate(&long, 100);
         assert_eq!(result.len(), 103); // 100 + "..."
         assert!(result.ends_with("..."));
+    }
+
+    #[test]
+    fn truncate_multibyte_string_is_utf8_safe() {
+        let text = format!("{}🙂tail", "a".repeat(99));
+        let result = truncate(&text, 100);
+        assert_eq!(result, format!("{}🙂...", "a".repeat(99)));
     }
 
     #[test]

--- a/plugins/web/src/content.rs
+++ b/plugins/web/src/content.rs
@@ -1,5 +1,7 @@
 use std::io::Cursor;
 
+use swink_agent::{prefix_chars, suffix_chars};
+
 /// Errors that can occur during content extraction.
 #[derive(Debug, thiserror::Error)]
 pub enum ContentError {
@@ -54,23 +56,23 @@ pub fn extract_readable_content(
 /// Otherwise, keeps 80% from the beginning and 20% from the end, inserting a
 /// truncation notice in the middle.
 pub fn truncate_content(text: &str, max_len: usize) -> (String, bool) {
-    if text.len() <= max_len {
+    let original_len = text.chars().count();
+    if original_len <= max_len {
         return (text.to_string(), false);
     }
 
-    let original_len = text.len();
     let head_len = max_len * 80 / 100;
     let tail_len = max_len * 20 / 100;
 
-    let head = &text[..head_len];
-    let tail = &text[original_len - tail_len..];
+    let head = prefix_chars(text, head_len);
+    let tail = suffix_chars(text, tail_len);
 
     let notice = format!(
         "\n\n[... content truncated ({original_len} chars total, \
          showing first {head_len} and last {tail_len}) ...]\n\n"
     );
 
-    let mut result = String::with_capacity(head_len + notice.len() + tail_len);
+    let mut result = String::with_capacity(head.len() + notice.len() + tail.len());
     result.push_str(head);
     result.push_str(&notice);
     result.push_str(tail);
@@ -104,6 +106,18 @@ mod tests {
         assert!(result.starts_with(&"a".repeat(160)));
         assert!(result.ends_with(&"a".repeat(40)));
         assert!(result.contains("[... content truncated"));
+    }
+
+    #[test]
+    fn truncate_content_multibyte_boundaries_are_utf8_safe() {
+        let text = format!("{}🙂{}", "a".repeat(159), "🙂".repeat(50));
+        let (result, truncated) = truncate_content(&text, 200);
+
+        assert!(truncated);
+        assert!(result.starts_with(&format!("{}🙂", "a".repeat(159))));
+        assert!(result.ends_with(&"🙂".repeat(40)));
+        assert!(result.contains("209 chars total"));
+        assert!(result.contains("showing first 160 and last 40"));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,7 +157,7 @@ pub use types::{
     deserialize_custom_message, restore_messages, restore_single_custom, serialize_custom_message,
     serialize_messages,
 };
-pub use util::now_timestamp;
+pub use util::{now_timestamp, prefix_chars, suffix_chars};
 
 #[cfg(feature = "artifact-store")]
 pub use artifact::{

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,8 +1,56 @@
 //! Internal utility functions shared across the crate.
 
+/// Return the longest prefix containing at most `max_chars` Unicode scalar values.
+#[must_use]
+pub fn prefix_chars(s: &str, max_chars: usize) -> &str {
+    if max_chars == 0 {
+        return "";
+    }
+
+    match s.char_indices().nth(max_chars) {
+        Some((idx, _)) => &s[..idx],
+        None => s,
+    }
+}
+
+/// Return the longest suffix containing at most `max_chars` Unicode scalar values.
+#[must_use]
+pub fn suffix_chars(s: &str, max_chars: usize) -> &str {
+    if max_chars == 0 {
+        return "";
+    }
+
+    let total_chars = s.chars().count();
+    if total_chars <= max_chars {
+        return s;
+    }
+
+    let start_idx = s
+        .char_indices()
+        .nth(total_chars - max_chars)
+        .map_or(0, |(idx, _)| idx);
+
+    &s[start_idx..]
+}
+
 /// Get the current Unix timestamp in seconds.
 pub fn now_timestamp() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map_or(0, |d| d.as_secs())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{prefix_chars, suffix_chars};
+
+    #[test]
+    fn prefix_chars_respects_utf8_boundaries() {
+        assert_eq!(prefix_chars("abc🙂def", 4), "abc🙂");
+    }
+
+    #[test]
+    fn suffix_chars_respects_utf8_boundaries() {
+        assert_eq!(suffix_chars("abc🙂def", 4), "🙂def");
+    }
 }


### PR DESCRIPTION
## What changed
- added shared `prefix_chars` / `suffix_chars` helpers in `swink-agent`
- switched `plugins/web::truncate_content` to character-boundary truncation
- switched `swink-agent-eval::response::truncate` to character-boundary truncation
- added focused multibyte regression tests for the shared helper, web truncation, and eval truncation

## Why
The previous web and eval truncation paths sliced `&str` values by byte offset while documenting character-oriented limits. A multibyte character at the cutoff could panic those paths.

## Issue slice completed
This PR completes issue #366 by extracting one shared UTF-8-safe truncation helper and reusing it from both affected call sites.

## Public API changes
- `swink-agent` now re-exports `prefix_chars` and `suffix_chars` for internal workspace consumers

## Validation
- attempted: `cargo test -p swink-agent --lib util::tests --quiet`
- blocked by an unrelated existing borrow-check failure in `src/agent/checkpointing.rs` on current `main`

Closes #366