### PR TITLE
docs: add local model backends guide and audit openai_compat

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Pure-Rust library for LLM-powered agentic loops. Provider-agnostic core with plu
 - **Test-driven.** Run `cargo test --workspace` before every commit. Bug found → regression test first, then fix.
 - **Speed.** Minimize allocations on hot paths. `tokio::spawn` for concurrent tool execution, not sequential awaits.
 - **No unsafe.** `#[forbid(unsafe_code)]` at every crate root.
-- **Lessons learned go in nested CLAUDE.md files.** Update when you discover something non-obvious.
+- **Lessons learned go in nested CLAUDE.md files.** Each subcrate and key subdirectory has its own `CLAUDE.md` (e.g., `adapters/CLAUDE.md`, `local-llm/CLAUDE.md`, `tui/src/ui/CLAUDE.md`). Update when you discover something non-obvious.
 - **Context7 first.** When researching any crate API, dependency docs, or library usage, always query the context7 MCP server before falling back to web search or training data. Training data may be stale; context7 pulls current docs.
 - **No parallel builds in agents.** Never have multiple subagents run `cargo build`/`test`/`clippy` concurrently — Cargo's global lock serializes them anyway, causing extended build times. Run all compilation in the main conversation first; subagents should only read and analyze code.
 - **Check specs and docs first.** Before making large changes, read the relevant spec files in `specs/NNN-*/` (spec.md, plan.md, tasks.md) and architecture docs in `docs/` (HLD, subsystem READMEs, planning docs). The project uses spec-driven development — changes should align with the agreed design.
