### PR TITLE
[codex] Share Azure Entra token source helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,7 @@ MSRV **1.88** (edition 2024). Workspace deps centralized in root `Cargo.toml`.
 **Adapters crate (`swink-agent-adapters`):**
 - `default = ["all"]` — backward compatible, all 9 adapters enabled.
 - Individual flags: `anthropic`, `openai`, `ollama`, `gemini`, `proxy`, `azure`, `bedrock`, `mistral`, `xai`.
+- Azure Entra ID auth should use the shared `swink-agent-auth::SingleFlightTokenSource`; an adapter-local `RwLock<Option<_>>` cache does not deduplicate concurrent token refreshes.
 - `gemini` feature gates the `google` module (file is `google.rs`, public type is `GeminiStreamFn`).
 - `proxy` activates `eventsource-stream` dep. `bedrock` activates `sha2` dep. All others are marker flags.
 - Shared infra (`base`, `sse`, `classify`, `convert`, `finalize`, `openai_compat`, `remote_presets`) compiles unconditionally.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7312,6 +7312,7 @@ dependencies = [
  "serde",
  "serde_json",
  "swink-agent",
+ "swink-agent-auth",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",

--- a/adapters/Cargo.toml
+++ b/adapters/Cargo.toml
@@ -31,6 +31,7 @@ xai = ["openai-compat"]
 
 [dependencies]
 swink-agent = { path = "..", default-features = false }
+swink-agent-auth = { path = "../auth" }
 reqwest.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true

--- a/adapters/src/azure.rs
+++ b/adapters/src/azure.rs
@@ -5,7 +5,6 @@
 //! the shared transport pipeline from [`oai_transport`].
 
 use std::pin::Pin;
-use std::sync::{Arc, PoisonError, RwLock};
 use std::time::{Duration, Instant};
 
 use futures::stream::{self, Stream, StreamExt as _};
@@ -14,6 +13,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::debug;
 
 use swink_agent::{AgentContext, AssistantMessageEvent, ModelSpec, StreamFn, StreamOptions};
+use swink_agent_auth::{ExpiringValue, SingleFlightTokenSource};
 
 use crate::oai_transport::{oai_send_and_parse, prepare_oai_request};
 
@@ -47,12 +47,6 @@ impl std::fmt::Debug for AzureAuth {
 /// Refresh tokens proactively 5 minutes before expiry.
 const REFRESH_MARGIN: Duration = Duration::from_secs(300);
 
-/// Cached `OAuth2` token for Entra ID authentication.
-struct CachedToken {
-    access_token: String,
-    expires_at: Instant,
-}
-
 /// Response from the Microsoft identity platform token endpoint.
 #[derive(Deserialize)]
 struct TokenResponse {
@@ -64,7 +58,7 @@ pub struct AzureStreamFn {
     client: reqwest::Client,
     base_url: String,
     auth: AzureAuth,
-    token_cache: Arc<RwLock<Option<CachedToken>>>,
+    token_source: SingleFlightTokenSource<String>,
     /// Override token endpoint URL (for testing). `None` = use Microsoft default.
     token_endpoint_override: Option<String>,
 }
@@ -76,7 +70,7 @@ impl AzureStreamFn {
             client: reqwest::Client::new(),
             base_url: base_url.into().trim_end_matches('/').to_string(),
             auth,
-            token_cache: Arc::new(RwLock::new(None)),
+            token_source: SingleFlightTokenSource::new(REFRESH_MARGIN),
             token_endpoint_override: None,
         }
     }
@@ -92,21 +86,22 @@ impl AzureStreamFn {
 impl AzureStreamFn {
     /// Acquire a fresh token from the Microsoft identity platform.
     async fn acquire_token(
-        &self,
-        tenant_id: &str,
-        client_id: &str,
-        client_secret: &str,
-    ) -> Result<CachedToken, String> {
-        let token_url = self.token_url(tenant_id);
+        client: reqwest::Client,
+        token_url: String,
+        client_id: String,
+        client_secret: String,
+    ) -> Result<ExpiringValue<String>, String> {
         let params = [
-            ("grant_type", "client_credentials"),
+            ("grant_type", "client_credentials".to_string()),
             ("client_id", client_id),
             ("client_secret", client_secret),
-            ("scope", "https://cognitiveservices.azure.com/.default"),
+            (
+                "scope",
+                "https://cognitiveservices.azure.com/.default".to_string(),
+            ),
         ];
 
-        let resp = self
-            .client
+        let resp = client
             .post(&token_url)
             .form(&params)
             .send()
@@ -123,10 +118,10 @@ impl AzureStreamFn {
             .await
             .map_err(|e| format!("failed to parse token response: {e}"))?;
 
-        Ok(CachedToken {
-            access_token: token_resp.access_token,
-            expires_at: Instant::now() + Duration::from_secs(token_resp.expires_in),
-        })
+        Ok(ExpiringValue::new(
+            token_resp.access_token,
+            Instant::now() + Duration::from_secs(token_resp.expires_in),
+        ))
     }
 
     /// Get a valid token, refreshing if necessary.
@@ -136,32 +131,16 @@ impl AzureStreamFn {
         client_id: &str,
         client_secret: &str,
     ) -> Result<String, String> {
-        // Check cache first
-        {
-            let cache = self
-                .token_cache
-                .read()
-                .unwrap_or_else(PoisonError::into_inner);
-            if let Some(cached) = cache.as_ref()
-                && Instant::now() + REFRESH_MARGIN < cached.expires_at
-            {
-                return Ok(cached.access_token.clone());
-            }
-        }
+        let client = self.client.clone();
+        let token_url = self.token_url(tenant_id);
+        let client_id = client_id.to_string();
+        let client_secret = client_secret.to_string();
 
-        // Acquire new token
-        let token = self
-            .acquire_token(tenant_id, client_id, client_secret)
-            .await?;
-        let access_token = token.access_token.clone();
-
-        // Update cache
-        *self
-            .token_cache
-            .write()
-            .unwrap_or_else(PoisonError::into_inner) = Some(token);
-
-        Ok(access_token)
+        self.token_source
+            .get_or_refresh(move || {
+                Self::acquire_token(client, token_url, client_id, client_secret)
+            })
+            .await
     }
 
     /// Build the token endpoint URL. Uses override if set, otherwise Microsoft default.

--- a/adapters/tests/azure.rs
+++ b/adapters/tests/azure.rs
@@ -3,12 +3,17 @@
 
 mod common;
 
+use std::sync::Arc;
+use std::time::Duration;
+
 use futures::StreamExt;
 use tokio_util::sync::CancellationToken;
 use wiremock::matchers::{body_string_contains, header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-use swink_agent::{AssistantMessageEvent, ModelSpec, StopReason, StreamErrorKind, StreamFn, StreamOptions};
+use swink_agent::{
+    AssistantMessageEvent, ModelSpec, StopReason, StreamErrorKind, StreamFn, StreamOptions,
+};
 use swink_agent_adapters::{AzureAuth, AzureStreamFn};
 
 use common::{event_name, sse_response, test_context};
@@ -544,6 +549,50 @@ async fn entra_id_token_caching() {
     );
 
     // wiremock will verify expect(1) on drop
+}
+
+#[tokio::test]
+async fn concurrent_entra_id_requests_share_one_token_refresh() {
+    let token_server = MockServer::start().await;
+    let api_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/token"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string(token_response_body("deduped-concurrent-token", 3600))
+                .set_delay(Duration::from_millis(75)),
+        )
+        .expect(1)
+        .mount(&token_server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .and(header("Authorization", "Bearer deduped-concurrent-token"))
+        .respond_with(sse_response(&simple_sse_body()))
+        .expect(2)
+        .mount(&api_server)
+        .await;
+
+    let token_url = format!("{}/token", token_server.uri());
+    let stream_fn = Arc::new(entra_stream_fn(&api_server, &token_url));
+    let left = Arc::clone(&stream_fn);
+    let right = Arc::clone(&stream_fn);
+
+    let (left_events, right_events) = tokio::join!(
+        tokio::spawn(async move { collect_events(left.as_ref()).await }),
+        tokio::spawn(async move { collect_events(right.as_ref()).await }),
+    );
+
+    for events in [left_events.unwrap(), right_events.unwrap()] {
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, AssistantMessageEvent::Done { .. })),
+            "expected successful Azure stream events, got: {events:?}"
+        );
+    }
 }
 
 // ── T034: Token refresh — expired token triggers re-acquisition ───────────

--- a/auth/src/lib.rs
+++ b/auth/src/lib.rs
@@ -10,6 +10,8 @@
 mod in_memory;
 pub mod oauth2;
 mod resolver;
+mod token_source;
 
 pub use in_memory::InMemoryCredentialStore;
 pub use resolver::DefaultCredentialResolver;
+pub use token_source::{ExpiringValue, SingleFlightTokenSource};

--- a/auth/src/token_source.rs
+++ b/auth/src/token_source.rs
@@ -1,0 +1,100 @@
+use std::future::Future;
+use std::sync::{PoisonError, RwLock};
+use std::time::{Duration, Instant};
+
+use futures::FutureExt;
+use futures::future::{BoxFuture, Shared};
+use tokio::sync::Mutex;
+
+#[derive(Clone, Debug)]
+pub struct ExpiringValue<T> {
+    value: T,
+    expires_at: Instant,
+}
+
+impl<T> ExpiringValue<T> {
+    #[must_use]
+    pub fn new(value: T, expires_at: Instant) -> Self {
+        Self { value, expires_at }
+    }
+
+    #[must_use]
+    pub fn value(&self) -> &T {
+        &self.value
+    }
+
+    #[must_use]
+    pub fn expires_at(&self) -> Instant {
+        self.expires_at
+    }
+}
+
+type RefreshFuture<T> = Shared<BoxFuture<'static, Result<ExpiringValue<T>, String>>>;
+
+pub struct SingleFlightTokenSource<T> {
+    cached: RwLock<Option<ExpiringValue<T>>>,
+    in_flight: Mutex<Option<RefreshFuture<T>>>,
+    refresh_margin: Duration,
+}
+
+impl<T> SingleFlightTokenSource<T>
+where
+    T: Clone + Send + Sync + 'static,
+{
+    #[must_use]
+    pub fn new(refresh_margin: Duration) -> Self {
+        Self {
+            cached: RwLock::new(None),
+            in_flight: Mutex::new(None),
+            refresh_margin,
+        }
+    }
+
+    pub async fn get_or_refresh<F, Fut>(&self, refresh: F) -> Result<T, String>
+    where
+        F: FnOnce() -> Fut + Send + 'static,
+        Fut: Future<Output = Result<ExpiringValue<T>, String>> + Send + 'static,
+    {
+        {
+            let cached = self.cached.read().unwrap_or_else(PoisonError::into_inner);
+            if let Some(cached) = cached.as_ref()
+                && Instant::now() + self.refresh_margin < cached.expires_at()
+            {
+                return Ok(cached.value().clone());
+            }
+        }
+
+        let shared_future = {
+            let mut in_flight = self.in_flight.lock().await;
+            if let Some(existing) = in_flight.as_ref() {
+                existing.clone()
+            } else {
+                let shared = refresh().boxed().shared();
+                *in_flight = Some(shared.clone());
+                shared
+            }
+        };
+
+        let refreshed = shared_future.await;
+        if let Ok(value) = &refreshed {
+            *self.cached.write().unwrap_or_else(PoisonError::into_inner) = Some(value.clone());
+        }
+
+        self.in_flight.lock().await.take();
+        refreshed.map(|value| value.value().clone())
+    }
+}
+
+impl<T> std::fmt::Debug for SingleFlightTokenSource<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let has_cached = self
+            .cached
+            .read()
+            .unwrap_or_else(PoisonError::into_inner)
+            .is_some();
+        f.debug_struct("SingleFlightTokenSource")
+            .field("has_cached", &has_cached)
+            .field("refresh_margin", &self.refresh_margin)
+            .finish()
+    }
+}

