### PR TITLE
[codex] Harden malformed <think> chunk parsing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,7 @@ MSRV **1.88** (edition 2024). Common workspace deps are centralized in root `Car
 ### Local LLM Streaming (`local-llm/src/stream.rs`)
 
 - Gemma 4 delimiter scanners must only slice `&str` at UTF-8 character boundaries. For partial `<|channel>thought\n` and `<tool_call|>` matches, use the shared UTF-8-safe suffix helper instead of raw byte-offset suffix slicing.
+- `extract_thinking_delta` must search for `</think>` only after the matching `<think>` opener. Stray closing tags can appear earlier in a chunk; treating the first closing tag globally can panic on an invalid slice.
 
 ### Test Infrastructure (`src/testing.rs`)
 

--- a/local-llm/src/stream.rs
+++ b/local-llm/src/stream.rs
@@ -834,23 +834,25 @@ fn extract_thinking_delta(content: &str) -> (Option<String>, String) {
     let think_start = "<think>";
     let think_end = "</think>";
 
-    if let Some(start_idx) = content.find(think_start)
-        && let Some(end_idx) = content.find(think_end)
-    {
-        let thinking = content[start_idx + think_start.len()..end_idx]
+    if let Some(start_idx) = content.find(think_start) {
+        let search_start = start_idx + think_start.len();
+        if let Some(relative_end_idx) = content[search_start..].find(think_end) {
+            let end_idx = search_start + relative_end_idx;
+            let thinking = content[search_start..end_idx]
             .trim()
             .to_string();
-        let before = &content[..start_idx];
-        let after = &content[end_idx + think_end.len()..];
-        let text = format!("{before}{after}").trim().to_string();
-        return (
-            if thinking.is_empty() {
-                None
-            } else {
-                Some(thinking)
-            },
-            text,
-        );
+            let before = &content[..start_idx];
+            let after = &content[end_idx + think_end.len()..];
+            let text = format!("{before}{after}").trim().to_string();
+            return (
+                if thinking.is_empty() {
+                    None
+                } else {
+                    Some(thinking)
+                },
+                text,
+            );
+        }
     }
 
     (None, content.to_string())
@@ -904,6 +906,22 @@ mod tests {
         let (thinking, text) = extract_thinking_delta(input);
         assert!(thinking.is_none());
         assert_eq!(text, "<think>unclosed thinking");
+    }
+
+    #[test]
+    fn extract_thinking_ignores_closing_tag_before_opening_tag() {
+        let input = "</think> stray <think>later";
+        let (thinking, text) = extract_thinking_delta(input);
+        assert!(thinking.is_none());
+        assert_eq!(text, "</think> stray <think>later");
+    }
+
+    #[test]
+    fn extract_thinking_finds_closing_tag_after_opening_tag() {
+        let input = "</think> stray <think>later</think>";
+        let (thinking, text) = extract_thinking_delta(input);
+        assert_eq!(thinking.as_deref(), Some("later"));
+        assert_eq!(text, "</think> stray");
     }
 
     #[test]


### PR DESCRIPTION
## What changed and why
This hardens the local `<think>...</think>` streaming parser against malformed chunk ordering. `extract_thinking_delta()` now searches for `</think>` only after the matching `<think>` opener, so stray closing tags earlier in the chunk no longer produce an invalid slice and panic the stream task.

## Slice completed
Completed the parser-safety slice for malformed `<think>` chunks in `swink-agent-local-llm`, including focused regression coverage for both the exact malformed-order case and a chunk that contains a stray earlier closer plus a valid later pair.

## What remains
No known follow-up remains for issue #433 beyond normal review.

## Validation output
- `cargo test -p swink-agent-local-llm extract_thinking --lib` ✅
- `cargo test -p swink-agent-local-llm --lib` ✅

## Pre-existing baseline failures
- `cargo clippy -p swink-agent-local-llm --lib --tests -- -D warnings` fails on existing unrelated workspace/package lint debt:
  - `src/agent.rs:211` (`clippy::too_many_lines` in `swink-agent`)
  - `src/testing.rs:164` (`clippy::collapsible_if` in `swink-agent`)
  - `local-llm/src/convert.rs:169` (`clippy::doc_markdown`)
  - `local-llm/tests/common/mod.rs:41` (`dead_code` in `local_live` test support)

Closes #433