@@ -191,7 +191,7 @@ MSRV **1.88** (edition 2024). Common workspace deps are centralized in root `Car
 - N/A (in-memory by default; `CheckpointStore` trait abstracts persistence) (010-loop-policies-observability)
 - Rust 1.88 (edition 2024) + `serde`, `serde_json`, `tokio` (fs), `chrono` (timestamps), `tracing` (warning on corrupted lines) (021-memory-crate)
 - Local filesystem via JSONL files (one file per session) (021-memory-crate)
-- Rust 1.88 (edition 2024) + `mistralrs` (0.7, GGUF inference engine), `hf-hub` (HuggingFace model download with ETag/SHA verification), `tokio`, `tokio-stream`, `futures`, `serde`/`serde_json`, `thiserror`, `tracing`, `uuid` (022-local-llm-crate)
+- Rust 1.88 (edition 2024) + `mistralrs` (0.8, GGUF inference engine), `hf-hub` (HuggingFace model download with ETag/SHA verification), `tokio`, `tokio-stream`, `futures`, `serde`/`serde_json`, `thiserror`, `tracing`, `uuid` (022-local-llm-crate)
 - Model weights cached in `~/.cache/huggingface/hub/` (managed by `hf-hub`) (022-local-llm-crate)
 - Rust 1.88, edition 2024 + ratatui 0.30 (terminal UI framework), crossterm 0.29 (terminal control, event-stream feature), tokio (async runtime), toml 0.8 (config parsing), dirs 6 (platform-native config/data dirs), keyring 3 (OS keychain), thiserror (error types), tracing + tracing-subscriber + tracing-appender (file-based logging) (025-tui-scaffold-config)
 - TOML config file at `dirs::config_dir()/swink-agent/tui.toml`; OS keychain for credentials (macOS Keychain, Windows Credential Manager, Linux secret-service) (025-tui-scaffold-config)
@@ -207,7 +207,7 @@ MSRV **1.88** (edition 2024). Common workspace deps are centralized in root `Car
 - Rust 1.88 (edition 2024) + `swink-agent` (core types — policy traits, message types, verdict enums), `regex` (pattern matching for injection/PII/content), `chrono` (timestamps for audit records), `serde`/`serde_json` (audit record serialization), `tracing` (error logging in audit sink) (032-policy-recipes-crate)
 - Local filesystem via JSONL (AuditLogger's `JsonlAuditSink` only) (032-policy-recipes-crate)
 - Rust 1.88 (edition 2024) + `swink-agent` (core), `reqwest`, `futures`, `serde`, `serde_json`, `tokio`, `tokio-util`, `tracing` (015-adapter-gemini)
-- Rust 1.88 (edition 2024) + Common workspace deps centralized in root Cargo.toml. Key deps for this feature: `mistralrs` 0.7 (backend features), `eventsource-stream` 0.2 (proxy-only), `sha2` (bedrock-only). (033-workspace-feature-gates)
+- Rust 1.88 (edition 2024) + Common workspace deps centralized in root Cargo.toml. Key deps for this feature: `mistralrs` 0.8 (backend features), `eventsource-stream` 0.2 (proxy-only), `sha2` (bedrock-only). (033-workspace-feature-gates)
 - Rust 1.88 (edition 2024) + `swink-agent` (core), `reqwest`, `futures`, `serde`/`serde_json`, `tokio`, `tokio-util`, `tracing`, `rand` (ID generation) (018-adapter-mistral)
 - Rust 1.88 (edition 2024) + serde, serde_json, tokio, std::sync::RwLock (no new external deps) (034-session-state-store)
 - JSONL via swink-agent-memory crate (extends existing SessionStore) (034-session-state-store)

--- a/README.md
+++ b/README.md
@@ -14,14 +14,15 @@ A pure-Rust library for building LLM-powered agentic loops. Provider-agnostic co
 | `swink-agent-adapters` | lib | `StreamFn` adapters — Anthropic, OpenAI, Google Gemini, Ollama, Azure, xAI, Mistral, Bedrock |
 | `swink-agent-policies` | lib | 10 feature-gated policy implementations (budget, sandbox, PII, audit, etc.) |
 | `swink-agent-memory` | lib | Session persistence, summarization compaction |
-| `swink-agent-local-llm` | lib | On-device inference via SmolLM3-3B (text/tools) and EmbeddingGemma-300M (embeddings) |
+| `swink-agent-local-llm` | lib | On-device inference — SmolLM3-3B (default), Gemma 4 (opt-in `gemma4` feature), EmbeddingGemma-300M (embeddings) |
 | `swink-agent-eval` | lib | Evaluation harness — efficiency scoring, budget guards, gate checks, audit trails |
 | `swink-agent-artifacts` | lib | Versioned artifact storage (filesystem + in-memory backends) |
 | `swink-agent-auth` | lib | OAuth2 credential management and refresh |
 | `swink-agent-mcp` | lib | Model Context Protocol integration (stdio/SSE) |
 | `swink-agent-patterns` | lib | Multi-agent orchestration patterns (pipeline, parallel, loop) |
 | `swink-agent-plugin-web` | lib | Web browsing and search plugin |
-| `swink-agent-tui` | bin | Interactive terminal UI with markdown, syntax highlighting, tool panel |
+| `swink-agent-macros` | proc-macro | `#[derive(ToolSchema)]` and `#[tool]` proc macros |
+| `swink-agent-tui` | lib + bin | Interactive terminal UI with markdown, syntax highlighting, tool panel |
 
 ## Key Ideas
 

--- a/docs/local-models.md
+++ b/docs/local-models.md
@@ -1,0 +1,294 @@
+# Running Local Models with Swink Agent
+
+This guide covers every supported path for running a local LLM with Swink Agent. **Gemma 4 E2B** is used as the worked example throughout, but the same patterns apply to any compatible model.
+
+## Table of Contents
+
+- [Ollama (Primary Supported Path)](#ollama-primary-supported-path)
+- [llama.cpp Server](#llamacpp-server)
+- [vLLM](#vllm)
+- [LM Studio](#lm-studio)
+- [Custom Ollama Modelfile](#custom-ollama-modelfile)
+- [Direct mistral.rs Path](#direct-mistralrs-path)
+
+---
+
+## Ollama (Primary Supported Path)
+
+Ollama is the recommended way to run local models with Swink Agent. It handles model downloading, quantization selection, and GPU offloading automatically. The model catalog ships with pre-configured Ollama presets for Gemma 4 variants.
+
+### Setup
+
+1. Install Ollama: <https://ollama.com/download>
+
+2. Pull the model:
+
+   ```bash
+   ollama pull gemma4:e2b
+   ```
+
+   Other available Gemma 4 tags: `gemma4:e4b`, `gemma4:26b`.
+
+3. Verify the server is running (default: `http://localhost:11434`):
+
+   ```bash
+   ollama list
+   ```
+
+### Usage with Swink Agent
+
+Use `OllamaStreamFn` from the adapters crate:
+
+```rust
+use swink_agent_adapters::OllamaStreamFn;
+
+let stream_fn = OllamaStreamFn::new("http://localhost:11434");
+```
+
+The Ollama adapter uses NDJSON streaming (not SSE) and requires no authentication. Gemma 4 models registered in the model catalog use these preset IDs:
+
+| Preset ID       | Ollama Tag    | Context Window | Notes          |
+|-----------------|---------------|----------------|----------------|
+| `gemma4_e2b`    | `gemma4:e2b`  | 128K tokens    | Default preset |
+| `gemma4_e4b`    | `gemma4:e4b`  | 128K tokens    |                |
+| `gemma4_26b`    | `gemma4:26b`  | 256K tokens    | Large; MoE     |
+
+Ollama handles tool calling, thinking mode, and streaming natively for Gemma 4.
+
+---
+
+## llama.cpp Server
+
+llama.cpp's built-in HTTP server exposes an OpenAI-compatible `/v1/chat/completions` endpoint, so it works with `OpenAiStreamFn`.
+
+### Setup
+
+1. Build llama.cpp with your preferred backend:
+
+   ```bash
+   git clone https://github.com/ggerganov/llama.cpp
+   cd llama.cpp
+   cmake -B build -DGGML_CUDA=ON    # or -DGGML_METAL=ON for Apple Silicon
+   cmake --build build --config Release
+   ```
+
+2. Download a GGUF quantization of Gemma 4 E2B (e.g. from HuggingFace).
+
+3. Start the server:
+
+   ```bash
+   ./build/bin/llama-server \
+     -m /path/to/gemma-4-E2B-it-Q4_K_M.gguf \
+     --port 8080 \
+     -c 8192 \
+     -ngl 99
+   ```
+
+   `-ngl 99` offloads all layers to GPU. Adjust `-c` for your available VRAM.
+
+### Usage with Swink Agent
+
+```rust
+use swink_agent_adapters::OpenAiStreamFn;
+
+// llama.cpp server requires no API key; pass an empty string
+let stream_fn = OpenAiStreamFn::new("http://localhost:8080", "");
+```
+
+Point the `ModelSpec` at whatever model name llama.cpp reports (usually the filename stem). Tool calling support depends on the llama.cpp version and model; check llama.cpp docs for `--jinja` flag requirements.
+
+---
+
+## vLLM
+
+vLLM provides an OpenAI-compatible API server with high-throughput batched inference. It works with `OpenAiStreamFn`.
+
+### Setup
+
+1. Install vLLM:
+
+   ```bash
+   pip install vllm
+   ```
+
+2. Start the server with Gemma 4 E2B:
+
+   ```bash
+   vllm serve google/gemma-4-E2B-it \
+     --port 8000 \
+     --max-model-len 8192 \
+     --enable-auto-tool-choice \
+     --tool-call-parser hermes
+   ```
+
+   `--enable-auto-tool-choice` and `--tool-call-parser` are required for tool calling support.
+
+### Usage with Swink Agent
+
+```rust
+use swink_agent_adapters::OpenAiStreamFn;
+
+// vLLM does not require authentication by default
+let stream_fn = OpenAiStreamFn::new("http://localhost:8000", "");
+```
+
+Set the `model_id` in your `ModelSpec` to `"google/gemma-4-E2B-it"` (the HuggingFace repo ID you passed to `vllm serve`).
+
+### Known Limitation: `reasoning_content` Not Parsed
+
+vLLM surfaces model thinking output via an extended OpenAI field (`delta.reasoning_content` in streaming chunks). The `openai_compat` module does **not** currently parse this field, so thinking content from vLLM will be silently dropped rather than surfaced as `ThinkingStart`/`ThinkingDelta`/`ThinkingEnd` events. See [issue #445](https://github.com/SuperSwinkAI/Swink-Agent/issues/445) for tracking. Regular text and tool call output works normally.
+
+---
+
+## LM Studio
+
+LM Studio provides a GUI for downloading and running models, with a built-in OpenAI-compatible server. It works with `OpenAiStreamFn`.
+
+### Setup
+
+1. Download LM Studio: <https://lmstudio.ai/>
+
+2. In the LM Studio UI, search for and download a Gemma 4 E2B GGUF quantization.
+
+3. Load the model and start the local server. By default it listens on `http://localhost:1234`.
+
+4. Verify the server is running:
+
+   ```bash
+   curl http://localhost:1234/v1/models
+   ```
+
+### Usage with Swink Agent
+
+```rust
+use swink_agent_adapters::OpenAiStreamFn;
+
+let stream_fn = OpenAiStreamFn::new("http://localhost:1234", "lm-studio");
+```
+
+LM Studio accepts any non-empty string as the API key. Set `model_id` in your `ModelSpec` to the model identifier shown in LM Studio's server panel (typically the filename or a short alias).
+
+Tool calling support depends on LM Studio's version and the loaded model's chat template.
+
+---
+
+## Custom Ollama Modelfile
+
+For fine-tuned weights, custom quantizations, or non-standard chat templates, you can create a custom Ollama Modelfile and register it as a local model.
+
+### Create a Modelfile
+
+```dockerfile
+FROM /path/to/your-gemma4-e2b-finetune.gguf
+
+TEMPLATE """{{ if .System }}<start_of_turn>system
+{{ .System }}<end_of_turn>
+{{ end }}{{ range .Messages }}{{ if eq .Role "user" }}<start_of_turn>user
+{{ .Content }}<end_of_turn>
+{{ else if eq .Role "assistant" }}<start_of_turn>model
+{{ .Content }}<end_of_turn>
+{{ end }}{{ end }}<start_of_turn>model
+"""
+
+PARAMETER stop "<end_of_turn>"
+PARAMETER num_ctx 8192
+PARAMETER temperature 0.7
+```
+
+### Register and run
+
+```bash
+ollama create my-gemma4-finetune -f Modelfile
+ollama run my-gemma4-finetune "Hello"
+```
+
+### Usage with Swink Agent
+
+Use `OllamaStreamFn` with the custom model name:
+
+```rust
+use swink_agent_adapters::OllamaStreamFn;
+
+let stream_fn = OllamaStreamFn::new("http://localhost:11434");
+// Set model_id to "my-gemma4-finetune" in your ModelSpec
+```
+
+This approach is useful when you need to:
+- Run a fine-tuned checkpoint not available in the Ollama library
+- Override the default chat template or system prompt
+- Set specific parameter defaults (temperature, top_k, num_ctx)
+
+---
+
+## Direct mistral.rs Path
+
+The `swink-agent-local-llm` crate provides direct in-process inference via the mistral.rs engine. This eliminates the need for an external server process but requires compiling mistral.rs into your binary.
+
+### When to use this
+
+- You want a single self-contained binary with no external server dependency
+- You need programmatic control over model loading, progress callbacks, and state transitions
+- You are building an embedded or offline application
+
+### Available backends
+
+Enable GPU acceleration via Cargo feature flags on `swink-agent-local-llm`:
+
+| Feature      | Backend        | Platform          |
+|--------------|----------------|-------------------|
+| _(none)_     | CPU-only       | All               |
+| `metal`      | Apple Metal    | macOS (Apple Silicon) |
+| `cuda`       | NVIDIA CUDA    | Linux, Windows    |
+| `cudnn`      | NVIDIA cuDNN   | Linux, Windows    |
+| `flash-attn` | Flash Attention| Linux (NVIDIA)    |
+| `mkl`        | Intel MKL      | Linux, Windows    |
+| `accelerate` | Apple Accelerate| macOS             |
+
+**Important:** Gemma 4 E2B requires GPU acceleration. CPU-only inference will hang silently on non-trivial prompts. Enable the `gemma4` feature alongside a GPU backend:
+
+```toml
+[dependencies]
+swink-agent-local-llm = { path = "../local-llm", features = ["gemma4", "metal"] }
+```
+
+### Usage
+
+```rust
+use swink_agent_local_llm::{LocalModel, LocalStreamFn, ModelPreset};
+
+// Create a model from a preset (downloads ~5 GB on first run)
+let model = LocalModel::from_preset(ModelPreset::Gemma4E2B);
+
+// Optional: track download and loading progress
+let model = model.with_progress(|event| {
+    println!("{event:?}");
+})?;
+
+// Ensure the model is downloaded and loaded
+model.ensure_ready().await?;
+
+// Create a StreamFn for use with the agent loop
+let stream_fn = LocalStreamFn::new(model);
+```
+
+Models are cached in `~/.cache/huggingface/hub/` and reused across runs. The `ModelState` lifecycle is: `Unloaded -> Downloading -> Loading -> Ready` (or `Failed`).
+
+### Available presets
+
+| Preset             | Model              | Size    | Context | Feature Gate |
+|--------------------|--------------------|---------|---------|-------------|
+| `SmolLM3_3B`      | SmolLM3-3B (GGUF)  | ~1.9 GB | 8K      | _(none)_    |
+| `Gemma4E2B`       | Gemma 4 E2B        | ~5 GB   | 128K    | `gemma4`    |
+| `Gemma4E4B`       | Gemma 4 E4B        | ~5.5 GB | 128K    | `gemma4`    |
+| `Gemma4_26B`      | Gemma 4 26B MoE    | ~16 GB  | 256K    | `gemma4`    |
+| `Gemma4_31B`      | Gemma 4 31B Dense  | ~20 GB  | 256K    | `gemma4`    |
+
+### Build notes
+
+On macOS with Metal, you may need Apple's Metal Toolchain installed:
+
+```bash
+xcodebuild -downloadComponent MetalToolchain
+```
+
+On Windows with CUDA, you must have the MSVC C++ compiler (`cl.exe`) in `PATH`. Build from a Visual Studio 2022 Developer Command Prompt.


### PR DESCRIPTION
## Summary
- Creates `docs/local-models.md` covering all 6 local model backend paths (Ollama, llama.cpp, vLLM, LM Studio, custom Modelfile, direct mistral.rs)
- Audits `openai_compat.rs` for vLLM `reasoning_content` handling — **not currently parsed**, filed follow-up as #445
- Uses Gemma 4 E2B as the primary worked example throughout

## Test plan
- [x] Documentation verified against current source code and manifests
- [x] openai_compat.rs audited for reasoning_content field handling
- [x] All backend instructions verified against adapter implementations
- [x] Documentation-only change (plus follow-up issue #445 for the code gap)

Closes #404
🤖 Generated with [Claude Code](https://claude.com/claude-code)