### PR TITLE
Fix pause checkpoint context snapshot

### DIFF
--- a/src/agent/checkpointing.rs
+++ b/src/agent/checkpointing.rs
@@ -148,11 +148,16 @@ impl Agent {
             token.cancel();
         }
 
+        let checkpoint_messages = self
+            .in_flight_llm_messages
+            .as_deref()
+            .unwrap_or(&self.state.messages);
+
         let mut checkpoint = crate::checkpoint::LoopCheckpoint::new(
             &self.state.system_prompt,
             &self.state.model.provider,
             &self.state.model.model_id,
-            &self.state.messages,
+            checkpoint_messages,
         )
         .with_pending_message_batch(&drain_messages_from_queue(&self.follow_up_queue))
         .with_pending_steering_message_batch(&drain_messages_from_queue(&self.steering_queue));
@@ -899,7 +904,10 @@ mod tests {
             .session_state()
             .read()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        assert!(state.is_empty(), "missing snapshot should clear stale state");
+        assert!(
+            state.is_empty(),
+            "missing snapshot should clear stale state"
+        );
     }
 
     #[tokio::test]
@@ -931,6 +939,9 @@ mod tests {
             .session_state()
             .read()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        assert!(state.is_empty(), "missing snapshot should clear stale state");
+        assert!(
+            state.is_empty(),
+            "missing snapshot should clear stale state"
+        );
     }
 }

--- a/tests/pause_resume.rs
+++ b/tests/pause_resume.rs
@@ -63,6 +63,21 @@ async fn pause_captures_pending_follow_up_messages() {
         .pause()
         .expect("pause should snapshot a running agent");
     assert_eq!(checkpoint.pending_messages.len(), 1);
+    let restored = checkpoint.restore_messages(None);
+    assert_eq!(
+        restored.len(),
+        1,
+        "pause should preserve the in-flight prompt messages"
+    );
+    match &restored[0] {
+        swink_agent::AgentMessage::Llm(swink_agent::LlmMessage::User(user)) => {
+            match &user.content[0] {
+                swink_agent::ContentBlock::Text { text } => assert_eq!(text, "start"),
+                other => panic!("expected text content, got {other:?}"),
+            }
+        }
+        other => panic!("expected user message, got {other:?}"),
+    }
 }
 
 #[tokio::test]
@@ -197,7 +212,10 @@ async fn pause_keeps_running_until_stream_dropped() {
 
     // Pause cancels the token but the agent stays running.
     let checkpoint = agent.pause().expect("should return checkpoint");
-    assert!(agent.is_running(), "agent should remain running after pause");
+    assert!(
+        agent.is_running(),
+        "agent should remain running after pause"
+    );
 
     // Trying to start a new run should fail — loop is still active.
     let err = agent.prompt_stream(vec![user_msg("again")]);
@@ -216,7 +234,10 @@ async fn pause_keeps_running_until_stream_dropped() {
     );
     let _checkpoint = checkpoint; // keep checkpoint alive for the assertion above
     let new_stream = agent.prompt_stream(vec![user_msg("new run")]);
-    assert!(new_stream.is_ok(), "new run should succeed after stream drop");
+    assert!(
+        new_stream.is_ok(),
+        "new run should succeed after stream drop"
+    );
 
     // Clean up: drain the new stream.
     let mut s = new_stream.unwrap();


### PR DESCRIPTION
## What changed
- make `pause()` checkpoint the active in-flight conversation snapshot when a streamed run has already moved wrapper-owned messages into the loop task
- keep the pending queue snapshot behavior unchanged
- extend pause/resume regression coverage to assert the original prompt survives a mid-stream pause

## Why
`prompt_stream()` drains `state.messages` before the loop finishes. Pausing during that window could serialize an empty or stale wrapper history, which breaks resume behavior for streamed runs.

## Issue slice completed
- addressed the stale/empty prompt snapshot path for issue #381
- added regression coverage for pausing a pending stream before `TurnEnd`/`AgentEnd`

## What remains
- if issue #381 needs broader follow-up beyond the streamed in-flight snapshot path, that can be handled separately

## Validation
- `cargo test -p swink-agent --features testkit pause_ -- --nocapture`

## Baseline notes
- the targeted test run passed
- unrelated existing warnings are still present in other test targets and adapters during the build output

Refs #381