### PR TITLE
[codex] Make FsEvalStore writes atomic

### DIFF
--- a/eval/AGENTS.md
+++ b/eval/AGENTS.md
@@ -3,3 +3,4 @@
 ## Lessons Learned
 
 - `FsEvalStore` must validate eval set IDs before any path join. Reject empty IDs, `.`/`..`, NUL, and both `/` and `\` separators even on non-Windows hosts so logical identifiers cannot escape `sets/` or `results/` when tests or artifacts move across platforms.
+- `FsEvalStore` set/result persistence must go through `swink_agent::atomic_fs` helpers rather than direct `fs::write`, so interrupted rewrites never leave partial JSON or clobber the last good file.

--- a/eval/src/store.rs
+++ b/eval/src/store.rs
@@ -4,6 +4,7 @@
 //! ([`FsEvalStore`]) that stores data as JSON files.
 
 use std::fs;
+use std::io::{self, BufWriter, Write};
 use std::path::{Component, Path, PathBuf};
 
 use crate::error::EvalError;
@@ -95,6 +96,18 @@ impl FsEvalStore {
         }
         Ok(())
     }
+
+    fn write_atomically(
+        target: &Path,
+        write: impl FnOnce(&mut BufWriter<&std::fs::File>) -> io::Result<()>,
+    ) -> Result<(), EvalError> {
+        swink_agent::atomic_fs::atomic_write(target, write)?;
+        Ok(())
+    }
+
+    fn write_json_atomically(target: &Path, json: &str) -> Result<(), EvalError> {
+        Self::write_atomically(target, |writer| writer.write_all(json.as_bytes()))
+    }
 }
 
 impl EvalStore for FsEvalStore {
@@ -102,7 +115,7 @@ impl EvalStore for FsEvalStore {
         Self::validate_identifier("eval set", &set.id)?;
         Self::ensure_dir(&self.sets_dir())?;
         let json = serde_json::to_string_pretty(set)?;
-        fs::write(self.set_path(&set.id), json)?;
+        Self::write_json_atomically(&self.set_path(&set.id), &json)?;
         Ok(())
     }
 
@@ -130,9 +143,9 @@ impl EvalStore for FsEvalStore {
         Self::validate_identifier("eval result set", &result.eval_set_id)?;
         Self::ensure_dir(&self.results_dir(&result.eval_set_id))?;
         let json = serde_json::to_string_pretty(result)?;
-        fs::write(
-            self.result_path(&result.eval_set_id, result.timestamp),
-            json,
+        Self::write_json_atomically(
+            &self.result_path(&result.eval_set_id, result.timestamp),
+            &json,
         )?;
         Ok(())
     }
@@ -170,5 +183,37 @@ impl EvalStore for FsEvalStore {
 
         timestamps.sort_unstable();
         Ok(timestamps)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FsEvalStore;
+    use std::fs;
+    use std::io::{self, Write};
+
+    #[test]
+    fn failed_atomic_rewrite_preserves_existing_eval_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("sets").join("suite.json");
+        fs::create_dir_all(target.parent().unwrap()).unwrap();
+        fs::write(&target, "{\"stable\":true}\n").unwrap();
+
+        let error = FsEvalStore::write_atomically(&target, |writer| {
+            writer.write_all(b"{\"stable\":false")?;
+            Err(io::Error::other("boom"))
+        })
+        .unwrap_err();
+
+        assert!(matches!(error, crate::error::EvalError::Io { .. }));
+        assert_eq!(fs::read_to_string(&target).unwrap(), "{\"stable\":true}\n");
+
+        let temp_files: Vec<_> = fs::read_dir(target.parent().unwrap())
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+            .filter(|name| name.starts_with(".suite.json.tmp."))
+            .collect();
+        assert!(temp_files.is_empty());
     }
 }


### PR DESCRIPTION
## What changed and why
- switched `FsEvalStore::save_set()` and `save_result()` from direct `fs::write` calls to the shared `swink_agent::atomic_fs` helper
- added a regression test that exercises a failed rewrite and verifies the last good JSON remains intact with no temp-file leak
- documented the atomic-write requirement in `eval/AGENTS.md`

## Slice completed
This PR completes the durability slice for eval set/result persistence by making both JSON write paths atomic.

## Validation
- `cargo test -p swink-agent-eval`

## Pre-existing baseline failures
- `cargo clippy -p swink-agent-eval --tests --no-deps -- -D warnings` still fails on the unrelated existing `clippy::default_trait_access` lint in `eval/src/trajectory.rs:419`

Closes #521