### PR TITLE
[codex] Fix current clippy backlog slice

### DIFF
--- a/adapters/src/base.rs
+++ b/adapters/src/base.rs
@@ -30,6 +30,7 @@
 /// that exceeds the boilerplate it removes. HTTP status classification
 /// (the truly duplicated logic) is handled by
 /// [`classify::error_event_from_status`](crate::classify::error_event_from_status).
+#[allow(dead_code)]
 pub struct AdapterBase {
     pub base_url: String,
     pub api_key: String,
@@ -37,6 +38,7 @@ pub struct AdapterBase {
 }
 
 impl AdapterBase {
+    #[allow(dead_code)]
     pub fn new(base_url: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             base_url: base_url.into().trim_end_matches('/').to_string(),

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -174,7 +174,7 @@ fn dispatch_plugin_on_init(agent: &Agent) {
 }
 
 #[cfg(not(feature = "plugins"))]
-fn dispatch_plugin_on_init(_agent: &Agent) {}
+const fn dispatch_plugin_on_init(_agent: &Agent) {}
 // ─── Agent ───────────────────────────────────────────────────────────────────
 
 /// Stateful wrapper over the agent loop.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -126,6 +126,31 @@ pub fn default_convert(msg: &AgentMessage) -> Option<LlmMessage> {
     }
 }
 
+type ModelStreamRegistry = Vec<(ModelSpec, Arc<dyn StreamFn>)>;
+
+fn available_models_and_stream_fns(
+    options: &AgentOptions,
+) -> (Vec<ModelSpec>, ModelStreamRegistry) {
+    let primary_model = options.model.clone();
+    let primary_stream_fn = Arc::clone(&options.stream_fn);
+    let mut available_models = vec![options.model.clone()];
+    available_models.extend(
+        options
+            .available_models
+            .iter()
+            .map(|(model, _): &(ModelSpec, _)| model.clone()),
+    );
+    let mut model_stream_fns = vec![(primary_model, primary_stream_fn)];
+    model_stream_fns.extend(
+        options
+            .available_models
+            .iter()
+            .map(|(model, stream_fn): &(ModelSpec, _)| (model.clone(), Arc::clone(stream_fn))),
+    );
+
+    (available_models, model_stream_fns)
+}
+
 #[cfg(feature = "plugins")]
 fn dispatch_plugin_on_init(agent: &Agent) {
     // Dispatch on_init to each plugin in priority order (already sorted).
@@ -150,7 +175,6 @@ fn dispatch_plugin_on_init(agent: &Agent) {
 
 #[cfg(not(feature = "plugins"))]
 fn dispatch_plugin_on_init(_agent: &Agent) {}
-
 // ─── Agent ───────────────────────────────────────────────────────────────────
 
 /// Stateful wrapper over the agent loop.
@@ -238,25 +262,9 @@ impl Agent {
         #[cfg(feature = "plugins")]
         let options = merge_plugin_contributions(options);
 
-        let primary_model = options.model.clone();
-        let primary_stream_fn = Arc::clone(&options.stream_fn);
-        let mut available_models = vec![options.model.clone()];
-        available_models.extend(
-            options
-                .available_models
-                .iter()
-                .map(|(m, _): &(ModelSpec, _)| m.clone()),
-        );
-        let mut model_stream_fns = vec![(primary_model, primary_stream_fn)];
-        model_stream_fns.extend(
-            options
-                .available_models
-                .iter()
-                .map(|(model, stream_fn): &(ModelSpec, _)| (model.clone(), Arc::clone(stream_fn))),
-        );
-
         // Compute the effective system prompt before partial moves.
         let effective_prompt = options.effective_system_prompt().to_owned();
+        let (available_models, model_stream_fns) = available_models_and_stream_fns(&options);
 
         // If a custom token counter is provided and no custom transform_context
         // was set, rebuild the default SlidingWindowTransformer with the counter.

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -161,14 +161,14 @@ fn evaluate_test_runtime(
     runtime: &TestRuntime,
     requirements: TestRuntimeRequirements,
 ) -> Result<(), String> {
-    if let Some(expected_os) = requirements.os {
-        if runtime.os != expected_os {
-            return Err(format!(
-                "requires {}, detected {}",
-                expected_os.as_str(),
-                runtime.os.as_str()
-            ));
-        }
+    if let Some(expected_os) = requirements.os
+        && runtime.os != expected_os
+    {
+        return Err(format!(
+            "requires {}, detected {}",
+            expected_os.as_str(),
+            runtime.os.as_str()
+        ));
     }
 
     match requirements.gpu {


### PR DESCRIPTION
## What changed and why
- extracted `available_models_and_stream_fns()` and `initialize_plugins()` from `Agent::new()` so the constructor stays under clippy's line-count threshold without changing behavior
- collapsed the nested OS check in `src/testing.rs` to satisfy the current style lint directly
- added a narrow `dead_code` allowance on `AdapterBase` and its constructor because this shared helper is intentionally compiled even when the feature-gated remote adapters that construct it are not

## Slice completed
- Cleared the current live lib-side clippy warnings in `src/agent.rs`, `src/testing.rs`, and `adapters/src/base.rs` so issue #435 can move past this part of the backlog.

## What remains
- `cargo clippy -p swink-agent --tests --features testkit -- -D warnings` still fails on a broader pre-existing backlog in test targets and helper modules, including `tests/pause_resume.rs`, `tests/abort_turn_end_reason.rs`, `tests/agent_structured.rs`, `tests/approval.rs`, `tests/agent_loop.rs`, `src/block_accumulator.rs`, `src/agent/checkpointing.rs`, `src/atomic_fs.rs`, `src/checkpoint.rs`, `src/loop_/tool_dispatch.rs`, and `src/types/message_codec.rs`.

## Validation
- `cargo clippy -p swink-agent --lib --features testkit -- -D warnings`
- `cargo clippy -p swink-agent-adapters --lib -- -D warnings`
- `cargo test -p swink-agent --features testkit wait_for_idle -- --nocapture`
- `cargo test -p swink-agent-adapters trailing_slash_stripped -- --nocapture`

## Baseline failures
- `cargo clippy -p swink-agent --tests --features testkit -- -D warnings` still fails on the pre-existing backlog listed above.

Ref #435