### PR TITLE
Fix adapter pre-stream Start/Error ordering

### DIFF
--- a/adapters/AGENTS.md
+++ b/adapters/AGENTS.md
@@ -2,6 +2,7 @@
 
 ## Lessons Learned
 
+- In the remote adapters, any failure before the provider yields its first streaming payload must still emit `[Start, Error]`. Returning only a terminal `Error` makes `accumulate_message()` fail with `no Start event found` and hides the real provider error.
 - In `src/ollama.rs`, the NDJSON parser must buffer raw bytes until it has a full newline-delimited record. Decoding each transport chunk independently with `from_utf8_lossy` corrupts split multibyte UTF-8 in streamed text and tool arguments.
 - In `src/openai_compat.rs`, OpenAI-compatible providers can stream tool-call arguments before `function.name`. Buffer those arguments and delay `ToolCallStart` until a non-empty name is known; otherwise the harness locks in an empty tool name and later deltas cannot repair it.
 - Runtime SSE adapters must thread `StreamOptions.on_raw_payload` into the callback-aware shared parser (`sse_data_lines_with_callback` or an equivalent hook). Calling the callback-free helper silently disables payload observers in production even though the shared SSE unit tests still pass.

--- a/adapters/src/anthropic.rs
+++ b/adapters/src/anthropic.rs
@@ -194,7 +194,7 @@ fn anthropic_stream<'a>(
     stream::once(async move {
         let response = match send_request(anthropic, model, context, options).await {
             Ok(resp) => resp,
-            Err(event) => return stream::iter(vec![event]).left_stream(),
+            Err(event) => return stream::iter(crate::base::pre_stream_error(event)).left_stream(),
         };
 
         let status = response.status();
@@ -213,7 +213,7 @@ fn anthropic_stream<'a>(
                     (504, crate::classify::HttpErrorKind::Network),
                 ],
             );
-            return stream::iter(vec![event]).left_stream();
+            return stream::iter(crate::base::pre_stream_error(event)).left_stream();
         }
 
         parse_sse_stream(response, cancellation_token).right_stream()

--- a/adapters/src/azure.rs
+++ b/adapters/src/azure.rs
@@ -233,7 +233,7 @@ fn azure_stream<'a>(
         let request = prepare_oai_request(azure.shell.client(), &url, model, context, options);
         let request = match azure.apply_auth(request, options).await {
             Ok(r) => r,
-            Err(event) => return stream::iter(vec![event]).left_stream(),
+            Err(event) => return stream::iter(crate::base::pre_stream_error(event)).left_stream(),
         };
 
         oai_send_and_parse(

--- a/adapters/src/base.rs
+++ b/adapters/src/base.rs
@@ -48,6 +48,24 @@ impl AdapterBase {
     }
 }
 
+impl std::fmt::Debug for AdapterBase {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AdapterBase")
+            .field("base_url", &self.base_url)
+            .field("api_key", &"[REDACTED]")
+            .finish_non_exhaustive()
+    }
+}
+
+/// Prefix a pre-stream terminal error with `Start` so the core accumulator
+/// still receives a valid stream envelope.
+#[must_use]
+pub const fn pre_stream_error(
+    event: swink_agent::AssistantMessageEvent,
+) -> [swink_agent::AssistantMessageEvent; 2] {
+    [swink_agent::AssistantMessageEvent::Start, event]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -69,13 +87,16 @@ mod tests {
         let base = AdapterBase::new("https://api.example.com", "key");
         assert_eq!(base.base_url, "https://api.example.com");
     }
-}
 
-impl std::fmt::Debug for AdapterBase {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("AdapterBase")
-            .field("base_url", &self.base_url)
-            .field("api_key", &"[REDACTED]")
-            .finish_non_exhaustive()
+    #[test]
+    fn pre_stream_error_prefixes_start() {
+        let events = pre_stream_error(swink_agent::AssistantMessageEvent::error("boom"));
+        assert!(matches!(
+            events,
+            [
+                swink_agent::AssistantMessageEvent::Start,
+                swink_agent::AssistantMessageEvent::Error { .. }
+            ]
+        ));
     }
 }

