### PR TITLE
fix: align approval event-order test with dispatch behavior

### DIFF
--- a/src/loop_/tool_dispatch/preprocess.rs
+++ b/src/loop_/tool_dispatch/preprocess.rs
@@ -157,6 +157,19 @@ pub(super) async fn preprocess_tool_calls(
 // ─── Approval helper ────────────────────────────────────────────────────────
 
 /// Run the approval gate for a single tool call.
+///
+/// # Canonical event order
+///
+/// The full per-tool-call event sequence is:
+///
+/// 1. [`AgentEvent::ToolApprovalRequested`] — emitted here, before the callback fires.
+/// 2. [`AgentEvent::ToolApprovalResolved`] — emitted here, after the callback resolves.
+/// 3. [`AgentEvent::ToolExecutionStart`] — emitted later by `dispatch_single_tool`.
+/// 4. [`AgentEvent::ToolExecutionEnd`] — emitted after the tool's `execute()` returns.
+///
+/// Approval always precedes execution: a tool must be approved before it is
+/// dispatched, so `ToolExecutionStart` cannot be observed until after
+/// `ToolApprovalResolved`. Consumers (TUI, eval, tests) may rely on this order.
 #[allow(clippy::too_many_arguments)]
 async fn check_approval(
     approve_fn: &ApproveToolFn,

--- a/tests/approval.rs
+++ b/tests/approval.rs
@@ -213,7 +213,14 @@ async fn selective_approval_by_tool_name() {
     assert!(result.error.is_none());
 }
 
-/// Test 5: Events appear in correct order.
+/// Test 5: Events appear in canonical order.
+///
+/// Canonical dispatch order (see `src/loop_/tool_dispatch.rs`):
+///   `ToolApprovalRequested` → `ToolApprovalResolved` → `ToolExecutionStart` → `ToolExecutionEnd`.
+///
+/// Approval always precedes execution — a tool call must be approved before it
+/// is dispatched, so `ToolExecutionStart` cannot be emitted until the approval
+/// gate has resolved.
 #[tokio::test]
 async fn approval_events_in_correct_order() {
     let tool = Arc::new(MockTool::new("test_tool"));
@@ -244,12 +251,13 @@ async fn approval_events_in_correct_order() {
     assert_eq!(
         tool_events,
         vec![
-            "ToolExecutionStart",
             "ToolApprovalRequested",
             "ToolApprovalResolved",
+            "ToolExecutionStart",
             "ToolExecutionEnd",
         ],
-        "events should follow Start → ApprovalRequested → ApprovalResolved → End order"
+        "events should follow ApprovalRequested → ApprovalResolved → ExecutionStart → ExecutionEnd \
+         order (approval precedes execution)"
     );
 }
 

--- a/tests/composed.rs
+++ b/tests/composed.rs
@@ -451,22 +451,28 @@ async fn subscriber_receives_approval_events() {
     let tool_end = find("ToolExecutionEnd").expect("should have ToolExecutionEnd");
     let agent_end = find("AgentEnd").expect("should have AgentEnd");
 
+    // Canonical order (see `src/loop_/tool_dispatch.rs`):
+    //   AgentStart → TurnStart → ToolApprovalRequested → ToolApprovalResolved
+    //   → ToolExecutionStart → ToolExecutionEnd → AgentEnd.
+    //
+    // Approval always precedes execution: a tool cannot be dispatched until the
+    // approval gate has resolved.
     assert!(agent_start < turn_start, "AgentStart before TurnStart");
     assert!(
-        turn_start < tool_start,
-        "TurnStart before ToolExecutionStart"
-    );
-    assert!(
-        tool_start < approval_requested,
-        "ToolExecutionStart before ApprovalRequested"
+        turn_start < approval_requested,
+        "TurnStart before ToolApprovalRequested"
     );
     assert!(
         approval_requested < approval_resolved,
         "ApprovalRequested before ApprovalResolved"
     );
     assert!(
-        approval_resolved < tool_end,
-        "ApprovalResolved before ToolExecutionEnd"
+        approval_resolved < tool_start,
+        "ApprovalResolved before ToolExecutionStart (approval precedes execution)"
+    );
+    assert!(
+        tool_start < tool_end,
+        "ToolExecutionStart before ToolExecutionEnd"
     );
     assert!(tool_end < agent_end, "ToolExecutionEnd before AgentEnd");
 }


### PR DESCRIPTION
## Summary
`approval_events_in_correct_order` was asserting start-before-approval, but dispatch now emits `ApprovalRequested -> ApprovalResolved -> ToolExecutionStart -> ToolExecutionEnd`. That is the correct contract — approval precedes execution. The test was stale from a prior dispatch refactor; updating the assertion and documenting the order.

A sibling test in `tests/composed.rs` (`subscriber_receives_approval_events`) had the same stale assertion and is updated to the canonical order as well.

## Canonical event order
`ToolApprovalRequested -> ToolApprovalResolved -> ToolExecutionStart -> ToolExecutionEnd`

Approval always precedes execution — a tool call cannot be dispatched until the approval gate has resolved. In `src/loop_/tool_dispatch.rs`, `check_approval` runs in Phase 1 (approval events), and `dispatch_single_tool` runs in Phase 3 (execution events).

## Changes
- `tests/approval.rs` — flip `approval_events_in_correct_order` expectation to match dispatch; add doc comment explaining the contract.
- `tests/composed.rs` — update `subscriber_receives_approval_events` lifecycle ordering assertions (discovered while running the workspace suite).
- `src/loop_/tool_dispatch.rs` — add a `# Canonical event order` doc block on `check_approval` so the contract lives next to the emission sites.

## Test plan
- [x] `approval_events_in_correct_order` passes
- [x] `cargo test -p swink-agent --features testkit` passes (all 391 unit tests + integration tests)
- [x] `cargo test -p swink-agent --no-default-features` passes
- [x] All approval/composed tests green

Note: Workspace `cargo fmt --all --check`, `cargo clippy --workspace -- -D warnings`, and `cargo test -p swink-agent-plugin-web` each fail on baseline (`main` at 2095ec0) due to unrelated pre-existing issues in `xtask/src/*.rs`, `tui/src/main.rs`, and `plugins/web/src/{content,tools/fetch}.rs`. None are touched by this PR.

Closes #523

🤖 Generated with [Claude Code](https://claude.com/claude-code)