### PR TITLE
fix: preserve pause checkpoints after queue polling

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -206,6 +206,7 @@ pub struct Agent {
     idle_notify: Arc<Notify>,
     in_flight_llm_messages: Option<Vec<AgentMessage>>,
     in_flight_messages: Option<Vec<AgentMessage>>,
+    pending_message_snapshot: Arc<crate::pause_state::PendingMessageSnapshot>,
     approve_tool: Option<ApproveToolArc>,
     approval_mode: ApprovalMode,
     pre_turn_policies: Vec<Arc<dyn crate::policy::PreTurnPolicy>>,
@@ -310,6 +311,9 @@ impl Agent {
             idle_notify: Arc::new(Notify::new()),
             in_flight_llm_messages: None,
             in_flight_messages: None,
+            pending_message_snapshot: Arc::new(
+                crate::pause_state::PendingMessageSnapshot::default(),
+            ),
             approve_tool: options.approve_tool,
             approval_mode: options.approval_mode,
             pre_turn_policies: options.pre_turn_policies,

--- a/src/agent/AGENTS.md
+++ b/src/agent/AGENTS.md
@@ -2,3 +2,4 @@
 
 - `pause()` must snapshot the full in-flight message history, not just `in_flight_llm_messages`. The LLM-only snapshot intentionally drops `CustomMessage`, so streamed pause/resume needs a separate authoritative in-flight message clone to avoid serializing stale or incomplete checkpoints.
 - Checkpoint restore must validate the optional `session_state` snapshot before mutating `messages`, `system_prompt`, `model`, or live queues. A corrupt state snapshot must leave the in-memory agent unchanged.
+- `pause()` also has to snapshot loop-local `pending_messages`, not only the live steering/follow-up queues. Follow-up or steering items can already be drained out of the shared queues and staged for the next turn when pause is requested; without the mirrored pending snapshot, those messages disappear from the checkpoint.

--- a/src/agent/checkpointing.rs
+++ b/src/agent/checkpointing.rs
@@ -158,6 +158,8 @@ impl Agent {
             token.cancel();
         }
 
+        let mut pending_messages = self.pending_message_snapshot.snapshot();
+        pending_messages.extend(drain_messages_from_queue(&self.follow_up_queue));
         let checkpoint_messages = self
             .in_flight_messages
             .as_deref()
@@ -169,7 +171,7 @@ impl Agent {
             &self.state.model.model_id,
             checkpoint_messages,
         )
-        .with_pending_message_batch(&drain_messages_from_queue(&self.follow_up_queue))
+        .with_pending_message_batch(&pending_messages)
         .with_pending_steering_message_batch(&drain_messages_from_queue(&self.steering_queue));
 
         let s = self
@@ -287,6 +289,9 @@ mod tests {
         }
         fn to_json(&self) -> Option<serde_json::Value> {
             Some(serde_json::json!({ "value": self.value }))
+        }
+        fn clone_box(&self) -> Option<Box<dyn CustomMessage>> {
+            Some(Box::new(self.clone()))
         }
     }
 
@@ -714,6 +719,50 @@ mod tests {
             },
             _ => panic!("expected llm steering message"),
         }
+    }
+
+    #[tokio::test]
+    async fn pause_captures_messages_already_moved_into_loop_local_pending_state() {
+        let mut agent = make_agent(Some(tagged_registry()));
+        agent.state.messages.push(user_msg("hi"));
+        agent.pending_message_snapshot.replace(&[
+            AgentMessage::Llm(LlmMessage::User(UserMessage {
+                content: vec![crate::types::ContentBlock::Text {
+                    text: "polled-follow-up".to_string(),
+                }],
+                timestamp: 1,
+                cache_hint: None,
+            })),
+            AgentMessage::Custom(Box::new(Tagged {
+                value: "polled-custom".to_string(),
+            })),
+        ]);
+
+        agent
+            .loop_active
+            .store(true, std::sync::atomic::Ordering::Release);
+
+        let checkpoint = agent.pause().expect("agent should be running");
+        let pending = checkpoint.restore_pending_messages(agent.custom_message_registry.as_deref());
+
+        assert_eq!(
+            pending.len(),
+            2,
+            "pause should include loop-local pending messages even when the shared queue is already empty"
+        );
+        match &pending[0] {
+            AgentMessage::Llm(LlmMessage::User(user)) => match &user.content[0] {
+                crate::types::ContentBlock::Text { text } => {
+                    assert_eq!(text, "polled-follow-up");
+                }
+                other => panic!("expected text content, got {other:?}"),
+            },
+            other => panic!("expected user message, got {other:?}"),
+        }
+        let restored_custom = pending[1]
+            .downcast_ref::<Tagged>()
+            .expect("custom pending message should be preserved");
+        assert_eq!(restored_custom.value, "polled-custom");
     }
 
     #[tokio::test]

