### PR TITLE
fix: make content_filter finish reason terminal in OpenAI-compat parser

### DIFF
--- a/adapters/tests/azure.rs
+++ b/adapters/tests/azure.rs
@@ -900,6 +900,21 @@ async fn sse_content_filter_finish_reason() {
         }
         _ => unreachable!(),
     }
+
+    // No Done event should follow — the Error is the sole terminal event (#427)
+    let terminal_count = events
+        .iter()
+        .filter(|e| {
+            matches!(
+                e,
+                AssistantMessageEvent::Done { .. } | AssistantMessageEvent::Error { .. }
+            )
+        })
+        .count();
+    assert_eq!(
+        terminal_count, 1,
+        "exactly one terminal event expected, got {terminal_count}"
+    );
 }
 
 // ── T045: HTTP error body with ContentFilterBlocked → ContentFiltered ──────

--- a/adapters/tests/openai.rs
+++ b/adapters/tests/openai.rs
@@ -689,6 +689,21 @@ async fn openai_content_filter_is_terminal_error() {
             .any(|e| matches!(e, AssistantMessageEvent::Done { .. })),
         "content_filter should stop the stream without a trailing Done: {events:?}"
     );
+
+    // Exactly one terminal event total
+    let terminal_count = events
+        .iter()
+        .filter(|e| {
+            matches!(
+                e,
+                AssistantMessageEvent::Done { .. } | AssistantMessageEvent::Error { .. }
+            )
+        })
+        .count();
+    assert_eq!(
+        terminal_count, 1,
+        "exactly one terminal event expected, got {terminal_count}"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- The `content_filter` finish reason now terminates the SSE state machine by storing the error in `state.terminal_error` (matching the existing Mistral `error` pattern)
- Prevents duplicate terminal events (Error + Done) that violate the stream accumulator contract
- Affects all OpenAI-compatible adapters (OpenAI, Azure, Mistral, xAI)

## Test plan
- [x] cargo test --workspace passes
- [x] cargo clippy -p swink-agent-adapters -- -D warnings clean
- [x] Updated regression test for content_filter terminal behavior (openai.rs)
- [x] Added terminal-count assertion to Azure content_filter test
- [x] No public API breakage

Closes #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)