### PR TITLE
[codex] Narrow stream-assembly API

### DIFF
--- a/adapters/src/block_accumulator.rs
+++ b/adapters/src/block_accumulator.rs
@@ -1,7 +1,5 @@
 //! Re-exports the shared incremental block accumulator from the core crate.
 //!
-//! The canonical definition now lives in `swink_agent` (re-exported at crate root).
-//! This module re-exports it for backward compatibility within the adapters
-//! crate.
+//! The canonical definition now lives in `swink_agent::stream_assembly`.
 
-pub use swink_agent::BlockAccumulator;
+pub use swink_agent::stream_assembly::BlockAccumulator;

--- a/adapters/src/finalize.rs
+++ b/adapters/src/finalize.rs
@@ -1,7 +1,5 @@
 //! Re-exports shared end-of-stream block finalization from the core crate.
 //!
-//! The canonical definitions now live in `swink_agent` (re-exported at crate root).
-//! This module re-exports them for backward compatibility within the adapters
-//! crate.
+//! The canonical definitions now live in `swink_agent::stream_assembly`.
 
-pub use swink_agent::{OpenBlock, StreamFinalize, finalize_blocks};
+pub use swink_agent::stream_assembly::{OpenBlock, StreamFinalize, finalize_blocks};

--- a/local-llm/src/stream.rs
+++ b/local-llm/src/stream.rs
@@ -14,9 +14,10 @@ use tracing::{debug, error, warn};
 #[cfg(feature = "gemma4")]
 use uuid::Uuid;
 
+use swink_agent::stream_assembly::{BlockAccumulator, finalize_blocks};
 use swink_agent::{
-    AgentContext, AssistantMessageEvent, BlockAccumulator, Cost, ModelSpec, StopReason, StreamFn,
-    StreamOptions, Usage, finalize_blocks,
+    AgentContext, AssistantMessageEvent, Cost, ModelSpec, StopReason, StreamFn, StreamOptions,
+    Usage,
 };
 
 use crate::loader::LoaderState;
@@ -549,8 +550,7 @@ impl StreamState {
         if let Some(reasoning) = &choice.delta.reasoning_content
             && !reasoning.is_empty()
         {
-            self.events
-                .extend(self.blocks.ensure_thinking_open());
+            self.events.extend(self.blocks.ensure_thinking_open());
             self.events
                 .extend(self.blocks.thinking_delta(reasoning.clone()));
         }
@@ -580,10 +580,8 @@ impl StreamState {
         if let Some(think) = thinking_part
             && !think.is_empty()
         {
-            self.events
-                .extend(self.blocks.ensure_thinking_open());
-            self.events
-                .extend(self.blocks.thinking_delta(think));
+            self.events.extend(self.blocks.ensure_thinking_open());
+            self.events.extend(self.blocks.thinking_delta(think));
         }
 
         // Step 2: Pass text through Gemma 4 tool call parser or emit directly.
@@ -608,12 +606,9 @@ impl StreamState {
         if let Some(text) = final_text
             && !text.is_empty()
         {
-            self.events
-                .extend(self.blocks.close_thinking(None));
-            self.events
-                .extend(self.blocks.ensure_text_open());
-            self.events
-                .extend(self.blocks.text_delta(text));
+            self.events.extend(self.blocks.close_thinking(None));
+            self.events.extend(self.blocks.ensure_text_open());
+            self.events.extend(self.blocks.text_delta(text));
         }
     }
 
@@ -628,14 +623,15 @@ impl StreamState {
 
         let id = Uuid::new_v4().to_string();
         self.has_tool_calls = true;
-        let (tc_content_index, start_ev) =
-            self.blocks.open_tool_call(id.clone(), call.name);
+        let (tc_content_index, start_ev) = self.blocks.open_tool_call(id.clone(), call.name);
         self.active_tool_calls.push((id, tc_content_index));
         self.events.push(start_ev);
 
         if !call.args.is_empty() {
-            self.events
-                .push(BlockAccumulator::tool_call_delta(tc_content_index, call.args));
+            self.events.push(BlockAccumulator::tool_call_delta(
+                tc_content_index,
+                call.args,
+            ));
         }
         // ToolCallEnd emitted in finalize() via BlockAccumulator::drain_open_blocks.
     }
@@ -929,10 +925,11 @@ mod tests {
             other => panic!("expected Error terminal, got {other:?}"),
         }
         // Open text block must be closed before the terminal error.
-        assert!(events.iter().any(|e| matches!(
-            e,
-            AssistantMessageEvent::TextEnd { .. }
-        )));
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, AssistantMessageEvent::TextEnd { .. }))
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,10 +11,10 @@ mod agent;
 mod agent_id;
 pub(crate) mod agent_options;
 pub(crate) mod agent_subscriptions;
