### PR TITLE
[codex] Isolate no-default-features regression coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
 
       - run: cargo test --workspace --doc
 
+      - run: cargo test -p swink-agent --no-default-features
+
       - name: Check docs
         run: cargo doc --no-deps --workspace
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,10 @@ jobs:
 
       - run: cargo test --workspace --doc
 
-      - run: cargo test -p swink-agent --no-default-features
+      - name: Test (no-default-features regression)
+        run: cargo test -p swink-agent --test no_default_features --no-default-features
+        env:
+          RUSTFLAGS: "--cfg swink_no_default_features_check"
 
       - name: Check docs
         run: cargo doc --no-deps --workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,6 @@ jobs:
 
       - run: cargo test --workspace --doc
 
-      - name: Test (no-default-features regression)
-        run: cargo test -p swink-agent --test no_default_features --no-default-features
-        env:
-          RUSTFLAGS: "--cfg swink_no_default_features_check"
-
       - name: Check docs
         run: cargo doc --no-deps --workspace
         env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,6 +126,7 @@ tracing-subscriber = { version = "0.3", features = ["registry"] }
 
 [lints.rust]
 unsafe_code = "forbid"
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(swink_no_default_features_check)'] }
 
 [lints.clippy]
 all = { level = "warn", priority = -1 }

--- a/tests/no_default_features.rs
+++ b/tests/no_default_features.rs
@@ -1,9 +1,12 @@
+#![cfg(swink_no_default_features_check)]
+
 //! Regression test for issue #205: `--no-default-features` must not re-enable
 //! `builtin-tools` or `transfer` through dev-dependency feature unification.
 //!
-//! This file compiles under `cargo test -p swink-agent --no-default-features`.
-//! If a dev-dependency leaks those features back in, the `#[cfg]` assertions
-//! below will fail at compile time, catching the regression immediately.
+//! This file only compiles in the dedicated no-default-features regression run.
+//! That keeps default-feature workspace test commands from evaluating the
+//! assertions under the wrong configuration while still catching feature leaks
+//! in the intended command immediately.
 
 /// When `builtin-tools` is genuinely disabled, `BashTool` must not exist.
 #[cfg(not(feature = "builtin-tools"))]


### PR DESCRIPTION
## What changed
- gated `tests/no_default_features.rs` behind a dedicated `swink_no_default_features_check` cfg so default-feature workspace test runs no longer evaluate `--no-default-features` assertions under the wrong configuration
- registered that cfg in `Cargo.toml` so the dedicated guard stays warning-free when intentionally enabled

## Why
`cargo test --workspace --features testkit` was compiling `tests/no_default_features.rs` in a default-feature workspace run even though the assertions only make sense in the dedicated `--no-default-features` configuration.

## Issue slice
This PR advances #379 by isolating the regression test from default-feature workspace runs.

A follow-up PR can add explicit CI coverage for the dedicated no-default-features command if the project still wants that contract enforced in CI, but that workflow change should go through separate human review.

Refs #379.

## Validation
- `git diff --check`
- attempted `cargo test -p swink-agent --test no_default_features --features testkit --quiet`
- attempted `cargo test -p swink-agent --test no_default_features --no-default-features -q` with `RUSTFLAGS="--cfg swink_no_default_features_check"`

Both cargo commands are still blocked by the unrelated existing `src/agent/checkpointing.rs` E0502 borrow-check failure already present on `origin/main`.

## Remaining work
- add dedicated CI coverage for the no-default-features regression in a separately reviewed workflow/configuration PR if that remains a requirement
