### PR TITLE
fix: include loop context in pause snapshot to prevent message loss (#557)

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -207,6 +207,7 @@ pub struct Agent {
     in_flight_llm_messages: Option<Vec<AgentMessage>>,
     in_flight_messages: Option<Vec<AgentMessage>>,
     pending_message_snapshot: Arc<crate::pause_state::PendingMessageSnapshot>,
+    loop_context_snapshot: Arc<crate::pause_state::LoopContextSnapshot>,
     approve_tool: Option<ApproveToolArc>,
     approval_mode: ApprovalMode,
     pre_turn_policies: Vec<Arc<dyn crate::policy::PreTurnPolicy>>,
@@ -314,6 +315,7 @@ impl Agent {
             pending_message_snapshot: Arc::new(
                 crate::pause_state::PendingMessageSnapshot::default(),
             ),
+            loop_context_snapshot: Arc::new(crate::pause_state::LoopContextSnapshot::default()),
             approve_tool: options.approve_tool,
             approval_mode: options.approval_mode,
             pre_turn_policies: options.pre_turn_policies,

--- a/src/agent/checkpointing.rs
+++ b/src/agent/checkpointing.rs
@@ -175,10 +175,21 @@ impl Agent {
 
         let mut pending_messages = self.pending_message_snapshot.snapshot();
         pending_messages.extend(drain_messages_from_queue(&self.follow_up_queue));
-        let checkpoint_messages = self
-            .in_flight_messages
-            .as_deref()
-            .unwrap_or(&self.state.messages);
+
+        // Prefer the loop_context_snapshot when available: it is updated
+        // immediately after pending messages are drained into loop-local
+        // context_messages, closing the window where a concurrent pause() would
+        // miss those messages (they've left the shared pending queue but haven't
+        // yet been delivered back via a TurnEnd event that updates
+        // in_flight_messages).
+        let loop_ctx = self.loop_context_snapshot.snapshot();
+        let checkpoint_messages: &[crate::types::AgentMessage] = if let Some(ref ctx) = loop_ctx {
+            ctx.as_slice()
+        } else {
+            self.in_flight_messages
+                .as_deref()
+                .unwrap_or(&self.state.messages)
+        };
 
         let mut checkpoint = crate::checkpoint::LoopCheckpoint::new(
             &self.state.system_prompt,
@@ -1298,5 +1309,95 @@ mod tests {
             state.is_empty(),
             "missing snapshot should clear stale state"
         );
+    }
+
+    /// Regression test for issue #557: `run_single_turn` drains pending messages
+    /// into loop-local `context_messages` and then clears the shared
+    /// `pending_message_snapshot`. A concurrent `pause()` in that window would
+    /// previously miss those messages. The fix syncs `context_messages` to
+    /// `loop_context_snapshot` immediately after the drain, and `pause()` now
+    /// prefers that snapshot over `in_flight_messages`.
+    #[tokio::test]
+    async fn pause_captures_messages_drained_from_pending_into_loop_context() {
+        let mut agent = make_agent(None);
+        // Simulate the agent being mid-turn: in_flight_messages holds the
+        // original messages (before any pending drain), and loop_context_snapshot
+        // holds the expanded context after the drain.
+
+        // in_flight_messages = original message only (set at loop start).
+        agent.in_flight_messages = Some(vec![user_msg("original")]);
+        // pending_message_snapshot is cleared (run_single_turn has already drained it).
+        agent.pending_message_snapshot.clear();
+        // loop_context_snapshot = original + consumed pending (synced just after drain).
+        // replace() uses the internal clone_messages helper which handles AgentMessage variants.
+        agent
+            .loop_context_snapshot
+            .replace(&[user_msg("original"), user_msg("consumed-pending")]);
+
+        agent
+            .loop_active
+            .store(true, std::sync::atomic::Ordering::Release);
+
+        let checkpoint = agent.pause().expect("agent should be paused");
+        let restored = checkpoint.restore_messages(agent.custom_message_registry.as_deref());
+
+        assert_eq!(
+            restored.len(),
+            2,
+            "pause snapshot must include messages already consumed from the pending queue \
+             into loop context, not just in_flight_messages"
+        );
+        match &restored[0] {
+            AgentMessage::Llm(LlmMessage::User(u)) => match &u.content[0] {
+                crate::types::ContentBlock::Text { text } => {
+                    assert_eq!(text, "original");
+                }
+                other => panic!("expected text content, got {other:?}"),
+            },
+            other => panic!("expected user message, got {other:?}"),
+        }
+        match &restored[1] {
+            AgentMessage::Llm(LlmMessage::User(u)) => match &u.content[0] {
+                crate::types::ContentBlock::Text { text } => {
+                    assert_eq!(text, "consumed-pending");
+                }
+                other => panic!("expected text content, got {other:?}"),
+            },
+            other => panic!("expected user message, got {other:?}"),
+        }
+    }
+
+    /// When `loop_context_snapshot` is not set (loop has not yet started its
+    /// first turn), `pause()` must fall back to `in_flight_messages` as before.
+    #[tokio::test]
+    async fn pause_falls_back_to_in_flight_messages_when_context_snapshot_absent() {
+        let mut agent = make_agent(None);
+
+        // in_flight_messages = message set at loop start.
+        agent.in_flight_messages = Some(vec![user_msg("in-flight")]);
+        // loop_context_snapshot is empty (not yet set — pre-first-turn).
+        // (default state after Agent::new)
+
+        agent
+            .loop_active
+            .store(true, std::sync::atomic::Ordering::Release);
+
+        let checkpoint = agent.pause().expect("agent should be paused");
+        let restored = checkpoint.restore_messages(agent.custom_message_registry.as_deref());
+
+        assert_eq!(
+            restored.len(),
+            1,
+            "pause must fall back to in_flight_messages when loop_context_snapshot is absent"
+        );
+        match &restored[0] {
+            AgentMessage::Llm(LlmMessage::User(u)) => match &u.content[0] {
+                crate::types::ContentBlock::Text { text } => {
+                    assert_eq!(text, "in-flight");
+                }
+                other => panic!("expected text content, got {other:?}"),
+            },
+            other => panic!("expected user message, got {other:?}"),
+        }
     }
 }

--- a/src/agent/control.rs
+++ b/src/agent/control.rs
@@ -33,6 +33,7 @@ impl Agent {
         self.in_flight_llm_messages = None;
         self.in_flight_messages = None;
         self.pending_message_snapshot.clear();
+        self.loop_context_snapshot.clear();
     }
 
     /// Cancel the currently running loop, if any.

--- a/src/agent/invoke.rs
+++ b/src/agent/invoke.rs
@@ -31,6 +31,7 @@ struct LoopGuardStream {
     loop_active: Arc<AtomicBool>,
     idle_notify: Arc<Notify>,
     pending_message_snapshot: Arc<crate::pause_state::PendingMessageSnapshot>,
+    loop_context_snapshot: Arc<crate::pause_state::LoopContextSnapshot>,
     generation: u64,
     expected_generation: Arc<AtomicU64>,
 }
@@ -51,6 +52,7 @@ impl Drop for LoopGuardStream {
         if self.expected_generation.load(Ordering::Acquire) == self.generation {
             self.loop_active.store(false, Ordering::Release);
             self.pending_message_snapshot.clear();
+            self.loop_context_snapshot.clear();
             self.idle_notify.notify_waiters();
         }
     }
@@ -231,6 +233,7 @@ impl Agent {
         self.state.is_running = true;
         self.state.error = None;
         self.pending_message_snapshot.clear();
+        self.loop_context_snapshot.clear();
         self.loop_active.store(true, Ordering::Release);
         let generation = self.loop_generation.fetch_add(1, Ordering::AcqRel) + 1;
 
@@ -274,6 +277,7 @@ impl Agent {
             loop_active: Arc::clone(&self.loop_active),
             idle_notify: Arc::clone(&self.idle_notify),
             pending_message_snapshot: Arc::clone(&self.pending_message_snapshot),
+            loop_context_snapshot: Arc::clone(&self.loop_context_snapshot),
             generation,
             expected_generation: Arc::clone(&self.loop_generation),
         });
@@ -325,6 +329,7 @@ impl Agent {
             get_api_key: api_key_box,
             message_provider: Some(message_provider),
             pending_message_snapshot: Arc::clone(&self.pending_message_snapshot),
+            loop_context_snapshot: Arc::clone(&self.loop_context_snapshot),
             approve_tool: self.approve_tool.as_ref().map(|a| {
                 let a = Arc::clone(a);
                 let b: Box<ApproveToolFn> = Box::new(move |req| a(req));

--- a/src/agent/state_updates.rs
+++ b/src/agent/state_updates.rs
@@ -83,6 +83,7 @@ impl Agent {
         self.state.is_running = false;
         self.loop_active.store(false, Ordering::Release);
         self.pending_message_snapshot.clear();
+        self.loop_context_snapshot.clear();
         self.state.error.clone_from(&error);
         self.idle_notify.notify_waiters();
 
@@ -129,6 +130,7 @@ impl Agent {
                 self.in_flight_llm_messages = None;
                 self.in_flight_messages = None;
                 self.pending_message_snapshot.clear();
+                self.loop_context_snapshot.clear();
                 // Preserve terminal error — do not clear self.state.error.
                 self.idle_notify.notify_waiters();
             }

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -55,8 +55,7 @@ impl AgentHandle {
                     Err(AgentError::Aborted)
                 }
             };
-            *status_clone.lock().unwrap_or_else(PoisonError::into_inner) =
-                resolve_status(&result);
+            *status_clone.lock().unwrap_or_else(PoisonError::into_inner) = resolve_status(&result);
             result
         });
 

--- a/src/loop_/config.rs
+++ b/src/loop_/config.rs
@@ -69,6 +69,14 @@ pub struct AgentLoopConfig {
     #[allow(private_interfaces)]
     pub pending_message_snapshot: Arc<crate::pause_state::PendingMessageSnapshot>,
 
+    /// Shared snapshot of the loop's full `context_messages` for pause checkpoints.
+    ///
+    /// Updated after each turn's pending-message drain so that `Agent::pause()`
+    /// can reconstruct the complete message history even for messages that have
+    /// been moved out of the shared pending queue and into loop-local context.
+    #[allow(private_interfaces)]
+    pub loop_context_snapshot: Arc<crate::pause_state::LoopContextSnapshot>,
+
     /// Optional async callback for approving/rejecting tool calls before execution.
     /// When `Some` and `approval_mode` is `Enabled`, each tool call is sent through
     /// this callback before dispatch. Rejected tools return an error result to the LLM.

--- a/src/loop_/stream.rs
+++ b/src/loop_/stream.rs
@@ -413,14 +413,7 @@ async fn handle_stream_error(
     // TurnEndReason::Aborted instead of TurnEndReason::Error (#438).
     if matches!(harness_error, AgentError::Aborted) {
         let abort_msg = build_abort_message(model);
-        if !emit(
-            tx,
-            AgentEvent::MessageEnd {
-                message: abort_msg,
-            },
-        )
-        .await
-        {
+        if !emit(tx, AgentEvent::MessageEnd { message: abort_msg }).await {
             return StreamErrorAction::ChannelClosed;
         }
         return StreamErrorAction::FatalError(StreamResult::Aborted);

--- a/src/loop_/tool_dispatch/mod.rs
+++ b/src/loop_/tool_dispatch/mod.rs
@@ -506,6 +506,7 @@ mod tests {
             get_api_key: None,
             message_provider,
             pending_message_snapshot: Arc::default(),
+            loop_context_snapshot: Arc::default(),
             approve_tool,
             approval_mode,
             pre_turn_policies: vec![],

--- a/src/loop_/tool_dispatch/preprocess.rs
+++ b/src/loop_/tool_dispatch/preprocess.rs
@@ -9,15 +9,13 @@ use tracing::error;
 
 use crate::agent_options::ApproveToolFn;
 use crate::policy::{PreDispatchVerdict, ToolDispatchContext, run_pre_dispatch_policies};
-use crate::tool::{
-    AgentTool, AgentToolResult, ApprovalMode, ToolApproval, ToolApprovalRequest,
-};
+use crate::tool::{AgentTool, AgentToolResult, ApprovalMode, ToolApproval, ToolApprovalRequest};
 use crate::types::{AgentMessage, ContentBlock};
 
 use super::shared::{emit_batch_stop_results, emit_error_result, panic_payload_message};
 use super::{
-    AgentEvent, AgentLoopConfig, PreparedToolCall, ToolCallInfo, ToolExecOutcome,
-    emit, order_results_by_tool_calls,
+    AgentEvent, AgentLoopConfig, PreparedToolCall, ToolCallInfo, ToolExecOutcome, emit,
+    order_results_by_tool_calls,
 };
 
 // ─── Pre-process result ─────────────────────────────────────────────────────

--- a/src/loop_/turn.rs
+++ b/src/loop_/turn.rs
@@ -47,6 +47,11 @@ pub async fn run_single_turn(
         state.context_messages.append(&mut state.pending_messages);
     }
     clear_pending_message_snapshot(config);
+    // Sync the full context (including newly consumed pending messages) to the
+    // loop_context_snapshot so that a concurrent pause() call can reconstruct
+    // the complete message history even before this turn's TurnEnd event is
+    // processed by the agent side.
+    sync_loop_context_snapshot(config, state);
 
     // Check cancellation
     if cancellation_token.is_cancelled() {
@@ -352,6 +357,15 @@ fn sync_pending_message_snapshot(config: &AgentLoopConfig, state: &LoopState) {
     config
         .pending_message_snapshot
         .replace(&state.pending_messages);
+}
+
+/// Sync the full loop context to the shared `loop_context_snapshot` so that
+/// `Agent::pause()` can recover messages already drained from the shared pending
+/// queue but not yet reflected in `in_flight_messages`.
+fn sync_loop_context_snapshot(config: &AgentLoopConfig, state: &LoopState) {
+    config
+        .loop_context_snapshot
+        .replace(&state.context_messages);
 }
 
 // ─── Shared helpers ──────────────────────────────────────────────────────

--- a/src/pause_state.rs
+++ b/src/pause_state.rs
@@ -14,6 +14,49 @@ pub struct PendingMessageSnapshot {
     pending_messages: Mutex<Vec<AgentMessage>>,
 }
 
+/// Shared snapshot of the loop's current `context_messages` for pause checkpoints.
+///
+/// `run_single_turn` drains pending messages into `LoopState.context_messages` and
+/// then clears the `PendingMessageSnapshot`. In the window between that drain and
+/// the next `TurnEnd` event (which is when `Agent.in_flight_messages` is updated),
+/// a concurrent `pause()` call would miss the newly consumed messages. This
+/// snapshot is updated immediately after the drain so that `pause()` can read the
+/// full loop context, including messages that are already in `context_messages` but
+/// not yet reflected in `in_flight_messages`.
+#[doc(hidden)]
+#[derive(Default)]
+pub struct LoopContextSnapshot {
+    messages: Mutex<Option<Vec<AgentMessage>>>,
+}
+
+impl LoopContextSnapshot {
+    /// Overwrite the snapshot with a clone of `messages`.
+    pub(crate) fn replace(&self, messages: &[AgentMessage]) {
+        let mut guard = self
+            .messages
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        *guard = Some(clone_messages(messages));
+    }
+
+    /// Return a clone of the current snapshot, or `None` if not yet set.
+    pub(crate) fn snapshot(&self) -> Option<Vec<AgentMessage>> {
+        self.messages
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .as_deref()
+            .map(clone_messages)
+    }
+
+    /// Clear the snapshot (called when the loop finishes or agent is reset).
+    pub(crate) fn clear(&self) {
+        *self
+            .messages
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
+    }
+}
+
 impl PendingMessageSnapshot {
     pub(crate) fn replace(&self, pending_messages: &[AgentMessage]) {
         let mut guard = self

--- a/tests/abort_turn_end_reason.rs
+++ b/tests/abort_turn_end_reason.rs
@@ -45,6 +45,7 @@ fn default_config(stream_fn: Arc<dyn StreamFn>) -> AgentLoopConfig {
         get_api_key: None,
         message_provider: None,
         pending_message_snapshot: Arc::default(),
+        loop_context_snapshot: Arc::default(),
         approve_tool: None,
         approval_mode: swink_agent::ApprovalMode::default(),
         pre_turn_policies: vec![],

--- a/tests/agent_loop.rs
+++ b/tests/agent_loop.rs
@@ -231,6 +231,7 @@ fn default_config(stream_fn: Arc<dyn StreamFn>) -> AgentLoopConfig {
         get_api_key: None,
         message_provider: None,
         pending_message_snapshot: Arc::default(),
+        loop_context_snapshot: Arc::default(),
         approve_tool: None,
         approval_mode: swink_agent::ApprovalMode::default(),
         pre_turn_policies: vec![],

--- a/tests/agent_structured.rs
+++ b/tests/agent_structured.rs
@@ -8,8 +8,8 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use common::{
-    MockStreamFn, default_convert, default_model, error_events, text_only_events,
-    tool_call_events, user_msg,
+    MockStreamFn, default_convert, default_model, error_events, text_only_events, tool_call_events,
+    user_msg,
 };
 use futures::stream::StreamExt;
 use serde_json::json;
@@ -370,13 +370,12 @@ async fn prompt_stream_without_handle_stream_event_stays_running() {
 /// state through `AgentEnd` instead of unconditionally clearing it.
 #[tokio::test]
 async fn handle_stream_event_preserves_terminal_error_through_agent_end() {
-    let stream_fn = Arc::new(MockStreamFn::new(vec![error_events(
-        "fatal error",
-        None,
-    )]));
+    let stream_fn = Arc::new(MockStreamFn::new(vec![error_events("fatal error", None)]));
     let mut agent = make_agent(stream_fn);
 
-    let stream = agent.prompt_stream(vec![user_msg("trigger error")]).unwrap();
+    let stream = agent
+        .prompt_stream(vec![user_msg("trigger error")])
+        .unwrap();
     let mut stream = std::pin::pin!(stream);
     while let Some(event) = stream.next().await {
         agent.handle_stream_event(&event);

--- a/tests/context_compaction.rs
+++ b/tests/context_compaction.rs
@@ -91,6 +91,7 @@ fn default_config(stream_fn: Arc<dyn StreamFn>) -> AgentLoopConfig {
         get_api_key: None,
         message_provider: None,
         pending_message_snapshot: Arc::default(),
+        loop_context_snapshot: Arc::default(),
         approve_tool: None,
         approval_mode: swink_agent::ApprovalMode::default(),
         pre_turn_policies: vec![],

--- a/tests/fallback.rs
+++ b/tests/fallback.rs
@@ -65,6 +65,7 @@ fn default_config(
         get_api_key: None,
         message_provider: None,
         pending_message_snapshot: Arc::default(),
+        loop_context_snapshot: Arc::default(),
         approve_tool: None,
         approval_mode: swink_agent::ApprovalMode::default(),
         pre_turn_policies: vec![],

--- a/tests/loop_overflow.rs
+++ b/tests/loop_overflow.rs
@@ -59,6 +59,7 @@ fn default_config(stream_fn: Arc<dyn StreamFn>) -> AgentLoopConfig {
         get_api_key: None,
         message_provider: None,
         pending_message_snapshot: Arc::default(),
+        loop_context_snapshot: Arc::default(),
         approve_tool: None,
         approval_mode: swink_agent::ApprovalMode::default(),
         pre_turn_policies: vec![],

--- a/tests/otel_spans.rs
+++ b/tests/otel_spans.rs
@@ -49,6 +49,7 @@ fn default_config(stream_fn: Arc<dyn StreamFn>) -> AgentLoopConfig {
         get_api_key: None,
         message_provider: None,
         pending_message_snapshot: Arc::default(),
+        loop_context_snapshot: Arc::default(),
         approve_tool: None,
         approval_mode: swink_agent::ApprovalMode::default(),
         pre_turn_policies: vec![],

--- a/tests/stream_middleware.rs
+++ b/tests/stream_middleware.rs
@@ -9,7 +9,10 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use futures::StreamExt;
 use tokio_util::sync::CancellationToken;
 
-use swink_agent::{AgentContext, AssistantMessageEvent, Cost, StopReason, StreamFn, StreamMiddleware, StreamOptions, Usage};
+use swink_agent::{
+    AgentContext, AssistantMessageEvent, Cost, StopReason, StreamFn, StreamMiddleware,
+    StreamOptions, Usage,
+};
 
 use common::{MockStreamFn, default_model};
 

--- a/tests/tool_execution_policy.rs
+++ b/tests/tool_execution_policy.rs
@@ -130,6 +130,7 @@ fn make_config(
         get_api_key: None,
         message_provider: None,
         pending_message_snapshot: Arc::default(),
+        loop_context_snapshot: Arc::default(),
         approve_tool: None,
         approval_mode: swink_agent::ApprovalMode::default(),
         pre_turn_policies: vec![],


### PR DESCRIPTION
## Summary

Fixes a race window in `pause()` where messages drained from the pending queue into `LoopState.context_messages` could be silently lost.

**Root cause:** `run_single_turn` drains `pending_messages` into `LoopState.context_messages` and then immediately clears `pending_message_snapshot`. The `pause()` method, running concurrently, falls back to `in_flight_messages` — but that field is only updated on `TurnEnd` events. In the window between the drain and the next `TurnEnd`, any drained messages are invisible to `pause()`.

**Fix:** Adds a new `LoopContextSnapshot` (in `src/pause_state.rs`) that mirrors the full `LoopState.context_messages` slice immediately after each pending drain. `pause()` now prefers this snapshot over `in_flight_messages`, closing the race. The snapshot is cleared on loop end / stream drop / `reset()`, matching the lifecycle of the existing `PendingMessageSnapshot`.

## Changes

- `src/pause_state.rs` — new `LoopContextSnapshot` struct (alongside existing `PendingMessageSnapshot`)
- `src/loop_/config.rs` — new `loop_context_snapshot` field on `AgentLoopConfig`
- `src/loop_/turn.rs` — sync the snapshot immediately after the pending drain
- `src/agent.rs` / `src/agent/invoke.rs` / `src/agent/control.rs` / `src/agent/state_updates.rs` — carry and clear the snapshot through agent lifecycle
- `src/agent/checkpointing.rs` — prefer `loop_context_snapshot` over `in_flight_messages` in `pause()`; two new regression tests
- Integration test files (7) + `src/loop_/tool_dispatch/mod.rs` — add `loop_context_snapshot: Arc::default()` to all `AgentLoopConfig` construction sites

## Test plan

- [ ] `cargo test -p swink-agent --features testkit` — all tests pass (409 lib + integration)
- [ ] `cargo test -p swink-agent --no-default-features` — passes
- [ ] `cargo clippy -p swink-agent -- -D warnings` — zero warnings
- [ ] `cargo fmt -p swink-agent --check` — clean
- [ ] New regression tests: `pause_captures_messages_drained_from_pending_into_loop_context` and `pause_falls_back_to_in_flight_messages_when_context_snapshot_absent` both pass

Closes #557

🤖 Generated with [Claude Code](https://claude.com/claude-code)