### PR TITLE
Fix Playwright bridge temp-file and extraction protocol

### DIFF
--- a/plugins/web/AGENTS.md
+++ b/plugins/web/AGENTS.md
@@ -1,0 +1,6 @@
+# AGENTS.md — plugins/web
+
+## Lessons Learned
+
+- `src/playwright.rs` must write a unique temp bridge script per `PlaywrightBridge::start()` call. Reusing one fixed temp filename is race-prone when multiple bridge instances start concurrently.
+- `src/playwright_bridge.js` must lazy-load the `playwright` package inside browser startup instead of at module load time. That keeps the bridge's pure extraction helpers testable from plain Node without requiring Playwright to be installed for unit tests.

--- a/plugins/web/src/playwright.rs
+++ b/plugins/web/src/playwright.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter};
@@ -80,6 +80,8 @@ pub enum PlaywrightError {
 
 /// Default timeout for bridge operations (30 seconds).
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+const BRIDGE_SCRIPT: &str = include_str!("playwright_bridge.js");
+static BRIDGE_SCRIPT_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// Bridge to a Playwright Node.js subprocess for headless browser operations.
 ///
@@ -102,11 +104,7 @@ impl PlaywrightBridge {
     ///
     /// `playwright_path` optionally overrides the Node.js binary path.
     pub async fn start(playwright_path: Option<&Path>) -> Result<Self, PlaywrightError> {
-        // Write bridge script to a temp file.
-        let bridge_js = include_str!("playwright_bridge.js");
-        let temp_dir = std::env::temp_dir();
-        let script_path = temp_dir.join("swink_playwright_bridge.js");
-        tokio::fs::write(&script_path, bridge_js).await?;
+        let script_path = write_bridge_script_temp_file().await?;
 
         // Resolve node binary path.
         let node_path = resolve_node_path(playwright_path);
@@ -283,6 +281,22 @@ impl PlaywrightBridge {
     }
 }
 
+async fn write_bridge_script_temp_file() -> Result<PathBuf, PlaywrightError> {
+    let sequence = BRIDGE_SCRIPT_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_nanos());
+    let script_path = std::env::temp_dir().join(format!(
+        "swink_playwright_bridge_{}_{}_{}.js",
+        std::process::id(),
+        timestamp,
+        sequence
+    ));
+
+    tokio::fs::write(&script_path, BRIDGE_SCRIPT).await?;
+    Ok(script_path)
+}
+
 /// Resolve the path to the `node` binary.
 ///
 /// Priority: explicit path > `which node` > bare `"node"`.
@@ -302,4 +316,140 @@ fn resolve_node_path(explicit: Option<&Path>) -> PathBuf {
     }
 
     PathBuf::from("node")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::path::Path;
+    use std::process::Command as StdCommand;
+
+    use super::{BRIDGE_SCRIPT, resolve_node_path, write_bridge_script_temp_file};
+
+    #[tokio::test]
+    async fn writes_unique_bridge_scripts_for_concurrent_startups() {
+        let handles = (0..8).map(|_| tokio::spawn(write_bridge_script_temp_file()));
+        let mut paths = Vec::new();
+
+        for handle in handles {
+            let path = handle
+                .await
+                .expect("task should complete")
+                .expect("temp script creation should succeed");
+            paths.push(path);
+        }
+
+        let unique_paths: HashSet<_> = paths.iter().cloned().collect();
+        assert_eq!(unique_paths.len(), paths.len());
+
+        for path in &paths {
+            let contents = tokio::fs::read_to_string(path)
+                .await
+                .expect("script contents should be readable");
+            assert_eq!(contents, BRIDGE_SCRIPT);
+            tokio::fs::remove_file(path)
+                .await
+                .expect("temp script cleanup should succeed");
+        }
+    }
+
+    #[test]
+    fn bridge_script_exports_data_only_extract_helpers() {
+        assert!(!BRIDGE_SCRIPT.contains("eval("));
+
+        let bridge_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/playwright_bridge.js");
+        let node_script = format!(
+            r"
+const bridge = require({bridge_path});
+
+const linksPlan = bridge.buildExtractionPlan({{ preset: 'links' }});
+if (linksPlan.selector !== 'a[href]' || linksPlan.preset !== 'links') {{
+  throw new Error('unexpected links plan: ' + JSON.stringify(linksPlan));
+}}
+
+const selectorPlan = bridge.buildExtractionPlan({{ selector: '.card' }});
+if (selectorPlan.selector !== '.card' || selectorPlan.preset !== null) {{
+  throw new Error('unexpected selector plan: ' + JSON.stringify(selectorPlan));
+}}
+
+const customElement = bridge.extractElementData(
+  {{
+    tagName: 'DIV',
+    textContent: '  Hello world  ',
+    attributes: [{{ name: 'data-id', value: '42' }}],
+    getAttribute(name) {{
+      return name === 'data-id' ? '42' : null;
+    }},
+    innerHTML: '<span>Hello world</span>',
+  }},
+  null
+);
+if (customElement.tag !== 'div' || customElement.text !== 'Hello world' || customElement.attributes['data-id'] !== '42') {{
+  throw new Error('unexpected custom element: ' + JSON.stringify(customElement));
+}}
+
+const linkElement = bridge.extractElementData(
+  {{
+    tagName: 'A',
+    textContent: ' Docs ',
+    attributes: [{{ name: 'href', value: '/docs' }}],
+    getAttribute(name) {{
+      return name === 'href' ? '/docs' : null;
+    }},
+    innerHTML: 'Docs',
+  }},
+  'links'
+);
+if (linkElement.attributes.href !== '/docs' || Object.keys(linkElement.attributes).length !== 1) {{
+  throw new Error('unexpected link element: ' + JSON.stringify(linkElement));
+}}
+
+const headingElement = bridge.extractElementData(
+  {{
+    tagName: 'H2',
+    textContent: ' Section ',
+    attributes: [{{ name: 'id', value: 'section' }}],
+    getAttribute() {{
+      return null;
+    }},
+    innerHTML: 'Section',
+  }},
+  'headings'
+);
+if (headingElement.tag !== 'h2' || headingElement.text !== 'Section' || Object.keys(headingElement.attributes).length !== 0) {{
+  throw new Error('unexpected heading element: ' + JSON.stringify(headingElement));
+}}
+
+const tableElement = bridge.extractElementData(
+  {{
+    tagName: 'TABLE',
+    textContent: '',
+    attributes: [],
+    getAttribute() {{
+      return null;
+    }},
+    innerHTML: '<tbody><tr><td>value</td></tr></tbody>',
+  }},
+  'tables'
+);
+if (tableElement.tag !== 'table' || !tableElement.text.includes('<tbody>')) {{
+  throw new Error('unexpected table element: ' + JSON.stringify(tableElement));
+}}
+",
+            bridge_path = serde_json::to_string(&bridge_path.display().to_string())
+                .expect("path should serialize"),
+        );
+
+        let output = StdCommand::new(resolve_node_path(None))
+            .arg("-e")
+            .arg(node_script)
+            .output()
+            .expect("node should run bridge helper assertions");
+
+        assert!(
+            output.status.success(),
+            "node assertions failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
 }

--- a/plugins/web/src/playwright_bridge.js
+++ b/plugins/web/src/playwright_bridge.js
@@ -2,23 +2,24 @@
 // Usage: node playwright_bridge.js
 
 const readline = require('readline');
-const { chromium } = require('playwright');
 
 let browser = null;
-
-const rl = readline.createInterface({
-  input: process.stdin,
-  output: process.stdout,
-  terminal: false,
-});
+let chromium = null;
 
 function respond(obj) {
   process.stdout.write(JSON.stringify(obj) + '\n');
 }
 
+function resolveChromium() {
+  if (!chromium) {
+    ({ chromium } = require('playwright'));
+  }
+  return chromium;
+}
+
 async function ensureBrowser() {
   if (!browser) {
-    browser = await chromium.launch({ headless: true });
+    browser = await resolveChromium().launch({ headless: true });
   }
   return browser;
 }
@@ -43,37 +44,70 @@ async function handleScreenshot(req) {
   }
 }
 
-function extractPreset(preset) {
+function buildExtractionPlan(req) {
+  let selector = req.selector || null;
+
+  if (req.preset) {
+    switch (req.preset) {
+      case 'links':
+        selector = 'a[href]';
+        break;
+      case 'headings':
+        selector = 'h1,h2,h3,h4,h5,h6';
+        break;
+      case 'tables':
+        selector = 'table';
+        break;
+      default:
+        return { error: `Unknown preset: ${req.preset}` };
+    }
+  }
+
+  if (!selector) {
+    return { error: 'No selector or preset provided' };
+  }
+
+  return { selector, preset: req.preset || null };
+}
+
+function collectAttributes(el) {
+  if (!el.attributes) {
+    return {};
+  }
+
+  const attributes = Array.isArray(el.attributes) ? el.attributes : Array.from(el.attributes);
+  return Object.fromEntries(attributes.map((attr) => [attr.name, attr.value]));
+}
+
+function extractElementData(el, preset) {
+  const tag = (el.tagName || '').toLowerCase();
+  const text = (el.textContent || '').trim().slice(0, 500);
+
   switch (preset) {
     case 'links':
       return {
-        selector: 'a[href]',
-        extract: (el) => ({
-          tag: el.tagName.toLowerCase(),
-          text: (el.textContent || '').trim().slice(0, 500),
-          attributes: { href: el.getAttribute('href') || '' },
-        }),
+        tag,
+        text,
+        attributes: { href: el.getAttribute('href') || '' },
       };
     case 'headings':
       return {
-        selector: 'h1,h2,h3,h4,h5,h6',
-        extract: (el) => ({
-          tag: el.tagName.toLowerCase(),
-          text: (el.textContent || '').trim().slice(0, 500),
-          attributes: {},
-        }),
+        tag,
+        text,
+        attributes: {},
       };
     case 'tables':
       return {
-        selector: 'table',
-        extract: (el) => ({
-          tag: 'table',
-          text: el.innerHTML.slice(0, 2000),
-          attributes: {},
-        }),
+        tag: 'table',
+        text: (el.innerHTML || '').slice(0, 2000),
+        attributes: {},
       };
     default:
-      return null;
+      return {
+        tag,
+        text,
+        attributes: collectAttributes(el),
+      };
   }
 }
 
@@ -84,40 +118,54 @@ async function handleExtract(req) {
   try {
     await page.goto(req.url, { waitUntil: 'load', timeout: 30000 });
 
-    let selectorStr = req.selector || null;
-    let presetConfig = null;
-
-    if (req.preset) {
-      presetConfig = extractPreset(req.preset);
-      if (!presetConfig) {
-        respond({ id: req.id, ok: false, error: `Unknown preset: ${req.preset}` });
-        return;
-      }
-      selectorStr = presetConfig.selector;
-    }
-
-    if (!selectorStr) {
-      respond({ id: req.id, ok: false, error: 'No selector or preset provided' });
+    const plan = buildExtractionPlan(req);
+    if (plan.error) {
+      respond({ id: req.id, ok: false, error: plan.error });
       return;
     }
 
-    const extractFnBody = presetConfig
-      ? presetConfig.extract.toString()
-      : `(el) => ({
-          tag: el.tagName.toLowerCase(),
-          text: (el.textContent || '').trim().slice(0, 500),
-          attributes: Object.fromEntries(
-            Array.from(el.attributes).map(a => [a.name, a.value])
-          ),
-        })`;
-
     const elements = await page.evaluate(
-      ({ sel, fnBody }) => {
-        const extractFn = eval('(' + fnBody + ')');
-        const els = document.querySelectorAll(sel);
-        return Array.from(els).slice(0, 200).map(extractFn);
+      ({ selector, preset }) => {
+        function collectAttributes(el) {
+          return Object.fromEntries(Array.from(el.attributes).map((attr) => [attr.name, attr.value]));
+        }
+
+        function extractElementData(el, activePreset) {
+          const tag = el.tagName.toLowerCase();
+          const text = (el.textContent || '').trim().slice(0, 500);
+
+          switch (activePreset) {
+            case 'links':
+              return {
+                tag,
+                text,
+                attributes: { href: el.getAttribute('href') || '' },
+              };
+            case 'headings':
+              return {
+                tag,
+                text,
+                attributes: {},
+              };
+            case 'tables':
+              return {
+                tag: 'table',
+                text: el.innerHTML.slice(0, 2000),
+                attributes: {},
+              };
+            default:
+              return {
+                tag,
+                text,
+                attributes: collectAttributes(el),
+              };
+          }
+        }
+
+        const elements = document.querySelectorAll(selector);
+        return Array.from(elements).slice(0, 200).map((el) => extractElementData(el, preset));
       },
-      { sel: selectorStr, fnBody: extractFnBody }
+      plan
     );
 
     respond({ id: req.id, ok: true, data: elements });
@@ -165,13 +213,32 @@ async function handleRequest(line) {
   }
 }
 
-rl.on('line', (line) => {
-  handleRequest(line);
-});
-
-rl.on('close', async () => {
+async function handleClose() {
   if (browser) {
     await browser.close();
+    browser = null;
   }
   process.exit(0);
-});
+}
+
+if (require.main === module) {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+    terminal: false,
+  });
+
+  rl.on('line', (line) => {
+    void handleRequest(line);
+  });
+
+  rl.on('close', () => {
+    void handleClose();
+  });
+}
+
+module.exports = {
+  buildExtractionPlan,
+  collectAttributes,
+  extractElementData,
+};


### PR DESCRIPTION
## Summary
- generate a unique temp bridge script for each `PlaywrightBridge::start()` call so concurrent bridge startups do not race on one shared temp path
- replace the extract-side `eval` protocol with data-only extraction helpers owned by `playwright_bridge.js`
- add regressions for concurrent bridge script creation and for preset/custom selector extraction helpers, and document the bridge constraints in `plugins/web/AGENTS.md`

## Slice completed
This PR completes the subprocess-protocol cleanup slice for the Playwright bridge in issue #413.

## Validation
- `cargo test -p swink-agent-plugin-web playwright::tests:: -- --nocapture`

## Baseline failures on current main
- `cargo test -p swink-agent-plugin-web` still fails in pre-existing tests:
  - `content::tests::truncate_content_multibyte_boundaries_are_utf8_safe`
  - `tools::fetch::tests::execute_rejects_body_that_exceeds_cap_before_extraction`
  - `tools::fetch::tests::execute_returns_readable_content_for_html_under_cap`
- `cargo clippy -p swink-agent-plugin-web --lib --tests --no-deps -- -D warnings` still fails on pre-existing warnings in `plugins/web/src/content.rs`, `plugins/web/src/tools/fetch.rs`, `plugins/web/src/policy/rate_limiter.rs`, `plugins/web/src/policy/sanitizer.rs`, plus the existing `swink-agent` dead-code warning in `src/transfer.rs`

Closes #413