### PR TITLE
[codex] Reuse shared OAI shell for Mistral

### DIFF
--- a/adapters/src/mistral.rs
+++ b/adapters/src/mistral.rs
@@ -28,9 +28,8 @@ use swink_agent::{
     AgentContext, AgentMessage, AssistantMessageEvent, ModelSpec, StreamFn, StreamOptions,
 };
 
-use crate::base::AdapterBase;
 use crate::convert;
-use crate::oai_transport::oai_send_and_parse;
+use crate::oai_transport::{OaiAdapterShell, oai_send_and_parse};
 use crate::openai_compat::{OaiConverter, OaiMessage, build_oai_tools};
 
 /// Charset for generating Mistral-compatible 9-char tool call IDs.
@@ -44,7 +43,7 @@ const MISTRAL_ID_CHARSET: &[u8] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQR
 /// tool call ID format, `max_tokens` naming, no `stream_options`,
 /// `model_length` finish reason, and message ordering constraints.
 pub struct MistralStreamFn {
-    base: AdapterBase,
+    shell: OaiAdapterShell,
 }
 
 impl MistralStreamFn {
@@ -57,17 +56,14 @@ impl MistralStreamFn {
     #[must_use]
     pub fn new(base_url: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
-            base: AdapterBase::new(base_url.into().trim_end_matches('/').to_string(), api_key),
+            shell: OaiAdapterShell::new("Mistral", base_url, api_key),
         }
     }
 }
 
 impl std::fmt::Debug for MistralStreamFn {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("MistralStreamFn")
-            .field("base_url", &self.base.base_url)
-            .field("api_key", &"[REDACTED]")
-            .finish_non_exhaustive()
+        self.shell.fmt_debug("MistralStreamFn", f)
     }
 }
 
@@ -186,7 +182,7 @@ fn mistral_stream<'a>(
     stream::once(async move {
         let mut id_map = MistralIdMap::new();
 
-        let url = format!("{}/v1/chat/completions", mistral.base.base_url);
+        let url = mistral.shell.chat_completions_url();
         debug!(
             %url,
             model = %model.model_id,
@@ -208,15 +204,14 @@ fn mistral_stream<'a>(
             tool_choice,
         };
 
-        let api_key = options.api_key.as_deref().unwrap_or(&mistral.base.api_key);
-        let request = mistral
-            .base
-            .client
-            .post(&url)
-            .header("Authorization", format!("Bearer {api_key}"))
-            .json(&body);
+        let request = mistral.shell.post_json_request(&url, &body, options);
 
-        let raw_stream = oai_send_and_parse(request, "Mistral", cancellation_token, |_, _| None);
+        let raw_stream = oai_send_and_parse(
+            request,
+            mistral.shell.provider(),
+            cancellation_token,
+            |_, _| None,
+        );
         normalize_response_stream(raw_stream, id_map)
     })
     .flatten()

--- a/adapters/src/oai_transport.rs
+++ b/adapters/src/oai_transport.rs
@@ -12,6 +12,7 @@
 use std::pin::Pin;
 
 use futures::stream::{self, Stream, StreamExt as _};
+use serde::Serialize;
 use tokio_util::sync::CancellationToken;
 use tracing::debug;
 use tracing::warn;
@@ -24,8 +25,12 @@ use crate::openai_compat::{
     OaiChatRequest, OaiConverter, OaiStreamOptions, build_oai_tools, parse_oai_sse_stream,
 };
 
-/// Shared shell for providers that only customize the OAI-compatible
-/// endpoint label while otherwise using the standard chat-completions flow.
+/// Shared shell for Bearer-auth OpenAI-compatible adapters.
+///
+/// Fully standard adapters can delegate their entire `stream()` implementation
+/// to this type, while adapters with provider-specific request normalization
+/// can still reuse the shared constructor, debug redaction, endpoint assembly,
+/// and API-key override handling.
 pub struct OaiAdapterShell {
     provider: &'static str,
     base: AdapterBase,
@@ -59,6 +64,31 @@ impl OaiAdapterShell {
             .finish_non_exhaustive()
     }
 
+    pub(crate) fn provider(&self) -> &'static str {
+        self.provider
+    }
+
+    pub(crate) fn chat_completions_url(&self) -> String {
+        format!("{}/v1/chat/completions", self.base.base_url)
+    }
+
+    pub(crate) fn api_key<'a>(&'a self, options: &'a StreamOptions) -> &'a str {
+        options.api_key.as_deref().unwrap_or(&self.base.api_key)
+    }
+
+    pub(crate) fn post_json_request<T: Serialize>(
+        &self,
+        url: &str,
+        body: &T,
+        options: &StreamOptions,
+    ) -> reqwest::RequestBuilder {
+        self.base
+            .client
+            .post(url)
+            .header("Authorization", format!("Bearer {}", self.api_key(options)))
+            .json(body)
+    }
+
     pub(crate) fn stream<'a>(
         &'a self,
         model: &'a ModelSpec,
@@ -66,8 +96,7 @@ impl OaiAdapterShell {
         options: &'a StreamOptions,
         cancellation_token: CancellationToken,
     ) -> Pin<Box<dyn Stream<Item = AssistantMessageEvent> + Send + 'a>> {
-        let url = format!("{}/v1/chat/completions", self.base.base_url);
-        let api_key = options.api_key.as_deref().unwrap_or(&self.base.api_key);
+        let url = self.chat_completions_url();
 
         debug!(
             provider = self.provider,
@@ -78,7 +107,7 @@ impl OaiAdapterShell {
         );
 
         let request = prepare_oai_request(&self.base.client, &url, model, context, options)
-            .header("Authorization", format!("Bearer {api_key}"));
+            .header("Authorization", format!("Bearer {}", self.api_key(options)));
 
         Box::pin(oai_send_and_parse(
             request,


### PR DESCRIPTION
## What changed and why
This follow-up slice for #412 moves `MistralStreamFn` onto the shared `OaiAdapterShell` for the parts it already shares with the other Bearer-auth OpenAI-compatible adapters: base URL trimming, redacted `Debug`, `/v1/chat/completions` endpoint assembly, and API-key override / `Authorization` header handling.

Mistral-specific request shaping stays local to `mistral.rs`. The custom message normalization, body shape (`max_tokens` without `stream_options`), and response normalization remain unchanged.

## Slice completed
This PR completes the next incremental shell-collapse step after the earlier OpenAI/xAI extraction by removing the duplicated outer wrapper code from the Mistral adapter.

## What remains
- Azure still owns its custom auth/header path and debug shell.
- Any broader adapter-shell collapse beyond this Mistral wrapper reuse is still open in #412.

## Validation
- `cargo test -p swink-agent-adapters --features openai,mistral,xai --test openai --test mistral --test xai`

## Pre-existing baseline failures
- `cargo clippy -p swink-agent-adapters --features openai,mistral,xai -- -D warnings` is still blocked by an unrelated existing `dead_code` warning in `swink-agent/src/transfer.rs` (`TransferToAgentTool::new` / `with_allowed_targets`).
- `cargo fmt --all --check` reports unrelated formatting drift across many untouched files on current `main`.

Ref #412