### PR TITLE
Thread raw SSE payload callbacks through runtime adapters

### DIFF
--- a/adapters/AGENTS.md
+++ b/adapters/AGENTS.md
@@ -3,3 +3,4 @@
 ## Lessons Learned
 
 - In `src/openai_compat.rs`, OpenAI-compatible providers can stream tool-call arguments before `function.name`. Buffer those arguments and delay `ToolCallStart` until a non-empty name is known; otherwise the harness locks in an empty tool name and later deltas cannot repair it.
+- Runtime SSE adapters must thread `StreamOptions.on_raw_payload` into the callback-aware shared parser (`sse_data_lines_with_callback` or an equivalent hook). Calling the callback-free helper silently disables payload observers in production even though the shared SSE unit tests still pass.

--- a/adapters/src/azure.rs
+++ b/adapters/src/azure.rs
@@ -240,6 +240,7 @@ fn azure_stream<'a>(
             request,
             azure.shell.provider(),
             cancellation_token,
+            options.on_raw_payload.clone(),
             |status, body| {
                 if is_content_filter_error(body) {
                     Some(AssistantMessageEvent::error_content_filtered(format!(

--- a/adapters/src/google.rs
+++ b/adapters/src/google.rs
@@ -21,7 +21,7 @@ use swink_agent::{
 };
 
 use crate::convert::extract_tool_schemas;
-use crate::sse::{SseAction, SseLine, sse_data_lines};
+use crate::sse::{SseAction, SseLine, sse_data_lines_with_callback};
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -292,7 +292,8 @@ fn gemini_stream<'a>(
             return stream::iter(vec![event]).left_stream();
         }
 
-        parse_sse_stream(response, cancellation_token).right_stream()
+        parse_sse_stream(response, cancellation_token, options.on_raw_payload.clone())
+            .right_stream()
     })
     .flatten()
 }
@@ -552,8 +553,9 @@ fn tool_result_part(
 fn parse_sse_stream(
     response: reqwest::Response,
     cancellation_token: CancellationToken,
+    on_raw_payload: Option<swink_agent::OnRawPayload>,
 ) -> impl Stream<Item = AssistantMessageEvent> + Send {
-    let line_stream = sse_data_lines(response.bytes_stream());
+    let line_stream = sse_data_lines_with_callback(response.bytes_stream(), on_raw_payload);
 
     // NOTE: Google's cancel behavior differs from Anthropic/OpenAI — it uses
     // error_network (retryable) rather than Aborted. We preserve this via a

--- a/adapters/src/mistral.rs
+++ b/adapters/src/mistral.rs
@@ -210,6 +210,7 @@ fn mistral_stream<'a>(
             request,
             mistral.shell.provider(),
             cancellation_token,
+            options.on_raw_payload.clone(),
             |_, _| None,
         );
         normalize_response_stream(raw_stream, id_map)

--- a/adapters/src/oai_transport.rs
+++ b/adapters/src/oai_transport.rs
@@ -138,6 +138,7 @@ impl OaiAdapterShell {
             request,
             self.provider,
             cancellation_token,
+            options.on_raw_payload.clone(),
             |_, _| None,
         ))
     }
@@ -193,6 +194,7 @@ pub fn oai_send_and_parse<'a>(
     request: reqwest::RequestBuilder,
     provider: &'static str,
     cancellation_token: tokio_util::sync::CancellationToken,
+    on_raw_payload: Option<swink_agent::OnRawPayload>,
     classify_error: impl Fn(u16, &str) -> Option<AssistantMessageEvent> + Send + 'a,
 ) -> impl Stream<Item = AssistantMessageEvent> + Send + 'a {
     stream::once(async move {
@@ -223,7 +225,7 @@ pub fn oai_send_and_parse<'a>(
             return stream::iter(vec![AssistantMessageEvent::Start, event]).left_stream();
         }
 
-        parse_oai_sse_stream(response, cancellation_token, provider).right_stream()
+        parse_oai_sse_stream(response, cancellation_token, provider, on_raw_payload).right_stream()
     })
     .flatten()
 }

--- a/adapters/src/openai_compat.rs
+++ b/adapters/src/openai_compat.rs
@@ -22,7 +22,7 @@ use swink_agent::{
 };
 
 use crate::convert::{MessageConverter, extract_tool_schemas};
-use crate::sse::{SseAction, SseLine, sse_data_lines};
+use crate::sse::{SseAction, SseLine, sse_data_lines_with_callback};
 
 // ─── Request types ──────────────────────────────────────────────────────────
 
