### PR TITLE
[codex] Make #[tool] decode errors non-panicking

### DIFF
--- a/macros/src/tool_attr.rs
+++ b/macros/src/tool_attr.rs
@@ -91,13 +91,22 @@ pub fn tool_attr_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
                     #[allow(unused_variables)]
                     let __cancel = cancellation_token;
 
+                    let __params = match __params {
+                        ::serde_json::Value::Null => {
+                            ::serde_json::Value::Object(::serde_json::Map::new())
+                        }
+                        value => value,
+                    };
+
                     // Deserialize the whole params JSON into the generated struct.
-                    let __p: #params_struct_name =
-                        ::serde_json::from_value(__params).unwrap_or_else(|_| {
-                            ::serde_json::from_value(::serde_json::Value::Object(
-                                ::serde_json::Map::new()
-                            )).unwrap_or_else(|_| panic!("failed to deserialize tool params"))
-                        });
+                    let __p: #params_struct_name = match ::serde_json::from_value(__params) {
+                        Ok(value) => value,
+                        Err(error) => {
+                            return swink_agent::AgentToolResult::error(format!(
+                                "invalid parameters: {error}"
+                            ));
+                        }
+                    };
 
                     async fn #fn_name(#(#fn_params),*) -> swink_agent::AgentToolResult #body
 

--- a/macros/tests/tool_attr_tests.rs
+++ b/macros/tests/tool_attr_tests.rs
@@ -6,6 +6,7 @@
 #![allow(dead_code)]
 
 use swink_agent::AgentTool;
+use swink_agent::ContentBlock;
 use swink_agent_macros::tool;
 
 // ── schema from a simple two-param tool ─────────────────────────────────────
@@ -93,4 +94,24 @@ fn tool_attr_cancellation_token_excluded_from_schema() {
     // The regular param is still present.
     assert_eq!(schema["properties"]["message"]["type"], "string");
     assert!(required.contains(&serde_json::json!("message")));
+}
+
+#[tokio::test]
+async fn tool_attr_invalid_params_return_tool_error() {
+    let result = GreetTool
+        .execute(
+            "call-greet",
+            serde_json::json!({}),
+            tokio_util::sync::CancellationToken::new(),
+            None,
+            std::sync::Arc::new(std::sync::RwLock::new(swink_agent::SessionState::default())),
+            None,
+        )
+        .await;
+
+    assert!(result.is_error);
+    let text = ContentBlock::extract_text(&result.content);
+    assert!(text.contains("invalid parameters:"));
+    assert!(text.contains("missing field"));
+    assert!(text.contains("name") || text.contains("times"));
 }


### PR DESCRIPTION
## Summary
- make the `#[tool]` macro-generated `execute()` path return `AgentToolResult::error(...)` on parameter decode failures instead of unwinding
- normalize `null` params to `{}` before decoding so zero/optional-param tools still behave like empty-object calls
- add a direct macro regression test proving malformed params surface a normal tool error

## Why
Issue #390 still had one remaining panic path in the `#[tool]` macro. Invalid or missing parameters could unwind inside generated code instead of reporting a structured tool failure.

## Issue Slice Completed
- replaced panic-based parameter deserialization in the `#[tool]` macro with a normal error result

## Validation
- `cargo test -p swink-agent-macros --test tool_attr_tests -- --nocapture`
- `cargo test -p swink-agent-macros`

Closes #390