### PR TITLE
[codex] Fix artifact store clippy visibility lint

### DIFF
--- a/artifacts/src/fs_store.rs
+++ b/artifacts/src/fs_store.rs
@@ -15,12 +15,12 @@ use swink_agent::{
 // ─── Internal meta.json schema ─────────────────────────────────────────────
 
 #[derive(Serialize, Deserialize)]
-pub(crate) struct MetaFile {
+pub struct MetaFile {
     pub(crate) versions: Vec<VersionRecord>,
 }
 
 #[derive(Serialize, Deserialize)]
-pub(crate) struct VersionRecord {
+pub struct VersionRecord {
     pub(crate) name: String,
     pub(crate) version: u32,
     pub(crate) created_at: DateTime<Utc>,
@@ -31,7 +31,7 @@ pub(crate) struct VersionRecord {
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
-pub(crate) fn storage_err(e: impl Error + Send + Sync + 'static) -> ArtifactError {
+pub fn storage_err(e: impl Error + Send + Sync + 'static) -> ArtifactError {
     ArtifactError::Storage(Box::new(e))
 }
 
@@ -75,7 +75,7 @@ impl FileArtifactStore {
     }
 
     /// Path to meta.json for an artifact.
-    pub(crate) fn meta_path(&self, session_id: &str, name: &str) -> PathBuf {
+    fn meta_path(&self, session_id: &str, name: &str) -> PathBuf {
         self.artifact_dir(session_id, name).join("meta.json")
     }
 


### PR DESCRIPTION
## What changed and why
- switched the internal `MetaFile`, `VersionRecord`, and `storage_err` items in `artifacts/src/fs_store.rs` from `pub(crate)` to `pub`
- kept `fs_store` itself as a private module, so these helpers remain internal to the crate while satisfying `clippy::redundant_pub_crate`
- left artifact-store behavior unchanged; this is visibility cleanup only

## Slice completed
- completed issue #524 by removing the `swink-agent-artifacts` visibility pattern that made `cargo clippy --workspace -- -D warnings` fail on main

## Validation output
- `cargo clippy --workspace -- -D warnings` ✅
- `cargo test -p swink-agent-artifacts` ✅
- `cargo test --workspace` ❌ stops at `-p swink-agent-adapters --test no_default_features`
- `cargo test -p swink-agent-adapters --test no_default_features -- --nocapture` ✅ passes on standalone rerun (10 passed)

## Pre-existing baseline failures
- the current `cargo test --workspace` run still stops in the adapters `no_default_features` target even though the same target passes when rerun directly; this appears to be the existing workspace-run instability already noted in recent PRs, not a regression from this slice

## Impact
- no runtime behavior changes
- no IPC contract changes

Closes #524
