### PR TITLE
fix(tui): make Agent the single source of truth for approval mode

### DIFF
--- a/src/agent/mutation.rs
+++ b/src/agent/mutation.rs
@@ -74,6 +74,11 @@ impl Agent {
         self.state.tools.len() < before
     }
 
+    /// Return the current approval mode.
+    pub const fn approval_mode(&self) -> ApprovalMode {
+        self.approval_mode
+    }
+
     /// Set the approval mode at runtime.
     pub const fn set_approval_mode(&mut self, mode: ApprovalMode) {
         self.approval_mode = mode;

--- a/tui/CLAUDE.md
+++ b/tui/CLAUDE.md
@@ -20,6 +20,7 @@
 
 ## Lessons Learned
 
+- **Approval mode is owned by `Agent`** — `App::approval_mode()` reads through to `agent.approval_mode()` and returns `Smart` before `set_agent` is called. Do not add an `App.approval_mode` field; doing so reintroduces the dual-write drift bug (#565). Configure the startup mode via `AgentOptions::with_approval_mode` before building the agent.
 - **Smart approval mode auto-approves trusted tools only** — untrusted tools still prompt even if they are read-only.
 - **Panic hook restores terminal** — without it, a panic leaves terminal in raw mode.
 - **Credentials** — env var checked first, then keychain. Env always wins.

--- a/tui/src/app/agent_bridge.rs
+++ b/tui/src/app/agent_bridge.rs
@@ -173,7 +173,7 @@ impl App {
         request: swink_agent::ToolApprovalRequest,
         responder: tokio::sync::oneshot::Sender<ToolApproval>,
     ) {
-        if self.approval_mode == swink_agent::ApprovalMode::Smart
+        if self.approval_mode() == swink_agent::ApprovalMode::Smart
             && self.session_trusted_tools.contains(&request.tool_name)
         {
             let _ = responder.send(ToolApproval::Approved);

--- a/tui/src/app/event_loop.rs
+++ b/tui/src/app/event_loop.rs
@@ -233,7 +233,7 @@ impl App {
                     if let Some((req, responder)) = self.pending_approval.take() {
                         let _ = responder.send(ToolApproval::Approved);
                         // In Smart mode, offer trust follow-up
-                        if self.approval_mode == ApprovalMode::Smart {
+                        if self.approval_mode() == ApprovalMode::Smart {
                             self.trust_follow_up = Some(TrustFollowUp {
                                 tool_name: req.tool_name,
                                 expires_at: Instant::now() + Duration::from_secs(3),
@@ -451,7 +451,6 @@ impl App {
                     ApprovalModeArg::Off => ApprovalMode::Bypassed,
                     ApprovalModeArg::Smart => ApprovalMode::Smart,
                 };
-                self.approval_mode = harness_mode;
                 if let Some(agent) = &mut self.agent {
                     agent.set_approval_mode(harness_mode);
                 }
@@ -484,7 +483,7 @@ impl App {
                 return;
             }
             CommandResult::QueryApprovalMode => {
-                let label = match self.approval_mode {
+                let label = match self.approval_mode() {
                     ApprovalMode::Enabled => "enabled",
                     ApprovalMode::Bypassed => "disabled (auto-approve)",
                     ApprovalMode::Smart => {
@@ -493,7 +492,7 @@ impl App {
                     _ => "unknown",
                 };
                 let mut msg = format!("Tool approval: {label}");
-                if self.approval_mode == ApprovalMode::Smart
+                if self.approval_mode() == ApprovalMode::Smart
                     && !self.session_trusted_tools.is_empty()
                 {
                     msg.push_str("\nTrusted tools: ");

--- a/tui/src/app/lifecycle.rs
+++ b/tui/src/app/lifecycle.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 use ratatui::layout::Rect;
 use tokio::sync::{mpsc, oneshot};
 
-use swink_agent::{Agent, ToolApproval, ToolApprovalRequest};
+use swink_agent::{Agent, ApprovalMode, ToolApproval, ToolApprovalRequest};
 
 use crate::config::TuiConfig;
 use crate::session::JsonlSessionStore;
@@ -67,7 +67,6 @@ impl App {
             approval_rx,
             approval_tx,
             pending_approval: None,
-            approval_mode: swink_agent::ApprovalMode::default(),
             context_budget: 0,
             context_tokens_used: 0,
             selected_tool_block: None,
@@ -172,6 +171,19 @@ impl App {
         self.model_index = 0;
         self.context_budget = 100_000;
         self.agent = Some(agent);
+    }
+
+    /// Return the current approval mode.
+    ///
+    /// Reads through to the underlying [`Agent`]. Before [`set_agent`](Self::set_agent) is
+    /// called, returns [`ApprovalMode::default()`] (Smart). Pass the desired mode to
+    /// [`swink_agent::AgentOptions::with_approval_mode`] before constructing the agent to
+    /// control startup behavior.
+    pub fn approval_mode(&self) -> ApprovalMode {
+        self.agent
+            .as_ref()
+            .map(Agent::approval_mode)
+            .unwrap_or_default()
     }
 
     /// Get a clone of the approval request sender for use in the agent callback.

--- a/tui/src/app/state.rs
+++ b/tui/src/app/state.rs
@@ -8,8 +8,8 @@ use ratatui::layout::Rect;
 use tokio::sync::{mpsc, oneshot};
 
 use swink_agent::{
-    Agent, AgentEvent, AgentTool, ApprovalMode, AssistantMessage, ContentBlock, DisplayRole,
-    StopReason, ToolApproval, ToolApprovalRequest,
+    Agent, AgentEvent, AgentTool, AssistantMessage, ContentBlock, DisplayRole, StopReason,
+    ToolApproval, ToolApprovalRequest,
 };
 
 use crate::config::TuiConfig;
@@ -182,8 +182,6 @@ pub struct App {
     pub(crate) approval_tx: mpsc::Sender<(ToolApprovalRequest, oneshot::Sender<ToolApproval>)>,
     /// Currently pending approval request and its response channel.
     pub(crate) pending_approval: Option<(ToolApprovalRequest, oneshot::Sender<ToolApproval>)>,
-    /// Current approval mode.
-    pub approval_mode: ApprovalMode,
     /// Estimated context window token budget.
     pub context_budget: u64,
     /// Estimated tokens currently used in context.

--- a/tui/src/app/tests/approval.rs
+++ b/tui/src/app/tests/approval.rs
@@ -12,10 +12,19 @@ use super::super::*;
 use super::super::state::TrustFollowUp;
 use super::helpers::*;
 
+/// Build a minimal `App` with the given `ApprovalMode` installed on the agent.
+fn make_app_with_mode(mode: ApprovalMode) -> App {
+    let stream_fn = Arc::new(ScriptedStreamFn::new(vec![]));
+    let mut agent = make_test_agent(stream_fn);
+    agent.set_approval_mode(mode);
+    let mut app = App::new(TuiConfig::default());
+    app.set_agent(agent);
+    app
+}
+
 #[tokio::test]
 async fn smart_mode_auto_approves_trusted_tool() {
-    let mut app = App::new(TuiConfig::default());
-    app.approval_mode = ApprovalMode::Smart;
+    let mut app = make_app_with_mode(ApprovalMode::Smart);
     app.session_trusted_tools.insert("bash".to_string());
 
     let (tx, rx) = tokio::sync::oneshot::channel();
@@ -38,8 +47,7 @@ async fn smart_mode_auto_approves_trusted_tool() {
 
 #[tokio::test]
 async fn smart_mode_prompts_for_untrusted_tool() {
-    let mut app = App::new(TuiConfig::default());
-    app.approval_mode = ApprovalMode::Smart;
+    let mut app = make_app_with_mode(ApprovalMode::Smart);
 
     let (tx, _rx) = tokio::sync::oneshot::channel();
     let request = ToolApprovalRequest {
@@ -99,18 +107,17 @@ async fn reset_clears_trusted_tools() {
 
 #[tokio::test]
 async fn query_approval_mode_shows_smart() {
-    let mut app = App::new(TuiConfig::default());
-    app.approval_mode = ApprovalMode::Smart;
+    let mut app = make_app_with_mode(ApprovalMode::Smart);
     app.session_trusted_tools.insert("bash".to_string());
 
-    let label = match app.approval_mode {
+    let label = match app.approval_mode() {
         ApprovalMode::Enabled => "enabled",
         ApprovalMode::Bypassed => "disabled (auto-approve)",
         ApprovalMode::Smart => "smart (auto-approve trusted tools, prompt for untrusted tools)",
         _ => "unknown",
     };
     let mut msg = format!("Tool approval: {label}");
-    if app.approval_mode == ApprovalMode::Smart && !app.session_trusted_tools.is_empty() {
+    if app.approval_mode() == ApprovalMode::Smart && !app.session_trusted_tools.is_empty() {
         msg.push_str("\nTrusted tools: ");
         let mut tools: Vec<&str> = app
             .session_trusted_tools
@@ -130,13 +137,12 @@ async fn query_approval_mode_shows_smart() {
 #[test]
 fn approval_mode_default_is_smart() {
     let app = App::new(TuiConfig::default());
-    assert_eq!(app.approval_mode, ApprovalMode::Smart);
+    assert_eq!(app.approval_mode(), ApprovalMode::Smart);
 }
 
 #[tokio::test]
 async fn smart_mode_prompts_for_untrusted_readonly_tool() {
-    let mut app = App::new(TuiConfig::default());
-    app.approval_mode = ApprovalMode::Smart;
+    let mut app = make_app_with_mode(ApprovalMode::Smart);
 
     let (tx, _rx) = tokio::sync::oneshot::channel();
     let request = ToolApprovalRequest {
@@ -157,8 +163,7 @@ async fn smart_mode_prompts_for_untrusted_readonly_tool() {
 
 #[tokio::test]
 async fn smart_mode_prompts_for_write_tool() {
-    let mut app = App::new(TuiConfig::default());
-    app.approval_mode = ApprovalMode::Smart;
+    let mut app = make_app_with_mode(ApprovalMode::Smart);
 
     let (tx, _rx) = tokio::sync::oneshot::channel();
     let request = ToolApprovalRequest {
@@ -175,8 +180,7 @@ async fn smart_mode_prompts_for_write_tool() {
 
 #[tokio::test]
 async fn enabled_mode_prompts_for_all_tools() {
-    let mut app = App::new(TuiConfig::default());
-    app.approval_mode = ApprovalMode::Enabled;
+    let mut app = make_app_with_mode(ApprovalMode::Enabled);
 
     let (tx, _rx) = tokio::sync::oneshot::channel();
     let request = ToolApprovalRequest {
@@ -196,9 +200,8 @@ async fn enabled_mode_prompts_for_all_tools() {
 
 #[tokio::test]
 async fn bypassed_mode_auto_approves_all() {
-    let mut app = App::new(TuiConfig::default());
-    app.approval_mode = ApprovalMode::Bypassed;
-    assert_eq!(app.approval_mode, ApprovalMode::Bypassed);
+    let app = make_app_with_mode(ApprovalMode::Bypassed);
+    assert_eq!(app.approval_mode(), ApprovalMode::Bypassed);
 }
 
 #[test]
@@ -222,8 +225,7 @@ fn approve_command_switches_modes() {
 
 #[tokio::test]
 async fn trust_follow_up_triggers_after_approval_in_smart_mode() {
-    let mut app = App::new(TuiConfig::default());
-    app.approval_mode = ApprovalMode::Smart;
+    let mut app = make_app_with_mode(ApprovalMode::Smart);
 
     let (tx, _rx) = tokio::sync::oneshot::channel();
     let request = ToolApprovalRequest {
@@ -248,8 +250,7 @@ async fn trust_follow_up_triggers_after_approval_in_smart_mode() {
 
 #[tokio::test]
 async fn trust_follow_up_not_triggered_in_enabled_mode() {
-    let mut app = App::new(TuiConfig::default());
-    app.approval_mode = ApprovalMode::Enabled;
+    let mut app = make_app_with_mode(ApprovalMode::Enabled);
 
     let (tx, _rx) = tokio::sync::oneshot::channel();
     let request = ToolApprovalRequest {
@@ -324,8 +325,7 @@ fn trust_follow_up_timeout_clears() {
 
 #[tokio::test]
 async fn trusted_tool_auto_approves_in_smart_mode() {
-    let mut app = App::new(TuiConfig::default());
-    app.approval_mode = ApprovalMode::Smart;
+    let mut app = make_app_with_mode(ApprovalMode::Smart);
     app.session_trusted_tools.insert("bash".to_string());
 
     let (tx, rx) = tokio::sync::oneshot::channel();
@@ -348,8 +348,7 @@ async fn trusted_tool_auto_approves_in_smart_mode() {
 
 #[tokio::test]
 async fn trusted_tool_still_prompts_in_enabled_mode() {
-    let mut app = App::new(TuiConfig::default());
-    app.approval_mode = ApprovalMode::Enabled;
+    let mut app = make_app_with_mode(ApprovalMode::Enabled);
     app.session_trusted_tools.insert("bash".to_string());
 
     let (tx, _rx) = tokio::sync::oneshot::channel();
@@ -439,8 +438,7 @@ fn untrust_all_clears_set() {
 
 #[tokio::test]
 async fn trust_follow_up_cleared_on_new_approval() {
-    let mut app = App::new(TuiConfig::default());
-    app.approval_mode = ApprovalMode::Smart;
+    let mut app = make_app_with_mode(ApprovalMode::Smart);
     app.trust_follow_up = Some(TrustFollowUp {
         tool_name: "old_tool".to_string(),
         expires_at: Instant::now() + Duration::from_secs(3),

--- a/tui/src/lib.rs
+++ b/tui/src/lib.rs
@@ -51,6 +51,7 @@ use tokio::sync::{mpsc, oneshot};
 use swink_agent::{Agent, ToolApproval, ToolApprovalRequest, selective_approve};
 
 pub use app::{AgentStatus, App, DisplayMessage, MessageRole, OperatingMode};
+pub use swink_agent::ApprovalMode;
 pub use config::TuiConfig;
 pub use error::TuiError;
 pub use session::JsonlSessionStore;
@@ -125,6 +126,13 @@ pub fn tui_approval_callback(approval_tx: &ApprovalSender) -> ApprovalCallbackFn
 ///
 /// The approval callback is wired automatically — callers should **not** set
 /// `with_approve_tool` on the supplied [`swink_agent::AgentOptions`].
+///
+/// To control the startup approval mode, configure it on `options` before calling:
+/// ```ignore
+/// let options = AgentOptions::new(...).with_approval_mode(ApprovalMode::Bypassed);
+/// launch(config, &mut terminal, options).await?;
+/// ```
+/// [`App::approval_mode`] reads the mode from the agent, so both sides stay in sync.
 pub async fn launch(
     config: TuiConfig,
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,

--- a/tui/tests/ac_tui.rs
+++ b/tui/tests/ac_tui.rs
@@ -277,7 +277,7 @@ fn operating_mode_field_is_writable() {
 #[test]
 fn default_approval_mode_is_smart() {
     let app = make_app();
-    assert_eq!(app.approval_mode, ApprovalMode::Smart);
+    assert_eq!(app.approval_mode(), ApprovalMode::Smart);
 }
 
 #[test]
@@ -297,13 +297,10 @@ fn approval_mode_variants_are_distinct() {
 }
 
 #[test]
-fn approval_mode_field_is_writable() {
-    let mut app = make_app();
-    app.approval_mode = ApprovalMode::Smart;
-    assert_eq!(app.approval_mode, ApprovalMode::Smart);
-
-    app.approval_mode = ApprovalMode::Bypassed;
-    assert_eq!(app.approval_mode, ApprovalMode::Bypassed);
+fn approval_mode_is_readable() {
+    let app = make_app();
+    // Default is Smart (no agent installed).
+    assert_eq!(app.approval_mode(), ApprovalMode::Smart);
 }
 
 #[test]
@@ -315,8 +312,6 @@ fn session_trusted_tools_starts_empty() {
 #[test]
 fn session_trusted_tools_tracks_tool_names() {
     let mut app = make_app();
-    app.approval_mode = ApprovalMode::Smart;
-
     app.session_trusted_tools.insert("ReadFile".to_string());
     app.session_trusted_tools.insert("ListDir".to_string());
 
@@ -334,7 +329,6 @@ fn smart_mode_trust_semantics() {
     // Tools NOT in the set require approval prompts.
     // This mirrors the logic in `handle_approval_request`.
     let mut app = make_app();
-    app.approval_mode = ApprovalMode::Smart;
     app.session_trusted_tools.insert("ReadFile".to_string());
 
     let trusted = app.session_trusted_tools.contains("ReadFile");


### PR DESCRIPTION
Closes #565

## Summary

- **Root cause**: `App.approval_mode` was a redundant mirror of `Agent.approval_mode`, forcing callers to sync two independent fields and making the startup drift in `launch()` possible.
- **Fix**: Delete `App.approval_mode`; add `Agent::approval_mode()` public getter (zero-cost `const fn`); add `App::approval_mode()` accessor that reads through to the agent and falls back to `ApprovalMode::default()` (Smart) before `set_agent` is called.
- **`launch()` unchanged**: Callers already configure mode via `AgentOptions::with_approval_mode` — it now propagates automatically with no signature change.
- **Re-export**: `pub use swink_agent::ApprovalMode` added to the TUI crate root so consumers don't need a separate import just to call `launch()` with a non-default mode.
- **`/approve` command**: Removed the redundant `self.approval_mode = harness_mode` write — only `agent.set_approval_mode` is needed now.

## Breaking change

`App.approval_mode` public field removed. Use `App::approval_mode()` method instead. (0.x semver — minor bump appropriate.)

## Test plan

- [ ] `cargo build -p swink-agent -p swink-agent-tui` compiles cleanly
- [ ] `cargo test -p swink-agent-tui` — full `approval.rs` suite passes, including `approval_mode_default_is_smart` (fallback path) and all mode-specific tests via `make_app_with_mode`
- [ ] `cargo test -p swink-agent --features testkit` — core tests unaffected
- [ ] `/approve on|off|smart` commands still toggle overlay behavior correctly at runtime
- [ ] TUI built with `AgentOptions::with_approval_mode(ApprovalMode::Bypassed)` shows no approval overlays (the yolo example use case from the issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)