### PR TITLE
fix: normalize trailing slashes in HTTP adapter base URLs

### DIFF
--- a/adapters/src/anthropic.rs
+++ b/adapters/src/anthropic.rs
@@ -1267,4 +1267,16 @@ mod tests {
             }
         ));
     }
+
+    #[test]
+    fn trailing_slash_stripped() {
+        let anthropic = AnthropicStreamFn::new("https://api.anthropic.com/", "key");
+        assert_eq!(anthropic.base.base_url, "https://api.anthropic.com");
+    }
+
+    #[test]
+    fn no_trailing_slash_unchanged() {
+        let anthropic = AnthropicStreamFn::new("https://api.anthropic.com", "key");
+        assert_eq!(anthropic.base.base_url, "https://api.anthropic.com");
+    }
 }

--- a/adapters/src/base.rs
+++ b/adapters/src/base.rs
@@ -39,10 +39,33 @@ pub struct AdapterBase {
 impl AdapterBase {
     pub fn new(base_url: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
-            base_url: base_url.into(),
+            base_url: base_url.into().trim_end_matches('/').to_string(),
             api_key: api_key.into(),
             client: reqwest::Client::new(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trailing_slash_stripped() {
+        let base = AdapterBase::new("https://api.example.com/", "key");
+        assert_eq!(base.base_url, "https://api.example.com");
+    }
+
+    #[test]
+    fn multiple_trailing_slashes_stripped() {
+        let base = AdapterBase::new("https://api.example.com///", "key");
+        assert_eq!(base.base_url, "https://api.example.com");
+    }
+
+    #[test]
+    fn no_trailing_slash_unchanged() {
+        let base = AdapterBase::new("https://api.example.com", "key");
+        assert_eq!(base.base_url, "https://api.example.com");
     }
 }
 

--- a/adapters/src/ollama.rs
+++ b/adapters/src/ollama.rs
@@ -143,7 +143,7 @@ impl OllamaStreamFn {
     #[must_use]
     pub fn new(base_url: impl Into<String>) -> Self {
         Self {
-            base_url: base_url.into(),
+            base_url: base_url.into().trim_end_matches('/').to_string(),
             client: Client::new(),
         }
     }
@@ -611,6 +611,20 @@ mod tests {
         AgentMessage, AssistantMessage as HarnessAssistantMessage, ContentBlock, Cost, LlmMessage,
         StopReason, ToolResultMessage, Usage, UserMessage,
     };
+
+    // ─── trailing slash normalization ────────────────────────────────────
+
+    #[test]
+    fn trailing_slash_stripped() {
+        let ollama = OllamaStreamFn::new("http://localhost:11434/");
+        assert_eq!(ollama.base_url, "http://localhost:11434");
+    }
+
+    #[test]
+    fn no_trailing_slash_unchanged() {
+        let ollama = OllamaStreamFn::new("http://localhost:11434");
+        assert_eq!(ollama.base_url, "http://localhost:11434");
+    }
 
     // ─── convert_messages: user + system ────────────────────────────────
 

--- a/adapters/src/openai.rs
+++ b/adapters/src/openai.rs
@@ -85,3 +85,20 @@ const _: () = {
     const fn assert_send_sync<T: Send + Sync>() {}
     assert_send_sync::<OpenAiStreamFn>();
 };
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trailing_slash_stripped() {
+        let oai = OpenAiStreamFn::new("https://api.openai.com/", "key");
+        assert_eq!(oai.base.base_url, "https://api.openai.com");
+    }
+
+    #[test]
+    fn no_trailing_slash_unchanged() {
+        let oai = OpenAiStreamFn::new("https://api.openai.com", "key");
+        assert_eq!(oai.base.base_url, "https://api.openai.com");
+    }
+}

--- a/adapters/src/proxy.rs
+++ b/adapters/src/proxy.rs
@@ -119,7 +119,7 @@ impl ProxyStreamFn {
     #[must_use]
     pub fn new(base_url: impl Into<String>, bearer_token: impl Into<String>) -> Self {
         Self {
-            base_url: base_url.into(),
+            base_url: base_url.into().trim_end_matches('/').to_string(),
             bearer_token: bearer_token.into(),
             client: Client::new(),
         }
@@ -419,6 +419,20 @@ const _: () = {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ─── trailing slash normalization ────────────────────────────────────
+
+    #[test]
+    fn trailing_slash_stripped() {
+        let proxy = ProxyStreamFn::new("http://localhost:8080/", "token");
+        assert_eq!(proxy.base_url, "http://localhost:8080");
+    }
+
+    #[test]
+    fn no_trailing_slash_unchanged() {
+        let proxy = ProxyStreamFn::new("http://localhost:8080", "token");
+        assert_eq!(proxy.base_url, "http://localhost:8080");
+    }
 
     #[test]
     fn parse_start_event() {


### PR DESCRIPTION
## Summary
- Normalizes trailing slashes in adapter base URLs so all adapters behave consistently
- Prevents double-slash paths when callers include a trailing `/` in base URL config
- OpenAI, Anthropic, Ollama, and Proxy adapters now match Azure/Mistral/Gemini behavior

## Test plan
- [x] cargo test --workspace passes
- [x] cargo clippy --workspace -- -D warnings clean
- [x] Regression tests for trailing-slash normalization
- [x] No public API breakage

Closes #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)