### PR TITLE
[codex] Add feature-gate smoke coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,30 @@ jobs:
 
       - run: cargo hack check --workspace --each-feature --no-dev-deps
 
+  feature-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Adapters no-default-features sentinel
+        run: cargo test -p swink-agent-adapters --no-default-features --test no_default_features
+
+      - name: Adapters anthropic feature smoke
+        run: cargo check -p swink-agent-adapters --no-default-features --features anthropic
+
+      - name: Adapters gemini feature smoke
+        run: cargo check -p swink-agent-adapters --no-default-features --features gemini
+
+      - name: Local LLM no-default-features sentinel
+        run: cargo test -p swink-agent-local-llm --no-default-features --test no_default_features
+
+      - name: Local LLM gemma4 feature smoke
+        run: cargo check -p swink-agent-local-llm --no-default-features --features gemma4
+
   all-features:
     runs-on: ubuntu-latest
     steps:

--- a/adapters/tests/no_default_features.rs
+++ b/adapters/tests/no_default_features.rs
@@ -1,0 +1,107 @@
+//! Regression test for issue #441: `--no-default-features` must keep every
+//! provider gate disabled in `swink-agent-adapters`.
+//!
+//! This file compiles under
+//! `cargo test -p swink-agent-adapters --no-default-features --test no_default_features`.
+//! If a default or dev-dependency leaks adapter features back in, the
+//! `#[cfg(feature = ...)]` assertions below flip and fail loudly.
+
+#[cfg(not(feature = "anthropic"))]
+#[test]
+fn anthropic_feature_is_off() {}
+
+#[cfg(feature = "anthropic")]
+#[test]
+fn anthropic_must_not_leak_into_no_default_features() {
+    panic!("anthropic feature is enabled but should not be");
+}
+
+#[cfg(not(feature = "openai"))]
+#[test]
+fn openai_feature_is_off() {}
+
+#[cfg(feature = "openai")]
+#[test]
+fn openai_must_not_leak_into_no_default_features() {
+    panic!("openai feature is enabled but should not be");
+}
+
+#[cfg(not(feature = "openai-compat"))]
+#[test]
+fn openai_compat_feature_is_off() {}
+
+#[cfg(feature = "openai-compat")]
+#[test]
+fn openai_compat_must_not_leak_into_no_default_features() {
+    panic!("openai-compat feature is enabled but should not be");
+}
+
+#[cfg(not(feature = "ollama"))]
+#[test]
+fn ollama_feature_is_off() {}
+
+#[cfg(feature = "ollama")]
+#[test]
+fn ollama_must_not_leak_into_no_default_features() {
+    panic!("ollama feature is enabled but should not be");
+}
+
+#[cfg(not(feature = "gemini"))]
+#[test]
+fn gemini_feature_is_off() {}
+
+#[cfg(feature = "gemini")]
+#[test]
+fn gemini_must_not_leak_into_no_default_features() {
+    panic!("gemini feature is enabled but should not be");
+}
+
+#[cfg(not(feature = "proxy"))]
+#[test]
+fn proxy_feature_is_off() {}
+
+#[cfg(feature = "proxy")]
+#[test]
+fn proxy_must_not_leak_into_no_default_features() {
+    panic!("proxy feature is enabled but should not be");
+}
+
+#[cfg(not(feature = "azure"))]
+#[test]
+fn azure_feature_is_off() {}
+
+#[cfg(feature = "azure")]
+#[test]
+fn azure_must_not_leak_into_no_default_features() {
+    panic!("azure feature is enabled but should not be");
+}
+
+#[cfg(not(feature = "bedrock"))]
+#[test]
+fn bedrock_feature_is_off() {}
+
+#[cfg(feature = "bedrock")]
+#[test]
+fn bedrock_must_not_leak_into_no_default_features() {
+    panic!("bedrock feature is enabled but should not be");
+}
+
+#[cfg(not(feature = "mistral"))]
+#[test]
+fn mistral_feature_is_off() {}
+
+#[cfg(feature = "mistral")]
+#[test]
+fn mistral_must_not_leak_into_no_default_features() {
+    panic!("mistral feature is enabled but should not be");
+}
+
+#[cfg(not(feature = "xai"))]
+#[test]
+fn xai_feature_is_off() {}
+
+#[cfg(feature = "xai")]
+#[test]
+fn xai_must_not_leak_into_no_default_features() {
+    panic!("xai feature is enabled but should not be");
+}

