### PR TITLE
[QA][CI] Isolate PR and base benchmark runs

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -23,14 +23,22 @@ jobs:
       - name: Bench PR
         run: cargo bench --workspace -- --save-baseline pr
 
-      - name: Checkout base
-        run: git checkout ${{ github.base_ref }}
+      - name: Export PR baseline
+        run: critcmp --export pr > "$RUNNER_TEMP/pr.json"
+
+      - name: Add base worktree
+        run: git worktree add ../bench-base ${{ github.event.pull_request.base.sha }}
 
       - name: Bench base
+        working-directory: ../bench-base
         run: cargo bench --workspace -- --save-baseline base
 
+      - name: Export base baseline
+        working-directory: ../bench-base
+        run: critcmp --export base > "$RUNNER_TEMP/base.json"
+
       - name: Compare
-        run: critcmp base pr | tee bench-diff.txt
+        run: critcmp "$RUNNER_TEMP/base.json" "$RUNNER_TEMP/pr.json" | tee bench-diff.txt
 
       - name: Post comment
         uses: actions/github-script@v8


### PR DESCRIPTION
## Summary
Run the PR and base benchmark suites in separate git worktrees, export each baseline to $RUNNER_TEMP, and compare the exported snapshots instead of reusing one checkout's build outputs.

## Verification
- git diff --check
- Cargo verification is currently blocked on an existing origin/main borrow-check failure in src/agent/checkpointing.rs

Fixes #394