### PR TITLE
[codex] Fix workspace clippy gate

### DIFF
--- a/plugins/web/src/plugin.rs
+++ b/plugins/web/src/plugin.rs
@@ -219,7 +219,7 @@ impl Plugin for WebPlugin {
 /// Extracted from [`WebPlugin::on_event`] so the namespace-gating logic can be
 /// exercised directly by unit tests without depending on a tracing subscriber.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum WebEventClass<'a> {
+enum WebEventClass<'a> {
     /// A `web.*` tool has started executing.
     Start(&'a str),
     /// A `web.*` tool has failed.
@@ -228,14 +228,16 @@ pub(crate) enum WebEventClass<'a> {
     Ignored,
 }
 
-pub(crate) fn classify_web_event(event: &AgentEvent) -> WebEventClass<'_> {
+fn classify_web_event(event: &AgentEvent) -> WebEventClass<'_> {
     match event {
         AgentEvent::ToolExecutionStart { name, .. } if name.starts_with("web.") => {
             WebEventClass::Start(name.as_str())
         }
-        AgentEvent::ToolExecutionEnd {
-            name, is_error, ..
-        } if *is_error && name.starts_with("web.") => WebEventClass::Error(name.as_str()),
+        AgentEvent::ToolExecutionEnd { name, is_error, .. }
+            if *is_error && name.starts_with("web.") =>
+        {
+            WebEventClass::Error(name.as_str())
+        }
         _ => WebEventClass::Ignored,
     }
 }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -126,6 +126,31 @@ pub fn default_convert(msg: &AgentMessage) -> Option<LlmMessage> {
     }
 }
 
+#[cfg(feature = "plugins")]
+fn dispatch_plugin_on_init(agent: &Agent) {
+    // Dispatch on_init to each plugin in priority order (already sorted).
+    // Panics are caught and logged — the plugin's other contributions
+    // (policies, tools, event observers) remain active.
+    for plugin in &agent.plugins {
+        let name = plugin.name().to_owned();
+        let plugin_ref = Arc::clone(plugin);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            plugin_ref.on_init(agent);
+        }));
+        if let Err(cause) = result {
+            let msg = cause
+                .downcast_ref::<&str>()
+                .map(|s| (*s).to_owned())
+                .or_else(|| cause.downcast_ref::<String>().cloned())
+                .unwrap_or_else(|| "unknown panic".to_owned());
+            tracing::warn!(plugin = %name, error = %msg, "plugin on_init panicked");
+        }
+    }
+}
+
+#[cfg(not(feature = "plugins"))]
+fn dispatch_plugin_on_init(_agent: &Agent) {}
+
 // ─── Agent ───────────────────────────────────────────────────────────────────
 
 /// Stateful wrapper over the agent loop.
@@ -300,27 +325,7 @@ impl Agent {
             plugins: options.plugins,
         };
 
-        // Dispatch on_init to each plugin in priority order (already sorted).
-        // Panics are caught and logged — the plugin's other contributions
-        // (policies, tools, event observers) remain active.
-        #[cfg(feature = "plugins")]
-        {
-            for plugin in &agent.plugins {
-                let name = plugin.name().to_owned();
-                let plugin_ref = Arc::clone(plugin);
-                let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                    plugin_ref.on_init(&agent);
-                }));
-                if let Err(cause) = result {
-                    let msg = cause
-                        .downcast_ref::<&str>()
-                        .map(|s| (*s).to_owned())
-                        .or_else(|| cause.downcast_ref::<String>().cloned())
-                        .unwrap_or_else(|| "unknown panic".to_owned());
-                    tracing::warn!(plugin = %name, error = %msg, "plugin on_init panicked");
-                }
-            }
-        }
+        dispatch_plugin_on_init(&agent);
 
         agent
     }


### PR DESCRIPTION
## What changed
- extracted plugin `on_init` dispatch out of `Agent::new` so the constructor stays under Clippy's `too_many_lines` threshold without changing runtime behavior
- removed redundant `pub(crate)` visibility from web-plugin event classification helpers inside the private `plugin` module

## Why
The documented zero-warning workspace policy was blocked by live Clippy failures on `main`. This restores `cargo clippy --workspace -- -D warnings` to green on the current tree.

## Slice completed
This PR completes the current workspace Clippy gate repair for issue #435.

## What remains
- unrelated test baseline failure in `tests/approval.rs::approval_events_in_correct_order`
- unrelated test warnings in `local-llm/tests/common/mod.rs:41`, `tests/approval.rs:540`, and `tests/approval.rs:569`

## Validation
- `cargo clippy --workspace -- -D warnings` ✅
- `cargo test --workspace` ❌ pre-existing failure in `tests/approval.rs::approval_events_in_correct_order`

Closes #435