### PR TITLE
Fix checkpoint resume compile blocker and stale stream expectations

### DIFF
--- a/src/agent/checkpointing.rs
+++ b/src/agent/checkpointing.rs
@@ -91,11 +91,13 @@ impl Agent {
                 .map_err(|e| invalid_state_snapshot(&e))?,
             None => crate::SessionState::new(),
         };
-        let mut s = self
-            .session_state
-            .write()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        *s = restored;
+        {
+            let mut s = self
+                .session_state
+                .write()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            *s = restored;
+        }
 
         Ok(())
     }
@@ -213,11 +215,13 @@ impl Agent {
                 .map_err(AgentError::stream)?,
             None => crate::SessionState::new(),
         };
-        let mut s = self
-            .session_state
-            .write()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        *s = restored;
+        {
+            let mut s = self
+                .session_state
+                .write()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            *s = restored;
+        }
 
         if self.state.messages.is_empty() {
             return Err(AgentError::NoMessages);

--- a/tests/stream_accumulate_errors.rs
+++ b/tests/stream_accumulate_errors.rs
@@ -133,7 +133,7 @@ fn tool_call_delta_after_partial_json_consumed() {
         },
     ];
     let err = accumulate_message(events, "p", "m").unwrap_err();
-    assert!(err.contains("partial_json already consumed"), "got: {err}");
+    assert!(err.contains("already closed"), "got: {err}");
 }
 
 // ── 9. ToolCallDelta on wrong block type (Text block) ──
@@ -168,7 +168,7 @@ fn tool_call_end_after_partial_json_consumed() {
         AssistantMessageEvent::ToolCallEnd { content_index: 0 },
     ];
     let err = accumulate_message(events, "p", "m").unwrap_err();
-    assert!(err.contains("partial_json already consumed"), "got: {err}");
+    assert!(err.contains("already closed"), "got: {err}");
 }
 
 // ── 11. ToolCallEnd with invalid JSON in partial_json ──


### PR DESCRIPTION
## Summary
- release the session-state write lock before queue restore in checkpointing.rs, which fixes the borrow-check failure that was blocking local and CI test runs on branches based on current main
- align 	ests/stream_accumulate_errors.rs with the current stream accumulator behavior, which now reports closed tool-call blocks as lready closed

## Verification
- cargo test -p swink-agent-memory interrupt
- cargo test -p swink-agent --test stream_accumulate_errors -q

## Notes
This is a prerequisite unblocker for the five draft issue PRs (#398, #399, #400, #401, #402). Once this lands, those PRs can be re-run against a compilable base branch.