### PR TITLE
[codex] Fix workspace clippy warnings

### DIFF
--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -96,7 +96,7 @@ impl TransferSignal {
     }
 
     /// Transfer chain captured at handoff time, if present.
-    pub fn transfer_chain(&self) -> Option<&TransferChain> {
+    pub const fn transfer_chain(&self) -> Option<&TransferChain> {
         self.transfer_chain.as_ref()
     }
 }

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -7,8 +7,9 @@ use std::sync::Arc;
 
 use swink_agent::{
     AgentOptions, CatalogPreset, ModelConnection, ModelConnections, ModelSpec, StreamFn,
-    model_catalog,
 };
+#[cfg(feature = "local")]
+use swink_agent::model_catalog;
 use swink_agent_adapters::{
     AnthropicStreamFn, OllamaStreamFn, OpenAiStreamFn, ProxyStreamFn, remote_presets,
 };


### PR DESCRIPTION
## What changed and why
- marked `TransferSignal::transfer_chain()` as `const`, which removes the `clippy::missing_const_for_fn` warning that was blocking the workspace clippy gate
- gated the TUI's `model_catalog` import behind `#[cfg(feature = "local")]` so the default-feature build no longer trips `unused_imports` once the transfer warning is fixed

## Slice completed
- completed the workspace clippy cleanup needed to resolve issue #493
- no product behavior changed; this is a warning-cleanup slice only
- remaining unrelated follow-up: investigate the existing `swink-agent-tui` test failure described below

## Validation output
- `cargo clippy --workspace -- -D warnings`
- `cargo test -p swink-agent transfer_signal -- --nocapture`

## Pre-existing baseline failures
- `cargo test --workspace` did not finish within a 20 minute timeout
- `cargo test -p swink-agent-tui -- --nocapture` fails at `editor::tests::open_editor_with_true_command_returns_none` (unrelated to this diff)

Closes #493