### PR TITLE
fix: gate no-default-features test to avoid workspace conflict

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,7 +126,7 @@ tracing-subscriber = { version = "0.3", features = ["registry"] }
 
 [lints.rust]
 unsafe_code = "forbid"
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(swink_no_default_features_check)'] }
+
 
 [lints.clippy]
 all = { level = "warn", priority = -1 }

--- a/tests/no_default_features.rs
+++ b/tests/no_default_features.rs
@@ -1,4 +1,4 @@
-#![cfg(swink_no_default_features_check)]
+#![cfg(not(feature = "builtin-tools"))]
 
 //! Regression test for issue #205: `--no-default-features` must not re-enable
 //! `builtin-tools` or `transfer` through dev-dependency feature unification.


### PR DESCRIPTION
## Summary
- `tests/no_default_features.rs` used a custom `cfg(swink_no_default_features_check)` gate that was never set, meaning the test never ran — not even under `cargo test -p swink-agent --no-default-features`
- Replaced with `#[cfg(not(feature = "builtin-tools"))]` so the test correctly runs when default features are disabled and is skipped during workspace-wide `cargo test --workspace --features testkit`
- Removed the now-unused `unexpected_cfgs` entry from `Cargo.toml`

## Test plan
- [x] `cargo test --workspace --features testkit` passes (test skipped, 0 tests in file)
- [x] `cargo test -p swink-agent --no-default-features` passes (8 tests run and pass)
- [x] `cargo clippy -p swink-agent -- -D warnings` clean

Closes #379

🤖 Generated with [Claude Code](https://claude.com/claude-code)