### PR TITLE
[codex] Wake wait_for_idle waiters on reset

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ MSRV **1.88** (edition 2024). Workspace deps centralized in root `Cargo.toml`.
 - Queues use `Arc<Mutex<>>` with `PoisonError::into_inner()` — never panics on poisoned locks.
 - `dispatch_event` now wraps event forwarders in `catch_unwind` — matching the existing listener panic safety. Panicking forwarders are logged and skipped, not auto-removed (unlike listeners).
 - `AgentId` lives in its own module `src/agent_id.rs` (extracted from `registry.rs` to break the `agent.rs` ↔ `registry.rs` circular import).
+- `reset()` must call `idle_notify.notify_waiters()` after clearing `loop_active`; `wait_for_idle()` depends on that wakeup for pending waiters when a run is cancelled/reset before the normal stream-end path fires.
 
 ### Agent Loop (`src/loop_.rs`)
 

--- a/src/agent/control.rs
+++ b/src/agent/control.rs
@@ -61,6 +61,7 @@ impl Agent {
         self.abort_controller = None;
         self.in_flight_llm_messages = None;
         self.clear_queues();
+        self.idle_notify.notify_waiters();
     }
 
     /// Returns a future that resolves when the agent is no longer running.
@@ -85,7 +86,13 @@ mod tests {
     use futures::pin_mut;
     use tokio::sync::Notify;
 
-    use super::wait_for_idle_future;
+    use crate::agent_options::AgentOptions;
+    use crate::stream::StreamFn;
+    use crate::testing::{
+        MockStreamFn, default_convert, default_model, text_only_events, user_msg,
+    };
+
+    use super::{Agent, wait_for_idle_future};
 
     #[tokio::test]
     async fn wait_for_idle_returns_when_idle_transition_happens_after_registration() {
@@ -100,7 +107,10 @@ mod tests {
         });
         pin_mut!(wait_for_idle);
 
-        assert!(matches!(futures::poll!(wait_for_idle.as_mut()), Poll::Ready(())));
+        assert!(matches!(
+            futures::poll!(wait_for_idle.as_mut()),
+            Poll::Ready(())
+        ));
     }
 
     #[tokio::test]
@@ -112,12 +122,52 @@ mod tests {
         let wait_for_idle = wait_for_idle_future(Arc::clone(&notify), Arc::clone(&active), || {});
         pin_mut!(wait_for_idle);
 
-        assert!(matches!(futures::poll!(wait_for_idle.as_mut()), Poll::Pending));
+        assert!(matches!(
+            futures::poll!(wait_for_idle.as_mut()),
+            Poll::Pending
+        ));
         assert!(active_for_assert.load(Ordering::Acquire));
 
         active.store(false, Ordering::Release);
         notify.notify_waiters();
 
-        assert!(matches!(futures::poll!(wait_for_idle.as_mut()), Poll::Ready(())));
+        assert!(matches!(
+            futures::poll!(wait_for_idle.as_mut()),
+            Poll::Ready(())
+        ));
+    }
+
+    #[tokio::test]
+    async fn reset_notifies_pending_wait_for_idle_waiters() {
+        let stream_fn = Arc::new(MockStreamFn::new(vec![text_only_events("done")]));
+        let mut agent = Agent::new(AgentOptions::new(
+            "sys",
+            default_model(),
+            stream_fn as Arc<dyn StreamFn>,
+            default_convert,
+        ));
+
+        let _stream = agent
+            .prompt_stream(vec![user_msg("hi")])
+            .expect("prompt_stream should start a loop");
+
+        let wait_for_idle = wait_for_idle_future(
+            Arc::clone(&agent.idle_notify),
+            Arc::clone(&agent.loop_active),
+            || {},
+        );
+        pin_mut!(wait_for_idle);
+
+        assert!(matches!(
+            futures::poll!(wait_for_idle.as_mut()),
+            Poll::Pending
+        ));
+
+        agent.reset();
+
+        assert!(matches!(
+            futures::poll!(wait_for_idle.as_mut()),
+            Poll::Ready(())
+        ));
     }
 }


### PR DESCRIPTION
## What changed
- notify pending `wait_for_idle()` callers when `Agent::reset()` clears `loop_active`
- add a focused regression test proving a pending idle waiter resolves after `reset()`
- record the reset/idle wakeup requirement in `AGENTS.md`

## Why
`wait_for_idle()` already handles the normal stream-end `notify_waiters()` path, but `reset()` cleared `loop_active` without waking pending waiters. That left a real idle-transition gap whenever a run was cancelled/reset before the usual stream shutdown path fired.

## Issue slice completed
This PR advances #336 by covering the remaining reset-driven idle-transition hole and adding regression coverage around it.

## What remains
- confirm whether any additional issue text cleanup is needed now that the normal `notify_waiters()` registration path and the reset path are both covered

## Validation
- `cargo fmt --all`
- `git diff --check`
- attempted: `cargo test --lib reset_notifies_pending_wait_for_idle_waiters`

## Baseline blocker
- `cargo test --lib reset_notifies_pending_wait_for_idle_waiters` is currently blocked on `main` by an unrelated borrow-check failure in `src/agent/checkpointing.rs:228`, `:231`, and `:236` (`E0502`) while compiling `swink-agent`

Advances #336