### PR TITLE
[codex] Add portable all-features CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,24 @@ jobs:
 
       - run: cargo hack check --workspace --each-feature --no-dev-deps
 
+  all-features:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Test portable all-features workspace surface
+        run: cargo test --workspace --all-features --exclude swink-agent-local-llm
+
+      - name: Build policies required-feature example
+        run: cargo build -p swink-agent-policies --all-features --example with_policies
+
+      - name: Build TUI required-feature example
+        run: cargo build -p swink-agent-tui --all-features --example custom_agent
+
   deny:
     runs-on: ubuntu-latest
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,6 +165,7 @@ MSRV **1.88** (edition 2024). Common workspace deps are centralized in root `Car
 **Local-LLM crate (`swink-agent-local-llm`):**
 - Backend flags: `metal`, `cuda`, `cudnn`, `flash-attn`, `mkl`, `accelerate` — each forwards to `mistralrs/<flag>`.
 - No default backend. CPU-only inference when none enabled.
+- Portable CI must not run `cargo ... --all-features` across `swink-agent-local-llm` on a generic Linux runner: `metal`/`accelerate` pull Apple-only dependencies. Cover the rest of the workspace with `--exclude swink-agent-local-llm`, then validate required-feature examples explicitly.
 
 **Policies crate (`swink-agent-policies`):**
 - `default = ["all"]`, 10 individual policy flags. Established pattern for feature gating.

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 
 use swink_agent::{
     AgentOptions, CatalogPreset, ModelConnection, ModelConnections, ModelSpec, StreamFn,
+    model_catalog,
 };
 use swink_agent_adapters::{
     AnthropicStreamFn, OllamaStreamFn, OpenAiStreamFn, ProxyStreamFn, remote_presets,
@@ -219,7 +220,7 @@ fn local_connections() -> ModelConnections {
     let catalog = model_catalog();
     let model = catalog
         .preset("local", "smollm3_3b")
-        .map(|p| p.model_spec())
+        .map(|preset: CatalogPreset| preset.model_spec())
         .unwrap_or_else(|| ModelSpec::new("local", "SmolLM3-3B-Q4_K_M"));
 
     ModelConnections::builder()
@@ -256,7 +257,7 @@ fn append_local_fallback(
     let catalog = model_catalog();
     let model = catalog
         .preset("local", "smollm3_3b")
-        .map(|p| p.model_spec())
+        .map(|preset: CatalogPreset| preset.model_spec())
         .unwrap_or_else(|| ModelSpec::new("local", "SmolLM3-3B-Q4_K_M"));
 
     builder.fallback(ModelConnection::new(model, local))


### PR DESCRIPTION
## What changed and why
- added a dedicated `all-features` GitHub Actions job to exercise the portable workspace `--all-features` surface on Ubuntu
- added explicit builds for the `swink-agent-policies` `with_policies` example and the `swink-agent-tui` `custom_agent` example so required-feature examples are covered in CI
- fixed `tui/src/main.rs` so the `swink` binary compiles under `--all-features`, which the new coverage path exposed
- documented the portable-`--all-features` constraint for `swink-agent-local-llm` in `AGENTS.md`

## Slice completed
- issue #436's missing CI coverage is added in a reviewable slice without trying to solve unrelated all-features failures outside this diff

## What remains
- the new portable all-features test command still exposes pre-existing failures in `hot_reload::tests::{script_tool_escapes_parameters,duplicate_tool_names_last_write_wins,script_tool_executes_command}` under `swink-agent`; those need follow-up fixes outside this slice

## Validation output
- `cargo build -p swink-agent-policies --all-features --example with_policies` ✅
- `cargo build -p swink-agent-tui --all-features --example custom_agent` ✅
- `cargo test --workspace --all-features --exclude swink-agent-local-llm` ❌ exposes the pre-existing `hot_reload` failures listed above
- initial cold run of `cargo test --workspace --all-features --exclude swink-agent-local-llm` also timed out on this Windows host before the cache was warm

## Baseline failures
- `hot_reload::tests::script_tool_escapes_parameters`
- `hot_reload::tests::duplicate_tool_names_last_write_wins`
- `hot_reload::tests::script_tool_executes_command`

Ref #436