--- a/adapters/src/google.rs
+++ b/adapters/src/google.rs
@@ -280,7 +280,7 @@ fn gemini_stream<'a>(
     stream::once(async move {
         let response = match send_request(gemini, model, context, options).await {
             Ok(response) => response,
-            Err(event) => return stream::iter(vec![event]).left_stream(),
+            Err(event) => return stream::iter(crate::base::pre_stream_error(event)).left_stream(),
         };
 
         let status = response.status();
@@ -289,7 +289,7 @@ fn gemini_stream<'a>(
             let body = response.text().await.unwrap_or_default();
             warn!(status = code, "Google Gemini HTTP error");
             let event = crate::classify::error_event_from_status(code, &body, "Google");
-            return stream::iter(vec![event]).left_stream();
+            return stream::iter(crate::base::pre_stream_error(event)).left_stream();
         }
 
         parse_sse_stream(response, cancellation_token, options.on_raw_payload.clone())

--- a/adapters/src/ollama.rs
+++ b/adapters/src/ollama.rs
@@ -187,7 +187,7 @@ fn ollama_stream<'a>(
     stream::once(async move {
         let response = match send_request(ollama, model, context, options).await {
             Ok(resp) => resp,
-            Err(event) => return stream::iter(vec![event]).left_stream(),
+            Err(event) => return stream::iter(crate::base::pre_stream_error(event)).left_stream(),
         };
 
         if !response.status().is_success() {
@@ -195,7 +195,7 @@ fn ollama_stream<'a>(
             let body = response.text().await.unwrap_or_default();
             warn!(status = code, "Ollama HTTP error");
             let event = crate::classify::error_event_from_status(code, &body, "Ollama");
-            return stream::iter(vec![event]).left_stream();
+            return stream::iter(crate::base::pre_stream_error(event)).left_stream();
         }
 
         parse_ndjson_stream(response, cancellation_token).right_stream()
@@ -728,7 +728,10 @@ mod tests {
         ]);
         let mut lines = ndjson_lines(bytes_stream);
 
-        assert_eq!(lines.next().await.unwrap().unwrap(), r#"{"message":"café"}"#);
+        assert_eq!(
+            lines.next().await.unwrap().unwrap(),
+            r#"{"message":"café"}"#
+        );
         assert!(lines.next().await.is_none());
     }
 

--- a/adapters/src/proxy.rs
+++ b/adapters/src/proxy.rs
@@ -190,13 +190,13 @@ fn proxy_stream<'a>(
     stream::once(async move {
         let response = match send_request(proxy, model, context, options).await {
             Ok(resp) => resp,
-            Err(event) => return stream::iter(vec![event]).left_stream(),
+            Err(event) => return stream::iter(crate::base::pre_stream_error(event)).left_stream(),
         };
 
         let status = response.status();
         if !status.is_success() {
             let event = error_event_from_status(status.as_u16(), "", "Proxy");
-            return stream::iter(vec![event]).left_stream();
+            return stream::iter(crate::base::pre_stream_error(event)).left_stream();
         }
 
         parse_sse_stream(response, cancellation_token, options.on_raw_payload.clone())

--- a/adapters/tests/anthropic.rs
+++ b/adapters/tests/anthropic.rs
@@ -299,6 +299,11 @@ async fn anthropic_http_401() {
     let sf = AnthropicStreamFn::new(server.uri(), "test-key");
     let events = collect_events(&sf).await;
 
+    assert!(
+        matches!(events.first(), Some(AssistantMessageEvent::Start)),
+        "pre-stream HTTP failures must start with Start: {events:?}"
+    );
+
     let err = find_error_message(&events).expect("expected error event");
     assert!(
         err.contains("auth error"),

--- a/adapters/tests/azure.rs
+++ b/adapters/tests/azure.rs
@@ -988,6 +988,11 @@ async fn entra_id_token_endpoint_failure() {
     let stream_fn = entra_stream_fn(&api_server, &token_url);
     let events = collect_events(&stream_fn).await;
 
+    assert!(
+        matches!(events.first(), Some(AssistantMessageEvent::Start)),
+        "pre-stream token failures must start with Start: {events:?}"
+    );
+
     let error_event = events
         .iter()
         .find(|e| matches!(e, AssistantMessageEvent::Error { .. }));

--- a/adapters/tests/google.rs
+++ b/adapters/tests/google.rs
@@ -505,6 +505,11 @@ async fn google_http_429_maps_to_throttled() {
     let stream_fn = GeminiStreamFn::new(server.uri(), "test-key", ApiVersion::V1beta);
     let events = collect_events(&stream_fn).await;
 
+    assert!(
+        matches!(events.first(), Some(AssistantMessageEvent::Start)),
+        "pre-stream HTTP failures must start with Start: {events:?}"
+    );
+
     let msg = find_error_message(&events).expect("expected error event");
     assert!(
         msg.contains("throttled") || msg.contains("rate") || msg.contains("429"),

--- a/adapters/tests/ollama.rs
+++ b/adapters/tests/ollama.rs
@@ -255,8 +255,9 @@ async fn ollama_http_error() {
     let ollama = OllamaStreamFn::new(server.uri());
     let events = collect_events(&ollama).await;
 
-    assert_eq!(events.len(), 1);
-    match &events[0] {
+    assert_eq!(events.len(), 2);
+    assert!(matches!(events[0], AssistantMessageEvent::Start));
+    match &events[1] {
         AssistantMessageEvent::Error {
             error_message,
             stop_reason,
@@ -278,8 +279,9 @@ async fn ollama_connection_error() {
     let ollama = OllamaStreamFn::new("http://127.0.0.1:1");
     let events = collect_events(&ollama).await;
 
-    assert_eq!(events.len(), 1);
-    match &events[0] {
+    assert_eq!(events.len(), 2);
+    assert!(matches!(events[0], AssistantMessageEvent::Start));
+    match &events[1] {
         AssistantMessageEvent::Error {
             error_message,
             stop_reason,

--- a/adapters/tests/proxy_http.rs
+++ b/adapters/tests/proxy_http.rs
@@ -183,8 +183,9 @@ async fn connection_failure_produces_network_error() {
     let proxy = ProxyStreamFn::new("http://127.0.0.1:1", "token");
     let events = collect_events(&proxy).await;
 
-    assert_eq!(events.len(), 1);
-    match &events[0] {
+    assert_eq!(events.len(), 2);
+    assert!(matches!(events[0], AssistantMessageEvent::Start));
+    match &events[1] {
         AssistantMessageEvent::Error {
             error_message,
             stop_reason,
@@ -214,8 +215,9 @@ async fn http_401_produces_auth_error() {
     let proxy = ProxyStreamFn::new(server.uri(), "bad-token");
     let events = collect_events(&proxy).await;
 
-    assert_eq!(events.len(), 1);
-    match &events[0] {
+    assert_eq!(events.len(), 2);
+    assert!(matches!(events[0], AssistantMessageEvent::Start));
+    match &events[1] {
         AssistantMessageEvent::Error {
             error_message,
             stop_reason,
@@ -245,8 +247,9 @@ async fn http_429_produces_rate_limit_error() {
     let proxy = ProxyStreamFn::new(server.uri(), "token");
     let events = collect_events(&proxy).await;
 
-    assert_eq!(events.len(), 1);
-    match &events[0] {
+    assert_eq!(events.len(), 2);
+    assert!(matches!(events[0], AssistantMessageEvent::Start));
+    match &events[1] {
         AssistantMessageEvent::Error {
             error_message,
             stop_reason,
@@ -323,8 +326,9 @@ async fn http_504_produces_network_error() {
     let proxy = ProxyStreamFn::new(server.uri(), "token");
     let events = collect_events(&proxy).await;
 
-    assert_eq!(events.len(), 1);
-    match &events[0] {
+    assert_eq!(events.len(), 2);
+    assert!(matches!(events[0], AssistantMessageEvent::Start));
+    match &events[1] {
         AssistantMessageEvent::Error {
             error_message,
             stop_reason,


### PR DESCRIPTION
## What changed
- normalized Anthropic, Gemini, Ollama, Proxy, and Azure pre-stream failure paths to emit `[Start, Error]` instead of a bare terminal error
- added a shared `pre_stream_error()` helper plus adapter regression coverage for HTTP, connection, and Azure token-acquisition failures
- recorded the streaming contract lesson in `adapters/AGENTS.md`

## Slice completed
- completed the pre-stream adapter error-ordering fix for the adapters cited in issue #560
- no remaining bare `return stream::iter(vec![event]).left_stream()` wrappers remain under `adapters/src`

## Validation
- `cargo test -p swink-agent-adapters --features "anthropic azure gemini ollama proxy" --test anthropic --test azure --test google --test ollama --test proxy_http`
- `cargo clippy -p swink-agent-adapters --features "anthropic azure gemini ollama proxy" --tests --no-deps -- -D warnings` still fails on pre-existing baseline warnings in untouched files: `src/transfer.rs:214`, `adapters/src/anthropic.rs:1119`, `:1173`, `:1200`, `:1259`, `adapters/src/oai_transport.rs:43`, and `adapters/src/classify.rs:259`

Closes #560