### PR TITLE
fix: cap web.fetch body before readability

### DIFF
--- a/plugins/web/src/tools/fetch.rs
+++ b/plugins/web/src/tools/fetch.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 
 use serde_json::Value;
 use swink_agent::{AgentTool, AgentToolResult, ToolFuture};
+use tokio_util::sync::CancellationToken;
 use tracing::warn;
 
 use crate::content::{extract_readable_content, is_html_content_type, truncate_content};
@@ -43,6 +44,38 @@ impl FetchTool {
             request_timeout,
             schema,
         }
+    }
+
+    async fn read_body_with_cap(
+        response: &mut reqwest::Response,
+        max_bytes: usize,
+        cancellation_token: &CancellationToken,
+    ) -> Result<Vec<u8>, String> {
+        let mut body = Vec::with_capacity(max_bytes.min(8 * 1024));
+
+        while let Some(chunk) = tokio::select! {
+            result = response.chunk() => {
+                match result {
+                    Ok(next) => next,
+                    Err(error) => {
+                        return Err(format!("Failed to read response body: {error}"));
+                    }
+                }
+            }
+            () = cancellation_token.cancelled() => {
+                return Err("Request cancelled".to_string());
+            }
+        } {
+            if body.len().saturating_add(chunk.len()) > max_bytes {
+                return Err(format!(
+                    "Response body exceeded configured limit of {max_bytes} bytes before readability extraction."
+                ));
+            }
+
+            body.extend_from_slice(&chunk);
+        }
+
+        Ok(body)
     }
 }
 
@@ -102,7 +135,7 @@ impl AgentTool for FetchTool {
                 .get(parsed_url.clone())
                 .timeout(self.request_timeout);
 
-            let response = tokio::select! {
+            let mut response = tokio::select! {
                 result = request.send() => {
                     match result {
                         Ok(resp) => resp,
@@ -138,12 +171,17 @@ impl AgentTool for FetchTool {
                 ));
             }
 
-            // Read response bytes.
-            let bytes = match response.bytes().await {
-                Ok(b) => b,
-                Err(e) => {
-                    return AgentToolResult::error(format!("Failed to read response body: {e}"));
-                }
+            // Bound the raw response body before readability extraction so the
+            // configured content limit caps network and parsing cost too.
+            let bytes = match Self::read_body_with_cap(
+                &mut response,
+                self.max_content_length,
+                &cancellation_token,
+            )
+            .await
+            {
+                Ok(body) => body,
+                Err(error) => return AgentToolResult::error(error),
             };
 
             // Extract readable content.
@@ -174,5 +212,98 @@ impl AgentTool for FetchTool {
 
             AgentToolResult::text(output)
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, RwLock};
+    use std::time::Duration;
+
+    use serde_json::json;
+    use swink_agent::{AgentTool, SessionState};
+    use tokio_util::sync::CancellationToken;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::FetchTool;
+
+    #[tokio::test]
+    async fn execute_returns_readable_content_for_html_under_cap() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/article"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/html; charset=utf-8")
+                    .set_body_string(
+                        r#"<!DOCTYPE html>
+                        <html>
+                        <head><title>Fetch Test</title></head>
+                        <body>
+                            <article>
+                                <p>This is the readable content for the fetch tool test.</p>
+                                <p>It should survive readability extraction.</p>
+                            </article>
+                        </body>
+                        </html>"#,
+                    ),
+            )
+            .mount(&server)
+            .await;
+
+        let tool = FetchTool::new(reqwest::Client::new(), 4_096, Duration::from_secs(5));
+        let state = Arc::new(RwLock::new(SessionState::default()));
+        let result = tool
+            .execute(
+                "call-1",
+                json!({ "url": format!("{}/article", server.uri()) }),
+                CancellationToken::new(),
+                None,
+                state,
+                None,
+            )
+            .await;
+
+        assert!(!result.is_error);
+        let text = format!("{:?}", result.content);
+        assert!(text.contains("Fetch Test"));
+        assert!(text.contains("readable content for the fetch tool test"));
+    }
+
+    #[tokio::test]
+    async fn execute_rejects_body_that_exceeds_cap_before_extraction() {
+        let server = MockServer::start().await;
+        let oversized_html = format!(
+            "<!DOCTYPE html><html><body><article><p>{}</p></article></body></html>",
+            "x".repeat(2_048)
+        );
+        Mock::given(method("GET"))
+            .and(path("/oversized"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/html; charset=utf-8")
+                    .set_body_string(oversized_html),
+            )
+            .mount(&server)
+            .await;
+
+        let tool = FetchTool::new(reqwest::Client::new(), 512, Duration::from_secs(5));
+        let state = Arc::new(RwLock::new(SessionState::default()));
+        let result = tool
+            .execute(
+                "call-2",
+                json!({ "url": format!("{}/oversized", server.uri()) }),
+                CancellationToken::new(),
+                None,
+                state,
+                None,
+            )
+            .await;
+
+        assert!(result.is_error);
+        let text = format!("{:?}", result.content);
+        assert!(text.contains("Response body exceeded configured limit of 512 bytes"));
+        assert!(text.contains("before readability extraction"));
     }
 }


### PR DESCRIPTION
## What changed
- stream `web.fetch` response bodies under a hard byte cap before readability extraction
- return a clear oversized-body error instead of buffering arbitrarily large HTML into memory
- add focused tool tests for an under-cap HTML fetch and the oversized-body rejection path

## Why
Issue #369 points out that `web.fetch` only enforced `max_content_length` after downloading the full body and running readability. This slice moves the cap to the raw response body so the configured limit also bounds network, memory, and parsing cost.

## Issue slice completed
This PR completes one reviewable slice of #369 by enforcing the fetch body cap before readability extraction while keeping the existing post-extraction presentation truncation flow for bounded pages.

## What remains
- decide whether the plugin should eventually expose a separate raw-byte cap and presentation-text cap instead of using the existing configured limit for both stages
- add any broader fetch integration coverage once `main` compiles again

## Validation
- `cargo fmt -p swink-agent-plugin-web`
- attempted: `cargo test -p swink-agent-plugin-web fetch -- --nocapture`

## Baseline blocker
- `cargo test -p swink-agent-plugin-web fetch -- --nocapture` is currently blocked on `main` by the unrelated `src/agent/checkpointing.rs` borrow-check failure (`E0502` at lines 228, 231, and 236) while compiling `swink-agent`

Refs #369