### PR TITLE
[codex] Make unconfigured SubAgent return tool errors

### DIFF
--- a/src/sub_agent.rs
+++ b/src/sub_agent.rs
@@ -32,7 +32,7 @@ pub struct SubAgent {
     description: String,
     schema: Value,
     requires_approval: bool,
-    options_factory: OptionsFactoryFn,
+    options_factory: Option<OptionsFactoryFn>,
     map_result: MapResultFn,
 }
 
@@ -62,9 +62,7 @@ impl SubAgent {
                 "required": ["prompt"]
             }),
             requires_approval: false,
-            options_factory: Arc::new(|| {
-                panic!("SubAgent options_factory not configured; call with_options() or simple()")
-            }),
+            options_factory: None,
             map_result: Arc::new(default_map_result),
         }
     }
@@ -105,7 +103,7 @@ impl SubAgent {
     /// Set the factory closure that creates agent options for each execution.
     #[must_use]
     pub fn with_options(mut self, f: impl Fn() -> AgentOptions + Send + Sync + 'static) -> Self {
-        self.options_factory = Arc::new(f);
+        self.options_factory = Some(Arc::new(f));
         self
     }
 
@@ -177,9 +175,16 @@ impl AgentTool for SubAgent {
         _state: std::sync::Arc<std::sync::RwLock<crate::SessionState>>,
         _credential: Option<crate::credential::ResolvedCredential>,
     ) -> ToolFuture<'_> {
-        let options = (self.options_factory)();
+        let options_factory = self.options_factory.clone();
         let map_result = Arc::clone(&self.map_result);
         Box::pin(async move {
+            let Some(options_factory) = options_factory else {
+                return AgentToolResult::error(
+                    "Sub-agent options were not configured; call with_options() or simple().",
+                );
+            };
+
+            let options = options_factory();
             let mut agent = Agent::new(options);
             let prompt = params["prompt"].as_str().unwrap_or("").to_owned();
             let result = tokio::select! {

--- a/tests/sub_agent.rs
+++ b/tests/sub_agent.rs
@@ -106,6 +106,26 @@ async fn sub_agent_cancellation() {
 }
 
 #[tokio::test]
+async fn sub_agent_without_options_returns_tool_error() {
+    let sub = SubAgent::new("unset", "Unset", "No options configured");
+
+    let result = sub
+        .execute(
+            "call-unset",
+            json!({ "prompt": "go" }),
+            CancellationToken::new(),
+            None,
+            test_state(),
+            None,
+        )
+        .await;
+
+    assert!(result.is_error);
+    let text = ContentBlock::extract_text(&result.content);
+    assert!(text.contains("with_options()") || text.contains("simple()"));
+}
+
+#[tokio::test]
 async fn sub_agent_shares_stream_fn() {
     let stream_fn: Arc<dyn StreamFn> = Arc::new(MockStreamFn::new(vec![text_only_events(
         "shared stream works",


### PR DESCRIPTION
## Summary
- make `SubAgent::new()` leave `options_factory` unset instead of installing a panic sentinel
- return `AgentToolResult::error(...)` from `execute()` when the sub-agent was never configured with `with_options()` or `simple()`
- add a focused regression test covering the unconfigured execution path

## Why
Issue #390 covers two extension panic paths. This PR ships the smaller, reviewable first slice: misconfigured `SubAgent` instances now fail like normal tools instead of unwinding the host agent.

## Issue Slice Completed
- `SubAgent::new()` no longer creates a publicly invalid tool that panics on `execute()`

## Remaining Work
- the `#[tool]` macro still uses panic-based parameter deserialization and should be handled in a follow-up slice under #390

## Validation
- `cargo test -p swink-agent --features testkit --test sub_agent -- --nocapture`

## Related
- Advances #390