### PR TITLE
fix: make Gemini final tool deltas deterministic

### DIFF
--- a/adapters/src/google.rs
+++ b/adapters/src/google.rs
@@ -777,9 +777,15 @@ impl GeminiStreamState {
     /// **before** [`finalize_blocks`](crate::finalize::finalize_blocks) (which
     /// drains and clears the tool-call map).
     fn emit_final_tool_deltas(&self) -> Vec<AssistantMessageEvent> {
-        self.tool_calls
+        let mut ordered_tool_calls: Vec<_> = self
+            .tool_calls
             .values()
             .filter(|tc| !tc.arguments.is_empty())
+            .collect();
+        ordered_tool_calls.sort_by_key(|tc| tc.content_index);
+
+        ordered_tool_calls
+            .into_iter()
             .map(|tc| AssistantMessageEvent::ToolCallDelta {
                 content_index: tc.content_index,
                 delta: tc.arguments.clone(),

--- a/adapters/tests/google.rs
+++ b/adapters/tests/google.rs
@@ -370,6 +370,62 @@ async fn google_multiple_tool_calls() {
     assert_eq!(stop_reason, Some(StopReason::ToolUse));
 }
 
+#[tokio::test]
+async fn google_final_tool_deltas_follow_tool_call_start_order() {
+    let body = [
+        r#"data: {"candidates":[{"content":{"parts":[{"functionCall":{"id":"c1","name":"get_weather","args":{"city":"Paris"}}},{"functionCall":{"id":"c2","name":"get_time","args":{"tz":"UTC"}}}]}}]}"#,
+        "",
+        r#"data: {"candidates":[{"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":12,"totalTokenCount":22}}"#,
+        "",
+        "data: [DONE]",
+        "",
+    ]
+    .join("\n");
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(sse_response(&body))
+        .mount(&server)
+        .await;
+
+    let stream_fn = GeminiStreamFn::new(server.uri(), "test-key", ApiVersion::V1beta);
+
+    for _ in 0..32 {
+        let events = collect_events(&stream_fn).await;
+
+        let starts: Vec<_> = events
+            .iter()
+            .filter_map(|event| match event {
+                AssistantMessageEvent::ToolCallStart {
+                    content_index, id, ..
+                } => Some((*content_index, id.as_str())),
+                _ => None,
+            })
+            .collect();
+        let deltas: Vec<_> = events
+            .iter()
+            .filter_map(|event| match event {
+                AssistantMessageEvent::ToolCallDelta {
+                    content_index,
+                    delta,
+                } => Some((*content_index, delta.as_str())),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(
+            starts,
+            vec![(0, "c1"), (1, "c2")],
+            "unexpected tool-call start order: {starts:?}"
+        );
+        assert_eq!(
+            deltas,
+            vec![(0, r#"{"city":"Paris"}"#), (1, r#"{"tz":"UTC"}"#)],
+            "final tool-call deltas must preserve tool-call order"
+        );
+    }
+}
+
 // T029: HTTP 429 → throttled
 #[tokio::test]
 async fn google_http_429_maps_to_throttled() {


### PR DESCRIPTION
## What changed and why
- sort buffered Gemini final `ToolCallDelta` emissions by harness `content_index` before flushing them at stream finalization
- add a regression test that repeatedly verifies final Gemini tool-call deltas stay aligned with their `ToolCallStart` order for multi-tool responses

## Slice completed
- completed issue #518 end to end; Gemini final tool-call delta ordering is now deterministic
- remaining work: none for this issue

## Validation output
- `cargo test -p swink-agent-adapters --features gemini --test google`
  - passed: 20 passed, 0 failed
- `cargo test -p swink-agent-adapters --features gemini --test google google_final_tool_deltas_follow_tool_call_start_order -- --exact`
  - passed: 1 passed, 0 failed

## Pre-existing baseline failures
- `cargo clippy --workspace -- -D warnings`
  - fails in `swink-agent-artifacts` on `clippy::redundant_pub_crate` at `artifacts/src/fs_store.rs:18`, `:23`, and `:34` (tracked separately by issue #524)
- `cargo test --workspace --no-fail-fast`
  - fails in `swink-agent-plugin-web`:
    - `content::tests::truncate_content_multibyte_boundaries_are_utf8_safe`
    - `tools::fetch::tests::execute_returns_readable_content_for_html_under_cap`
    - `tools::fetch::tests::execute_rejects_body_that_exceeds_cap_before_extraction`
  - fails in `swink-agent-tui`:
    - `editor::tests::open_editor_with_true_command_returns_none`

Closes #518