### PR TITLE
Fix atomic_fs replace semantics on Windows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,11 @@ MSRV **1.88** (edition 2024). Common workspace deps are centralized in root `Car
 
 - `DefaultCredentialResolver` can reuse a per-key `SingleFlightTokenSource`, but the credential store remains the source of truth. Clear the token source's cached value before resolving an expired key from the store, or a previously refreshed token can mask later external store updates.
 
+### Atomic FS (`src/atomic_fs.rs`)
+
+- `atomic_fs` must keep replacement to a single `std::fs::rename` call on Windows. Delete-then-rename widens the crash window enough to lose both old and new files.
+- `atomic_fs` only syncs the parent directory on Unix where directory `sync_all()` is supported. Docs for callers must not promise cross-platform post-rename durability beyond the file-content sync and rename step.
+
 ### Checkpoint / Persistence
 
 - Checkpoint and SessionStore now support CustomMessage persistence via `custom_messages` field and `save_full`/`load_full`. Old checkpoints without `custom_messages` field deserialize fine (backward compat via `#[serde(default)]`).

--- a/src/atomic_fs.rs
+++ b/src/atomic_fs.rs
@@ -1,8 +1,9 @@
 //! Atomic file-write helpers shared across workspace crates.
 //!
 //! Provides [`atomic_write`] and [`atomic_write_bytes`] — both write to a
-//! unique temporary file, `fsync`, and atomically rename over the target.
-//! On error the temp file is removed so a crash mid-write never leaves a
+//! unique temporary file, sync file contents, rename over the target, and
+//! sync the parent directory where the platform exposes directory fsync.
+//! On error the temp file is removed so an interrupted write never leaves a
 //! partial or zero-length file at the target path.
 //!
 //! Concurrent writes to the **same target** within one process are serialized
@@ -21,8 +22,10 @@ static TMP_SEQ: AtomicU64 = AtomicU64::new(0);
 /// Write to `target` atomically.
 ///
 /// `contents_fn` receives a buffered writer backed by a unique temp file.
-/// After it returns successfully the temp file is fsynced and renamed over
-/// `target`.  If `contents_fn` fails (or panics) the temp file is cleaned up.
+/// After it returns successfully the temp file contents are synced, the temp
+/// file is renamed over `target`, and the parent directory is synced where the
+/// platform supports that durability step. If `contents_fn` fails (or panics)
+/// the temp file is cleaned up.
 ///
 /// Concurrent calls targeting the same path are serialized internally;
 /// distinct paths are fully concurrent.
@@ -97,7 +100,10 @@ where
         }
         file.sync_all()?;
         drop(file);
-        rename_replacing(&tmp_path, target)
+        rename_replacing(&tmp_path, target)?;
+        #[cfg(unix)]
+        sync_parent_dir(parent)?;
+        Ok(())
     })();
 
     if result.is_err() {
@@ -108,17 +114,16 @@ where
 
 /// Rename `from` to `to`, replacing `to` if it already exists.
 ///
-/// On Unix, `std::fs::rename` is an atomic replace. On Windows it fails with
-/// `ERROR_ALREADY_EXISTS` when the destination is present, so we remove it
-/// first. To keep concurrent rewrites of the same target safe on Windows,
-/// callers must serialize via [`lock_for_target`] around the whole
-/// write-and-rename sequence.
+/// Keep the replacement to a single rename operation. The previous
+/// delete-then-rename Windows path could lose both files if the process or
+/// host crashed in the gap between those two syscalls.
 fn rename_replacing(from: &Path, to: &Path) -> io::Result<()> {
-    #[cfg(windows)]
-    if to.exists() {
-        std::fs::remove_file(to)?;
-    }
     std::fs::rename(from, to)
+}
+
+#[cfg(unix)]
+fn sync_parent_dir(parent: &Path) -> io::Result<()> {
+    std::fs::File::open(parent)?.sync_all()
 }
 
 /// Per-target serialization guard.
@@ -206,5 +211,17 @@ mod tests {
         // File should contain one complete writer's output (no corruption).
         let content = fs::read_to_string(&target).unwrap();
         assert!(content.starts_with("writer-"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn atomic_write_replaces_existing_on_windows_without_predelete() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("replace.txt");
+        fs::write(&target, "old").unwrap();
+
+        atomic_write_bytes(&target, b"new").unwrap();
+
+        assert_eq!(fs::read_to_string(&target).unwrap(), "new");
     }
 }


### PR DESCRIPTION
## What changed and why
- removed the delete-then-rename Windows path from `src/atomic_fs.rs` so replacement stays a single `std::fs::rename` operation
- added a post-rename parent-directory sync on Unix to tighten crash-durability where the platform supports directory `sync_all()`
- narrowed the `atomic_fs` docs to match the actual cross-platform guarantees and recorded the non-obvious rule in `AGENTS.md`
- added a Windows-specific regression test that verifies replacing an existing target still succeeds without a pre-delete step

## Slice completed; what remains
- completed the shared `atomic_fs` persistence helper fix for issue #540
- no follow-up implementation is required in the memory/eval/artifacts callers because they already route through this helper

## Validation output
- `cargo test -p swink-agent atomic_write -- --nocapture`
- `cargo clippy -p swink-agent --lib -- -D warnings`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace --no-fail-fast -- --format=terse`

## Pre-existing baseline failures
- `-p swink-agent-adapters --test no_default_features`
- `-p swink-agent-plugin-web --lib`
- `-p swink-agent-tui --lib`
- `cargo fmt --all --check` reports unrelated formatting drift in untouched files across the repo, so formatting was limited to the edited Rust file

Closes #540