### PR TITLE
[codex] Unify post-turn policy snapshots

### DIFF
--- a/src/loop_/AGENTS.md
+++ b/src/loop_/AGENTS.md
@@ -2,3 +2,4 @@
 
 - `ToolExecutionUpdate` must include the originating tool call `id` and `name`, and partial tool updates must flow through an awaited relay instead of `try_send`; otherwise concurrent tool progress becomes unattributed and can be silently dropped under channel backpressure.
 - Post-turn assistant replacements must preserve the original `ToolCall` blocks. A text-only replacement on a tool turn breaks the core invariant that assistant tool calls stay paired with the committed `ToolResult` messages that follow.
+- `TurnPolicyContext.context_messages` must always be a committed turn snapshot. Text-only turns need the assistant message committed before post-turn policies run, and transfer turns must also execute post-turn policies before honoring transfer termination.

--- a/src/loop_/mod.rs
+++ b/src/loop_/mod.rs
@@ -171,11 +171,11 @@ async fn run_loop_inner(
                     TurnOutcome::Return => return,
                 };
 
-                // Post-turn policies are now evaluated inside the turn handlers
-                // (handle_no_tool_calls / handle_tool_calls) BEFORE the assistant
-                // message is committed to context and TurnEnd is emitted. This
-                // ensures Inject verdicts (e.g. PII redaction) can replace the
-                // assistant message before it is observed by listeners.
+                // Post-turn policies are evaluated inside the turn handlers
+                // (handle_no_tool_calls / handle_tool_calls) against the
+                // committed turn snapshot before TurnEnd is emitted or transfer
+                // termination is honored. This lets policies replace the
+                // assistant message before listeners observe the turn.
 
                 if should_break {
                     break 'inner;

--- a/src/loop_/turn.rs
+++ b/src/loop_/turn.rs
@@ -707,8 +707,9 @@ fn assistant_replacement_preserves_tool_calls(
     original_tool_calls == replacement_tool_calls
 }
 
-/// Handle the case where no tool calls are present: run post-turn policies,
-/// commit the (possibly replaced) message, emit `TurnEnd`, break inner.
+/// Handle the case where no tool calls are present: commit the assistant,
+/// run post-turn policies against the committed snapshot, emit `TurnEnd`,
+/// and break inner.
 #[allow(clippy::too_many_arguments)]
 async fn handle_no_tool_calls(
     assistant_message: AssistantMessage,
@@ -732,16 +733,22 @@ async fn handle_no_tool_calls(
     )
     .await;
 
-    // Run post-turn policies BEFORE committing to context or emitting TurnEnd.
-    let (assistant_message, policy_stop) =
-        run_post_turn_policy_check(&assistant_message, &[], state, config, system_prompt);
-
-    let stop = assistant_message.stop_reason;
+    let assistant_ctx_index = state.context_messages.len();
     state
         .context_messages
         .push(AgentMessage::Llm(LlmMessage::Assistant(
             assistant_message.clone(),
         )));
+
+    // Run post-turn policies against the committed turn snapshot so text-only,
+    // tool, and transfer turns expose the same history shape.
+    let (assistant_message, policy_stop) =
+        run_post_turn_policy_check(&assistant_message, &[], state, config, system_prompt);
+
+    state.context_messages[assistant_ctx_index] =
+        AgentMessage::Llm(LlmMessage::Assistant(assistant_message.clone()));
+
+    let stop = assistant_message.stop_reason;
     let state_delta = flush_state_delta(config, tx).await;
     let snapshot = build_snapshot(state, stop, state_delta);
     if !emit(
@@ -863,10 +870,23 @@ async fn handle_tool_calls(
     // Store tool results for post-turn hook access
     state.last_tool_results.clone_from(&tool_results);
 
+    // xiii. Run post-turn policies against the committed tool-turn snapshot
+    // before emitting TurnEnd or honoring transfer termination.
+    let (msg_for_turn_end, policy_stop) = run_post_turn_policy_check(
+        &msg_for_turn_end,
+        &tool_results,
+        state,
+        config,
+        system_prompt,
+    );
+
+    // Update the assistant message in context in case a policy replaced it.
+    state.context_messages[assistant_ctx_index] =
+        AgentMessage::Llm(LlmMessage::Assistant(msg_for_turn_end.clone()));
+
     // xiii-a. Transfer signal detection: if a tool signaled a transfer,
-    // enrich the signal with conversation history and exit with Transfer.
+    // enrich the signal with the committed conversation history and exit.
     if let Some(mut signal) = detected_transfer_signal {
-        // Enrich with LLM-only conversation history from context
         let llm_history: Vec<LlmMessage> = state
             .context_messages
             .iter()
@@ -883,7 +903,6 @@ async fn handle_tool_calls(
             "transfer signal detected, terminating turn"
         );
 
-        // Emit TransferInitiated event so callers can capture the signal
         let _ = emit(
             tx,
             AgentEvent::TransferInitiated {
@@ -904,20 +923,6 @@ async fn handle_tool_calls(
         )
         .await;
     }
-
-    // xiii. Run post-turn policies BEFORE emitting TurnEnd so Inject can
-    //       replace the assistant message before it is observed by listeners.
-    let (msg_for_turn_end, policy_stop) = run_post_turn_policy_check(
-        &msg_for_turn_end,
-        &tool_results,
-        state,
-        config,
-        system_prompt,
-    );
-
-    // Update the assistant message in context in case a policy replaced it.
-    state.context_messages[assistant_ctx_index] =
-        AgentMessage::Llm(LlmMessage::Assistant(msg_for_turn_end.clone()));
 
     // xiv. Emit TurnEnd
     let state_delta = flush_state_delta(config, tx).await;

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -129,7 +129,11 @@ pub struct TurnPolicyContext<'a> {
     pub system_prompt: &'a str,
     /// The model specification active during this turn.
     pub model_spec: &'a ModelSpec,
-    /// All context messages (the full conversation history).
+    /// The committed conversation history for the completed turn.
+    ///
+    /// This always includes the current turn's assistant message and any tool
+    /// results before `PostTurn` policies run, regardless of whether the turn
+    /// ended with plain text, tool execution, or transfer termination.
     pub context_messages: &'a [AgentMessage],
 }
 

--- a/tests/agent_loop.rs
+++ b/tests/agent_loop.rs
@@ -237,6 +237,95 @@ impl PostTurnPolicy for StoppingPostTurnPolicy {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct RecordedTurnContext {
+    message_count: usize,
+    tool_result_count: usize,
+    last_message_kind: &'static str,
+}
+
+struct RecordingPostTurnPolicy {
+    observations: Arc<Mutex<Vec<RecordedTurnContext>>>,
+}
+
+impl PostTurnPolicy for RecordingPostTurnPolicy {
+    fn name(&self) -> &str {
+        "recording-post-turn"
+    }
+
+    fn evaluate(&self, _ctx: &PolicyContext<'_>, turn: &TurnPolicyContext<'_>) -> PolicyVerdict {
+        let last_message_kind = match turn.context_messages.last() {
+            Some(AgentMessage::Llm(LlmMessage::Assistant(_))) => "assistant",
+            Some(AgentMessage::Llm(LlmMessage::ToolResult(_))) => "tool_result",
+            Some(AgentMessage::Llm(LlmMessage::User(_))) => "user",
+            Some(AgentMessage::Custom(_)) => "custom",
+            None => "none",
+        };
+
+        self.observations.lock().unwrap().push(RecordedTurnContext {
+            message_count: turn.context_messages.len(),
+            tool_result_count: turn.tool_results.len(),
+            last_message_kind,
+        });
+
+        PolicyVerdict::Continue
+    }
+}
+
+struct MockTransferTool {
+    tool_name: String,
+    target_agent: String,
+    reason: String,
+}
+
+impl MockTransferTool {
+    fn new(name: &str, target_agent: &str, reason: &str) -> Self {
+        Self {
+            tool_name: name.to_string(),
+            target_agent: target_agent.to_string(),
+            reason: reason.to_string(),
+        }
+    }
+}
+
+impl AgentTool for MockTransferTool {
+    fn name(&self) -> &str {
+        &self.tool_name
+    }
+
+    fn label(&self) -> &str {
+        &self.tool_name
+    }
+
+    fn description(&self) -> &'static str {
+        "A tool that always requests an agent transfer"
+    }
+
+    fn parameters_schema(&self) -> &serde_json::Value {
+        static SCHEMA: std::sync::OnceLock<serde_json::Value> = std::sync::OnceLock::new();
+        SCHEMA.get_or_init(|| {
+            json!({
+                "type": "object",
+                "properties": {},
+                "additionalProperties": true
+            })
+        })
+    }
+
+    fn execute(
+        &self,
+        _tool_call_id: &str,
+        _params: serde_json::Value,
+        _cancellation_token: CancellationToken,
+        _on_update: Option<Box<dyn Fn(AgentToolResult) + Send + Sync>>,
+        _state: std::sync::Arc<std::sync::RwLock<swink_agent::SessionState>>,
+        _credential: Option<swink_agent::ResolvedCredential>,
+    ) -> Pin<Box<dyn Future<Output = AgentToolResult> + Send + '_>> {
+        let signal = swink_agent::TransferSignal::new(&self.target_agent, &self.reason);
+        Box::pin(async move { AgentToolResult::transfer(signal) })
+    }
+}
+
 // ─── 3.1: Single-turn no-tool ────────────────────────────────────────────
 
 #[tokio::test]
@@ -1486,6 +1575,38 @@ async fn post_turn_inject_replaces_assistant_message_in_turn_end() {
 }
 
 #[tokio::test]
+async fn post_turn_context_messages_include_committed_assistant_without_tools() {
+    let stream_fn = Arc::new(MockStreamFn::new(vec![text_only_events("Hello!")]));
+    let observations = Arc::new(Mutex::new(Vec::new()));
+
+    let mut config = default_config(stream_fn);
+    config.post_turn_policies = vec![Arc::new(RecordingPostTurnPolicy {
+        observations: Arc::clone(&observations),
+    })];
+
+    let events = collect_events(agent_loop(
+        vec![],
+        "system".to_string(),
+        config,
+        CancellationToken::new(),
+    ))
+    .await;
+
+    assert!(has_event(&events, "TurnEnd"));
+    let recorded = observations.lock().unwrap().clone();
+    assert_eq!(recorded.len(), 1, "post-turn policy should run once");
+    assert_eq!(
+        recorded[0],
+        RecordedTurnContext {
+            message_count: 1,
+            tool_result_count: 0,
+            last_message_kind: "assistant",
+        },
+        "post-turn policies should observe the committed assistant snapshot even on text-only turns"
+    );
+}
+
+#[tokio::test]
 async fn post_turn_inject_cannot_drop_tool_calls_from_turn_history() {
     let stream_fn = Arc::new(MockStreamFn::new(vec![
         tool_call_events("call_1", "noop", "{}"),
@@ -1555,6 +1676,59 @@ async fn post_turn_inject_cannot_drop_tool_calls_from_turn_history() {
                 if result.tool_call_id == "call_1"
         ),
         "tool call must remain paired with its tool result in final history"
+    );
+}
+
+#[tokio::test]
+async fn post_turn_policy_runs_before_transfer_termination() {
+    let stream_fn = Arc::new(MockStreamFn::new(vec![
+        tool_call_events("call_transfer", "handoff", "{}"),
+        text_only_events("should not reach this"),
+    ]));
+    let observations = Arc::new(Mutex::new(Vec::new()));
+
+    let mut config = default_config(stream_fn);
+    config.tools = vec![Arc::new(MockTransferTool::new(
+        "handoff",
+        "billing",
+        "billing question",
+    ))];
+    config.post_turn_policies = vec![Arc::new(RecordingPostTurnPolicy {
+        observations: Arc::clone(&observations),
+    })];
+
+    let events = collect_events(agent_loop(
+        vec![common::user_msg("transfer me")],
+        "system".to_string(),
+        config,
+        CancellationToken::new(),
+    ))
+    .await;
+
+    let recorded = observations.lock().unwrap().clone();
+    assert_eq!(
+        recorded.len(),
+        1,
+        "transfer turns must still run post-turn policies"
+    );
+    assert_eq!(
+        recorded[0],
+        RecordedTurnContext {
+            message_count: 3,
+            tool_result_count: 1,
+            last_message_kind: "tool_result",
+        },
+        "transfer turns should expose the same committed turn snapshot shape as normal tool turns"
+    );
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            AgentEvent::TurnEnd {
+                reason: swink_agent::TurnEndReason::Transfer,
+                ..
+            }
+        )),
+        "transfer turn should still terminate with TurnEndReason::Transfer"
     );
 }
 


### PR DESCRIPTION
## What changed
- commit text-only assistant messages before post-turn policies run so `TurnPolicyContext.context_messages` always reflects the completed turn
- run post-turn policies before honoring transfer termination, then enrich transfer history from that committed snapshot
- document the committed-snapshot contract and add focused regressions for text-only and transfer turns

## Why
Issue #387 reports that post-turn policies see different state shapes depending on turn path, and transfer turns skip post-turn entirely. That breaks checkpointing, auditing, loop detection, and similar post-turn hooks.

## Issue slice completed
- completed the core loop fix so post-turn policies now observe one committed-turn snapshot across text-only, tool, and transfer turns

## What remains
- nothing for #387 if review agrees this snapshot contract is the intended behavior

## Validation
- `cargo test -p swink-agent --features testkit --test agent_loop post_turn_ -- --nocapture`
- `cargo test -p swink-agent --features testkit --test transfer -- --nocapture`

## Unrelated baseline notes
- test builds still surface existing `swink-agent-adapters` warnings for unused `AdapterBase` helpers in `adapters/src/base.rs`; this change does not touch that path

Closes #387