### PR TITLE
[codex] Preserve TUI thinking blocks on reload

### DIFF
--- a/tui/src/app/agent_bridge.rs
+++ b/tui/src/app/agent_bridge.rs
@@ -84,31 +84,7 @@ impl App {
                 }
             }
             AgentEvent::MessageEnd { message } => {
-                let mut text_parts = Vec::new();
-                let mut thinking_parts = Vec::new();
-                for block in &message.content {
-                    match block {
-                        ContentBlock::Text { text } => text_parts.push(text.as_str()),
-                        ContentBlock::Thinking { thinking, .. } => {
-                            thinking_parts.push(thinking.as_str());
-                        }
-                        _ => {}
-                    }
-                }
-
-                let content = if !text_parts.is_empty() {
-                    text_parts.join("")
-                } else if message.stop_reason == swink_agent::StopReason::Error {
-                    message.error_message.clone().unwrap_or_default()
-                } else {
-                    String::new()
-                };
-
-                let thinking = if thinking_parts.is_empty() {
-                    None
-                } else {
-                    Some(thinking_parts.join(""))
-                };
+                let (content, thinking) = DisplayMessage::assistant_content(&message);
 
                 if let Some(msg) = self
                     .messages

--- a/tui/src/app/persistence.rs
+++ b/tui/src/app/persistence.rs
@@ -90,22 +90,20 @@ impl App {
                             ));
                         }
                         AgentMessage::Llm(LlmMessage::Assistant(assistant)) => {
-                            let text = ContentBlock::extract_text(&assistant.content);
-                            let (role, content) =
-                                if assistant.stop_reason == StopReason::Error {
-                                    let content = if text.is_empty() {
-                                        assistant
-                                            .error_message
-                                            .clone()
-                                            .unwrap_or_default()
-                                    } else {
-                                        text
-                                    };
-                                    (MessageRole::Error, content)
+                            let (text, thinking) = DisplayMessage::assistant_content(assistant);
+                            let (role, content) = if assistant.stop_reason == StopReason::Error {
+                                let content = if text.is_empty() {
+                                    assistant.error_message.clone().unwrap_or_default()
                                 } else {
-                                    (MessageRole::Assistant, text)
+                                    text
                                 };
-                            self.messages.push(DisplayMessage::new(role, content));
+                                (MessageRole::Error, content)
+                            } else {
+                                (MessageRole::Assistant, text)
+                            };
+                            let mut message = DisplayMessage::new(role, content);
+                            message.thinking = thinking;
+                            self.messages.push(message);
                         }
                         AgentMessage::Llm(LlmMessage::ToolResult(tool_result)) => {
                             let content = ContentBlock::extract_text(&tool_result.content);

--- a/tui/src/app/state.rs
+++ b/tui/src/app/state.rs
@@ -8,7 +8,8 @@ use ratatui::layout::Rect;
 use tokio::sync::{mpsc, oneshot};
 
 use swink_agent::{
-    Agent, AgentEvent, AgentTool, ApprovalMode, DisplayRole, ToolApproval, ToolApprovalRequest,
+    Agent, AgentEvent, AgentTool, ApprovalMode, AssistantMessage, ContentBlock, DisplayRole,
+    StopReason, ToolApproval, ToolApprovalRequest,
 };
 
 use crate::config::TuiConfig;
@@ -94,6 +95,32 @@ impl DisplayMessage {
             plan_mode: false,
             diff_data: None,
         }
+    }
+
+    /// Extract the assistant text/thinking payload shown by the TUI.
+    pub fn assistant_content(message: &AssistantMessage) -> (String, Option<String>) {
+        let mut text_parts = Vec::new();
+        let mut thinking_parts = Vec::new();
+        for block in &message.content {
+            match block {
+                ContentBlock::Text { text } => text_parts.push(text.as_str()),
+                ContentBlock::Thinking { thinking, .. } => {
+                    thinking_parts.push(thinking.as_str());
+                }
+                _ => {}
+            }
+        }
+
+        let content = if !text_parts.is_empty() {
+            text_parts.join("")
+        } else if message.stop_reason == StopReason::Error {
+            message.error_message.clone().unwrap_or_default()
+        } else {
+            String::new()
+        };
+
+        let thinking = (!thinking_parts.is_empty()).then(|| thinking_parts.join(""));
+        (content, thinking)
     }
 }
 

--- a/tui/src/app/tests/persistence.rs
+++ b/tui/src/app/tests/persistence.rs
@@ -113,3 +113,64 @@ async fn load_session_error_with_text_content_uses_text() {
     // Text content is preferred over error_message when present
     assert_eq!(error_msgs[0].content, "partial response before error");
 }
+
+#[tokio::test]
+async fn load_session_restores_assistant_thinking_blocks() {
+    let tempdir = tempdir().unwrap();
+    let store = JsonlSessionStore::new(tempdir.path().to_path_buf()).unwrap();
+
+    let thinking_msg = swink_agent::AgentMessage::Llm(swink_agent::LlmMessage::Assistant(
+        swink_agent::AssistantMessage {
+            content: vec![
+                swink_agent::ContentBlock::Thinking {
+                    thinking: "step one\nstep two".to_string(),
+                    signature: None,
+                },
+                swink_agent::ContentBlock::Text {
+                    text: "final answer".to_string(),
+                },
+            ],
+            provider: "test".to_string(),
+            model_id: "mock-model".to_string(),
+            usage: swink_agent::Usage::default(),
+            cost: swink_agent::Cost::default(),
+            stop_reason: swink_agent::StopReason::Stop,
+            error_message: None,
+            error_kind: None,
+            timestamp: 0,
+            cache_hint: None,
+        },
+    ));
+
+    let messages = vec![make_user_agent_message("hello"), thinking_msg];
+
+    let session_id = "thinking-session";
+    let now = swink_agent_memory::now_utc();
+    let meta = SessionMeta {
+        id: session_id.to_string(),
+        title: "mock-model".to_string(),
+        created_at: now,
+        updated_at: now,
+        version: 1,
+        sequence: 0,
+    };
+    store.save(session_id, &meta, &messages).unwrap();
+
+    let stream_fn = Arc::new(ScriptedStreamFn::new(vec![]));
+    let agent = make_test_agent(stream_fn);
+    let mut app = App::new(TuiConfig::default());
+    app.session_store = Some(store);
+    app.set_agent(agent);
+
+    app.load_session(session_id).unwrap();
+
+    let assistant_msg = app
+        .messages
+        .iter()
+        .find(|m| m.role == MessageRole::Assistant && m.content == "final answer")
+        .expect("assistant message should be restored");
+    assert_eq!(
+        assistant_msg.thinking.as_deref(),
+        Some("step one\nstep two")
+    );
+}


### PR DESCRIPTION
## What changed
- centralized TUI assistant display extraction so live events and session reloads rebuild the same text/thinking payload
- `load_session()` now restores assistant thinking content alongside text and error content
- added regression coverage for persisted sessions that contain assistant thinking blocks

## Why
Saved sessions were reconstructing assistant display messages from text only, so reloaded conversations dropped thinking content that the live bridge already knows how to render.

## Issue slice
This PR completes the reload-path fix for preserved assistant thinking blocks.

## Validation
- `cargo test -p swink-agent-tui load_session_ -- --nocapture`
- `cargo test -p swink-agent-tui` *(currently fails on existing unrelated baseline `editor::tests::open_editor_with_true_command_returns_none` in `tui/src/editor.rs`)*

Closes #391