### PR TITLE
refactor: narrow FetchedContent to extractor-known data only

### DIFF
--- a/plugins/web/src/content.rs
+++ b/plugins/web/src/content.rs
@@ -9,16 +9,18 @@ pub enum ContentError {
     ExtractionFailed(String),
 }
 
-/// Result of fetching and extracting content from a web page.
+/// Result of extracting readable content from raw HTML.
+///
+/// Contains only data the readability extractor actually knows. HTTP metadata
+/// (status code, content type, truncation) belongs in the caller that holds the
+/// real HTTP response.
 #[derive(Debug, Clone)]
 pub struct FetchedContent {
     pub url: String,
     pub title: Option<String>,
     pub text: String,
-    pub content_type: String,
-    pub content_length: usize,
-    pub truncated: bool,
-    pub status_code: u16,
+    /// Character length of the extracted text.
+    pub text_length: usize,
 }
 
 /// Extract readable content from raw HTML bytes using the readability algorithm.
@@ -39,14 +41,13 @@ pub fn extract_readable_content(
         Some(product.title)
     };
 
+    let text_length = product.text.chars().count();
+
     Ok(FetchedContent {
         url: url.to_string(),
         title,
         text: product.text,
-        content_type: "text/html".to_string(),
-        content_length: html.len(),
-        truncated: false,
-        status_code: 200,
+        text_length,
     })
 }
 
@@ -151,11 +152,71 @@ mod tests {
         let result = extract_readable_content(html, &url).unwrap();
 
         assert_eq!(result.url, "https://example.com/article");
-        assert_eq!(result.content_type, "text/html");
-        assert_eq!(result.content_length, html.len());
-        assert!(!result.truncated);
-        assert_eq!(result.status_code, 200);
         assert!(result.title.is_some());
         assert!(result.text.contains("main article content"));
+        assert!(result.text_length > 0);
+        assert_eq!(result.text_length, result.text.chars().count());
+    }
+
+    #[test]
+    fn fetched_content_has_no_http_metadata_fields() {
+        // Pin the struct contract: FetchedContent only carries extractor-known data.
+        let content = super::FetchedContent {
+            url: "https://example.com".to_string(),
+            title: Some("Title".to_string()),
+            text: "Body text".to_string(),
+            text_length: 9,
+        };
+        assert_eq!(content.url, "https://example.com");
+        assert_eq!(content.title.as_deref(), Some("Title"));
+        assert_eq!(content.text, "Body text");
+        assert_eq!(content.text_length, 9);
+    }
+
+    #[test]
+    fn extract_readable_content_empty_title_becomes_none() {
+        let html = br#"
+        <!DOCTYPE html>
+        <html>
+        <head><title></title></head>
+        <body>
+            <article>
+                <p>Content without a meaningful title in the document head. This paragraph
+                   has enough text for readability to pick it up as the main content block.</p>
+                <p>A second paragraph to reinforce that this is the article body content.</p>
+            </article>
+        </body>
+        </html>
+        "#;
+
+        let url = url::Url::parse("https://example.com/no-title").unwrap();
+        let result = extract_readable_content(html, &url).unwrap();
+
+        assert!(result.title.is_none());
+        assert!(result.text_length > 0);
+    }
+
+    #[test]
+    fn text_length_counts_chars_not_bytes() {
+        // Multibyte characters: text_length should be char count, not byte count.
+        let html = br#"
+        <!DOCTYPE html>
+        <html>
+        <head><title>Unicode</title></head>
+        <body>
+            <article>
+                <p>Here are some emoji characters for testing multibyte length counting
+                in the readability extractor output.</p>
+                <p>Second paragraph to ensure readability picks this up as the main content.</p>
+            </article>
+        </body>
+        </html>
+        "#;
+
+        let url = url::Url::parse("https://example.com/unicode").unwrap();
+        let result = extract_readable_content(html, &url).unwrap();
+
+        // text_length must equal chars().count(), not bytes len()
+        assert_eq!(result.text_length, result.text.chars().count());
     }
 }

--- a/plugins/web/src/tools/fetch.rs
+++ b/plugins/web/src/tools/fetch.rs
@@ -199,8 +199,7 @@ impl AgentTool for FetchTool {
             if truncated {
                 warn!(
                     "Content from {url_str} was truncated from {} to ~{} chars",
-                    fetched.text.len(),
-                    self.max_content_length
+                    fetched.text_length, self.max_content_length
                 );
             }
 


### PR DESCRIPTION
## Summary
- Removed fabricated HTTP metadata fields from `FetchedContent` (`status_code`, `content_type`, `content_length`, `truncated`)
- `FetchedContent` now only contains data the extractor actually knows: `url`, `title`, `text`, `text_length`
- HTTP metadata handling stays in `FetchTool` where real response info is available

**Public API change**: `FetchedContent` fields removed. SuperSwink-Core depends on Swink-Agent — this narrows the public type.

## Test plan
- [x] Unit tests for narrowed FetchedContent contract
- [x] Fetch tool output still correct
- [x] cargo test -p swink-agent-plugin-web passes (3 pre-existing failures unrelated to this change)
- [x] cargo clippy -p swink-agent-plugin-web -- -D warnings clean

Closes #471

🤖 Generated with [Claude Code](https://claude.com/claude-code)