### PR TITLE
[codex] Align root guidance with AGENTS conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Pure-Rust library for LLM-powered agentic loops. Provider-agnostic core with plu
 - **Test-driven.** Run `cargo test --workspace` before every commit. Bug found → regression test first, then fix.
 - **Speed.** Minimize allocations on hot paths. `tokio::spawn` for concurrent tool execution, not sequential awaits.
 - **No unsafe.** `#[forbid(unsafe_code)]` at every crate root.
-- **Lessons learned go in nested CLAUDE.md files.** Each subcrate and key subdirectory has its own `CLAUDE.md` (e.g., `adapters/CLAUDE.md`, `local-llm/CLAUDE.md`, `tui/src/ui/CLAUDE.md`). Update when you discover something non-obvious.
+- **Lessons learned go in nested guidance files.** Update the nearest `AGENTS.md` when present; some areas still have legacy `CLAUDE.md` files (for example `adapters/CLAUDE.md`, `local-llm/CLAUDE.md`, `tui/src/ui/CLAUDE.md`) that should stay in sync until they are migrated.
 - **Context7 first.** When researching any crate API, dependency docs, or library usage, always query the context7 MCP server before falling back to web search or training data. Training data may be stale; context7 pulls current docs.
 - **No parallel builds in agents.** Never have multiple subagents run `cargo build`/`test`/`clippy` concurrently — Cargo's global lock serializes them anyway, causing extended build times. Run all compilation in the main conversation first; subagents should only read and analyze code.
 - **Check specs and docs first.** Before making large changes, read the relevant spec files in `specs/NNN-*/` (spec.md, plan.md, tasks.md) and architecture docs in `docs/` (HLD, subsystem READMEs, planning docs). The project uses spec-driven development — changes should align with the agreed design.


### PR DESCRIPTION
## What changed
- updated the root `CLAUDE.md` contributor-guidance bullet to point contributors at the nearest `AGENTS.md` when present
- clarified that legacy nested `CLAUDE.md` files still exist in some areas and should stay in sync until migrated

## Why
Issue #437 reported root documentation drift. Most of the README-side drift is already resolved on `main`; the remaining mismatch was the root guidance telling contributors to record lessons only in nested `CLAUDE.md` files even though the repo now uses `AGENTS.md` as the active instruction source in the main tree.

## Slice completed
This PR completes the remaining root-guidance mismatch called out in the issue.

## Validation
- `cargo clippy --workspace -- -D warnings` ❌ baseline failure in `src/transfer.rs:99` (`clippy::missing_const_for_fn` on `transfer_chain`)
- `cargo test --workspace` ❌ baseline failure in `tests/approval.rs:244` (`approval_events_in_correct_order` currently observes `ToolApprovalRequested -> ToolApprovalResolved -> ToolExecutionStart -> ToolExecutionEnd`)

## Baseline notes
These validation failures were present while preparing this docs-only change and were not expanded into this PR.

Closes #437