--- a/src/agent/control.rs
+++ b/src/agent/control.rs
@@ -57,6 +57,7 @@ impl Agent {
         self.abort_controller = None;
         self.in_flight_llm_messages = None;
         self.in_flight_messages = None;
+        self.pending_message_snapshot.clear();
         self.clear_queues();
         self.idle_notify.notify_waiters();
     }

--- a/src/agent/invoke.rs
+++ b/src/agent/invoke.rs
@@ -30,6 +30,7 @@ struct LoopGuardStream {
     inner: Pin<Box<dyn Stream<Item = AgentEvent> + Send>>,
     loop_active: Arc<AtomicBool>,
     idle_notify: Arc<Notify>,
+    pending_message_snapshot: Arc<crate::pause_state::PendingMessageSnapshot>,
     generation: u64,
     expected_generation: Arc<AtomicU64>,
 }
@@ -49,6 +50,7 @@ impl Drop for LoopGuardStream {
         // this guard's generation stale.
         if self.expected_generation.load(Ordering::Acquire) == self.generation {
             self.loop_active.store(false, Ordering::Release);
+            self.pending_message_snapshot.clear();
             self.idle_notify.notify_waiters();
         }
     }
@@ -228,6 +230,7 @@ impl Agent {
     ) -> Result<Pin<Box<dyn Stream<Item = AgentEvent> + Send>>, AgentError> {
         self.state.is_running = true;
         self.state.error = None;
+        self.pending_message_snapshot.clear();
         self.loop_active.store(true, Ordering::Release);
         let generation = self.loop_generation.fetch_add(1, Ordering::AcqRel) + 1;
 
@@ -270,6 +273,7 @@ impl Agent {
             inner: raw_stream,
             loop_active: Arc::clone(&self.loop_active),
             idle_notify: Arc::clone(&self.idle_notify),
+            pending_message_snapshot: Arc::clone(&self.pending_message_snapshot),
             generation,
             expected_generation: Arc::clone(&self.loop_generation),
         });
@@ -295,6 +299,7 @@ impl Agent {
             follow_up_queue: Arc::clone(&self.follow_up_queue),
             steering_mode: self.steering_mode,
             follow_up_mode: self.follow_up_mode,
+            pending_message_snapshot: Arc::clone(&self.pending_message_snapshot),
         });
 
         let message_provider: Arc<dyn MessageProvider> =
