### PR TITLE
[codex] Stop follow-up polling after post-turn policy stop

### DIFF
--- a/src/loop_/turn.rs
+++ b/src/loop_/turn.rs
@@ -408,6 +408,18 @@ pub(super) async fn emit_turn_end_and_agent_end(
     TurnOutcome::Return
 }
 
+/// Emit only `AgentEnd`, returning `TurnOutcome::Return`.
+async fn emit_agent_end(state: &mut LoopState, tx: &mpsc::Sender<AgentEvent>) -> TurnOutcome {
+    let _ = emit(
+        tx,
+        AgentEvent::AgentEnd {
+            messages: Arc::new(std::mem::take(&mut state.context_messages)),
+        },
+    )
+    .await;
+    TurnOutcome::Return
+}
+
 // ─── Snapshot builder ────────────────────────────────────────────────────
 
 /// Build a `TurnSnapshot` from current loop state.
@@ -690,18 +702,15 @@ async fn handle_no_tool_calls(
     .await;
 
     // Run post-turn policies BEFORE committing to context or emitting TurnEnd.
-    let (assistant_message, policy_stop) = run_post_turn_policy_check(
-        &assistant_message,
-        &[],
-        state,
-        config,
-        system_prompt,
-    );
+    let (assistant_message, policy_stop) =
+        run_post_turn_policy_check(&assistant_message, &[], state, config, system_prompt);
 
     let stop = assistant_message.stop_reason;
     state
         .context_messages
-        .push(AgentMessage::Llm(LlmMessage::Assistant(assistant_message.clone())));
+        .push(AgentMessage::Llm(LlmMessage::Assistant(
+            assistant_message.clone(),
+        )));
     let state_delta = flush_state_delta(config, tx).await;
     let snapshot = build_snapshot(state, stop, state_delta);
     if !emit(
@@ -720,6 +729,7 @@ async fn handle_no_tool_calls(
 
     if let Some(reason) = policy_stop {
         tracing::info!("post-turn policy stopped agent: {reason}");
+        return emit_agent_end(state, tx).await;
     }
 
     TurnOutcome::BreakInner
@@ -746,7 +756,9 @@ async fn handle_tool_calls(
     let assistant_ctx_index = state.context_messages.len();
     state
         .context_messages
-        .push(AgentMessage::Llm(LlmMessage::Assistant(assistant_message.clone())));
+        .push(AgentMessage::Llm(LlmMessage::Assistant(
+            assistant_message.clone(),
+        )));
     let msg_for_turn_end = assistant_message;
 
     // Max tokens recovery: replace incomplete tool calls with error results
@@ -899,7 +911,7 @@ async fn handle_tool_calls(
 
     if let Some(reason) = policy_stop {
         tracing::info!("post-turn policy stopped agent: {reason}");
-        return TurnOutcome::BreakInner;
+        return emit_agent_end(state, tx).await;
     }
 
     // Poll steering if not already interrupted

--- a/tests/agent_loop.rs
+++ b/tests/agent_loop.rs
@@ -225,6 +225,18 @@ fn count_events(events: &[AgentEvent], name: &str) -> usize {
         .count()
 }
 
+struct StoppingPostTurnPolicy;
+
+impl PostTurnPolicy for StoppingPostTurnPolicy {
+    fn name(&self) -> &str {
+        "stopping-post-turn"
+    }
+
+    fn evaluate(&self, _ctx: &PolicyContext<'_>, _turn: &TurnPolicyContext<'_>) -> PolicyVerdict {
+        PolicyVerdict::Stop("budget exceeded".to_string())
+    }
+}
+
 // ─── 3.1: Single-turn no-tool ────────────────────────────────────────────
 
 #[tokio::test]
@@ -1474,22 +1486,6 @@ async fn post_turn_inject_replaces_assistant_message_in_turn_end() {
 /// Regression test: post-turn Stop verdict still emits TurnEnd before stopping.
 #[tokio::test]
 async fn post_turn_stop_still_emits_turn_end() {
-    struct StoppingPostTurnPolicy;
-
-    impl PostTurnPolicy for StoppingPostTurnPolicy {
-        fn name(&self) -> &str {
-            "stopping-post-turn"
-        }
-
-        fn evaluate(
-            &self,
-            _ctx: &PolicyContext<'_>,
-            _turn: &TurnPolicyContext<'_>,
-        ) -> PolicyVerdict {
-            PolicyVerdict::Stop("budget exceeded".to_string())
-        }
-    }
-
     let stream_fn = Arc::new(MockStreamFn::new(vec![text_only_events("Hello!")]));
     let mut config = default_config(stream_fn);
     config.post_turn_policies = vec![Arc::new(StoppingPostTurnPolicy)];
@@ -1505,4 +1501,86 @@ async fn post_turn_stop_still_emits_turn_end() {
     // TurnEnd should still be emitted even when the policy stops the loop.
     assert!(has_event(&events, "TurnEnd"));
     assert!(has_event(&events, "AgentEnd"));
+}
+
+#[tokio::test]
+async fn post_turn_stop_skips_follow_up_polling_without_tool_calls() {
+    let stream_fn = Arc::new(MockStreamFn::new(vec![
+        text_only_events("Hello!"),
+        text_only_events("unexpected follow-up"),
+    ]));
+
+    let follow_up_polled = Arc::new(AtomicBool::new(false));
+    let follow_up_polled_clone = Arc::clone(&follow_up_polled);
+
+    let mut config = default_config(stream_fn);
+    config.post_turn_policies = vec![Arc::new(StoppingPostTurnPolicy)];
+    config.message_provider = Some(Arc::new(MockMessageProvider::follow_up_only(move || {
+        follow_up_polled_clone.store(true, Ordering::SeqCst);
+        vec![AgentMessage::Llm(LlmMessage::User(UserMessage {
+            content: vec![ContentBlock::Text {
+                text: "follow up question".to_string(),
+            }],
+            timestamp: 0,
+            cache_hint: None,
+        }))]
+    })));
+
+    let events = collect_events(agent_loop(
+        vec![],
+        "system".to_string(),
+        config,
+        CancellationToken::new(),
+    ))
+    .await;
+
+    assert_eq!(count_events(&events, "TurnStart"), 1);
+    assert!(has_event(&events, "TurnEnd"));
+    assert!(has_event(&events, "AgentEnd"));
+    assert!(
+        !follow_up_polled.load(Ordering::SeqCst),
+        "follow-up should NOT be polled after a post-turn Stop"
+    );
+}
+
+#[tokio::test]
+async fn post_turn_stop_skips_follow_up_polling_after_tool_calls() {
+    let stream_fn = Arc::new(MockStreamFn::new(vec![
+        tool_call_events("call_1", "noop", "{}"),
+        text_only_events("unexpected follow-up"),
+    ]));
+    let tool = Arc::new(MockTool::new("noop"));
+
+    let follow_up_polled = Arc::new(AtomicBool::new(false));
+    let follow_up_polled_clone = Arc::clone(&follow_up_polled);
+
+    let mut config = default_config(stream_fn);
+    config.tools = vec![tool];
+    config.post_turn_policies = vec![Arc::new(StoppingPostTurnPolicy)];
+    config.message_provider = Some(Arc::new(MockMessageProvider::follow_up_only(move || {
+        follow_up_polled_clone.store(true, Ordering::SeqCst);
+        vec![AgentMessage::Llm(LlmMessage::User(UserMessage {
+            content: vec![ContentBlock::Text {
+                text: "follow up question".to_string(),
+            }],
+            timestamp: 0,
+            cache_hint: None,
+        }))]
+    })));
+
+    let events = collect_events(agent_loop(
+        vec![],
+        "system".to_string(),
+        config,
+        CancellationToken::new(),
+    ))
+    .await;
+
+    assert_eq!(count_events(&events, "TurnStart"), 1);
+    assert!(has_event(&events, "TurnEnd"));
+    assert!(has_event(&events, "AgentEnd"));
+    assert!(
+        !follow_up_polled.load(Ordering::SeqCst),
+        "follow-up should NOT be polled after a post-turn Stop"
+    );
 }


### PR DESCRIPTION
## Summary
- stop the loop immediately after `TurnEnd` when a post-turn policy returns `PolicyVerdict::Stop`
- skip post-loop policy evaluation and follow-up polling once that hard-stop verdict has fired
- add focused regression coverage for both text-only and tool-call turns

## Why
Issue #380 reports that a post-turn `Stop` only broke the inner loop, which still allowed the outer loop to poll queued follow-ups and start another turn. That made the stop verdict path-dependent instead of terminal.

## Issue Slice
This PR completes issue #380 by making post-turn `Stop` a true loop-terminating control path after the final `TurnEnd`.

## Validation
- `cargo test -p swink-agent --test agent_loop --features testkit post_turn_stop -- --nocapture`

Closes #380