### PR TITLE
fix: make artifact streaming saves incremental

### DIFF
--- a/artifacts/src/fs_store.rs
+++ b/artifacts/src/fs_store.rs
@@ -15,23 +15,23 @@ use swink_agent::{
 // ─── Internal meta.json schema ─────────────────────────────────────────────
 
 #[derive(Serialize, Deserialize)]
-struct MetaFile {
-    versions: Vec<VersionRecord>,
+pub(crate) struct MetaFile {
+    pub(crate) versions: Vec<VersionRecord>,
 }
 
 #[derive(Serialize, Deserialize)]
-struct VersionRecord {
-    name: String,
-    version: u32,
-    created_at: DateTime<Utc>,
-    size: usize,
-    content_type: String,
-    metadata: HashMap<String, String>,
+pub(crate) struct VersionRecord {
+    pub(crate) name: String,
+    pub(crate) version: u32,
+    pub(crate) created_at: DateTime<Utc>,
+    pub(crate) size: usize,
+    pub(crate) content_type: String,
+    pub(crate) metadata: HashMap<String, String>,
 }
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
-fn storage_err(e: impl Error + Send + Sync + 'static) -> ArtifactError {
+pub(crate) fn storage_err(e: impl Error + Send + Sync + 'static) -> ArtifactError {
     ArtifactError::Storage(Box::new(e))
 }
 
@@ -60,7 +60,7 @@ impl FileArtifactStore {
     }
 
     /// Get or create the per-artifact lock for a (session, name) pair.
-    async fn artifact_lock(&self, session_id: &str, name: &str) -> Arc<Mutex<()>> {
+    pub(crate) async fn artifact_lock(&self, session_id: &str, name: &str) -> Arc<Mutex<()>> {
         let key = (session_id.to_string(), name.to_string());
         let mut locks = self.locks.lock().await;
         locks
@@ -70,7 +70,7 @@ impl FileArtifactStore {
     }
 
     /// Path to the artifact directory: `{root}/{session_id}/{artifact_name}/`
-    fn artifact_dir(&self, session_id: &str, name: &str) -> PathBuf {
+    pub(crate) fn artifact_dir(&self, session_id: &str, name: &str) -> PathBuf {
         self.root.join(session_id).join(name)
     }
 
@@ -86,7 +86,11 @@ impl FileArtifactStore {
     }
 
     /// Read meta.json, returning an empty `MetaFile` if it doesn't exist.
-    async fn read_meta(&self, session_id: &str, name: &str) -> Result<MetaFile, ArtifactError> {
+    pub(crate) async fn read_meta(
+        &self,
+        session_id: &str,
+        name: &str,
+    ) -> Result<MetaFile, ArtifactError> {
         let path = self.meta_path(session_id, name);
         match tokio::fs::read_to_string(&path).await {
             Ok(contents) => serde_json::from_str(&contents).map_err(storage_err),
@@ -98,7 +102,7 @@ impl FileArtifactStore {
     }
 
     /// Write meta.json atomically via the shared atomic-write helper.
-    async fn write_meta(
+    pub(crate) async fn write_meta(
         &self,
         session_id: &str,
         name: &str,

--- a/artifacts/src/streaming.rs
+++ b/artifacts/src/streaming.rs
@@ -1,21 +1,82 @@
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use bytes::Bytes;
 use futures::{StreamExt, stream};
+use tokio::fs::OpenOptions;
 use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader, BufWriter};
 
 use swink_agent::{
-    ArtifactByteStream, ArtifactData, ArtifactError, ArtifactStore, ArtifactVersion,
-    StreamingArtifactStore, validate_artifact_name,
+    ArtifactByteStream, ArtifactError, ArtifactVersion, StreamingArtifactStore,
+    validate_artifact_name,
 };
 
-use crate::fs_store::FileArtifactStore;
+use crate::fs_store::{FileArtifactStore, VersionRecord, storage_err};
 
 /// 64 KiB chunk size for buffered streaming I/O.
 const CHUNK_SIZE: usize = 64 * 1024;
+static STREAM_TMP_SEQ: AtomicU64 = AtomicU64::new(0);
 
-fn storage_err(e: impl std::error::Error + Send + Sync + 'static) -> ArtifactError {
-    ArtifactError::Storage(Box::new(e))
+fn temp_version_path(target: &Path) -> Result<PathBuf, ArtifactError> {
+    let parent = target.parent().ok_or_else(|| {
+        storage_err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "target path has no parent directory",
+        ))
+    })?;
+    let file_name = target
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| {
+            storage_err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "target path has no file name",
+            ))
+        })?;
+    let seq = STREAM_TMP_SEQ.fetch_add(1, Ordering::Relaxed);
+
+    Ok(parent.join(format!(
+        ".{file_name}.stream.tmp.{}.{seq}",
+        std::process::id()
+    )))
+}
+
+async fn write_stream_to_temp_file(
+    temp_path: &Path,
+    mut stream: ArtifactByteStream,
+) -> Result<usize, ArtifactError> {
+    let write_result = async {
+        let file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(temp_path)
+            .await
+            .map_err(storage_err)?;
+        let mut writer = BufWriter::with_capacity(CHUNK_SIZE, file);
+        let mut size = 0usize;
+
+        while let Some(chunk) = stream.next().await {
+            let bytes = chunk?;
+            size = size.checked_add(bytes.len()).ok_or_else(|| {
+                storage_err(std::io::Error::other("artifact stream size overflow"))
+            })?;
+            writer.write_all(&bytes).await.map_err(storage_err)?;
+        }
+
+        writer.flush().await.map_err(storage_err)?;
+        let file = writer.into_inner();
+        file.sync_all().await.map_err(storage_err)?;
+
+        Ok(size)
+    }
+    .await;
+
+    if write_result.is_err() {
+        let _ = tokio::fs::remove_file(temp_path).await;
+    }
+
+    write_result
 }
 
 impl StreamingArtifactStore for FileArtifactStore {
@@ -25,29 +86,57 @@ impl StreamingArtifactStore for FileArtifactStore {
         name: &str,
         content_type: String,
         metadata: HashMap<String, String>,
-        mut stream: ArtifactByteStream,
+        stream: ArtifactByteStream,
     ) -> Result<ArtifactVersion, ArtifactError> {
         validate_artifact_name(name)?;
 
-        // Collect the stream into a temp file, then delegate to the base save.
-        // This keeps version numbering and meta.json logic in one place.
-        let mut collected = Vec::new();
-        let mut writer = BufWriter::with_capacity(CHUNK_SIZE, &mut collected);
+        let lock = self.artifact_lock(session_id, name).await;
+        let _guard = lock.lock().await;
 
-        while let Some(chunk) = stream.next().await {
-            let bytes = chunk?;
-            writer.write_all(&bytes).await.map_err(storage_err)?;
+        let dir = self.artifact_dir(session_id, name);
+        tokio::fs::create_dir_all(&dir).await.map_err(storage_err)?;
+
+        let mut meta = self.read_meta(session_id, name).await?;
+
+        #[allow(clippy::cast_possible_truncation)]
+        let next_version = meta.versions.len() as u32 + 1;
+        let now = chrono::Utc::now();
+        let content_path = self.version_path(session_id, name, next_version);
+        let temp_path = temp_version_path(&content_path)?;
+        let size = write_stream_to_temp_file(&temp_path, stream).await?;
+
+        if let Err(error) = tokio::fs::rename(&temp_path, &content_path).await {
+            let _ = tokio::fs::remove_file(&temp_path).await;
+            return Err(storage_err(error));
         }
-        writer.flush().await.map_err(storage_err)?;
-        drop(writer);
 
-        let data = ArtifactData {
-            content: collected,
-            content_type,
-            metadata,
+        let record = VersionRecord {
+            name: name.to_string(),
+            version: next_version,
+            created_at: now,
+            size,
+            content_type: content_type.clone(),
+            metadata: metadata.clone(),
         };
+        let version = ArtifactVersion {
+            name: name.to_string(),
+            version: next_version,
+            created_at: now,
+            size,
+            content_type,
+        };
+        meta.versions.push(record);
+        self.write_meta(session_id, name, &meta).await?;
 
-        self.save(session_id, name, data).await
+        tracing::info!(
+            session_id,
+            name,
+            version = next_version,
+            size,
+            "artifact saved from stream"
+        );
+
+        Ok(version)
     }
 
     async fn load_stream(
@@ -56,27 +145,11 @@ impl StreamingArtifactStore for FileArtifactStore {
         name: &str,
         version: Option<u32>,
     ) -> Result<Option<ArtifactByteStream>, ArtifactError> {
-        #[derive(serde::Deserialize)]
-        struct StreamMetaFile {
-            versions: Vec<StreamVersionEntry>,
-        }
-        #[derive(serde::Deserialize)]
-        struct StreamVersionEntry {
-            version: u32,
-        }
-
         // Resolve the target version number.
         let target_version = if let Some(v) = version {
             v
         } else {
-            let meta_path = self.meta_path(session_id, name);
-            let contents = match tokio::fs::read_to_string(&meta_path).await {
-                Ok(c) => c,
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-                Err(e) => return Err(storage_err(e)),
-            };
-
-            let meta: StreamMetaFile = serde_json::from_str(&contents).map_err(storage_err)?;
+            let meta = self.read_meta(session_id, name).await?;
             match meta.versions.last() {
                 Some(entry) => entry.version,
                 None => return Ok(None),

--- a/artifacts/tests/streaming.rs
+++ b/artifacts/tests/streaming.rs
@@ -199,3 +199,54 @@ async fn non_streaming_api_still_works() {
     let bytes_v1 = collect_stream(loaded_v1).await;
     assert_eq!(bytes_v1, content);
 }
+
+// T065: streaming_save_error_does_not_publish_partial_version
+// A failed stream write must not leave temp files behind or consume a version number.
+#[tokio::test]
+async fn streaming_save_error_does_not_publish_partial_version() {
+    let tmpdir = tempfile::TempDir::new().unwrap();
+    let store = FileArtifactStore::new(tmpdir.path());
+
+    let input_stream = Box::pin(stream::iter(vec![
+        Ok(Bytes::from_static(b"partial")),
+        Err(ArtifactError::Storage(Box::new(std::io::Error::other(
+            "stream failed",
+        )))),
+    ]));
+
+    let result = store
+        .save_stream(
+            "sess4",
+            "broken",
+            "application/octet-stream".to_string(),
+            HashMap::new(),
+            input_stream,
+        )
+        .await;
+
+    assert!(result.is_err());
+    assert!(
+        store.load("sess4", "broken").await.unwrap().is_none(),
+        "failed stream must not publish a readable artifact"
+    );
+
+    let artifact_dir = tmpdir.path().join("sess4").join("broken");
+    let entries: Vec<_> = std::fs::read_dir(&artifact_dir).unwrap().collect();
+    assert!(
+        entries.is_empty(),
+        "failed stream should clean up temp files and avoid writing metadata"
+    );
+
+    let version = store
+        .save_stream(
+            "sess4",
+            "broken",
+            "application/octet-stream".to_string(),
+            HashMap::new(),
+            Box::pin(stream::iter(vec![Ok(Bytes::from_static(b"recovered"))])),
+        )
+        .await
+        .expect("subsequent save_stream should still succeed");
+
+    assert_eq!(version.version, 1);
+}


### PR DESCRIPTION
## What changed and why
- rewrote `FileArtifactStore::save_stream()` to write incoming chunks to a unique temp file and rename it into the version path under the existing per-artifact lock
- preserved the current `meta.json` finalization/versioning flow while removing the full-payload `Vec<u8>` buffer from the filesystem streaming save path
- added a regression test proving a mid-stream failure does not publish partial content, leak temp files, or consume a version number

## Slice completed and what remains
- completed the issue's filesystem streaming-write slice by making `save_stream()` actually incremental for `FileArtifactStore`
- no follow-up implementation is required for this issue unless maintainers want additional zero-byte/interrupted-upload coverage beyond the new regression

## Validation output
- `cargo test -p swink-agent-artifacts --test streaming`
- `cargo test -p swink-agent-artifacts`

## Pre-existing baseline failures
- `cargo clippy --workspace -- -D warnings` still fails on the unrelated dead-code warning for `TransferToAgentTool::new` / `with_allowed_targets` in `src/transfer.rs`
- `cargo test --workspace` exceeded the automation run window in this environment, so I did not get a full-workspace green result for this branch

Closes #470