### PR TITLE
fix: make SAFETY finish reason terminal in Gemini parser

### DIFF
--- a/adapters/src/google.rs
+++ b/adapters/src/google.rs
@@ -206,6 +206,10 @@ struct GeminiStreamState {
     saw_tool_call: bool,
     usage: Usage,
     stop_reason: Option<StopReason>,
+    /// Set to `true` when a terminal error (e.g. SAFETY finish reason) has
+    /// already been emitted, so the later `[DONE]` sentinel does not produce
+    /// a duplicate terminal event.
+    terminated: bool,
 }
 
 pub struct GeminiStreamFn {
@@ -563,6 +567,11 @@ fn parse_sse_stream(
         "Google request cancelled",
         |item, state| match item {
             None => {
+                // If we already emitted a terminal event (e.g. SAFETY error),
+                // don't produce a second one.
+                if state.terminated {
+                    return SseAction::Done(Vec::new());
+                }
                 let mut events = state.emit_final_tool_deltas();
                 events.extend(crate::finalize::finalize_blocks(state));
                 if state.stop_reason.is_none() {
@@ -579,6 +588,11 @@ fn parse_sse_stream(
                 SseAction::Done(events)
             }
             Some(SseLine::Done) => {
+                // If we already emitted a terminal event (e.g. SAFETY error),
+                // don't produce a second one.
+                if state.terminated {
+                    return SseAction::Done(Vec::new());
+                }
                 let mut events = state.emit_final_tool_deltas();
                 events.extend(crate::finalize::finalize_blocks(state));
                 events.push(AssistantMessageEvent::Done {
@@ -595,11 +609,19 @@ fn parse_sse_stream(
                 SseAction::Done(events)
             }
             Some(SseLine::Data(line)) => {
+                // If we already emitted a terminal event, skip further data.
+                if state.terminated {
+                    return SseAction::Done(Vec::new());
+                }
                 let mut events = Vec::new();
                 match serde_json::from_str::<GeminiChunk>(&line) {
                     Ok(chunk) => {
                         process_chunk(chunk, state, &mut events);
-                        SseAction::Continue(events)
+                        if state.terminated {
+                            SseAction::Done(events)
+                        } else {
+                            SseAction::Continue(events)
+                        }
                     }
                     Err(parse_error) => {
                         error!(error = %parse_error, "Google Gemini JSON parse error");
@@ -684,11 +706,14 @@ fn process_chunk(
     if let Some(ref finish_reason) = candidate.finish_reason {
         if finish_reason == "SAFETY" {
             warn!("Google Gemini response blocked by safety filter");
+            events.extend(state.emit_final_tool_deltas());
             events.extend(state.blocks.close_text());
             events.extend(state.blocks.close_thinking(None));
+            events.extend(crate::finalize::finalize_blocks(state));
             events.push(AssistantMessageEvent::error_content_filtered(
                 "Google Gemini: response blocked by safety filter",
             ));
+            state.terminated = true;
         } else {
             state.stop_reason = Some(map_finish_reason(finish_reason, state.saw_tool_call));
         }

--- a/adapters/tests/google.rs
+++ b/adapters/tests/google.rs
@@ -412,6 +412,53 @@ async fn google_safety_finish_reason_emits_error() {
     );
 }
 
+// T035: SAFETY finish reason is terminal — no Done event after the error (#428)
+#[tokio::test]
+async fn google_safety_finish_reason_is_terminal_no_done_after_error() {
+    let body = [
+        r#"data: {"candidates":[{"content":{"parts":[{"text":"partial"}]},"finishReason":"SAFETY"}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":1,"totalTokenCount":6}}"#,
+        "",
+        "data: [DONE]",
+        "",
+    ]
+    .join("\n");
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path(
+            "/v1beta/models/gemini-3-flash-preview:streamGenerateContent",
+        ))
+        .and(query_param("alt", "sse"))
+        .respond_with(sse_response(&body))
+        .mount(&server)
+        .await;
+
+    let stream_fn = GeminiStreamFn::new(server.uri(), "test-key", ApiVersion::V1beta);
+    let events = collect_events(&stream_fn).await;
+
+    let types: Vec<_> = events.iter().map(event_name).collect();
+
+    // Must contain exactly one terminal event: the Error from SAFETY.
+    assert!(
+        types.contains(&"Error"),
+        "expected Error event for SAFETY finish reason: {types:?}"
+    );
+    assert!(
+        !types.contains(&"Done"),
+        "SAFETY must be terminal — no Done event should follow the Error: {types:?}"
+    );
+
+    // Count terminal events (Error + Done). Must be exactly 1.
+    let terminal_count = types
+        .iter()
+        .filter(|t| **t == "Error" || **t == "Done")
+        .count();
+    assert_eq!(
+        terminal_count, 1,
+        "expected exactly 1 terminal event, got {terminal_count}: {types:?}"
+    );
+}
+
 // ── BlockAccumulator regression tests ─────────────────────────────────────────
 //
 // These tests verify the content-index ordering contract introduced when


### PR DESCRIPTION
## Summary
- The `SAFETY` finish reason now terminates the Gemini stream parser
- Prevents duplicate terminal events (Error + Done) that violate the stream accumulator contract
- Added `terminated` flag to `GeminiStreamState` so `[DONE]` sentinel and EOF are skipped after a SAFETY error

## Test plan
- [x] cargo test --workspace passes
- [x] cargo clippy --workspace -- -D warnings clean (pre-existing failures in unrelated crates)
- [x] Regression test `google_safety_finish_reason_is_terminal_no_done_after_error` verifies no Done event follows SAFETY error
- [x] No public API breakage

Closes #428

🤖 Generated with [Claude Code](https://claude.com/claude-code)