### PR TITLE
docs: refresh root README workspace table

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,15 @@ A pure-Rust library for building LLM-powered agentic loops. Provider-agnostic co
 | `swink-agent-adapters` | lib | `StreamFn` adapters — Anthropic, OpenAI, Google Gemini, Ollama, Azure, xAI, Mistral, Bedrock |
 | `swink-agent-policies` | lib | 10 feature-gated policy implementations (budget, sandbox, PII, audit, etc.) |
 | `swink-agent-memory` | lib | Session persistence, summarization compaction |
-| `swink-agent-local-llm` | lib | On-device inference via SmolLM3-3B (text/tools) and EmbeddingGemma-300M (embeddings) |
+| `swink-agent-local-llm` | lib | On-device inference — SmolLM3-3B (default), Gemma 4 (opt-in `gemma4` feature), EmbeddingGemma-300M (embeddings) |
 | `swink-agent-eval` | lib | Evaluation harness — efficiency scoring, budget guards, gate checks, audit trails |
 | `swink-agent-artifacts` | lib | Versioned artifact storage (filesystem + in-memory backends) |
 | `swink-agent-auth` | lib | OAuth2 credential management and refresh |
 | `swink-agent-mcp` | lib | Model Context Protocol integration (stdio/SSE) |
 | `swink-agent-patterns` | lib | Multi-agent orchestration patterns (pipeline, parallel, loop) |
 | `swink-agent-plugin-web` | lib | Web browsing and search plugin |
-| `swink-agent-tui` | bin | Interactive terminal UI with markdown, syntax highlighting, tool panel |
+| `swink-agent-macros` | proc-macro | `#[derive(ToolSchema)]` and `#[tool]` proc macros |
+| `swink-agent-tui` | lib + bin | Interactive terminal UI with markdown, syntax highlighting, tool panel |
 
 ## Key Ideas
 


### PR DESCRIPTION
## Summary
- Refreshes the root README workspace table to match the current crate layout
- Updates the `swink-agent-local-llm` description to mention the optional `gemma4` backend
- Adds the missing `swink-agent-macros` crate and corrects `swink-agent-tui` to `lib + bin`
- Keeps this PR to the README-only slice so protected governance docs stay out of automation-managed diffs

## Test plan
- [x] Documentation-only change, no code modified
- [x] Verified the PR diff now only touches `README.md`

Ref #437