### PR TITLE
[QA][CI] Pin rust-toolchain action ref

### DIFF
--- a/.github/actions/rust-setup/action.yml
+++ b/.github/actions/rust-setup/action.yml
@@ -13,7 +13,7 @@ runs:
   using: composite
   steps:
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@master
+      uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
       with:
         toolchain: ${{ inputs.toolchain }}
         components: clippy, rustfmt


### PR DESCRIPTION
## Summary
Pin the shared Rust setup action to a fixed dtolnay/rust-toolchain commit instead of master so CI and release workflows no longer track a moving branch.

## Verification
- git diff --check
- Cargo verification is currently blocked on an existing origin/main borrow-check failure in src/agent/checkpointing.rs

Fixes #393