### PR TITLE
Fix web rate limiter cutoff underflow

### DIFF
--- a/plugins/web/AGENTS.md
+++ b/plugins/web/AGENTS.md
@@ -4,3 +4,4 @@
 
 - `src/playwright.rs` must write a unique temp bridge script per `PlaywrightBridge::start()` call. Reusing one fixed temp filename is race-prone when multiple bridge instances start concurrently.
 - `src/playwright_bridge.js` must lazy-load the `playwright` package inside browser startup instead of at module load time. That keeps the bridge's pure extraction helpers testable from plain Node without requiring Playwright to be installed for unit tests.
+- `src/policy/rate_limiter.rs` must treat `Instant::checked_sub()` underflow as a no-prune tick instead of unwrapping. Short-uptime hosts can otherwise panic in the live rate-limit path.

--- a/plugins/web/src/policy/rate_limiter.rs
+++ b/plugins/web/src/policy/rate_limiter.rs
@@ -15,10 +15,25 @@ pub struct RateLimitPolicy {
 }
 
 impl RateLimitPolicy {
+    const WINDOW: Duration = Duration::from_secs(60);
+
     pub fn new(state: Arc<Mutex<VecDeque<Instant>>>, rate_limit_rpm: u32) -> Self {
         Self {
             state,
             rate_limit_rpm,
+        }
+    }
+
+    fn prune_expired(timestamps: &mut VecDeque<Instant>, now: Instant, window: Duration) {
+        let Some(cutoff) = now.checked_sub(window) else {
+            return;
+        };
+
+        while timestamps
+            .front()
+            .is_some_and(|&timestamp| timestamp < cutoff)
+        {
+            timestamps.pop_front();
         }
     }
 }
@@ -37,10 +52,8 @@ impl PreDispatchPolicy for RateLimitPolicy {
         let mut timestamps = self.state.lock().unwrap_or_else(|e| e.into_inner());
 
         // Prune timestamps older than 60 seconds.
-        let cutoff = Instant::now().checked_sub(Duration::from_secs(60)).unwrap();
-        while timestamps.front().is_some_and(|&t| t < cutoff) {
-            timestamps.pop_front();
-        }
+        let now = Instant::now();
+        Self::prune_expired(&mut timestamps, now, Self::WINDOW);
 
         // Check limit.
         if timestamps.len() >= self.rate_limit_rpm as usize {
@@ -50,7 +63,7 @@ impl PreDispatchPolicy for RateLimitPolicy {
             ));
         }
 
-        timestamps.push_back(Instant::now());
+        timestamps.push_back(now);
         PreDispatchVerdict::Continue
     }
 }
@@ -90,7 +103,10 @@ mod tests {
             let call_id = format!("tc_{i}");
             let mut args = json!({"url": "https://example.com"});
             let mut ctx = make_dispatch_ctx("web.fetch", &call_id, &mut args, &session);
-            assert!(matches!(policy.evaluate(&mut ctx), PreDispatchVerdict::Continue));
+            assert!(matches!(
+                policy.evaluate(&mut ctx),
+                PreDispatchVerdict::Continue
+            ));
         }
     }
 
@@ -103,12 +119,18 @@ mod tests {
             let call_id = format!("tc_{i}");
             let mut args = json!({"url": "https://example.com"});
             let mut ctx = make_dispatch_ctx("web.fetch", &call_id, &mut args, &session);
-            assert!(matches!(policy.evaluate(&mut ctx), PreDispatchVerdict::Continue));
+            assert!(matches!(
+                policy.evaluate(&mut ctx),
+                PreDispatchVerdict::Continue
+            ));
         }
 
         let mut args = json!({"url": "https://example.com"});
         let mut ctx = make_dispatch_ctx("web.fetch", "tc_over", &mut args, &session);
-        assert!(matches!(policy.evaluate(&mut ctx), PreDispatchVerdict::Skip(_)));
+        assert!(matches!(
+            policy.evaluate(&mut ctx),
+            PreDispatchVerdict::Skip(_)
+        ));
     }
 
     #[test]
@@ -116,16 +138,41 @@ mod tests {
         let rl_state = shared_state();
         {
             let mut timestamps = rl_state.lock().unwrap();
-            let old = Instant::now() - Duration::from_secs(120);
+            let old = Instant::now();
             for _ in 0..5 {
                 timestamps.push_back(old);
             }
+        }
+
+        let now = rl_state
+            .lock()
+            .unwrap()
+            .front()
+            .copied()
+            .and_then(|timestamp| timestamp.checked_add(Duration::from_secs(120)))
+            .expect("timestamp + 120s should remain representable");
+        {
+            let mut timestamps = rl_state.lock().unwrap();
+            RateLimitPolicy::prune_expired(&mut timestamps, now, Duration::from_secs(60));
         }
 
         let policy = RateLimitPolicy::new(rl_state, 5);
         let session = SessionState::default();
         let mut args = json!({"url": "https://example.com"});
         let mut ctx = make_dispatch_ctx("web.fetch", "tc_after_prune", &mut args, &session);
-        assert!(matches!(policy.evaluate(&mut ctx), PreDispatchVerdict::Continue));
+        assert!(matches!(
+            policy.evaluate(&mut ctx),
+            PreDispatchVerdict::Continue
+        ));
+    }
+
+    #[test]
+    fn underflowing_cutoff_does_not_prune_or_panic() {
+        let now = Instant::now();
+        let mut timestamps = VecDeque::from([now]);
+
+        RateLimitPolicy::prune_expired(&mut timestamps, now, Duration::MAX);
+
+        assert_eq!(timestamps.len(), 1);
     }
 }


### PR DESCRIPTION
## What changed and why
- replaced the live `Instant::checked_sub(...).unwrap()` in the web rate-limit policy with a helper that treats underflow as a no-prune tick
- reused the same `Instant::now()` value for pruning and enqueueing so the rate-limit window stays internally consistent
- added regressions covering both the underflow path and direct timestamp pruning
- recorded the short-uptime rule in `plugins/web/AGENTS.md`

## Slice completed; what remains
- completed the issue’s requested runtime hardening for the web plugin rate-limit policy
- no additional scope is planned in this PR

## Validation output
- `cargo test -p swink-agent-plugin-web rate_limiter` ✅
- `cargo clippy -p swink-agent-plugin-web --lib --no-deps -- -D warnings` ✅

## Pre-existing baseline failures
- `cargo test -p swink-agent-plugin-web` still fails in unrelated existing tests:
  - `content::tests::truncate_content_multibyte_boundaries_are_utf8_safe`
  - `tools::fetch::tests::execute_rejects_body_that_exceeds_cap_before_extraction`
  - `tools::fetch::tests::execute_returns_readable_content_for_html_under_cap`
- broader `cargo clippy` runs remain blocked by the existing `swink-agent` dead-code warning in `src/transfer.rs:214` and `src/transfer.rs:223`

Closes #542