### PR TITLE
[codex] Extract shared OpenAI-compatible adapter shell

### DIFF
--- a/adapters/src/oai_transport.rs
+++ b/adapters/src/oai_transport.rs
@@ -9,15 +9,85 @@
 //! Adapters that need provider-specific hooks (Azure auth, Mistral message
 //! ordering, etc.) apply those before or after calling into this module.
 
+use std::pin::Pin;
+
 use futures::stream::{self, Stream, StreamExt as _};
+use tokio_util::sync::CancellationToken;
+use tracing::debug;
 use tracing::warn;
 
 use swink_agent::{AgentContext, AssistantMessageEvent, ModelSpec, StreamOptions};
 
+use crate::base::AdapterBase;
 use crate::convert;
 use crate::openai_compat::{
     OaiChatRequest, OaiConverter, OaiStreamOptions, build_oai_tools, parse_oai_sse_stream,
 };
+
+/// Shared shell for providers that only customize the OAI-compatible
+/// endpoint label while otherwise using the standard chat-completions flow.
+pub struct OaiAdapterShell {
+    provider: &'static str,
+    base: AdapterBase,
+}
+
+impl OaiAdapterShell {
+    pub(crate) fn new(
+        provider: &'static str,
+        base_url: impl Into<String>,
+        api_key: impl Into<String>,
+    ) -> Self {
+        Self {
+            provider,
+            base: AdapterBase::new(base_url, api_key),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn base_url(&self) -> &str {
+        &self.base.base_url
+    }
+
+    pub(crate) fn fmt_debug(
+        &self,
+        name: &'static str,
+        f: &mut std::fmt::Formatter<'_>,
+    ) -> std::fmt::Result {
+        f.debug_struct(name)
+            .field("base_url", &self.base.base_url)
+            .field("api_key", &"[REDACTED]")
+            .finish_non_exhaustive()
+    }
+
+    pub(crate) fn stream<'a>(
+        &'a self,
+        model: &'a ModelSpec,
+        context: &'a AgentContext,
+        options: &'a StreamOptions,
+        cancellation_token: CancellationToken,
+    ) -> Pin<Box<dyn Stream<Item = AssistantMessageEvent> + Send + 'a>> {
+        let url = format!("{}/v1/chat/completions", self.base.base_url);
+        let api_key = options.api_key.as_deref().unwrap_or(&self.base.api_key);
+
+        debug!(
+            provider = self.provider,
+            %url,
+            model = %model.model_id,
+            messages = context.messages.len(),
+            "sending OAI-compatible request"
+        );
+
+        let request = prepare_oai_request(&self.base.client, &url, model, context, options)
+            .header("Authorization", format!("Bearer {api_key}"));
+
+        Box::pin(oai_send_and_parse(
+            request,
+            self.provider,
+            cancellation_token,
+            |_, _| None,
+        ))
+    }
+}
 
 /// Build a standard OAI-compatible HTTP request (without auth headers).
 ///

--- a/adapters/src/openai.rs
+++ b/adapters/src/openai.rs
@@ -8,12 +8,10 @@ use std::pin::Pin;
 
 use futures::Stream;
 use tokio_util::sync::CancellationToken;
-use tracing::debug;
 
 use swink_agent::{AgentContext, AssistantMessageEvent, ModelSpec, StreamFn, StreamOptions};
 
-use crate::base::AdapterBase;
-use crate::oai_transport::{oai_send_and_parse, prepare_oai_request};
+use crate::oai_transport::OaiAdapterShell;
 
 // ─── OpenAiStreamFn ─────────────────────────────────────────────────────────
 
@@ -22,7 +20,7 @@ use crate::oai_transport::{oai_send_and_parse, prepare_oai_request};
 /// Works with OpenAI, vLLM, LM Studio, Groq, Together, and any other provider
 /// that implements the OpenAI chat completions SSE streaming format.
 pub struct OpenAiStreamFn {
-    pub(crate) base: AdapterBase,
+    pub(crate) shell: OaiAdapterShell,
 }
 
 impl OpenAiStreamFn {
@@ -35,17 +33,14 @@ impl OpenAiStreamFn {
     #[must_use]
     pub fn new(base_url: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
-            base: AdapterBase::new(base_url, api_key),
+            shell: OaiAdapterShell::new("OpenAI", base_url, api_key),
         }
     }
 }
 
 impl std::fmt::Debug for OpenAiStreamFn {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("OpenAiStreamFn")
-            .field("base_url", &self.base.base_url)
-            .field("api_key", &"[REDACTED]")
-            .finish_non_exhaustive()
+        self.shell.fmt_debug("OpenAiStreamFn", f)
     }
 }
 
@@ -57,25 +52,8 @@ impl StreamFn for OpenAiStreamFn {
         options: &'a StreamOptions,
         cancellation_token: CancellationToken,
     ) -> Pin<Box<dyn Stream<Item = AssistantMessageEvent> + Send + 'a>> {
