### PR TITLE
[codex] Fix Bedrock cancellation classification

### DIFF
--- a/adapters/src/bedrock.rs
+++ b/adapters/src/bedrock.rs
@@ -259,6 +259,15 @@ impl StreamFinalize for BedrockStreamState {
     }
 }
 
+fn cancelled_event(message: &'static str) -> AssistantMessageEvent {
+    AssistantMessageEvent::Error {
+        stop_reason: StopReason::Aborted,
+        error_message: message.to_string(),
+        usage: None,
+        error_kind: None,
+    }
+}
+
 pub struct BedrockStreamFn {
     base_url: String,
     region: String,
@@ -412,9 +421,7 @@ impl BedrockStreamFn {
                             return Some((
                                 vec![
                                     AssistantMessageEvent::Start,
-                                    AssistantMessageEvent::error_network(
-                                        "Bedrock request cancelled",
-                                    ),
+                                    cancelled_event("Bedrock request cancelled"),
                                 ],
                                 StreamUnfoldState::Done,
                             ));
@@ -501,9 +508,7 @@ impl BedrockStreamFn {
                                 biased;
                                 () = cancellation_token.cancelled() => {
                                     let mut events = finalize::finalize_blocks(state.as_mut());
-                                    events.push(AssistantMessageEvent::error_network(
-                                        "Bedrock stream cancelled",
-                                    ));
+                                    events.push(cancelled_event("Bedrock stream cancelled"));
                                     return Some((events, StreamUnfoldState::Done));
                                 }
                                 chunk = byte_stream.next() => {

--- a/adapters/tests/bedrock.rs
+++ b/adapters/tests/bedrock.rs
@@ -154,6 +154,42 @@ async fn bedrock_text_response_maps_to_text_events() {
     )));
 }
 
+#[tokio::test]
+async fn bedrock_pre_request_cancellation_is_aborted() {
+    let token = CancellationToken::new();
+    token.cancel();
+
+    let stream_fn = BedrockStreamFn::new_with_base_url(
+        "http://127.0.0.1:9",
+        "us-east-1",
+        "AKIDEXAMPLE",
+        "secret",
+        None,
+    );
+    let events = stream_fn
+        .stream(
+            &ModelSpec::new("bedrock", "amazon.nova-pro-v1:0"),
+            &AgentContext {
+                system_prompt: String::new(),
+                messages: Vec::new(),
+                tools: Vec::new(),
+            },
+            &StreamOptions::default(),
+            token,
+        )
+        .collect::<Vec<_>>()
+        .await;
+
+    assert!(events.iter().any(|event| matches!(
+        event,
+        AssistantMessageEvent::Error {
+            stop_reason: StopReason::Aborted,
+            error_kind: None,
+            ..
+        }
+    )));
+}
+
 struct DummyTool;
 
 impl AgentTool for DummyTool {
@@ -291,6 +327,58 @@ async fn bedrock_session_token_is_forwarded() {
         e,
         AssistantMessageEvent::Done {
             stop_reason: StopReason::Stop,
+            ..
+        }
+    )));
+}
+
+#[tokio::test]
+async fn bedrock_stream_cancellation_is_aborted() {
+    let server = MockServer::start().await;
+    let slow_response = ResponseTemplate::new(200)
+        .insert_header("Content-Type", "application/vnd.amazon.eventstream")
+        .set_body_bytes(text_response_body("hello"))
+        .set_delay(std::time::Duration::from_secs(30));
+
+    Mock::given(method("POST"))
+        .and(path("/model/amazon.nova-pro-v1:0/converse-stream"))
+        .respond_with(slow_response)
+        .mount(&server)
+        .await;
+
+    let stream_fn = BedrockStreamFn::new_with_base_url(
+        server.uri(),
+        "us-east-1",
+        "AKIDEXAMPLE",
+        "secret",
+        None,
+    );
+    let token = CancellationToken::new();
+    let cancel_token = token.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        cancel_token.cancel();
+    });
+
+    let events = stream_fn
+        .stream(
+            &ModelSpec::new("bedrock", "amazon.nova-pro-v1:0"),
+            &AgentContext {
+                system_prompt: String::new(),
+                messages: Vec::new(),
+                tools: Vec::new(),
+            },
+            &StreamOptions::default(),
+            token,
+        )
+        .collect::<Vec<_>>()
+        .await;
+
+    assert!(events.iter().any(|event| matches!(
+        event,
+        AssistantMessageEvent::Error {
+            stop_reason: StopReason::Aborted,
+            error_kind: None,
             ..
         }
     )));


### PR DESCRIPTION
## What changed
- mapped Bedrock request cancellation and streaming-loop cancellation to `StopReason::Aborted` instead of retryable network errors
- added Bedrock adapter regression tests covering both cancellation entry points

## Why
Bedrock was treating user-driven cancellation as a retryable network failure, which diverged from the workspace cancellation contract used by the other adapters.

## Issue slice completed
- completed the focused issue #385 slice to normalize Bedrock cancellation handling and lock it in with tests

## What remains
- issue #385 should be complete if no broader Bedrock cancellation edge cases surface in review

## Validation
- `cargo test -p swink-agent-adapters --features bedrock --test bedrock`

## Unrelated baseline failures
- the targeted Bedrock test run still reports existing `AdapterBase` dead-code warnings in `swink-agent-adapters`; this change does not touch that code path

Refs #385