### PR TITLE
fix: roll back pre-dispatch args after policy panic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,7 @@ MSRV **1.88** (edition 2024). Common workspace deps are centralized in root `Car
 - Four configurable policy slots: PreTurn (before LLM call), PreDispatch (per tool call), PostTurn (after turn), PostLoop (after inner loop).
 - Two verdict enums: `PolicyVerdict` (Continue/Stop/Inject) and `PreDispatchVerdict` (+ Skip). Compile-time enforcement that Skip is only valid in PreDispatch.
 - Slot runner uses `AssertUnwindSafe` + `catch_unwind` — traits only need `Send + Sync`, not `UnwindSafe`.
+- Pre-dispatch policy panics must restore the prior `arguments` snapshot before later policies or approval run; otherwise partial `serde_json::Value` rewrites leak through even though the panic is caught.
 - Empty policy vecs = zero overhead, no allocation. Default is anything-goes.
 - `ToolDispatchContext.execution_root` carries the tool's working directory when known. Policies that validate relative paths must reject them when this context is absent instead of assuming lexical containment.
 - Reusable shared policy implementations primarily live in `swink-agent-policies`; plugin crates can also define crate-local policies against the core traits.

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -300,7 +300,7 @@ fn run_policies_inner<'a>(
 /// - **Stop** short-circuits: aborts the entire tool batch.
 /// - **Skip** short-circuits: skips this tool call with error text.
 /// - **Inject** accumulates.
-/// - **Panics** are caught and treated as Continue.
+/// - **Panics** are caught, argument mutations are rolled back, and evaluation continues.
 pub fn run_pre_dispatch_policies(
     policies: &[Arc<dyn PreDispatchPolicy>],
     ctx: &mut ToolDispatchContext<'_>,
@@ -309,6 +309,7 @@ pub fn run_pre_dispatch_policies(
 
     for policy in policies {
         let policy_name = policy.name().to_string();
+        let argument_snapshot = ctx.arguments.clone();
         let result = std::panic::catch_unwind(AssertUnwindSafe(|| policy.evaluate(ctx)));
 
         match result {
@@ -325,6 +326,7 @@ pub fn run_pre_dispatch_policies(
                 injections.extend(msgs);
             }
             Err(_) => {
+                *ctx.arguments = argument_snapshot;
                 warn!(policy = %policy_name, "policy panicked during evaluation, skipping");
             }
         }

--- a/tests/pre_dispatch_panic_rollback.rs
+++ b/tests/pre_dispatch_panic_rollback.rs
@@ -1,0 +1,77 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use swink_agent::{
+    PreDispatchPolicy, PreDispatchVerdict, SessionState, ToolDispatchContext,
+    run_pre_dispatch_policies,
+};
+
+struct PanickingMutatingPolicy;
+
+impl PreDispatchPolicy for PanickingMutatingPolicy {
+    fn name(&self) -> &str {
+        "panicking_mutator"
+    }
+
+    fn evaluate(&self, ctx: &mut ToolDispatchContext<'_>) -> PreDispatchVerdict {
+        ctx.arguments
+            .as_object_mut()
+            .expect("test arguments should be an object")
+            .insert("panic_injected".to_string(), serde_json::json!("leaked"));
+        panic!("panic after mutating arguments");
+    }
+}
+
+struct RejectIfKeyPresentPolicy {
+    called: Arc<AtomicBool>,
+}
+
+impl PreDispatchPolicy for RejectIfKeyPresentPolicy {
+    fn name(&self) -> &str {
+        "reject_if_key_present"
+    }
+
+    fn evaluate(&self, ctx: &mut ToolDispatchContext<'_>) -> PreDispatchVerdict {
+        self.called.store(true, Ordering::SeqCst);
+        if ctx.arguments.get("panic_injected").is_some() {
+            PreDispatchVerdict::Skip("panic mutation leaked".to_string())
+        } else {
+            PreDispatchVerdict::Continue
+        }
+    }
+}
+
+#[test]
+fn panicking_pre_dispatch_policy_restores_arguments_before_continuing() {
+    let called = Arc::new(AtomicBool::new(false));
+    let policies: Vec<Arc<dyn PreDispatchPolicy>> = vec![
+        Arc::new(PanickingMutatingPolicy),
+        Arc::new(RejectIfKeyPresentPolicy {
+            called: Arc::clone(&called),
+        }),
+    ];
+    let state = SessionState::new();
+    let mut arguments = serde_json::json!({
+        "path": "safe.txt",
+        "mode": "overwrite"
+    });
+    let mut ctx = ToolDispatchContext {
+        tool_name: "write_file",
+        tool_call_id: "call-1",
+        arguments: &mut arguments,
+        execution_root: None,
+        state: &state,
+    };
+
+    let verdict = run_pre_dispatch_policies(&policies, &mut ctx);
+
+    assert!(matches!(verdict, PreDispatchVerdict::Continue));
+    assert!(called.load(Ordering::SeqCst));
+    assert_eq!(
+        arguments,
+        serde_json::json!({
+            "path": "safe.txt",
+            "mode": "overwrite"
+        })
+    );
+}


### PR DESCRIPTION
## Summary
- restore the original tool-argument snapshot when a pre-dispatch policy panics so partial mutations cannot leak into later policies or approval
- document the panic-rollback behavior in `AGENTS.md`
- add a public regression test that proves a panicking mutator does not leak rewritten arguments to the next policy

## Slice Completed
- completed the core panic-isolation fix for pre-dispatch argument mutation handling
- no further implementation should be needed for issue #492 beyond review/merge

## Validation
- `cargo test -p swink-agent --test pre_dispatch_panic_rollback`
- `cargo clippy -p swink-agent --test pre_dispatch_panic_rollback -- -D warnings`

## Pre-existing Baseline Failures
- `cargo clippy -p swink-agent --test pre_dispatch_panic_rollback -- -D warnings` still fails on the existing `clippy::missing_const_for_fn` warning in `src/transfer.rs:99` (`TransferSignal::transfer_chain()`), matching open issue #493

Closes #492