@@ -578,8 +578,9 @@ pub fn parse_oai_sse_stream(
     response: reqwest::Response,
     cancellation_token: CancellationToken,
     provider: &'static str,
+    on_raw_payload: Option<swink_agent::OnRawPayload>,
 ) -> Pin<Box<dyn Stream<Item = AssistantMessageEvent> + Send>> {
-    let line_stream = sse_data_lines(response.bytes_stream());
+    let line_stream = sse_data_lines_with_callback(response.bytes_stream(), on_raw_payload);
 
     crate::sse::sse_adapter_stream(
         line_stream,

--- a/adapters/src/proxy.rs
+++ b/adapters/src/proxy.rs
@@ -19,7 +19,7 @@ use swink_agent::{
 };
 
 use crate::classify::error_event_from_status;
-use crate::sse::{SseLine, sse_data_lines};
+use crate::sse::{SseLine, sse_data_lines_with_callback};
 
 // ─── Request types ──────────────────────────────────────────────────────────
 
@@ -199,7 +199,8 @@ fn proxy_stream<'a>(
             return stream::iter(vec![event]).left_stream();
         }
 
-        parse_sse_stream(response, cancellation_token).right_stream()
+        parse_sse_stream(response, cancellation_token, options.on_raw_payload.clone())
+            .right_stream()
     })
     .flatten()
 }
@@ -258,8 +259,9 @@ async fn send_request(
 fn parse_sse_stream(
     response: reqwest::Response,
     cancellation_token: CancellationToken,
+    on_raw_payload: Option<swink_agent::OnRawPayload>,
 ) -> impl Stream<Item = AssistantMessageEvent> + Send {
-    let sse_stream = sse_data_lines(response.bytes_stream());
+    let sse_stream = sse_data_lines_with_callback(response.bytes_stream(), on_raw_payload);
 
     stream::unfold(
         (Box::pin(sse_stream), cancellation_token, false),

--- a/adapters/tests/google.rs
+++ b/adapters/tests/google.rs
@@ -3,6 +3,8 @@
 
 mod common;
 
+use std::sync::{Arc, Mutex};
+
 use futures::StreamExt;
 use tokio_util::sync::CancellationToken;
 use wiremock::matchers::{header, method, path, query_param};
@@ -19,9 +21,15 @@ fn test_model() -> ModelSpec {
 }
 
 async fn collect_events(stream_fn: &GeminiStreamFn) -> Vec<AssistantMessageEvent> {
+    collect_events_with_options(stream_fn, StreamOptions::default()).await
+}
+
+async fn collect_events_with_options(
+    stream_fn: &GeminiStreamFn,
+    options: StreamOptions,
+) -> Vec<AssistantMessageEvent> {
     let model = test_model();
     let context = test_context();
-    let options = StreamOptions::default();
     let token = CancellationToken::new();
     let stream = stream_fn.stream(&model, &context, &options, token);
     stream.collect::<Vec<_>>().await
@@ -130,7 +138,10 @@ async fn google_cancellation_after_first_chunk_emits_aborted_and_closes_text() {
     assert!(types.contains(&"TextDelta"), "missing TextDelta: {types:?}");
     assert!(types.contains(&"TextEnd"), "missing TextEnd: {types:?}");
     assert!(types.contains(&"Error"), "missing Error: {types:?}");
-    assert!(!types.contains(&"Done"), "cancellation should not emit Done: {types:?}");
+    assert!(
+        !types.contains(&"Done"),
+        "cancellation should not emit Done: {types:?}"
+    );
 
     let text_end_pos = types
         .iter()
@@ -158,7 +169,10 @@ async fn google_cancellation_after_first_chunk_emits_aborted_and_closes_text() {
         })
         .expect("missing terminal Error event");
     assert_eq!(terminal_error.0, StopReason::Aborted);
-    assert_eq!(terminal_error.2, None, "cancellation should not be retryable");
+    assert_eq!(
+        terminal_error.2, None,
+        "cancellation should not be retryable"
+    );
     assert!(
         terminal_error.1.contains("Google request cancelled"),
         "unexpected cancellation message: {}",
@@ -368,6 +382,59 @@ async fn google_multiple_tool_calls() {
         _ => None,
     });
     assert_eq!(stop_reason, Some(StopReason::ToolUse));
+}
+
+#[tokio::test]
+async fn google_on_raw_payload_observes_runtime_sse_lines() {
+    let body = [
+        r#"data: {"candidates":[{"content":{"parts":[{"text":"hello"}]}}]}"#,
+        "",
+        r#"data: {"candidates":[{"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5,"totalTokenCount":15}}"#,
+        "",
+        "data: [DONE]",
+        "",
+    ]
+    .join("\n");
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path(
+            "/v1beta/models/gemini-3-flash-preview:streamGenerateContent",
+        ))
+        .and(query_param("alt", "sse"))
+        .respond_with(sse_response(&body))
+        .mount(&server)
+        .await;
+
+    let observed = Arc::new(Mutex::new(Vec::<String>::new()));
+    let callback_lines = Arc::clone(&observed);
+    let options = StreamOptions {
+        on_raw_payload: Some(Arc::new(move |line| {
+            callback_lines
+                .lock()
+                .expect("callback buffer poisoned")
+                .push(line.to_owned());
+        })),
+        ..StreamOptions::default()
+    };
+
+    let stream_fn = GeminiStreamFn::new(server.uri(), "test-key", ApiVersion::V1beta);
+    let events = collect_events_with_options(&stream_fn, options).await;
+    let observed = observed.lock().expect("callback buffer poisoned").clone();
+
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, AssistantMessageEvent::Done { .. })),
+        "expected runtime stream to complete successfully"
+    );
+    assert_eq!(
+        observed,
+        vec![
+            r#"{"candidates":[{"content":{"parts":[{"text":"hello"}]}}]}"#.to_string(),
+            r#"{"candidates":[{"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5,"totalTokenCount":15}}"#.to_string(),
+        ]
+    );
 }
 
 #[tokio::test]

