### PR TITLE
[QA][TUI] Align approval docs with current behavior

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -113,7 +113,6 @@ On first launch with no keys configured, the setup wizard walks you through prov
 | `#save` / `#load <id>` | Session persistence |
 | `#keys` | Show configured providers |
 | `#key <provider> <key>` | Store an API key in the OS keychain |
-| `/model <id>` | Change model |
 | `/thinking <level>` | Set thinking depth (off/minimal/low/medium/high) |
 | `/system <prompt>` | Set system prompt |
 | `/reset` | Reset conversation |

--- a/tui/CLAUDE.md
+++ b/tui/CLAUDE.md
@@ -20,6 +20,6 @@
 
 ## Lessons Learned
 
-- **`/model` changes model ID, not provider** — to switch providers, update `.env` and restart.
+- **Smart approval mode auto-approves trusted tools only** — untrusted tools still prompt even if they are read-only.
 - **Panic hook restores terminal** — without it, a panic leaves terminal in raw mode.
 - **Credentials** — env var checked first, then keychain. Env always wins.

--- a/tui/src/app/event_loop.rs
+++ b/tui/src/app/event_loop.rs
@@ -458,7 +458,9 @@ impl App {
                 let label = match mode {
                     ApprovalModeArg::On => "enabled",
                     ApprovalModeArg::Off => "disabled (auto-approve)",
-                    ApprovalModeArg::Smart => "smart (auto-approve reads, prompt for writes)",
+                    ApprovalModeArg::Smart => {
+                        "smart (auto-approve trusted tools, prompt for untrusted tools)"
+                    }
                 };
                 self.push_system_message(format!("Tool approval: {label}"));
                 return;
@@ -485,7 +487,9 @@ impl App {
                 let label = match self.approval_mode {
                     ApprovalMode::Enabled => "enabled",
                     ApprovalMode::Bypassed => "disabled (auto-approve)",
-                    ApprovalMode::Smart => "smart (auto-approve reads, prompt for writes)",
+                    ApprovalMode::Smart => {
+                        "smart (auto-approve trusted tools, prompt for untrusted tools)"
+                    }
                     _ => "unknown",
                 };
                 let mut msg = format!("Tool approval: {label}");

--- a/tui/src/app/tests/approval.rs
+++ b/tui/src/app/tests/approval.rs
@@ -105,7 +105,7 @@ async fn query_approval_mode_shows_smart() {
     let label = match app.approval_mode {
         ApprovalMode::Enabled => "enabled",
         ApprovalMode::Bypassed => "disabled (auto-approve)",
-        ApprovalMode::Smart => "smart (auto-approve reads, prompt for writes)",
+        ApprovalMode::Smart => "smart (auto-approve trusted tools, prompt for untrusted tools)",
         _ => "unknown",
     };
     let mut msg = format!("Tool approval: {label}");
@@ -133,7 +133,7 @@ fn approval_mode_default_is_smart() {
 }
 
 #[tokio::test]
-async fn smart_mode_auto_approves_readonly_tool() {
+async fn smart_mode_prompts_for_untrusted_readonly_tool() {
     let mut app = App::new(TuiConfig::default());
     app.approval_mode = ApprovalMode::Smart;
 

--- a/tui/src/commands.rs
+++ b/tui/src/commands.rs
@@ -1,7 +1,7 @@
 //! Command system for the TUI.
 //!
 //! Hash commands (`#help`, `#clear`, etc.) are TUI-internal.
-//! Slash commands (`/quit`, `/model`, etc.) affect agent configuration.
+//! Slash commands (`/quit`, `/thinking`, etc.) affect agent configuration.
 
 /// Result of parsing and executing a command.
 #[derive(Debug)]


### PR DESCRIPTION
## Summary
Update TUI docs, runtime approval labels, and approval tests so Smart mode is described as auto-approving trusted tools while still prompting for untrusted tools. Remove the unsupported /model command from user-facing docs.

## Verification
- git diff --check
- cargo test -p swink-agent-tui approval is currently blocked on an existing origin/main borrow-check failure in src/agent/checkpointing.rs

Fixes #392