@@ -319,6 +324,7 @@ impl Agent {
             transform_context: transform,
             get_api_key: api_key_box,
             message_provider: Some(message_provider),
+            pending_message_snapshot: Arc::clone(&self.pending_message_snapshot),
             approve_tool: self.approve_tool.as_ref().map(|a| {
                 let a = Arc::clone(a);
                 let b: Box<ApproveToolFn> = Box::new(move |req| a(req));

--- a/src/agent/queueing.rs
+++ b/src/agent/queueing.rs
@@ -73,21 +73,26 @@ pub(super) struct QueueMessageProvider {
     pub(super) follow_up_queue: Arc<Mutex<VecDeque<AgentMessage>>>,
     pub(super) steering_mode: SteeringMode,
     pub(super) follow_up_mode: FollowUpMode,
+    pub(super) pending_message_snapshot: Arc<crate::pause_state::PendingMessageSnapshot>,
 }
 
 impl MessageProvider for QueueMessageProvider {
     fn poll_steering(&self) -> Vec<AgentMessage> {
-        drain_queue(
+        let drained = drain_queue(
             &self.steering_queue,
             self.steering_mode == SteeringMode::OneAtATime,
-        )
+        );
+        self.pending_message_snapshot.append(&drained);
+        drained
     }
 
     fn poll_follow_up(&self) -> Vec<AgentMessage> {
-        drain_queue(
+        let drained = drain_queue(
             &self.follow_up_queue,
             self.follow_up_mode == FollowUpMode::OneAtATime,
-        )
+        );
+        self.pending_message_snapshot.append(&drained);
+        drained
     }
 }
 

--- a/src/agent/state_updates.rs
+++ b/src/agent/state_updates.rs
@@ -82,6 +82,7 @@ impl Agent {
         }
         self.state.is_running = false;
         self.loop_active.store(false, Ordering::Release);
+        self.pending_message_snapshot.clear();
         self.state.error.clone_from(&error);
         self.idle_notify.notify_waiters();
 
@@ -127,6 +128,7 @@ impl Agent {
                 self.state.messages = clone_messages(messages.as_ref());
                 self.in_flight_llm_messages = None;
                 self.in_flight_messages = None;
+                self.pending_message_snapshot.clear();
                 // Preserve terminal error — do not clear self.state.error.
                 self.idle_notify.notify_waiters();
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,8 @@ mod noop_tool;
 mod orchestrator;
 #[cfg(feature = "otel")]
 pub mod otel;
+#[doc(hidden)]
+pub mod pause_state;
 #[cfg(feature = "plugins")]
 pub(crate) mod plugin;
 pub(crate) mod policy;
@@ -52,9 +54,9 @@ mod schema;
 mod state;
 pub(crate) mod stream;
 pub mod stream_assembly;
-mod task_core;
 mod stream_middleware;
 mod sub_agent;
+mod task_core;
 pub(crate) mod tool;
 mod tool_execution_policy;
 pub(crate) mod tool_filter;

--- a/src/loop_/config.rs
+++ b/src/loop_/config.rs
@@ -65,6 +65,10 @@ pub struct AgentLoopConfig {
     /// [`MessageProvider::poll_follow_up`] is called when the agent would otherwise stop.
     pub message_provider: Option<Arc<dyn MessageProvider>>,
 
+    /// Shared snapshot of loop-local pending messages for pause checkpoints.
+    #[allow(private_interfaces)]
+    pub pending_message_snapshot: Arc<crate::pause_state::PendingMessageSnapshot>,
+
     /// Optional async callback for approving/rejecting tool calls before execution.
     /// When `Some` and `approval_mode` is `Enabled`, each tool call is sent through
     /// this callback before dispatch. Rejected tools return an error result to the LLM.

--- a/src/loop_/mod.rs
+++ b/src/loop_/mod.rs
@@ -227,6 +227,9 @@ async fn run_loop_inner(
                     }
                     PolicyVerdict::Inject(msgs) => {
                         state.pending_messages.extend(msgs);
+                        config
+                            .pending_message_snapshot
+                            .replace(&state.pending_messages);
                         continue 'outer;
                     }
                 }
@@ -237,6 +240,9 @@ async fn run_loop_inner(
                 let msgs = provider.poll_follow_up();
                 if !msgs.is_empty() {
                     state.pending_messages.extend(msgs);
+                    config
+                        .pending_message_snapshot
+                        .replace(&state.pending_messages);
                     continue 'outer;
                 }
             }

--- a/src/loop_/tool_dispatch/mod.rs
+++ b/src/loop_/tool_dispatch/mod.rs
@@ -117,12 +117,9 @@ pub async fn execute_tools_concurrently(
     };
 
     // Phase 2: Compute execution groups and dispatch.
-    let groups = execute::compute_execution_groups(
-        &config.tool_execution_policy,
-        tool_calls,
-        &prepared,
-    )
-    .await;
+    let groups =
+        execute::compute_execution_groups(&config.tool_execution_policy, tool_calls, &prepared)
+            .await;
 
     // Phase 3: Execute each group and collect results.
     for group in groups {
@@ -225,9 +222,7 @@ mod tests {
     use crate::testing::{MockStreamFn, MockTool, default_convert, default_model};
     use crate::tool::{AgentToolResult, ApprovalMode};
     use crate::types::ContentBlock;
-    use crate::{
-        DefaultRetryStrategy, StreamOptions, ToolApproval, ToolExecutionPolicy,
-    };
+    use crate::{DefaultRetryStrategy, StreamOptions, ToolApproval, ToolExecutionPolicy};
 
     struct BurstUpdatingTool {
         update_count: usize,
@@ -340,6 +335,7 @@ mod tests {
             transform_context: None,
             get_api_key: None,
             message_provider: None,
+            pending_message_snapshot: Arc::default(),
             approve_tool,
             approval_mode,
             pre_turn_policies: vec![],

--- a/src/loop_/turn.rs
+++ b/src/loop_/turn.rs
@@ -46,6 +46,7 @@ pub async fn run_single_turn(
     if !state.pending_messages.is_empty() {
         state.context_messages.append(&mut state.pending_messages);
     }
+    clear_pending_message_snapshot(config);
 
     // Check cancellation
     if cancellation_token.is_cancelled() {
@@ -90,6 +91,7 @@ pub async fn run_single_turn(
             }
             PolicyVerdict::Inject(msgs) => {
                 state.pending_messages.extend(msgs);
+                sync_pending_message_snapshot(config, state);
             }
         }
     }
@@ -340,6 +342,16 @@ pub(super) async fn run_context_transformers(
     }
 
     any_compacted
+}
+
+fn clear_pending_message_snapshot(config: &AgentLoopConfig) {
+    config.pending_message_snapshot.clear();
+}
+
+fn sync_pending_message_snapshot(config: &AgentLoopConfig, state: &LoopState) {
+    config
+        .pending_message_snapshot
+        .replace(&state.pending_messages);
 }
 
 // ─── Shared helpers ──────────────────────────────────────────────────────
@@ -677,6 +689,7 @@ fn run_post_turn_policy_check(
                     }
                     other => {
                         state.pending_messages.push(other);
+                        sync_pending_message_snapshot(config, state);
                     }
                 }
             }
@@ -836,6 +849,7 @@ async fn handle_tool_calls(
                 collected_tool_metrics = tool_metrics;
                 detected_transfer_signal = transfer_signal;
                 state.pending_messages.extend(injected_messages);
+                sync_pending_message_snapshot(config, state);
             }
             ToolExecOutcome::SteeringInterrupt {
                 completed,
@@ -850,6 +864,7 @@ async fn handle_tool_calls(
                 collected_tool_metrics = tool_metrics;
                 state.pending_messages.extend(injected_messages);
                 state.pending_messages.extend(steering_messages);
+                sync_pending_message_snapshot(config, state);
             }
             ToolExecOutcome::ChannelClosed => return TurnOutcome::Return,
         }
@@ -1008,6 +1023,7 @@ async fn handle_tool_calls(
         let msgs = provider.poll_steering();
         if !msgs.is_empty() {
             state.pending_messages.extend(msgs);
+            sync_pending_message_snapshot(config, state);
         }
     }
     // Inner loop continues — model must process tool results.

--- a/src/pause_state.rs
+++ b/src/pause_state.rs
@@ -1,0 +1,59 @@
+use std::sync::Mutex;
+
+use crate::types::AgentMessage;
+
+/// Shared snapshot of loop-local pending messages for pause checkpoints.
+///
+/// The live loop can move queued follow-up or steering messages into its local
+/// `LoopState.pending_messages` between turns. `Agent::pause()` runs outside
+/// that task, so it needs a synchronized view of the loop-local pending batch
+/// in addition to whatever still remains in the shared queues.
+#[doc(hidden)]
+#[derive(Default)]
+pub struct PendingMessageSnapshot {
+    pending_messages: Mutex<Vec<AgentMessage>>,
+}
+
+impl PendingMessageSnapshot {
+    pub(crate) fn replace(&self, pending_messages: &[AgentMessage]) {
+        let mut guard = self
+            .pending_messages
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        *guard = clone_messages(pending_messages);
+    }
+
+    pub(crate) fn append(&self, pending_messages: &[AgentMessage]) {
+        let mut guard = self
+            .pending_messages
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        guard.extend(clone_messages(pending_messages));
+    }
+
+    pub(crate) fn clear(&self) {
+        self.pending_messages
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clear();
+    }
+
+    pub(crate) fn snapshot(&self) -> Vec<AgentMessage> {
+        clone_messages(
+            &self
+                .pending_messages
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+        )
+    }
+}
+
+fn clone_messages(messages: &[AgentMessage]) -> Vec<AgentMessage> {
+    messages
+        .iter()
+        .filter_map(|message| match message {
+            AgentMessage::Llm(llm) => Some(AgentMessage::Llm(llm.clone())),
+            AgentMessage::Custom(custom) => custom.clone_box().map(AgentMessage::Custom),
+        })
+        .collect()
+}

--- a/tests/abort_turn_end_reason.rs
+++ b/tests/abort_turn_end_reason.rs
@@ -44,6 +44,7 @@ fn default_config(stream_fn: Arc<dyn StreamFn>) -> AgentLoopConfig {
         transform_context: None,
         get_api_key: None,
         message_provider: None,
+        pending_message_snapshot: Arc::default(),
         approve_tool: None,
         approval_mode: swink_agent::ApprovalMode::default(),
         pre_turn_policies: vec![],

--- a/tests/agent_loop.rs
+++ b/tests/agent_loop.rs
@@ -190,6 +190,7 @@ fn default_config(stream_fn: Arc<dyn StreamFn>) -> AgentLoopConfig {
         transform_context: None,
         get_api_key: None,
         message_provider: None,
+        pending_message_snapshot: Arc::default(),
         approve_tool: None,
         approval_mode: swink_agent::ApprovalMode::default(),
         pre_turn_policies: vec![],

--- a/tests/context_compaction.rs
+++ b/tests/context_compaction.rs
@@ -90,6 +90,7 @@ fn default_config(stream_fn: Arc<dyn StreamFn>) -> AgentLoopConfig {
         transform_context: None,
         get_api_key: None,
         message_provider: None,
+        pending_message_snapshot: Arc::default(),
         approve_tool: None,
         approval_mode: swink_agent::ApprovalMode::default(),
         pre_turn_policies: vec![],

--- a/tests/fallback.rs
+++ b/tests/fallback.rs
@@ -64,6 +64,7 @@ fn default_config(
         transform_context: None,
         get_api_key: None,
         message_provider: None,
+        pending_message_snapshot: Arc::default(),
         approve_tool: None,
         approval_mode: swink_agent::ApprovalMode::default(),
         pre_turn_policies: vec![],

--- a/tests/loop_overflow.rs
+++ b/tests/loop_overflow.rs
@@ -58,6 +58,7 @@ fn default_config(stream_fn: Arc<dyn StreamFn>) -> AgentLoopConfig {
         transform_context: None,
         get_api_key: None,
         message_provider: None,
+        pending_message_snapshot: Arc::default(),
         approve_tool: None,
         approval_mode: swink_agent::ApprovalMode::default(),
         pre_turn_policies: vec![],

--- a/tests/otel_spans.rs
+++ b/tests/otel_spans.rs
@@ -48,6 +48,7 @@ fn default_config(stream_fn: Arc<dyn StreamFn>) -> AgentLoopConfig {
         transform_context: None,
         get_api_key: None,
         message_provider: None,
+        pending_message_snapshot: Arc::default(),
         approve_tool: None,
         approval_mode: swink_agent::ApprovalMode::default(),
         pre_turn_policies: vec![],

--- a/tests/tool_execution_policy.rs
+++ b/tests/tool_execution_policy.rs
@@ -129,6 +129,7 @@ fn make_config(
         transform_context: None,
         get_api_key: None,
         message_provider: None,
+        pending_message_snapshot: Arc::default(),
         approve_tool: None,
         approval_mode: swink_agent::ApprovalMode::default(),
         pre_turn_policies: vec![],


### PR DESCRIPTION
## What changed and why
- Added a shared pending-message snapshot so `pause()` captures loop-local `pending_messages` as well as whatever still remains in the live follow-up and steering queues.
- Taught the queue-backed message provider and loop state transitions to keep that snapshot synchronized whenever pending next-turn messages are drained, injected, committed, or the run ends.
- Added a regression test covering the exact race window from issue #490: shared queue already drained into loop-local pending state, then `pause()` still needs to serialize that pending work into the checkpoint.

## Slice completed / remaining
- Completed the pause/checkpoint queue-ownership fix for the reported race.
- Nothing remains for issue #490's queue polling checkpoint gap.

## Validation output
- `cargo test -p swink-agent --features testkit pause_captures_messages_already_moved_into_loop_local_pending_state`
- `cargo test -p swink-agent --features testkit --test pause_resume pause_captures_pending_follow_up_messages`

## Pre-existing baseline failures
- `cargo clippy --workspace --all-targets --features testkit -- -D warnings` still fails on unrelated existing issues in `src/transfer.rs` (`dead_code` on `TransferToAgentTool::{new,with_allowed_targets}` and `clippy::missing_const_for_fn` on `transfer_chain()`), which matches the open build-cleanup work around issue #493.
- `cargo test --workspace --features testkit` did not finish before the automation timeout (244s), so I do not have a clean full-workspace result to report from this run.

Closes #490