### PR TITLE
fix: validate eval store filesystem ids

### DIFF
--- a/eval/AGENTS.md
+++ b/eval/AGENTS.md
@@ -1,0 +1,5 @@
+# AGENTS.md — eval
+
+## Lessons Learned
+
+- `FsEvalStore` must validate eval set IDs before any path join. Reject empty IDs, `.`/`..`, NUL, and both `/` and `\` separators even on non-Windows hosts so logical identifiers cannot escape `sets/` or `results/` when tests or artifacts move across platforms.

--- a/eval/src/error.rs
+++ b/eval/src/error.rs
@@ -26,6 +26,10 @@ pub enum EvalError {
     #[error("invalid eval case: {reason}")]
     InvalidCase { reason: String },
 
+    /// A filesystem-facing identifier is invalid.
+    #[error("invalid {kind} identifier: {id}")]
+    InvalidIdentifier { kind: &'static str, id: String },
+
     /// Filesystem or IO error during persistence.
     #[error("io error")]
     Io {
@@ -59,6 +63,14 @@ impl EvalError {
     pub fn invalid_case(reason: impl Into<String>) -> Self {
         Self::InvalidCase {
             reason: reason.into(),
+        }
+    }
+
+    /// Convenience constructor for [`EvalError::InvalidIdentifier`].
+    pub fn invalid_identifier(kind: &'static str, id: impl Into<String>) -> Self {
+        Self::InvalidIdentifier {
+            kind,
+            id: id.into(),
         }
     }
 }

--- a/eval/src/store.rs
+++ b/eval/src/store.rs
@@ -4,7 +4,7 @@
 //! ([`FsEvalStore`]) that stores data as JSON files.
 
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use crate::error::EvalError;
 use crate::types::{EvalSet, EvalSetResult};
@@ -77,6 +77,18 @@ impl FsEvalStore {
             .join(format!("{timestamp}.json"))
     }
 
+    fn validate_identifier(kind: &'static str, id: &str) -> Result<(), EvalError> {
+        if id.is_empty() || id.contains('\0') || id.contains('/') || id.contains('\\') {
+            return Err(EvalError::invalid_identifier(kind, id));
+        }
+
+        let mut components = Path::new(id).components();
+        match (components.next(), components.next()) {
+            (Some(Component::Normal(_)), None) => Ok(()),
+            _ => Err(EvalError::invalid_identifier(kind, id)),
+        }
+    }
+
     fn ensure_dir(path: &Path) -> Result<(), EvalError> {
         if !path.exists() {
             fs::create_dir_all(path)?;
@@ -87,6 +99,7 @@ impl FsEvalStore {
 
 impl EvalStore for FsEvalStore {
     fn save_set(&self, set: &EvalSet) -> Result<(), EvalError> {
+        Self::validate_identifier("eval set", &set.id)?;
         Self::ensure_dir(&self.sets_dir())?;
         let json = serde_json::to_string_pretty(set)?;
         fs::write(self.set_path(&set.id), json)?;
@@ -94,6 +107,7 @@ impl EvalStore for FsEvalStore {
     }
 
     fn load_set(&self, id: &str) -> Result<EvalSet, EvalError> {
+        Self::validate_identifier("eval set", id)?;
         #[cfg(feature = "yaml")]
         {
             for path in [self.set_path_yaml(id), self.set_path_yml(id)] {
@@ -113,6 +127,7 @@ impl EvalStore for FsEvalStore {
     }
 
     fn save_result(&self, result: &EvalSetResult) -> Result<(), EvalError> {
+        Self::validate_identifier("eval result set", &result.eval_set_id)?;
         Self::ensure_dir(&self.results_dir(&result.eval_set_id))?;
         let json = serde_json::to_string_pretty(result)?;
         fs::write(
@@ -123,6 +138,7 @@ impl EvalStore for FsEvalStore {
     }
 
     fn load_result(&self, eval_set_id: &str, timestamp: u64) -> Result<EvalSetResult, EvalError> {
+        Self::validate_identifier("eval result set", eval_set_id)?;
         let path = self.result_path(eval_set_id, timestamp);
         if !path.exists() {
             return Err(EvalError::ResultNotFound {
@@ -135,6 +151,7 @@ impl EvalStore for FsEvalStore {
     }
 
     fn list_results(&self, eval_set_id: &str) -> Result<Vec<u64>, EvalError> {
+        Self::validate_identifier("eval result set", eval_set_id)?;
         let dir = self.results_dir(eval_set_id);
         if !dir.exists() {
             return Ok(Vec::new());

--- a/eval/tests/store.rs
+++ b/eval/tests/store.rs
@@ -138,3 +138,67 @@ fn list_results_empty_set() {
     let timestamps = store.list_results("nonexistent").unwrap();
     assert!(timestamps.is_empty());
 }
+
+#[test]
+fn save_set_rejects_invalid_identifier() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = FsEvalStore::new(dir.path());
+
+    for invalid_id in ["", "..", "nested/id", r"nested\id", "nul\0byte"] {
+        let mut set = sample_eval_set();
+        set.id = invalid_id.to_string();
+
+        assert!(
+            matches!(
+                store.save_set(&set),
+                Err(EvalError::InvalidIdentifier { kind, id })
+                    if kind == "eval set" && id == invalid_id
+            ),
+            "expected invalid eval set id to be rejected: {invalid_id:?}"
+        );
+        assert!(
+            matches!(
+                store.load_set(invalid_id),
+                Err(EvalError::InvalidIdentifier { kind, id })
+                    if kind == "eval set" && id == invalid_id
+            ),
+            "expected invalid eval set id to be rejected on load: {invalid_id:?}"
+        );
+    }
+}
+
+#[test]
+fn result_operations_reject_invalid_eval_set_identifier() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = FsEvalStore::new(dir.path());
+
+    for invalid_id in ["", "..", "nested/id", r"nested\id", "nul\0byte"] {
+        let mut result = sample_result();
+        result.eval_set_id = invalid_id.to_string();
+
+        assert!(
+            matches!(
+                store.save_result(&result),
+                Err(EvalError::InvalidIdentifier { kind, id })
+                    if kind == "eval result set" && id == invalid_id
+            ),
+            "expected invalid eval result set id to be rejected on save: {invalid_id:?}"
+        );
+        assert!(
+            matches!(
+                store.load_result(invalid_id, 1_000_000),
+                Err(EvalError::InvalidIdentifier { kind, id })
+                    if kind == "eval result set" && id == invalid_id
+            ),
+            "expected invalid eval result set id to be rejected on load: {invalid_id:?}"
+        );
+        assert!(
+            matches!(
+                store.list_results(invalid_id),
+                Err(EvalError::InvalidIdentifier { kind, id })
+                    if kind == "eval result set" && id == invalid_id
+            ),
+            "expected invalid eval result set id to be rejected when listing: {invalid_id:?}"
+        );
+    }
+}


### PR DESCRIPTION
## What changed and why
- validate eval set and result IDs before `FsEvalStore` builds any filesystem path
- reject empty IDs, `.`/`..`, NUL bytes, and both slash separators so caller-provided identifiers cannot escape the configured eval root
- add regression coverage for invalid IDs across save/load/list operations and document the store rule in `eval/AGENTS.md`

## Slice completed
- completed issue #520 end to end by hardening `FsEvalStore` path construction against identifier traversal
- remaining work: none for this issue

## Validation output
- `cargo test -p swink-agent-eval --test store`
  - passed: 8 passed, 0 failed
- `cargo clippy --workspace -- -D warnings`
  - failed due to pre-existing baseline issue `#524` in `swink-agent-artifacts` (`artifacts/src/fs_store.rs:18`, `:23`, `:34`)
- `cargo test --workspace --no-fail-fast`
  - failed in `swink-agent-plugin-web` lib tests:
    - `content::tests::truncate_content_multibyte_boundaries_are_utf8_safe`
    - `tools::fetch::tests::execute_returns_readable_content_for_html_under_cap`
    - `tools::fetch::tests::execute_rejects_body_that_exceeds_cap_before_extraction`
  - failed in `swink-agent-tui` lib tests:
    - `editor::tests::open_editor_with_true_command_returns_none`
  - the workspace run also reported `-p swink-agent-adapters --test no_default_features`, but a standalone rerun of that target passed (10 passed, 0 failed)

Closes #520