--- a/auth/tests/token_source_tests.rs
+++ b/auth/tests/token_source_tests.rs
@@ -1,0 +1,81 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
+
+use swink_agent_auth::{ExpiringValue, SingleFlightTokenSource};
+
+#[tokio::test]
+async fn concurrent_refresh_deduplicates_single_token_source() {
+    let source = Arc::new(SingleFlightTokenSource::new(Duration::from_secs(60)));
+    let refreshes = Arc::new(AtomicUsize::new(0));
+
+    let left_source = Arc::clone(&source);
+    let left_refreshes = Arc::clone(&refreshes);
+    let right_source = Arc::clone(&source);
+    let right_refreshes = Arc::clone(&refreshes);
+
+    let (left, right) = tokio::join!(
+        tokio::spawn(async move {
+            left_source
+                .get_or_refresh(move || async move {
+                    left_refreshes.fetch_add(1, Ordering::SeqCst);
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                    Ok::<_, String>(ExpiringValue::new(
+                        "shared-token".to_string(),
+                        Instant::now() + Duration::from_secs(300),
+                    ))
+                })
+                .await
+        }),
+        tokio::spawn(async move {
+            right_source
+                .get_or_refresh(move || async move {
+                    right_refreshes.fetch_add(1, Ordering::SeqCst);
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                    Ok::<_, String>(ExpiringValue::new(
+                        "shared-token".to_string(),
+                        Instant::now() + Duration::from_secs(300),
+                    ))
+                })
+                .await
+        }),
+    );
+
+    assert_eq!(left.unwrap().unwrap(), "shared-token");
+    assert_eq!(right.unwrap().unwrap(), "shared-token");
+    assert_eq!(refreshes.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn cached_token_skips_refresh() {
+    let source = SingleFlightTokenSource::new(Duration::from_secs(60));
+
+    let first = source
+        .get_or_refresh(|| async {
+            Ok::<_, String>(ExpiringValue::new(
+                "initial-token".to_string(),
+                Instant::now() + Duration::from_secs(300),
+            ))
+        })
+        .await
+        .unwrap();
+    assert_eq!(first, "initial-token");
+
+    let refreshes = Arc::new(AtomicUsize::new(0));
+    let cached = source
+        .get_or_refresh({
+            let refreshes = Arc::clone(&refreshes);
+            move || async move {
+                refreshes.fetch_add(1, Ordering::SeqCst);
+                Ok::<_, String>(ExpiringValue::new(
+                    "unexpected-refresh".to_string(),
+                    Instant::now() + Duration::from_secs(300),
+                ))
+            }
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(cached, "initial-token");
+    assert_eq!(refreshes.load(Ordering::SeqCst), 0);
+}


### PR DESCRIPTION
## What changed
- extracted `swink-agent-auth::SingleFlightTokenSource` and `ExpiringValue` for reusable single-token caching with shared refresh
- switched `AzureStreamFn` Entra ID auth to acquire tokens through that helper instead of its local `RwLock<Option<_>>` cache
- added focused auth helper tests plus an Azure regression test for concurrent Entra requests sharing a single token refresh
- documented the concurrency lesson in `AGENTS.md`

## Why this changed
Issue #368 calls out duplicated Azure auth infrastructure with weaker concurrency semantics than the shared auth crate. This slice removes the adapter-local refresh/cache path and gives Azure Entra auth the same single-flight behavior for concurrent token fetches.

## Issue slice completed
Completed one reviewable increment for #368: extracted a small shared token-source abstraction and wired Azure Entra token acquisition through it.

## What remains
- broader auth-path consolidation is still open if we want `DefaultCredentialResolver` and any future service-token clients to share more of the same machinery
- full end-to-end validation is still blocked by the current `src/agent/checkpointing.rs` borrow-check failure on `main`

## Validation
- `rustfmt --edition 2024 auth/src/lib.rs auth/src/token_source.rs auth/tests/token_source_tests.rs adapters/src/azure.rs adapters/tests/azure.rs`
- `git diff --check`
- attempted `cargo test -p swink-agent-adapters --features azure concurrent_entra_id_requests_share_one_token_refresh --quiet`

## Baseline failure
The targeted cargo test currently stops before reaching the new Azure/auth tests because `main` already fails to compile in `src/agent/checkpointing.rs` with `E0502` borrow-check errors around `clear_queues`, `follow_up`, and `steer` while holding the session-state write guard.

Refs #368