--- a/adapters/tests/openai.rs
+++ b/adapters/tests/openai.rs
@@ -3,6 +3,8 @@
 
 mod common;
 
+use std::sync::{Arc, Mutex};
+
 use futures::StreamExt;
 use tokio_util::sync::CancellationToken;
 use wiremock::matchers::{header, method, path};
@@ -20,9 +22,15 @@ fn test_model() -> ModelSpec {
 }
 
 async fn collect_events(stream_fn: &OpenAiStreamFn) -> Vec<AssistantMessageEvent> {
+    collect_events_with_options(stream_fn, StreamOptions::default()).await
+}
+
+async fn collect_events_with_options(
+    stream_fn: &OpenAiStreamFn,
+    options: StreamOptions,
+) -> Vec<AssistantMessageEvent> {
     let model = test_model();
     let context = test_context();
-    let options = StreamOptions::default();
     let token = CancellationToken::new();
     let stream = stream_fn.stream(&model, &context, &options, token);
     stream.collect::<Vec<_>>().await
@@ -298,6 +306,57 @@ async fn openai_usage_in_separate_chunk() {
     assert_eq!(
         usage.output, 25,
         "expected output tokens from separate chunk"
+    );
+}
+
+#[tokio::test]
+async fn openai_on_raw_payload_observes_runtime_sse_lines() {
+    let body = [
+        r#"data: {"choices":[{"delta":{"content":"hello"},"index":0}]}"#,
+        "",
+        r#"data: {"choices":[{"delta":{},"finish_reason":"stop","index":0}],"usage":{"prompt_tokens":10,"completion_tokens":5}}"#,
+        "",
+        "data: [DONE]",
+        "",
+        "",
+    ]
+    .join("\n");
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(sse_response(&body))
+        .mount(&server)
+        .await;
+
+    let observed = Arc::new(Mutex::new(Vec::<String>::new()));
+    let callback_lines = Arc::clone(&observed);
+    let options = StreamOptions {
+        on_raw_payload: Some(Arc::new(move |line| {
+            callback_lines
+                .lock()
+                .expect("callback buffer poisoned")
+                .push(line.to_owned());
+        })),
+        ..StreamOptions::default()
+    };
+
+    let sf = OpenAiStreamFn::new(server.uri(), "test-key");
+    let events = collect_events_with_options(&sf, options).await;
+    let observed = observed.lock().expect("callback buffer poisoned").clone();
+
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, AssistantMessageEvent::Done { .. })),
+        "expected runtime stream to complete successfully"
+    );
+    assert_eq!(
+        observed,
+        vec![
+            r#"{"choices":[{"delta":{"content":"hello"},"index":0}]}"#.to_string(),
+            r#"{"choices":[{"delta":{},"finish_reason":"stop","index":0}],"usage":{"prompt_tokens":10,"completion_tokens":5}}"#.to_string(),
+        ]
     );
 }
 

