### PR TITLE
Emit pipeline failure events on execution errors

### DIFF
--- a/patterns/src/pipeline/event_tests.rs
+++ b/patterns/src/pipeline/event_tests.rs
@@ -100,12 +100,73 @@ async fn failed_pipeline_emits_failed_event() {
     let result = executor.run(&id, "input".into(), token).await;
     assert!(result.is_err());
 
-    // The Started event should fire before the AgentNotFound error,
-    // and StepStarted may or may not fire depending on implementation.
-    // At minimum, we verify Started was emitted.
     let captured = events.lock().unwrap();
-    assert!(!captured.is_empty(), "should have at least a Started event");
+    assert!(
+        captured
+            .iter()
+            .any(|event| matches!(event, PipelineEvent::Failed { error_message, .. } if error_message.contains("ghost"))),
+        "expected a Failed event mentioning the missing agent, got: {captured:?}"
+    );
     assert!(matches!(&captured[0], PipelineEvent::Started { .. }));
+}
+
+#[tokio::test]
+async fn failed_parallel_pipeline_emits_failed_event() {
+    let mut factory = SimpleAgentFactory::new();
+    factory.register("agent-a", || make_text_agent("hello"));
+
+    let registry = PipelineRegistry::new();
+    let pipeline = Pipeline::parallel(
+        "parallel-failing",
+        vec!["agent-a".into(), "ghost".into()],
+        crate::pipeline::types::MergeStrategy::Concat {
+            separator: "\n".to_owned(),
+        },
+    );
+    let id = pipeline.id().clone();
+    registry.register(pipeline);
+
+    let (executor, events) = build_executor_with_events(factory, registry);
+    let token = CancellationToken::new();
+
+    let result = executor.run(&id, "input".into(), token).await;
+    assert!(result.is_err());
+
+    let captured = events.lock().unwrap();
+    assert!(
+        captured
+            .iter()
+            .any(|event| matches!(event, PipelineEvent::Failed { error_message, .. } if error_message.contains("ghost"))),
+        "expected a Failed event mentioning the missing agent, got: {captured:?}"
+    );
+}
+
+#[tokio::test]
+async fn failed_loop_pipeline_emits_failed_event() {
+    let factory = SimpleAgentFactory::new();
+
+    let registry = PipelineRegistry::new();
+    let pipeline = Pipeline::loop_(
+        "loop-failing",
+        "ghost",
+        crate::pipeline::types::ExitCondition::MaxIterations,
+    );
+    let id = pipeline.id().clone();
+    registry.register(pipeline);
+
+    let (executor, events) = build_executor_with_events(factory, registry);
+    let token = CancellationToken::new();
+
+    let result = executor.run(&id, "input".into(), token).await;
+    assert!(result.is_err());
+
+    let captured = events.lock().unwrap();
+    assert!(
+        captured
+            .iter()
+            .any(|event| matches!(event, PipelineEvent::Failed { error_message, .. } if error_message.contains("ghost"))),
+        "expected a Failed event mentioning the missing loop body agent, got: {captured:?}"
+    );
 }
 
 // T056: StepCompleted carries agent_name, duration, usage

--- a/patterns/src/pipeline/executor.rs
+++ b/patterns/src/pipeline/executor.rs
@@ -105,14 +105,21 @@ impl PipelineExecutor {
         input: String,
         cancellation_token: CancellationToken,
     ) -> Result<PipelineOutput, PipelineError> {
-        let pipeline =
-            self.registry
-                .get(pipeline_id)
-                .ok_or_else(|| PipelineError::PipelineNotFound {
+        let pipeline = match self.registry.get(pipeline_id) {
+            Some(pipeline) => pipeline,
+            None => {
+                let err = PipelineError::PipelineNotFound {
                     id: pipeline_id.clone(),
-                })?;
+                };
+                self.emit(PipelineEvent::Failed {
+                    pipeline_id: pipeline_id.clone(),
+                    error_message: err.to_string(),
+                });
+                return Err(err);
+            }
+        };
 
-        match pipeline {
+        let result = match pipeline {
             Pipeline::Sequential {
                 id,
                 name,
@@ -160,7 +167,16 @@ impl PipelineExecutor {
                 )
                 .await
             }
+        };
+
+        if let Err(err) = &result {
+            self.emit(PipelineEvent::Failed {
+                pipeline_id: pipeline_id.clone(),
+                error_message: err.to_string(),
+            });
         }
+
+        result
     }
 
     async fn run_sequential(


### PR DESCRIPTION
## What changed and why
- centralised `PipelineEvent::Failed` emission in `PipelineExecutor::run()` so any pipeline execution error now emits the documented failure event before returning the error
- covered sequential, parallel, and loop failure paths with regression tests in `patterns/src/pipeline/event_tests.rs`

## Slice completed
- completed the runtime failure-event slice for pipeline execution
- remaining scope: none for `#466`; this change aligns the live runners with the existing `PipelineEvent::Failed` contract

## Validation output
- `cargo test -p swink-agent-patterns --features testkit`
- `cargo test -p swink-agent-patterns --features testkit event_tests`
- `cargo clippy -p swink-agent-patterns --tests --features testkit --no-deps -- -D warnings`

## Pre-existing baseline failures
- `cargo clippy -p swink-agent-patterns --tests --features testkit -- -D warnings` still trips an unrelated existing dead-code warning in `src/transfer.rs:214` and `src/transfer.rs:223` from the `swink-agent` crate dependency path

Closes #466
