### PR TITLE
[codex] Fix non-tool length truncation handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,7 @@ MSRV **1.88** (edition 2024). Common workspace deps are centralized in root `Car
 
 - `accumulate_message` enforces strict ordering: one Start, indexed content blocks, one terminal (Done/Error).
 - `partial_json` consumed on `ToolCallEnd` — parsed once. Empty string → `{}`, not null.
+- `Done(Length)` tolerance is only for unfinished `ToolCall` blocks that preserve `partial_json` for `recover_incomplete_tool_calls`; unterminated text/thinking blocks must still be rejected as malformed.
 - `AssistantMessageEvent::error()` is the canonical error constructor — adapters must use it.
 
 ### OpenAI-Compatible Adapters (`adapters/src/openai_compat.rs`)

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -369,6 +369,19 @@ pub fn accumulate_message(
         }
     }
 
+    fn all_open_blocks_are_tool_calls(content: &[ContentBlock], open_blocks: &[bool]) -> bool {
+        open_blocks
+            .iter()
+            .enumerate()
+            .filter(|(_, open)| **open)
+            .all(|(content_index, _)| {
+                matches!(
+                    content.get(content_index),
+                    Some(ContentBlock::ToolCall { .. })
+                )
+            })
+    }
+
     let mut content: Option<Vec<ContentBlock>> = None;
     // Parallel to `content`: tracks whether each block is still open (awaiting
     // its matching `*End` event). Finalization (on `Done`) fails if any block
@@ -639,7 +652,10 @@ pub fn accumulate_message(
                 cost: c,
             } => {
                 if let Some(idx) = open_blocks.iter().position(|open| *open) {
-                    if tolerate_truncated_tool_args {
+                    let content = content.as_ref().ok_or("Done before Start")?;
+                    if tolerate_truncated_tool_args
+                        && all_open_blocks_are_tool_calls(content, &open_blocks)
+                    {
                         // Max-tokens truncation: leave open tool-call blocks
                         // with `partial_json` set so the loop's
                         // `recover_incomplete_tool_calls` path can convert
@@ -937,6 +953,46 @@ mod tests {
             }
             other => panic!("expected ToolCall, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn done_length_with_unterminated_text_block_is_rejected() {
+        let events = vec![
+            AssistantMessageEvent::Start,
+            AssistantMessageEvent::TextStart { content_index: 0 },
+            AssistantMessageEvent::TextDelta {
+                content_index: 0,
+                delta: "partial".into(),
+            },
+            AssistantMessageEvent::Done {
+                stop_reason: StopReason::Length,
+                usage: Usage::default(),
+                cost: Cost::default(),
+            },
+        ];
+
+        let err = accumulate_message(events, "test", "test").unwrap_err();
+        assert!(err.contains("unterminated content block"), "got: {err}");
+    }
+
+    #[test]
+    fn done_length_with_unterminated_thinking_block_is_rejected() {
+        let events = vec![
+            AssistantMessageEvent::Start,
+            AssistantMessageEvent::ThinkingStart { content_index: 0 },
+            AssistantMessageEvent::ThinkingDelta {
+                content_index: 0,
+                delta: "partial".into(),
+            },
+            AssistantMessageEvent::Done {
+                stop_reason: StopReason::Length,
+                usage: Usage::default(),
+                cost: Cost::default(),
+            },
+        ];
+
+        let err = accumulate_message(events, "test", "test").unwrap_err();
+        assert!(err.contains("unterminated content block"), "got: {err}");
     }
 
     #[test]


### PR DESCRIPTION
## What changed
- tightened `accumulate_message` so `Done(Length)` only tolerates unfinished `ToolCall` blocks
- kept the existing max-token recovery path for incomplete tool-call JSON intact
- added regression coverage proving unterminated `Text` and `Thinking` blocks are still rejected under `StopReason::Length`
- documented the rule in `AGENTS.md`

## Why
The stream accumulator was treating any open content block as recoverable whenever the terminal stop reason was `Length`. That weakened the strict stream ordering contract by accepting malformed text/thinking responses that should still be rejected.

## Slice completed
This PR completes the issue slice for stream-terminal validation in `accumulate_message`. Nothing remains for issue #558.

## Validation
- `cargo test -p swink-agent done_length_with_unterminated_`
- `cargo clippy --workspace -- -D warnings` *(pre-existing unrelated failure: `tui/src/ui/mod.rs:56` triggers `clippy::cast_possible_truncation`)*
- `cargo test --workspace --features testkit` *(pre-existing unrelated failures in `swink-agent-plugin-web`: `content::tests::truncate_content_multibyte_boundaries_are_utf8_safe`, `tools::fetch::tests::execute_rejects_body_that_exceeds_cap_before_extraction`, `tools::fetch::tests::execute_returns_readable_content_for_html_under_cap`)*

## Notes
- No IPC contract changes.

Closes #558