--- a/adapters/tests/proxy_http.rs
+++ b/adapters/tests/proxy_http.rs
@@ -8,6 +8,8 @@
 
 mod common;
 
+use std::sync::{Arc, Mutex};
+
 use futures::StreamExt;
 use swink_agent::{
     AssistantMessageEvent, ContentBlock, ModelSpec, StopReason, StreamFn, StreamOptions,
@@ -69,9 +71,15 @@ fn text_and_tool_call_sse_body() -> String {
 }
 
 async fn collect_events(proxy: &ProxyStreamFn) -> Vec<AssistantMessageEvent> {
+    collect_events_with_options(proxy, StreamOptions::default()).await
+}
+
+async fn collect_events_with_options(
+    proxy: &ProxyStreamFn,
+    options: StreamOptions,
+) -> Vec<AssistantMessageEvent> {
     let model = test_model();
     let context = test_context();
-    let options = StreamOptions::default();
     let token = CancellationToken::new();
     let stream = proxy.stream(&model, &context, &options, token);
     stream.collect::<Vec<_>>().await
@@ -256,6 +264,49 @@ async fn http_429_produces_rate_limit_error() {
         }
         other => panic!("expected Error event, got {other:?}"),
     }
+}
+
+#[tokio::test]
+async fn proxy_on_raw_payload_observes_runtime_sse_lines() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/stream"))
+        .respond_with(sse_response(&text_only_sse_body()))
+        .mount(&server)
+        .await;
+
+    let observed = Arc::new(Mutex::new(Vec::<String>::new()));
+    let callback_lines = Arc::clone(&observed);
+    let options = StreamOptions {
+        on_raw_payload: Some(Arc::new(move |line| {
+            callback_lines
+                .lock()
+                .expect("callback buffer poisoned")
+                .push(line.to_owned());
+        })),
+        ..StreamOptions::default()
+    };
+
+    let proxy = ProxyStreamFn::new(server.uri(), "test-token");
+    let events = collect_events_with_options(&proxy, options).await;
+    let observed = observed.lock().expect("callback buffer poisoned").clone();
+
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, AssistantMessageEvent::Done { .. })),
+        "expected runtime stream to complete successfully"
+    );
+    assert_eq!(
+        observed,
+        vec![
+            r#"{"type":"start"}"#.to_string(),
+            r#"{"type":"text_start","content_index":0}"#.to_string(),
+            r#"{"type":"text_delta","content_index":0,"delta":"hello"}"#.to_string(),
+            r#"{"type":"text_end","content_index":0}"#.to_string(),
+            r#"{"type":"done","stop_reason":"stop","usage":{"input":10,"output":20,"cache_read":0,"cache_write":0,"total":30},"cost":{"input":0.01,"output":0.02,"cache_read":0.0,"cache_write":0.0,"total":0.03}}"#.to_string(),
+        ]
+    );
 }
 
 // ── 5.7: 504 response produces network error ───────────────────────────


### PR DESCRIPTION
## Summary
- thread `StreamOptions.on_raw_payload` through the runtime SSE entrypoints used by the OpenAI-compatible transport, Gemini, and proxy adapters
- keep the callback on the shared callback-aware parser path so raw `data:` payload observers fire before JSON parsing in production streams
- add regression coverage that exercises the runtime adapter streams rather than only the shared SSE helper

## Slice Completed
- completed issue #538 end to end for the affected built-in runtime SSE adapter paths
- documented the adapter-side lesson in `adapters/AGENTS.md`
- remaining issue scope: none

## Validation
- `cargo test --offline -p swink-agent-adapters --features openai,gemini,proxy --test openai --test google --test proxy_http`
- `cargo clippy --offline -p swink-agent-adapters --features openai,gemini,proxy --tests -- -D warnings` *(fails on pre-existing `dead_code` warnings in `src/transfer.rs:214` and `src/transfer.rs:223` outside this change)*
- `cargo test --workspace --no-fail-fast -- --format=terse` *(same patch before worktree cleanup; still fails on pre-existing targets: `-p swink-agent-adapters --test no_default_features`, `-p swink-agent-memory --test stress_append`, `-p swink-agent-plugin-web --lib`, and `-p swink-agent-tui --lib`)*

Closes #538
