### PR TITLE
fix: reject duplicate orchestrator registrations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,10 @@ MSRV **1.88** (edition 2024). Common workspace deps are centralized in root `Car
 - `on_init(&self, &Agent)` dispatched in priority order, wrapped in `catch_unwind` — panicking `on_init` is logged and skipped, construction continues (plugin's other contributions remain active).
 - Entire module behind `#[cfg(feature = "plugins")]` — opt-in, not default-enabled, zero cost when disabled.
 
+### Orchestrator (`src/orchestrator.rs`)
+
+- `AgentOrchestrator::add_agent()` and `add_child()` reject duplicate names with a panic instead of replacing existing entries. This preserves `parent_of()` / `children_of()` consistency until a dedicated replace/relink API exists.
+
 ### MCP Integration (`mcp/`)
 
 - `McpManager::shutdown()` must operate on shared connection-owned state, not `Arc::try_unwrap()`: exported `McpTool` handles keep `Arc<McpConnection>` clones alive, so deterministic disconnect has to clear the session/monitor even when callers still retain tool `Arc`s.

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -249,12 +249,20 @@ impl AgentOrchestrator {
     /// Register an agent by name with a factory that produces its options.
     ///
     /// The factory is called each time the agent is spawned or restarted.
+    ///
+    /// # Panics
+    ///
+    /// Panics if an agent with the same name has already been registered.
     pub fn add_agent(
         &mut self,
         name: impl Into<String>,
         options_factory: impl Fn() -> AgentOptions + Send + Sync + 'static,
     ) {
         let name = name.into();
+        assert!(
+            !self.entries.contains_key(&name),
+            "agent '{name}' already registered"
+        );
         self.entries.insert(
             name,
             AgentEntry {
@@ -270,7 +278,8 @@ impl AgentOrchestrator {
     ///
     /// # Panics
     ///
-    /// Panics if the parent agent has not been registered.
+    /// Panics if the parent agent has not been registered or if the child name
+    /// is already registered.
     pub fn add_child(
         &mut self,
         name: impl Into<String>,
@@ -282,6 +291,10 @@ impl AgentOrchestrator {
         assert!(
             self.entries.contains_key(&parent),
             "parent agent '{parent}' not registered"
+        );
+        assert!(
+            !self.entries.contains_key(&name),
+            "agent '{name}' already registered"
         );
 
         self.entries
@@ -501,6 +514,8 @@ impl std::fmt::Debug for AgentOrchestrator {
 
 #[cfg(test)]
 mod tests {
+    use std::panic::AssertUnwindSafe;
+
     use super::*;
 
     #[test]
@@ -543,6 +558,46 @@ mod tests {
     fn add_child_missing_parent_panics() {
         let mut orch = AgentOrchestrator::new();
         orch.add_child("child", "missing", || panic!("not called"));
+    }
+
+    #[test]
+    #[should_panic(expected = "agent 'alpha' already registered")]
+    fn add_agent_duplicate_name_panics() {
+        let mut orch = AgentOrchestrator::new();
+        orch.add_agent("alpha", || panic!("not called"));
+        orch.add_agent("alpha", || panic!("not called"));
+    }
+
+    #[test]
+    fn duplicate_child_registration_preserves_existing_hierarchy() {
+        let mut orch = AgentOrchestrator::new();
+        orch.add_agent("parent1", || panic!("not called"));
+        orch.add_agent("parent2", || panic!("not called"));
+        orch.add_child("child", "parent1", || panic!("not called"));
+
+        let duplicate = std::panic::catch_unwind(AssertUnwindSafe(|| {
+            orch.add_child("child", "parent2", || panic!("not called"));
+        }));
+
+        assert!(duplicate.is_err());
+        assert_eq!(orch.parent_of("child"), Some("parent1"));
+        assert_eq!(orch.children_of("parent1").unwrap(), &["child"]);
+        assert!(orch.children_of("parent2").unwrap().is_empty());
+    }
+
+    #[test]
+    fn duplicate_top_level_registration_preserves_child_link() {
+        let mut orch = AgentOrchestrator::new();
+        orch.add_agent("parent", || panic!("not called"));
+        orch.add_child("child", "parent", || panic!("not called"));
+
+        let duplicate = std::panic::catch_unwind(AssertUnwindSafe(|| {
+            orch.add_agent("child", || panic!("not called"));
+        }));
+
+        assert!(duplicate.is_err());
+        assert_eq!(orch.parent_of("child"), Some("parent"));
+        assert_eq!(orch.children_of("parent").unwrap(), &["child"]);
     }
 
     #[test]


### PR DESCRIPTION
## What changed and why
- make `AgentOrchestrator::add_agent()` reject duplicate names instead of silently overwriting an existing entry
- make `add_child()` reject duplicate child names before mutating the parent `children` list
- add regression tests that prove duplicate top-level and child registrations leave the existing hierarchy intact
- document the duplicate-registration rule in `AGENTS.md`

## Slice completed
This PR completes the smallest safe slice for #467: duplicate registrations now fail fast instead of leaving stale parent/child links behind.

## What remains
- if the project still wants replacement semantics later, that should come back as an explicit replace/relink API instead of silent `HashMap::insert()` overwrite behavior

## Validation output
- `cargo test -p swink-agent orchestrator -- --nocapture`
- `cargo test -p swink-agent --test stress_orchestrator -- --nocapture`

## Pre-existing baseline failures
- `cargo clippy -p swink-agent --lib --tests -- -D warnings` still fails on unrelated existing warnings in `tests/pre_dispatch_panic_rollback.rs`, `src/block_accumulator.rs`, `src/atomic_fs.rs`, `src/checkpoint.rs`, `src/task_core.rs`, `src/tool_middleware.rs`, and `src/types/message_codec.rs`
- `cargo fmt --all` currently rewrites unrelated files on `main`, so this PR keeps formatting scoped to the touched file only

Closes #467