### PR TITLE
[codex] Fix duplicate content_filter terminal event

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,10 @@ MSRV **1.88** (edition 2024). Common workspace deps are centralized in root `Car
 - `partial_json` consumed on `ToolCallEnd` — parsed once. Empty string → `{}`, not null.
 - `AssistantMessageEvent::error()` is the canonical error constructor — adapters must use it.
 
+### OpenAI-Compatible Adapters (`adapters/src/openai_compat.rs`)
+
+- `finish_reason == "content_filter"` must be routed through `OaiSseStreamState.terminal_error`; emitting an inline error and then consuming a later `[DONE]` produces a duplicate terminal event that `accumulate_message` rejects.
+
 ### Local LLM Streaming (`local-llm/src/stream.rs`)
 
 - Gemma 4 delimiter scanners must only slice `&str` at UTF-8 character boundaries. For partial `<|channel>thought\n` and `<tool_call|>` matches, use the shared UTF-8-safe suffix helper instead of raw byte-offset suffix slicing.

--- a/adapters/src/openai_compat.rs
+++ b/adapters/src/openai_compat.rs
@@ -379,9 +379,9 @@ pub fn process_oai_chunk(
         if let Some(reason) = &choice.finish_reason {
             if reason == "content_filter" {
                 events.extend(crate::finalize::finalize_blocks(state));
-                events.push(AssistantMessageEvent::error_content_filtered(format!(
-                    "{provider} response stopped by content filter"
-                )));
+                state.terminal_error = Some(AssistantMessageEvent::error_content_filtered(
+                    format!("{provider} response stopped by content filter"),
+                ));
                 return;
             }
 

--- a/adapters/tests/azure.rs
+++ b/adapters/tests/azure.rs
@@ -771,6 +771,12 @@ async fn http_401_auth_error() {
         }
         _ => unreachable!(),
     }
+    assert!(
+        !events
+            .iter()
+            .any(|e| matches!(e, AssistantMessageEvent::Done { .. })),
+        "content_filter should stop the stream without a trailing Done: {events:?}"
+    );
 }
 
 // ── T042: HTTP 404 → non-retryable error ──────────────────────────────────

--- a/adapters/tests/openai.rs
+++ b/adapters/tests/openai.rs
@@ -644,7 +644,7 @@ async fn openai_multiple_tool_calls() {
 }
 
 #[tokio::test]
-async fn openai_content_filter_stop_reason() {
+async fn openai_content_filter_is_terminal_error() {
     let body = [
         r#"data: {"choices":[{"delta":{"content":"filtered"},"index":0}]}"#,
         "",
@@ -666,15 +666,28 @@ async fn openai_content_filter_stop_reason() {
     let sf = OpenAiStreamFn::new(server.uri(), "test-key");
     let events = collect_events(&sf).await;
 
-    // content_filter maps to the catch-all StopReason::Stop
-    let done = events.iter().find_map(|e| match e {
-        AssistantMessageEvent::Done { stop_reason, .. } => Some(*stop_reason),
-        _ => None,
-    });
-    assert_eq!(
-        done,
-        Some(StopReason::Stop),
-        "content_filter should map to Stop"
+    let error_event = events
+        .iter()
+        .find(|e| matches!(e, AssistantMessageEvent::Error { .. }));
+    assert!(
+        error_event.is_some(),
+        "expected a content-filter terminal error, got: {events:?}"
+    );
+    assert!(
+        matches!(
+            error_event,
+            Some(AssistantMessageEvent::Error {
+                error_kind: Some(swink_agent::StreamErrorKind::ContentFiltered),
+                ..
+            })
+        ),
+        "expected ContentFiltered error kind, got: {events:?}"
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|e| matches!(e, AssistantMessageEvent::Done { .. })),
+        "content_filter should stop the stream without a trailing Done: {events:?}"
     );
 }
 


### PR DESCRIPTION
## What changed
- route OpenAI-compatible `finish_reason == "content_filter"` through the shared `terminal_error` path instead of emitting an inline error event
- update the OpenAI regression to assert `content_filter` is a terminal `Error` with no trailing `Done`
- tighten the Azure regression on the same shared parser behavior
- record the invariant in `AGENTS.md`

## Why it changed
The shared OpenAI-compatible SSE parser emitted a content-filter error immediately, but then still consumed a later `[DONE]` sentinel and produced a second terminal `Done`. That violates the single-terminal stream contract and breaks `accumulate_message()`.

## Issue slice completed
- fixed issue #382 end to end by suppressing the duplicate terminal on `content_filter`

## What remains
- nothing for this issue if CI agrees with the targeted adapter coverage

## Validation
- `cargo test -p swink-agent-adapters --features "openai azure" content_filter -- --nocapture`

## Baseline notes
- targeted adapter tests passed in the issue worktree

Closes #382