-pub mod atomic_fs;
 #[cfg(feature = "artifact-store")]
 pub mod artifact;
 mod async_context_transformer;
+pub mod atomic_fs;
 pub(crate) mod block_accumulator;
 mod checkpoint;
 mod config;
@@ -51,6 +51,7 @@ mod retry;
 mod schema;
 mod state;
 pub(crate) mod stream;
+pub mod stream_assembly;
 mod stream_middleware;
 mod sub_agent;
 pub(crate) mod tool;
@@ -73,7 +74,6 @@ pub use agent::{
     SubscriptionId, default_convert,
 };
 pub use agent_id::AgentId;
-pub use block_accumulator::{BlockAccumulator, OpenBlock, StreamFinalize, finalize_blocks};
 pub use async_context_transformer::{AsyncContextTransformer, AsyncTransformFuture};
 pub use checkpoint::{Checkpoint, CheckpointFuture, CheckpointStore, LoopCheckpoint};
 pub use config::{

--- a/src/stream_assembly.rs
+++ b/src/stream_assembly.rs
@@ -1,0 +1,6 @@
+//! Narrow public module for shared stream-assembly helpers.
+//!
+//! These types support adapter implementations and streaming backends, but
+//! they are not part of the crate root facade.
+
+pub use crate::block_accumulator::{BlockAccumulator, OpenBlock, StreamFinalize, finalize_blocks};

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -95,8 +95,34 @@ fn metrics_types_re_exported() {
 }
 
 #[test]
-fn block_accumulator_re_exported() {
-    let _ = std::any::type_name::<swink_agent::BlockAccumulator>();
+fn stream_assembly_types_remain_available_via_narrow_module() {
+    struct FakeState {
+        blocks: Vec<swink_agent::stream_assembly::OpenBlock>,
+    }
+
+    impl swink_agent::stream_assembly::StreamFinalize for FakeState {
+        fn drain_open_blocks(&mut self) -> Vec<swink_agent::stream_assembly::OpenBlock> {
+            std::mem::take(&mut self.blocks)
+        }
+    }
+
+    let _ = std::any::type_name::<swink_agent::stream_assembly::BlockAccumulator>();
+
+    let mut state = FakeState {
+        blocks: vec![
+            swink_agent::stream_assembly::OpenBlock::Text { content_index: 0 },
+            swink_agent::stream_assembly::OpenBlock::ToolCall { content_index: 1 },
+        ],
+    };
+    let events = swink_agent::stream_assembly::finalize_blocks(&mut state);
+
+    assert!(matches!(
+        events.as_slice(),
+        [
+            swink_agent::AssistantMessageEvent::TextEnd { content_index: 0 },
+            swink_agent::AssistantMessageEvent::ToolCallEnd { content_index: 1 }
+        ]
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## What changed
- remove the root `swink_agent::{BlockAccumulator, OpenBlock, StreamFinalize, finalize_blocks}` re-exports
- add a narrower `swink_agent::stream_assembly` module for those adapter-facing helpers
- update the adapters and local-LLM crates to consume the narrower module path
- replace the public-API root-facade assertion with a behavior-level integration test through `stream_assembly`

## Why
- stream-assembly helpers are implementation support for streaming backends, not part of the root facade
- narrowing the public surface makes future streaming refactors less semver-sensitive
- this is a breaking public API change by design

## Issue slice completed
- completes issue #396 by moving stream-assembly internals off the root facade while keeping them available through a dedicated module

## Validation
- `cargo test -p swink-agent --test public_api -- --nocapture`
- `cargo check -p swink-agent-local-llm --lib --message-format short`

## Baseline failures
- none observed in the targeted validation

Closes #396
