### PR TITLE
[codex] Narrow swink-agent-tui public API surface

### DIFF
--- a/tui/src/app/mod.rs
+++ b/tui/src/app/mod.rs
@@ -7,18 +7,16 @@ mod persistence;
 mod render_helpers;
 mod state;
 
-pub use state::{
-    AgentStatus, App, DisplayMessage, Focus, MessageRole, OperatingMode, TrustFollowUp,
-};
+pub use state::{AgentStatus, App, DisplayMessage, Focus, MessageRole, OperatingMode};
 
-pub(crate) type AppResult<T> = Result<T, Box<dyn std::error::Error>>;
+type AppResult<T> = Result<T, Box<dyn std::error::Error>>;
 
 /// Seconds before a tool result auto-collapses (unless user-expanded).
-pub(crate) const AUTO_COLLAPSE_SECS: u64 = 10;
+const AUTO_COLLAPSE_SECS: u64 = 10;
 /// Mouse wheel scroll distance in rendered lines.
-pub(crate) const MOUSE_SCROLL_STEP: usize = 3;
+const MOUSE_SCROLL_STEP: usize = 3;
 /// Maximum number of visible turns retained in the TUI display model.
-pub(crate) const MAX_VISIBLE_TURNS: usize = 20;
+const MAX_VISIBLE_TURNS: usize = 20;
 
 #[cfg(test)]
 mod tests;

--- a/tui/src/app/tests/approval.rs
+++ b/tui/src/app/tests/approval.rs
@@ -9,6 +9,7 @@ use swink_agent::{AgentTool, ApprovalMode, ToolApproval, ToolApprovalRequest};
 use crate::config::TuiConfig;
 
 use super::super::*;
+use super::super::state::TrustFollowUp;
 use super::helpers::*;
 
 #[tokio::test]

--- a/tui/src/lib.rs
+++ b/tui/src/lib.rs
@@ -3,6 +3,17 @@
 //!
 //! Re-exports the types and helpers needed to embed the interactive TUI
 //! in your own binary or example.
+//!
+//! The supported public API is exposed from the crate root. Internal
+//! implementation modules stay private so they do not become stable surface.
+//!
+//! ```rust
+//! use swink_agent_tui::{App, TuiConfig, TuiError};
+//! ```
+//!
+//! ```compile_fail
+//! use swink_agent_tui::app::Focus;
+//! ```
 
 mod commands;
 mod editor;
@@ -11,9 +22,9 @@ mod session;
 mod theme;
 mod ui;
 
-pub mod app;
-pub mod config;
-pub mod error;
+mod app;
+mod config;
+mod error;
 
 #[cfg(feature = "cli")]
 pub mod credentials;
@@ -39,8 +50,9 @@ use tokio::sync::{mpsc, oneshot};
 
 use swink_agent::{Agent, ToolApproval, ToolApprovalRequest, selective_approve};
 
-pub use app::App;
+pub use app::{AgentStatus, App, DisplayMessage, MessageRole, OperatingMode};
 pub use config::TuiConfig;
+pub use error::TuiError;
 pub use session::JsonlSessionStore;
 pub use ui::conversation::ConversationView;
 pub use ui::input::InputEditor;

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -13,10 +13,11 @@ use swink_agent_adapters::{
 };
 
 use swink_agent_tui::{
-    TuiConfig, credentials, launch, resolve_system_prompt, restore_terminal, setup_terminal, wizard,
+    TuiConfig, TuiError, credentials, launch, resolve_system_prompt, restore_terminal,
+    setup_terminal, wizard,
 };
 
-type AppResult<T> = Result<T, swink_agent_tui::error::TuiError>;
+type AppResult<T> = Result<T, TuiError>;
 
 fn main() -> AppResult<()> {
     if !std::io::stdout().is_terminal() {
@@ -76,7 +77,7 @@ fn run(
 
         launch(config, terminal, create_options(system_prompt))
             .await
-            .map_err(|e| swink_agent_tui::error::TuiError::Other(e.to_string().into()))
+            .map_err(|e| TuiError::Other(e.to_string().into()))
     })
 }
 

--- a/tui/tests/ac_tui.rs
+++ b/tui/tests/ac_tui.rs
@@ -3,14 +3,15 @@
 //! Tests T038–T043: role-based colors, inline diff coloring, context gauge
 //! thresholds, plan mode, and approval mode classification.
 //!
-//! Because the TUI crate keeps `theme` and `ui` modules private, these tests
-//! exercise the public API surface: `App`, `OperatingMode`, `ApprovalMode`,
-//! `MessageRole`, `AgentStatus`, `DisplayMessage`, and `TuiConfig`.
+//! Because the TUI crate keeps its implementation modules private, these tests
+//! exercise the supported crate-root API surface: `App`, `OperatingMode`,
+//! `ApprovalMode`, `MessageRole`, `AgentStatus`, `DisplayMessage`, and
+//! `TuiConfig`.
 
 use swink_agent::ApprovalMode;
-use swink_agent_tui::App;
-use swink_agent_tui::app::{AgentStatus, DisplayMessage, MessageRole, OperatingMode};
-use swink_agent_tui::config::TuiConfig;
+use swink_agent_tui::{
+    AgentStatus, App, DisplayMessage, MessageRole, OperatingMode, TuiConfig,
+};
 
 // ---------------------------------------------------------------------------
 // Regression: credentials and wizard modules are gated behind `cli` feature


### PR DESCRIPTION
## What changed and why
- made `tui`'s `app`, `config`, and `error` modules private so they stop acting as stable public namespaces
- re-exported the supported embed types from the crate root (`App`, `AgentStatus`, `DisplayMessage`, `MessageRole`, `OperatingMode`, `TuiConfig`, `TuiError`)
- updated the TUI binary and integration tests to consume the root API, and added `lib.rs` doctests that prove root imports compile while `swink_agent_tui::app::Focus` no longer does
- kept internal `app` helpers available only inside the crate and adjusted the approval unit tests to import `TrustFollowUp` from internal state directly

## Slice completed; what remains
- completed the issue's public-surface slice by removing the unintended `app`/`config`/`error` module API exposure while preserving the documented crate-root embed API
- no known follow-up remains for issue #211 after this change

## Validation output
- `cargo clippy -p swink-agent-tui --no-deps -- -D warnings` ✅
- `cargo test -p swink-agent-tui --test ac_tui` ✅
- `cargo test -p swink-agent-tui --doc` ✅
- `cargo test --workspace` ❌ pre-existing failure in `swink-agent` test `approval_events_in_correct_order`

## Pre-existing baseline failures
- `cargo test --workspace` currently fails in `tests/approval.rs::approval_events_in_correct_order` because the test still expects `ToolExecutionStart` before the approval events, while current behavior is `ToolApprovalRequested -> ToolApprovalResolved -> ToolExecutionStart -> ToolExecutionEnd`
- earlier targeted `cargo test -p swink-agent-tui` also reproduced the existing unrelated `editor::tests::open_editor_with_true_command_returns_none` failure in `tui/src/editor.rs`

Closes #211