### PR TITLE
[codex] Reuse shared OAI shell for Azure

### DIFF
--- a/adapters/src/azure.rs
+++ b/adapters/src/azure.rs
@@ -15,7 +15,7 @@ use tracing::debug;
 use swink_agent::{AgentContext, AssistantMessageEvent, ModelSpec, StreamFn, StreamOptions};
 use swink_agent_auth::{ExpiringValue, SingleFlightTokenSource};
 
-use crate::oai_transport::{oai_send_and_parse, prepare_oai_request};
+use crate::oai_transport::{OaiAdapterShell, oai_send_and_parse, prepare_oai_request};
 
 /// Authentication method for Azure `OpenAI` deployments.
 #[derive(Clone)]
@@ -55,8 +55,7 @@ struct TokenResponse {
 }
 
 pub struct AzureStreamFn {
-    client: reqwest::Client,
-    base_url: String,
+    shell: OaiAdapterShell,
     auth: AzureAuth,
     token_source: SingleFlightTokenSource<String>,
     /// Override token endpoint URL (for testing). `None` = use Microsoft default.
@@ -66,9 +65,18 @@ pub struct AzureStreamFn {
 impl AzureStreamFn {
     #[must_use]
     pub fn new(base_url: impl Into<String>, auth: AzureAuth) -> Self {
+        let shell_api_key = match &auth {
+            AzureAuth::ApiKey(key) => key.clone(),
+            AzureAuth::EntraId { .. } => String::new(),
+        };
+
         Self {
-            client: reqwest::Client::new(),
-            base_url: base_url.into().trim_end_matches('/').to_string(),
+            shell: OaiAdapterShell::new_with_path(
+                "Azure",
+                base_url,
+                shell_api_key,
+                "/chat/completions",
+            ),
             auth,
             token_source: SingleFlightTokenSource::new(REFRESH_MARGIN),
             token_endpoint_override: None,
@@ -131,7 +139,7 @@ impl AzureStreamFn {
         client_id: &str,
         client_secret: &str,
     ) -> Result<String, String> {
-        let client = self.client.clone();
+        let client = self.shell.client().clone();
         let token_url = self.token_url(tenant_id);
         let client_id = client_id.to_string();
         let client_secret = client_secret.to_string();
@@ -182,7 +190,7 @@ impl AzureStreamFn {
 impl std::fmt::Debug for AzureStreamFn {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AzureStreamFn")
-            .field("base_url", &self.base_url)
+            .field("base_url", &self.shell.base_url())
             .field("auth", &self.auth)
             .finish_non_exhaustive()
     }
@@ -214,7 +222,7 @@ fn azure_stream<'a>(
     cancellation_token: CancellationToken,
 ) -> impl Stream<Item = AssistantMessageEvent> + Send + 'a {
     stream::once(async move {
-        let url = format!("{}/chat/completions", azure.base_url);
+        let url = azure.shell.chat_completions_url();
         debug!(
             %url,
             model = %model.model_id,
@@ -222,21 +230,26 @@ fn azure_stream<'a>(
             "sending Azure request"
         );
 
-        let request = prepare_oai_request(&azure.client, &url, model, context, options);
+        let request = prepare_oai_request(azure.shell.client(), &url, model, context, options);
         let request = match azure.apply_auth(request, options).await {
             Ok(r) => r,
             Err(event) => return stream::iter(vec![event]).left_stream(),
         };
 
-        oai_send_and_parse(request, "Azure", cancellation_token, |status, body| {
-            if is_content_filter_error(body) {
-                Some(AssistantMessageEvent::error_content_filtered(format!(
-                    "Azure content filter blocked request (HTTP {status})"
-                )))
-            } else {
-                None
-            }
-        })
+        oai_send_and_parse(
+            request,
+            azure.shell.provider(),
+            cancellation_token,
+            |status, body| {
+                if is_content_filter_error(body) {
+                    Some(AssistantMessageEvent::error_content_filtered(format!(
+                        "Azure content filter blocked request (HTTP {status})"
+                    )))
+                } else {
+                    None
+                }
+            },
+        )
         .right_stream()
     })
     .flatten()

--- a/adapters/src/oai_transport.rs
+++ b/adapters/src/oai_transport.rs
@@ -12,10 +12,12 @@
 use std::pin::Pin;
 
 use futures::stream::{self, Stream, StreamExt as _};
-use serde::Serialize;
 use tokio_util::sync::CancellationToken;
 use tracing::debug;
 use tracing::warn;
+
+#[cfg(feature = "mistral")]
+use serde::Serialize;
 
 use swink_agent::{AgentContext, AssistantMessageEvent, ModelSpec, StreamOptions};
 
@@ -34,6 +36,7 @@ use crate::openai_compat::{
 pub struct OaiAdapterShell {
     provider: &'static str,
     base: AdapterBase,
+    chat_completions_path: &'static str,
 }
 
 impl OaiAdapterShell {
@@ -45,12 +48,32 @@ impl OaiAdapterShell {
         Self {
             provider,
             base: AdapterBase::new(base_url, api_key),
+            chat_completions_path: "/v1/chat/completions",
         }
     }
 
-    #[cfg(test)]
+    #[cfg(any(test, feature = "azure"))]
+    pub(crate) fn new_with_path(
+        provider: &'static str,
+        base_url: impl Into<String>,
+        api_key: impl Into<String>,
+        chat_completions_path: &'static str,
+    ) -> Self {
+        Self {
+            provider,
+            base: AdapterBase::new(base_url, api_key),
+            chat_completions_path,
+        }
+    }
+
+    #[cfg(any(test, feature = "azure"))]
     pub(crate) fn base_url(&self) -> &str {
         &self.base.base_url
+    }
+
+    #[cfg(feature = "azure")]
+    pub(crate) const fn client(&self) -> &reqwest::Client {
+        &self.base.client
     }
 
     pub(crate) fn fmt_debug(
@@ -64,18 +87,20 @@ impl OaiAdapterShell {
             .finish_non_exhaustive()
     }
 
-    pub(crate) fn provider(&self) -> &'static str {
+    #[cfg(any(feature = "azure", feature = "mistral"))]
+    pub(crate) const fn provider(&self) -> &'static str {
         self.provider
     }
 
     pub(crate) fn chat_completions_url(&self) -> String {
-        format!("{}/v1/chat/completions", self.base.base_url)
+        format!("{}{}", self.base.base_url, self.chat_completions_path)
     }
 
     pub(crate) fn api_key<'a>(&'a self, options: &'a StreamOptions) -> &'a str {
         options.api_key.as_deref().unwrap_or(&self.base.api_key)
     }
 
+    #[cfg(feature = "mistral")]
     pub(crate) fn post_json_request<T: Serialize>(
         &self,
         url: &str,
@@ -201,4 +226,24 @@ pub fn oai_send_and_parse<'a>(
         parse_oai_sse_stream(response, cancellation_token, provider).right_stream()
     })
     .flatten()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn custom_chat_path_is_used() {
+        let shell = OaiAdapterShell::new_with_path(
+            "Azure",
+            "https://example.openai.azure.com/openai/deployments/gpt-4/",
+            "",
+            "/chat/completions",
+        );
+
+        assert_eq!(
+            shell.chat_completions_url(),
+            "https://example.openai.azure.com/openai/deployments/gpt-4/chat/completions"
+        );
+    }
 }


### PR DESCRIPTION
## What changed
- moved `AzureStreamFn` onto the shared `OaiAdapterShell` for base URL normalization, shared client ownership, debug redaction, and chat-completions URL assembly
- extended `OaiAdapterShell` with a provider-specific chat path so Azure can reuse the shell without inheriting the `/v1/chat/completions` suffix used by standard OpenAI-compatible providers
- kept Azure-specific auth, token refresh, and content-filter classification local so request semantics stay unchanged
- added a focused shell unit test covering custom chat-path assembly

## Slice completed
This completes the Azure slice of #412. Earlier merged slices already moved the OpenAI/xAI and Mistral adapters onto the shared shell; this PR applies the same shell reuse to Azure's provider-specific path/auth wrapper.

## Validation
- `cargo test -p swink-agent-adapters --features azure,openai,xai,mistral --test azure --test openai --test xai --test mistral`
- `cargo test -p swink-agent-adapters --features azure,openai,xai,mistral --lib oai_transport`
- `cargo test --workspace` *(fails on a pre-existing unrelated test: `tests/approval.rs::approval_events_in_correct_order` expecting `ToolExecutionStart` before approval events)*
- `cargo clippy --workspace -- -D warnings` *(fails on pre-existing unrelated warnings promoted to errors, including `src/transfer.rs:214` and `src/transfer.rs:223`, plus existing adapters clippy debt in `adapters/src/base.rs`, `adapters/src/classify.rs`, `adapters/src/remote_presets.rs`, and `adapters/tests/azure_live.rs`)*

## Notes
- No IPC contract changes.
- The branch only changes `adapters/src/azure.rs` and `adapters/src/oai_transport.rs`.

Closes #412