### PR TITLE
[codex] Classify missing eval results separately

### DIFF
--- a/eval/src/error.rs
+++ b/eval/src/error.rs
@@ -18,6 +18,10 @@ pub enum EvalError {
     #[error("eval set not found: {id}")]
     SetNotFound { id: String },
 
+    /// The requested eval result was not found.
+    #[error("eval result not found: {eval_set_id}/{timestamp}")]
+    ResultNotFound { eval_set_id: String, timestamp: u64 },
+
     /// An eval case definition is invalid.
     #[error("invalid eval case: {reason}")]
     InvalidCase { reason: String },

--- a/eval/src/store.rs
+++ b/eval/src/store.rs
@@ -125,8 +125,9 @@ impl EvalStore for FsEvalStore {
     fn load_result(&self, eval_set_id: &str, timestamp: u64) -> Result<EvalSetResult, EvalError> {
         let path = self.result_path(eval_set_id, timestamp);
         if !path.exists() {
-            return Err(EvalError::SetNotFound {
-                id: format!("{eval_set_id}/{timestamp}"),
+            return Err(EvalError::ResultNotFound {
+                eval_set_id: eval_set_id.to_string(),
+                timestamp,
             });
         }
         let json = fs::read_to_string(path)?;

--- a/eval/tests/store.rs
+++ b/eval/tests/store.rs
@@ -4,8 +4,8 @@ use std::time::Duration;
 
 use swink_agent::{Cost, ModelSpec, StopReason, Usage};
 use swink_agent_eval::{
-    EvalCase, EvalCaseResult, EvalMetricResult, EvalSet, EvalSetResult, EvalStore, EvalSummary,
-    FsEvalStore, Invocation, Score, Verdict,
+    EvalCase, EvalCaseResult, EvalError, EvalMetricResult, EvalSet, EvalSetResult, EvalStore,
+    EvalSummary, FsEvalStore, Invocation, Score, Verdict,
 };
 
 fn sample_eval_set() -> EvalSet {
@@ -114,6 +114,21 @@ fn load_missing_set_returns_error() {
     let dir = tempfile::tempdir().unwrap();
     let store = FsEvalStore::new(dir.path());
     assert!(store.load_set("nonexistent").is_err());
+}
+
+#[test]
+fn load_missing_result_returns_result_not_found() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = FsEvalStore::new(dir.path());
+
+    let error = store.load_result("test-set", 1_000_000).unwrap_err();
+    assert!(matches!(
+        error,
+        EvalError::ResultNotFound {
+            eval_set_id,
+            timestamp
+        } if eval_set_id == "test-set" && timestamp == 1_000_000
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## What changed and why
- added `EvalError::ResultNotFound` so callers can distinguish a missing timestamped eval result from a missing eval set
- updated `FsEvalStore::load_result()` to return the new variant instead of overloading `SetNotFound`
- added regression coverage for the missing-result path in `eval/tests/store.rs`

## Slice completed
- completed the issue's targeted error-classification fix in the eval store
- remaining work: none for this issue

## Validation output
- `cargo test -p swink-agent-eval`
- `cargo clippy -p swink-agent-eval --tests -- -D warnings` *(fails due to pre-existing unrelated `dead_code` lint in `src/transfer.rs:214` and `src/transfer.rs:223` in the root crate)*

## Pre-existing baseline failures
- `cargo clippy -p swink-agent-eval --tests -- -D warnings` is currently blocked by unrelated `swink-agent` dead-code warnings promoted to errors in `src/transfer.rs`

Closes #496