### PR TITLE
fix: preserve ToolMiddleware auth and metadata passthrough

### DIFF
--- a/src/tool_middleware.rs
+++ b/src/tool_middleware.rs
@@ -51,8 +51,9 @@ type MiddlewareFn = Arc<
 
 /// Intercepts [`execute()`](AgentTool::execute) on a wrapped [`AgentTool`].
 ///
-/// All metadata methods (`name`, `label`, `description`, `parameters_schema`,
-/// `requires_approval`) delegate to the inner tool.
+/// All descriptor methods (`name`, `label`, `description`,
+/// `parameters_schema`, `metadata`, `requires_approval`, `auth_config`)
+/// delegate to the inner tool.
 pub struct ToolMiddleware {
     inner: Arc<dyn AgentTool>,
     middleware_fn: MiddlewareFn,
@@ -153,12 +154,20 @@ impl AgentTool for ToolMiddleware {
         self.inner.parameters_schema()
     }
 
+    fn metadata(&self) -> Option<crate::tool::ToolMetadata> {
+        self.inner.metadata()
+    }
+
     fn requires_approval(&self) -> bool {
         self.inner.requires_approval()
     }
 
     fn approval_context(&self, params: &Value) -> Option<Value> {
         self.inner.approval_context(params)
+    }
+
+    fn auth_config(&self) -> Option<crate::credential::AuthConfig> {
+        self.inner.auth_config()
     }
 
     fn execute(
@@ -221,8 +230,57 @@ mod tests {
     }
 
     #[test]
-    fn metadata_delegates_to_inner() {
-        let inner: Arc<dyn AgentTool> = dummy_tool();
+    fn metadata_and_auth_config_delegate_to_inner() {
+        struct MetadataAuthTool;
+
+        impl AgentTool for MetadataAuthTool {
+            fn name(&self) -> &str {
+                "auth_tool"
+            }
+
+            fn label(&self) -> &str {
+                "Auth Tool"
+            }
+
+            fn description(&self) -> &str {
+                "A tool with metadata and auth config."
+            }
+
+            fn parameters_schema(&self) -> &Value {
+                &Value::Null
+            }
+
+            fn metadata(&self) -> Option<crate::tool::ToolMetadata> {
+                Some(
+                    crate::tool::ToolMetadata::with_namespace("middleware-tests")
+                        .with_version("1.0.0"),
+                )
+            }
+
+            fn auth_config(&self) -> Option<crate::credential::AuthConfig> {
+                Some(crate::credential::AuthConfig {
+                    credential_key: "weather-api".to_string(),
+                    auth_scheme: crate::credential::AuthScheme::ApiKeyHeader(
+                        "X-Api-Key".to_string(),
+                    ),
+                    credential_type: crate::credential::CredentialType::ApiKey,
+                })
+            }
+
+            fn execute(
+                &self,
+                _tool_call_id: &str,
+                _params: Value,
+                _cancellation_token: CancellationToken,
+                _on_update: Option<Box<dyn Fn(AgentToolResult) + Send + Sync>>,
+                _state: std::sync::Arc<std::sync::RwLock<crate::SessionState>>,
+                _credential: Option<crate::credential::ResolvedCredential>,
+            ) -> ToolFuture<'_> {
+                Box::pin(async { AgentToolResult::text("ok") })
+            }
+        }
+
+        let inner: Arc<dyn AgentTool> = Arc::new(MetadataAuthTool);
         let mw = ToolMiddleware::new(
             inner,
             |tool, id, params, cancel, on_update, state, credential| {
@@ -233,10 +291,29 @@ mod tests {
             },
         );
 
-        assert_eq!(mw.name(), "dummy");
-        assert_eq!(mw.label(), "Dummy");
-        assert_eq!(mw.description(), "A dummy tool.");
-        assert!(mw.requires_approval());
+        assert_eq!(mw.name(), "auth_tool");
+        assert_eq!(mw.label(), "Auth Tool");
+        assert_eq!(mw.description(), "A tool with metadata and auth config.");
+        assert!(!mw.requires_approval());
+        assert_eq!(
+            mw.metadata(),
+            Some(
+                crate::tool::ToolMetadata::with_namespace("middleware-tests").with_version("1.0.0"),
+            )
+        );
+
+        let auth_config = mw
+            .auth_config()
+            .expect("middleware should delegate auth config");
+        assert_eq!(auth_config.credential_key, "weather-api");
+        assert!(matches!(
+            auth_config.auth_scheme,
+            crate::credential::AuthScheme::ApiKeyHeader(ref header) if header == "X-Api-Key"
+        ));
+        assert_eq!(
+            auth_config.credential_type,
+            crate::credential::CredentialType::ApiKey
+        );
     }
 
     fn test_state() -> std::sync::Arc<std::sync::RwLock<crate::SessionState>> {

--- a/tests/tool_middleware.rs
+++ b/tests/tool_middleware.rs
@@ -5,14 +5,101 @@ mod common;
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
 
 use common::{
     MockStreamFn, MockTool, default_convert, default_model, text_only_events, tool_call_events,
     user_msg,
 };
+use serde_json::{Value, json};
 
-use swink_agent::{Agent, AgentOptions, DefaultRetryStrategy, ToolMiddleware};
+use swink_agent::{
+    Agent, AgentOptions, AgentTool, AgentToolResult, AuthConfig, AuthScheme, CredentialFuture,
+    CredentialResolver, CredentialType, DefaultRetryStrategy, ResolvedCredential, ToolFuture,
+    ToolMetadata, ToolMiddleware,
+};
+use tokio_util::sync::CancellationToken;
+
+fn auth_tool_schema() -> &'static Value {
+    static SCHEMA: OnceLock<Value> = OnceLock::new();
+    SCHEMA.get_or_init(|| json!({"type": "object"}))
+}
+
+#[derive(Default)]
+struct StaticCredentialResolver;
+
+impl CredentialResolver for StaticCredentialResolver {
+    fn resolve(&self, key: &str) -> CredentialFuture<'_, ResolvedCredential> {
+        let key = key.to_string();
+        Box::pin(async move {
+            if key == "weather-api" {
+                Ok(ResolvedCredential::ApiKey("test-secret".to_string()))
+            } else {
+                Err(swink_agent::CredentialError::NotFound { key })
+            }
+        })
+    }
+}
+
+struct AuthCapturingTool {
+    seen_credentials: Arc<Mutex<Vec<Option<ResolvedCredential>>>>,
+}
+
+impl AuthCapturingTool {
+    fn new() -> Self {
+        Self {
+            seen_credentials: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn seen_credentials(&self) -> Arc<Mutex<Vec<Option<ResolvedCredential>>>> {
+        Arc::clone(&self.seen_credentials)
+    }
+}
+
+impl AgentTool for AuthCapturingTool {
+    fn name(&self) -> &str {
+        "secure_echo"
+    }
+
+    fn label(&self) -> &str {
+        "Secure Echo"
+    }
+
+    fn description(&self) -> &str {
+        "Captures resolved credentials."
+    }
+
+    fn parameters_schema(&self) -> &Value {
+        auth_tool_schema()
+    }
+
+    fn metadata(&self) -> Option<ToolMetadata> {
+        Some(ToolMetadata::with_namespace("middleware-tests").with_version("1.0.0"))
+    }
+
+    fn auth_config(&self) -> Option<AuthConfig> {
+        Some(AuthConfig {
+            credential_key: "weather-api".to_string(),
+            auth_scheme: AuthScheme::ApiKeyHeader("X-Api-Key".to_string()),
+            credential_type: CredentialType::ApiKey,
+        })
+    }
+
+    fn execute(
+        &self,
+        _tool_call_id: &str,
+        _params: Value,
+        _cancellation_token: CancellationToken,
+        _on_update: Option<Box<dyn Fn(AgentToolResult) + Send + Sync>>,
+        _state: Arc<std::sync::RwLock<swink_agent::SessionState>>,
+        credential: Option<ResolvedCredential>,
+    ) -> ToolFuture<'_> {
+        self.seen_credentials.lock().unwrap().push(credential);
+        Box::pin(async { AgentToolResult::text("secure result") })
+    }
+}
 
 #[tokio::test]
 async fn middleware_runs_in_agent_loop() {
@@ -55,4 +142,60 @@ async fn middleware_runs_in_agent_loop() {
         1,
         "middleware should have been called once"
     );
+}
+
+#[tokio::test]
+async fn middleware_preserves_metadata_and_auth_config_in_agent_loop() {
+    let inner = Arc::new(AuthCapturingTool::new());
+    let seen_credentials = inner.seen_credentials();
+    let wrapped = ToolMiddleware::new(
+        inner.clone(),
+        |tool, id, params, cancel, on_update, state, credential| {
+            Box::pin(async move {
+                tool.execute(&id, params, cancel, on_update, state, credential)
+                    .await
+            })
+        },
+    );
+
+    assert_eq!(
+        wrapped.metadata(),
+        Some(ToolMetadata::with_namespace("middleware-tests").with_version("1.0.0"))
+    );
+
+    let auth_config = wrapped
+        .auth_config()
+        .expect("wrapped tool should expose auth config");
+    assert_eq!(auth_config.credential_key, "weather-api");
+    assert!(matches!(
+        auth_config.auth_scheme,
+        AuthScheme::ApiKeyHeader(ref header) if header == "X-Api-Key"
+    ));
+    assert_eq!(auth_config.credential_type, CredentialType::ApiKey);
+
+    let stream_fn = Arc::new(MockStreamFn::new(vec![
+        tool_call_events("call_1", "secure_echo", "{}"),
+        text_only_events("done"),
+    ]));
+
+    let mut agent = Agent::new(
+        AgentOptions::new("test", default_model(), stream_fn, default_convert)
+            .with_tools(vec![Arc::new(wrapped)])
+            .with_credential_resolver(Arc::new(StaticCredentialResolver))
+            .with_retry_strategy(Box::new(
+                DefaultRetryStrategy::default()
+                    .with_jitter(false)
+                    .with_base_delay(Duration::from_millis(1)),
+            )),
+    );
+
+    let result = agent.prompt_async(vec![user_msg("hi")]).await.unwrap();
+
+    assert!(!result.messages.is_empty());
+    let seen_credentials = seen_credentials.lock().unwrap();
+    assert_eq!(seen_credentials.len(), 1);
+    assert!(matches!(
+        seen_credentials.first(),
+        Some(Some(ResolvedCredential::ApiKey(secret))) if secret == "test-secret"
+    ));
 }


### PR DESCRIPTION
## What changed and why
- `ToolMiddleware` now forwards the wrapped tool's `metadata()` and `auth_config()` instead of only forwarding the basic descriptor methods.
- Added unit coverage in `src/tool_middleware.rs` for both passthrough methods.
- Added an integration test that runs a wrapped authenticated tool through the agent loop and proves credential resolution still reaches the inner tool.

## Slice completed / remaining
- Completed this issue's middleware passthrough slice.
- Nothing remains for the reported `ToolMiddleware` auth/metadata regression.

## Validation output
- `cargo test -p swink-agent --features testkit --test tool_middleware`
- `cargo test -p swink-agent --features testkit tool_middleware`

## Pre-existing baseline failures
- `cargo clippy -p swink-agent --tests --features testkit -- -D warnings` still fails on an unrelated existing lint in `src/transfer.rs:99` (`clippy::missing_const_for_fn`).

Closes #489