--- a/local-llm/tests/no_default_features.rs
+++ b/local-llm/tests/no_default_features.rs
@@ -1,0 +1,77 @@
+//! Regression test for issue #441: `--no-default-features` must keep the
+//! optional local-LLM feature gates disabled.
+//!
+//! This file compiles under
+//! `cargo test -p swink-agent-local-llm --no-default-features --test no_default_features`.
+//! If a dependency leak re-enables one of these features, the matching panic
+//! test becomes active and fails the build.
+
+#[cfg(not(feature = "gemma4"))]
+#[test]
+fn gemma4_feature_is_off() {}
+
+#[cfg(feature = "gemma4")]
+#[test]
+fn gemma4_must_not_leak_into_no_default_features() {
+    panic!("gemma4 feature is enabled but should not be");
+}
+
+#[cfg(not(feature = "metal"))]
+#[test]
+fn metal_feature_is_off() {}
+
+#[cfg(feature = "metal")]
+#[test]
+fn metal_must_not_leak_into_no_default_features() {
+    panic!("metal feature is enabled but should not be");
+}
+
+#[cfg(not(feature = "cuda"))]
+#[test]
+fn cuda_feature_is_off() {}
+
+#[cfg(feature = "cuda")]
+#[test]
+fn cuda_must_not_leak_into_no_default_features() {
+    panic!("cuda feature is enabled but should not be");
+}
+
+#[cfg(not(feature = "cudnn"))]
+#[test]
+fn cudnn_feature_is_off() {}
+
+#[cfg(feature = "cudnn")]
+#[test]
+fn cudnn_must_not_leak_into_no_default_features() {
+    panic!("cudnn feature is enabled but should not be");
+}
+
+#[cfg(not(feature = "flash-attn"))]
+#[test]
+fn flash_attn_feature_is_off() {}
+
+#[cfg(feature = "flash-attn")]
+#[test]
+fn flash_attn_must_not_leak_into_no_default_features() {
+    panic!("flash-attn feature is enabled but should not be");
+}
+
+#[cfg(not(feature = "mkl"))]
+#[test]
+fn mkl_feature_is_off() {}
+
+#[cfg(feature = "mkl")]
+#[test]
+fn mkl_must_not_leak_into_no_default_features() {
+    panic!("mkl feature is enabled but should not be");
+}
+
+#[cfg(not(feature = "accelerate"))]
+#[test]
+fn accelerate_feature_is_off() {}
+
+#[cfg(feature = "accelerate")]
+#[test]
+fn accelerate_must_not_leak_into_no_default_features() {
+    panic!("accelerate feature is enabled but should not be");
+}


### PR DESCRIPTION
## What changed
- added `adapters/tests/no_default_features.rs` to fail fast if any adapter feature leaks into a `--no-default-features` build
- added `local-llm/tests/no_default_features.rs` to do the same for optional local-LLM features
- extended `.github/workflows/ci.yml` with a `feature-smoke` job that runs those sentinels plus representative single-feature checks for `anthropic`, `gemini`, and `gemma4`

## Why
Issue #441 called out that the adapter and local-LLM feature-gated crate roots had no direct compile coverage guard. `cargo hack --each-feature` exercises feature markers, but it does not catch no-default-feature leaks through dev-dependencies or give a dedicated smoke path for the gated roots themselves.

## Slice completed
This PR adds reviewable CI smoke coverage for the adapter and local-LLM crate roots.

## What remains
Platform-specific backend feature smoke beyond the portable `gemma4` path can be added later if we want a broader matrix.

## Validation
- `cargo test -p swink-agent-adapters --no-default-features --test no_default_features`
- `cargo check -p swink-agent-adapters --no-default-features --features anthropic`
- `cargo check -p swink-agent-adapters --no-default-features --features gemini`
- `cargo test -p swink-agent-local-llm --no-default-features --test no_default_features`
- `cargo check -p swink-agent-local-llm --no-default-features --features gemma4`

## Pre-existing baseline failures
- `cargo clippy --workspace -- -D warnings` fails on `tui/src/main.rs` because `model_catalog` is an unused import on `main`
- `cargo test --workspace` fails in `tests/approval.rs::approval_events_in_correct_order` on `main`
- `cargo fmt --check` reports unrelated formatting drift across the repository on `main`

Ref #441