### PR TITLE
[codex] Enforce proxy terminal event before [DONE]

### DIFF
--- a/adapters/AGENTS.md
+++ b/adapters/AGENTS.md
@@ -4,3 +4,4 @@
 
 - In `src/openai_compat.rs`, OpenAI-compatible providers can stream tool-call arguments before `function.name`. Buffer those arguments and delay `ToolCallStart` until a non-empty name is known; otherwise the harness locks in an empty tool name and later deltas cannot repair it.
 - Runtime SSE adapters must thread `StreamOptions.on_raw_payload` into the callback-aware shared parser (`sse_data_lines_with_callback` or an equivalent hook). Calling the callback-free helper silently disables payload observers in production even though the shared SSE unit tests still pass.
+- In `src/proxy.rs`, treat transport `data: [DONE]` as a protocol error unless the proxy has already emitted a typed `done` or `error` JSON event. The SSE sentinel only closes the transport; it is not the adapter's semantic terminal event.

--- a/adapters/src/proxy.rs
+++ b/adapters/src/proxy.rs
@@ -292,12 +292,13 @@ fn parse_sse_stream(
                             ))
                         }
                         Some(SseLine::Done) => {
-                            // [DONE] is the normal SSE stream terminator.
-                            // The proxy protocol's actual Done/Error events
-                            // arrive as JSON data payloads (SseEventData::Done),
-                            // so this sentinel just means the transport is
-                            // finished — stop the unfold cleanly.
-                            None
+                            done = true;
+                            Some((
+                                AssistantMessageEvent::error_network(
+                                    "network error: proxy SSE transport ended before protocol terminal event",
+                                ),
+                                (sse, token, done),
+                            ))
                         }
                         Some(SseLine::Data(data)) => {
                             let parsed = parse_sse_event_data(&data);
@@ -665,22 +666,19 @@ mod tests {
         assert!(debug.contains("[redacted]"));
     }
 
-    /// Regression test for #432: SseLine::Done must produce a clean stream
-    /// termination, not a network error.
+    /// Regression test for #543: transport [DONE] is not a valid substitute
+    /// for the proxy protocol's terminal done/error JSON event.
     #[tokio::test]
-    async fn sse_done_sentinel_is_clean_termination() {
+    async fn sse_done_sentinel_without_protocol_terminal_is_error() {
         use futures::StreamExt as _;
 
-        // Simulate an SSE byte stream with a Start event, a text delta, a
-        // protocol-level Done event (JSON), and finally the [DONE] sentinel.
+        // Simulate an SSE byte stream with a Start event, a text delta, and
+        // then a transport-level [DONE] sentinel without a protocol terminal.
         let sse_body = concat!(
             "data: {\"type\":\"start\"}\n\n",
             "data: {\"type\":\"text_start\",\"content_index\":0}\n\n",
             "data: {\"type\":\"text_delta\",\"content_index\":0,\"delta\":\"hi\"}\n\n",
             "data: {\"type\":\"text_end\",\"content_index\":0}\n\n",
-            "data: {\"type\":\"done\",\"stop_reason\":\"stop\",",
-            "\"usage\":{\"input\":5,\"output\":3,\"cache_read\":0,\"cache_write\":0,\"total\":8},",
-            "\"cost\":{\"input\":0.01,\"output\":0.02,\"cache_read\":0.0,\"cache_write\":0.0,\"total\":0.03}}\n\n",
             "data: [DONE]\n\n",
         );
 
@@ -717,7 +715,15 @@ mod tests {
                                     (sse, token, done),
                                 ))
                             }
-                            Some(SseLine::Done) => None,
+                            Some(SseLine::Done) => {
+                                done = true;
+                                Some((
+                                    AssistantMessageEvent::error_network(
+                                        "network error: proxy SSE transport ended before protocol terminal event",
+                                    ),
+                                    (sse, token, done),
+                                ))
+                            }
                             Some(SseLine::Data(data)) => {
                                 let parsed = parse_sse_event_data(&data);
                                 done = is_terminal_event(&parsed);
@@ -738,18 +744,26 @@ mod tests {
 
         let events: Vec<AssistantMessageEvent> = event_stream.collect().await;
 
-        // The last event must be a clean Done, not an Error.
+        // The last event must be a terminal network error because the proxy
+        // never emitted its protocol-level done/error JSON event.
         let last = events.last().expect("stream should produce events");
         assert!(
-            matches!(last, AssistantMessageEvent::Done { .. }),
-            "expected Done as last event, got {last:?}"
+            matches!(
+                last,
+                AssistantMessageEvent::Error {
+                    stop_reason: StopReason::Error,
+                    ..
+                }
+            ),
+            "expected Error as last event, got {last:?}"
         );
 
-        // No event should be a network error.
-        for event in &events {
-            if let AssistantMessageEvent::Error { error_message, .. } = event {
-                panic!("unexpected error event in stream: {error_message}");
-            }
+        match last {
+            AssistantMessageEvent::Error { error_message, .. } => assert!(
+                error_message.contains("protocol terminal event"),
+                "expected terminal-event diagnostic, got: {error_message}"
+            ),
+            other => panic!("expected Error, got {other:?}"),
         }
     }
 

--- a/adapters/tests/proxy_http.rs
+++ b/adapters/tests/proxy_http.rs
@@ -420,6 +420,57 @@ async fn mid_stream_disconnect_produces_network_error() {
     }
 }
 
+#[tokio::test]
+async fn done_sentinel_without_protocol_terminal_produces_network_error() {
+    let body = [
+        r#"data: {"type":"start"}"#,
+        "",
+        r#"data: {"type":"text_start","content_index":0}"#,
+        "",
+        r#"data: {"type":"text_delta","content_index":0,"delta":"partial"}"#,
+        "",
+        r#"data: {"type":"text_end","content_index":0}"#,
+        "",
+        "data: [DONE]",
+        "",
+        "",
+    ]
+    .join("\n");
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/stream"))
+        .respond_with(sse_response(&body))
+        .mount(&server)
+        .await;
+
+    let proxy = ProxyStreamFn::new(server.uri(), "token");
+    let events = collect_events(&proxy).await;
+
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event, AssistantMessageEvent::Done { .. })),
+        "expected missing protocol terminal to avoid emitting Done: {events:?}"
+    );
+
+    let last = events.last().expect("should have at least one event");
+    match last {
+        AssistantMessageEvent::Error {
+            error_message,
+            stop_reason,
+            ..
+        } => {
+            assert_eq!(*stop_reason, StopReason::Error);
+            assert!(
+                error_message.contains("protocol terminal event"),
+                "expected terminal-event diagnostic, got: {error_message}"
+            );
+        }
+        other => panic!("expected terminal Error event, got {other:?}"),
+    }
+}
+
 // ── 5.10: Cancellation drops connection and yields Aborted ──────────────
 
 #[tokio::test]


### PR DESCRIPTION
## What changed
- treat transport-level `data: [DONE]` as a network error when the proxy never emitted a typed protocol `done` or `error` event
- update the proxy module regression to assert that incomplete transport termination fails closed
- add an HTTP integration test covering `[DONE]` arriving without a protocol terminal event
- record the invariant in [`adapters/AGENTS.md`](https://github.com/SuperSwinkAI/Swink-Agent/blob/main/adapters/AGENTS.md)

## Why
The proxy adapter could previously end the stream cleanly on `[DONE]` even when the proxy protocol never emitted its semantic terminal event. That masks truncated or malformed proxy streams and can leave callers with an incomplete event sequence.

## Slice completed
This PR completes the narrow issue slice for transport termination classification in the proxy adapter.

## What remains
- nothing for this bug slice beyond review and merge

## Validation
- `cargo test -p swink-agent-adapters proxy`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace --no-fail-fast` *(fails on unrelated baseline targets listed below)*

## Pre-existing baseline failures
- `-p swink-agent-adapters --test no_default_features`
- `-p swink-agent-plugin-web --lib`
- `-p swink-agent-tui --lib`

Ref #543