-        let url = format!("{}/v1/chat/completions", self.base.base_url);
-        let api_key = options.api_key.as_deref().unwrap_or(&self.base.api_key);
-
-        debug!(
-            %url,
-            model = %model.model_id,
-            messages = context.messages.len(),
-            "sending OpenAI request"
-        );
-
-        let request = prepare_oai_request(&self.base.client, &url, model, context, options)
-            .header("Authorization", format!("Bearer {api_key}"));
-
-        Box::pin(oai_send_and_parse(
-            request,
-            "OpenAI",
-            cancellation_token,
-            |_, _| None,
-        ))
+        self.shell
+            .stream(model, context, options, cancellation_token)
     }
 }
 
@@ -93,12 +71,12 @@ mod tests {
     #[test]
     fn trailing_slash_stripped() {
         let oai = OpenAiStreamFn::new("https://api.openai.com/", "key");
-        assert_eq!(oai.base.base_url, "https://api.openai.com");
+        assert_eq!(oai.shell.base_url(), "https://api.openai.com");
     }
 
     #[test]
     fn no_trailing_slash_unchanged() {
         let oai = OpenAiStreamFn::new("https://api.openai.com", "key");
-        assert_eq!(oai.base.base_url, "https://api.openai.com");
+        assert_eq!(oai.shell.base_url(), "https://api.openai.com");
     }
 }

--- a/adapters/src/xai.rs
+++ b/adapters/src/xai.rs
@@ -8,32 +8,27 @@ use std::pin::Pin;
 
 use futures::Stream;
 use tokio_util::sync::CancellationToken;
-use tracing::debug;
 
 use swink_agent::{AgentContext, AssistantMessageEvent, ModelSpec, StreamFn, StreamOptions};
 
-use crate::base::AdapterBase;
-use crate::oai_transport::{oai_send_and_parse, prepare_oai_request};
+use crate::oai_transport::OaiAdapterShell;
 
 pub struct XAiStreamFn {
-    base: AdapterBase,
+    shell: OaiAdapterShell,
 }
 
 impl XAiStreamFn {
     #[must_use]
     pub fn new(base_url: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
-            base: AdapterBase::new(base_url, api_key),
+            shell: OaiAdapterShell::new("xAI", base_url, api_key),
         }
     }
 }
 
 impl std::fmt::Debug for XAiStreamFn {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("XAiStreamFn")
-            .field("base_url", &self.base.base_url)
-            .field("api_key", &"[REDACTED]")
-            .finish()
+        self.shell.fmt_debug("XAiStreamFn", f)
     }
 }
 
@@ -45,24 +40,7 @@ impl StreamFn for XAiStreamFn {
         options: &'a StreamOptions,
         cancellation_token: CancellationToken,
     ) -> Pin<Box<dyn Stream<Item = AssistantMessageEvent> + Send + 'a>> {
-        let url = format!("{}/v1/chat/completions", self.base.base_url);
-        let api_key = options.api_key.as_deref().unwrap_or(&self.base.api_key);
-
-        debug!(
-            %url,
-            model = %model.model_id,
-            messages = context.messages.len(),
-            "sending xAI request"
-        );
-
-        let request = prepare_oai_request(&self.base.client, &url, model, context, options)
-            .header("Authorization", format!("Bearer {api_key}"));
-
-        Box::pin(oai_send_and_parse(
-            request,
-            "xAI",
-            cancellation_token,
-            |_, _| None,
-        ))
+        self.shell
+            .stream(model, context, options, cancellation_token)
     }
 }


### PR DESCRIPTION
## What changed
This PR extracts a shared OpenAI-compatible adapter shell in `adapters/src/oai_transport.rs` and moves the duplicated constructor/debug/request shell out of `OpenAiStreamFn` and `XAiStreamFn`.

The new shell now owns:
- base URL normalization and client/api-key storage
- redacted debug formatting
- the standard `/v1/chat/completions` request path with bearer auth
- the shared `prepare_oai_request` -> `oai_send_and_parse` flow

`OpenAiStreamFn` and `XAiStreamFn` stay as first-class public types, but now delegate their common shell behavior to that shared implementation.

## Why
Issue #412 calls out the repeated OpenAI-compatible adapter shell across `openai`, `xai`, `azure`, and parts of `mistral`. This PR ships the smallest safe slice first by collapsing the simplest duplicate pair without changing Azure or Mistral behavior.

## Slice completed / what remains
Completed in this PR:
- extracted a shared shell for the OpenAI/xAI pair
- kept provider-specific labels intact (`OpenAI` vs `xAI`)
- preserved the existing OpenAI/xAI test surface

Still remaining for #412:
- Azure still owns its custom auth/application shell
- Mistral still owns its custom normalization/request shell
- any broader provider-spec abstraction beyond this pair

## Validation
- `cargo clippy --workspace -- -D warnings`
- `cargo test -p swink-agent-adapters --features "openai xai" --test openai --test xai`
- `cargo test --workspace`

## Pre-existing baseline failures observed
- `cargo test --workspace` still fails in `swink-agent` integration test `tests/approval.rs::approval_events_in_correct_order`.
- Failure detail: the test expects `ToolExecutionStart -> ToolApprovalRequested -> ToolApprovalResolved -> ToolExecutionEnd`, but the runtime emits `ToolApprovalRequested -> ToolApprovalResolved -> ToolExecutionStart -> ToolExecutionEnd`.
- This PR does not touch `swink-agent` approval ordering code, so I left that unrelated baseline failure out of scope.

Ref #412