### PR TITLE
[codex] Guard post-turn tool call replacements

### DIFF
--- a/src/loop_/AGENTS.md
+++ b/src/loop_/AGENTS.md
@@ -1,3 +1,4 @@
 # Loop Lessons
 
 - `ToolExecutionUpdate` must include the originating tool call `id` and `name`, and partial tool updates must flow through an awaited relay instead of `try_send`; otherwise concurrent tool progress becomes unattributed and can be silently dropped under channel backpressure.
+- Post-turn assistant replacements must preserve the original `ToolCall` blocks. A text-only replacement on a tool turn breaks the core invariant that assistant tool calls stay paired with the committed `ToolResult` messages that follow.

--- a/src/loop_/turn.rs
+++ b/src/loop_/turn.rs
@@ -662,7 +662,13 @@ fn run_post_turn_policy_check(
             for msg in msgs {
                 match msg {
                     AgentMessage::Llm(LlmMessage::Assistant(new_msg)) => {
-                        replaced = new_msg;
+                        if assistant_replacement_preserves_tool_calls(assistant_message, &new_msg) {
+                            replaced = new_msg;
+                        } else {
+                            tracing::warn!(
+                                "ignoring post-turn assistant replacement that would drop tool calls"
+                            );
+                        }
                     }
                     other => {
                         state.pending_messages.push(other);
@@ -674,6 +680,31 @@ fn run_post_turn_policy_check(
             (replaced, None)
         }
     }
+}
+
+fn assistant_replacement_preserves_tool_calls(
+    original: &AssistantMessage,
+    replacement: &AssistantMessage,
+) -> bool {
+    let original_tool_calls: Vec<ContentBlock> = original
+        .content
+        .iter()
+        .filter(|block| matches!(block, ContentBlock::ToolCall { .. }))
+        .cloned()
+        .collect();
+
+    if original_tool_calls.is_empty() {
+        return true;
+    }
+
+    let replacement_tool_calls: Vec<ContentBlock> = replacement
+        .content
+        .iter()
+        .filter(|block| matches!(block, ContentBlock::ToolCall { .. }))
+        .cloned()
+        .collect();
+
+    original_tool_calls == replacement_tool_calls
 }
 
 /// Handle the case where no tool calls are present: run post-turn policies,

--- a/tests/agent_loop.rs
+++ b/tests/agent_loop.rs
@@ -1485,6 +1485,79 @@ async fn post_turn_inject_replaces_assistant_message_in_turn_end() {
     );
 }
 
+#[tokio::test]
+async fn post_turn_inject_cannot_drop_tool_calls_from_turn_history() {
+    let stream_fn = Arc::new(MockStreamFn::new(vec![
+        tool_call_events("call_1", "noop", "{}"),
+        text_only_events("done"),
+    ]));
+
+    let policy: Arc<dyn PostTurnPolicy> = Arc::new(ReplacingPostTurnPolicy {
+        replacement_text: "tool output [REDACTED]".to_string(),
+    });
+
+    let mut config = default_config(stream_fn);
+    config.tools = vec![Arc::new(MockTool::new("noop"))];
+    config.post_turn_policies = vec![policy];
+
+    let events = collect_events(agent_loop(
+        vec![],
+        "system".to_string(),
+        config,
+        CancellationToken::new(),
+    ))
+    .await;
+
+    let turn_end_messages: Vec<&AssistantMessage> = events
+        .iter()
+        .filter_map(|event| match event {
+            AgentEvent::TurnEnd {
+                assistant_message, ..
+            } => Some(assistant_message),
+            _ => None,
+        })
+        .collect();
+    let tool_turn_message = turn_end_messages
+        .first()
+        .expect("first turn should emit TurnEnd after tool execution");
+    assert!(
+        tool_turn_message.content.iter().any(
+            |block| matches!(block, ContentBlock::ToolCall { id, name, arguments, .. }
+                if id == "call_1" && name == "noop" && arguments == &json!({}))
+        ),
+        "tool-turn TurnEnd must keep the original tool call block",
+    );
+    assert_eq!(
+        ContentBlock::extract_text(&tool_turn_message.content),
+        "",
+        "tool-turn replacement must not flatten tool calls into text"
+    );
+
+    let agent_end_messages = events.iter().find_map(|event| match event {
+        AgentEvent::AgentEnd { messages } => Some(messages.clone()),
+        _ => None,
+    });
+    let messages = agent_end_messages.expect("should have AgentEnd");
+    let assistant_with_tool_call = messages
+        .iter()
+        .position(|message| match message {
+            AgentMessage::Llm(LlmMessage::Assistant(assistant_message)) => assistant_message
+                .content
+                .iter()
+                .any(|block| matches!(block, ContentBlock::ToolCall { id, .. } if id == "call_1")),
+            _ => false,
+        })
+        .expect("final history should keep the assistant tool call");
+    assert!(
+        matches!(
+            messages.get(assistant_with_tool_call + 1),
+            Some(AgentMessage::Llm(LlmMessage::ToolResult(result)))
+                if result.tool_call_id == "call_1"
+        ),
+        "tool call must remain paired with its tool result in final history"
+    );
+}
+
 /// Regression test: post-turn Stop verdict still emits TurnEnd before stopping.
 #[tokio::test]
 async fn post_turn_stop_still_emits_turn_end() {


### PR DESCRIPTION
## What changed
- guarded post-turn assistant replacements so tool turns only accept a replacement when it preserves the original `ToolCall` blocks
- kept dropping replacements as a warning-only path instead of rewriting committed tool-turn history into malformed text-only assistant messages
- added an `agent_loop` regression that proves a text-only post-turn replacement can no longer break assistant/tool-result pairing, and recorded the invariant in `src/loop_/AGENTS.md`

## Why it changed
Post-turn policies such as `PiiRedactor` can inject a replacement assistant message after tool execution. On tool turns, the old loop logic blindly swapped in that replacement even when it removed the committed `ToolCall` blocks, leaving later `ToolResult` messages orphaned in history.

## Issue slice completed
- completed the core guard for #386 so post-turn assistant rewrites cannot drop tool-call structure after tool execution

## What remains
- nothing for #386 if review agrees that rejecting tool-call-dropping replacements is the correct safety contract

## Validation
- `cargo test -p swink-agent --features testkit --test agent_loop post_turn_inject_ -- --nocapture`
- `cargo test -p swink-agent --features testkit --test agent_loop -- --nocapture`

Closes #386