### PR TITLE
[codex] Fix session ID collisions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7343,6 +7343,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
+ "uuid 1.23.0",
 ]
 
 [[package]]

--- a/memory/AGENTS.md
+++ b/memory/AGENTS.md
@@ -3,3 +3,4 @@
 ## Lessons Learned
 
 - `JsonlSessionStore::save_entries()` rewrites must preserve both `_state` records and existing `_custom` message envelopes. Mixed `save()` / `save_entries()` flows rely on those pass-through wrappers surviving entry-oriented rewrites.
+- Auto-generated session IDs map directly to JSONL filenames, so second-resolution timestamps are not unique enough; keep the readable UTC timestamp prefix, but append random entropy (currently UUID v4 hex) to avoid same-second collisions without changing file semantics.

--- a/memory/Cargo.toml
+++ b/memory/Cargo.toml
@@ -22,6 +22,7 @@ tokio.workspace = true
 dirs.workspace = true
 tracing.workspace = true
 chrono.workspace = true
+uuid.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/memory/src/jsonl.rs
+++ b/memory/src/jsonl.rs
@@ -370,7 +370,7 @@ impl JsonlSessionStore {
         dirs::config_dir().map(|d| d.join("swink-agent").join("sessions"))
     }
 
-    /// Generate a new unique session ID using `YYYYMMDD_HHMMSS` format.
+    /// Generate a new unique session ID using a UTC timestamp plus UUID suffix.
     pub fn new_session_id() -> String {
         format_session_id()
     }
@@ -842,8 +842,10 @@ mod tests {
     #[test]
     fn new_session_id_format() {
         let id = JsonlSessionStore::new_session_id();
-        assert_eq!(id.len(), 15);
-        assert_eq!(id.as_bytes()[8], b'_');
+        let (timestamp, suffix) = id.rsplit_once('_').unwrap();
+        assert_eq!(timestamp.len(), 15);
+        assert_eq!(timestamp.as_bytes()[8], b'_');
+        assert_eq!(suffix.len(), 32);
     }
 
     #[test]

--- a/memory/src/lib.rs
+++ b/memory/src/lib.rs
@@ -15,7 +15,7 @@
 //!
 //! let dir = JsonlSessionStore::default_dir().expect("config dir");
 //! let store = JsonlSessionStore::new(dir)?;
-//! let id = format_session_id();
+//! let id = format_session_id(); // e.g. "20260320_143000_6f00bfe3f7c54b2f86d780df58ccf0a1"
 //! let meta = SessionMeta {
 //!     id: id.clone(),
 //!     title: "My session".into(),

--- a/memory/src/time.rs
+++ b/memory/src/time.rs
@@ -1,15 +1,28 @@
 //! Time utilities for session management.
 
 use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+const SESSION_ID_TIMESTAMP_FORMAT: &str = "%Y%m%d_%H%M%S";
 
 /// Returns the current UTC time.
 pub fn now_utc() -> DateTime<Utc> {
     Utc::now()
 }
 
-/// Generate a session ID in `YYYYMMDD_HHMMSS` format from the current UTC time.
+/// Generate a session ID as `YYYYMMDD_HHMMSS_<uuid-v4-hex>`.
+///
+/// The timestamp prefix keeps IDs readable in logs and filenames, while the
+/// random suffix avoids collisions for sessions created within the same second.
 pub fn format_session_id() -> String {
-    now_utc().format("%Y%m%d_%H%M%S").to_string()
+    format_session_id_with_suffix(now_utc(), Uuid::new_v4().simple())
+}
+
+fn format_session_id_with_suffix(now: DateTime<Utc>, suffix: impl std::fmt::Display) -> String {
+    format!(
+        "{timestamp}_{suffix}",
+        timestamp = now.format(SESSION_ID_TIMESTAMP_FORMAT)
+    )
 }
 
 #[cfg(test)]
@@ -25,10 +38,11 @@ mod tests {
     #[test]
     fn format_session_id_format() {
         let id = format_session_id();
-        // Should be YYYYMMDD_HHMMSS: 15 chars with underscore at index 8
-        assert_eq!(id.len(), 15);
-        assert_eq!(id.as_bytes()[8], b'_');
-        for (i, ch) in id.chars().enumerate() {
+        let (timestamp, suffix) = id.rsplit_once('_').unwrap();
+
+        assert_eq!(timestamp.len(), 15);
+        assert_eq!(timestamp.as_bytes()[8], b'_');
+        for (i, ch) in timestamp.chars().enumerate() {
             if i == 8 {
                 assert_eq!(ch, '_');
             } else {
@@ -38,5 +52,21 @@ mod tests {
                 );
             }
         }
+        assert_eq!(suffix.len(), 32);
+        assert!(
+            suffix.chars().all(|ch| ch.is_ascii_hexdigit()),
+            "suffix should be lowercase hex, got {suffix}"
+        );
+    }
+
+    #[test]
+    fn format_session_id_supports_multiple_ids_per_second() {
+        let fixed = DateTime::from_timestamp(1_710_500_000, 0).unwrap().to_utc();
+        let first = format_session_id_with_suffix(fixed, "aaaa");
+        let second = format_session_id_with_suffix(fixed, "bbbb");
+
+        assert_eq!(first, "20240315_105320_aaaa");
+        assert_eq!(second, "20240315_105320_bbbb");
+        assert_ne!(first, second);
     }
 }

--- a/memory/tests/public_api.rs
+++ b/memory/tests/public_api.rs
@@ -20,7 +20,9 @@ fn memory_root_reexports_remain_consumable() {
     let _ = std::any::type_name::<SessionStoreFuture<'static, ()>>();
 
     let id = format_session_id();
-    assert_eq!(id.len(), 15);
+    let (timestamp, suffix) = id.rsplit_once('_').unwrap();
+    assert_eq!(timestamp.len(), 15);
+    assert_eq!(suffix.len(), 32);
     let now = now_utc();
     assert!(now.timestamp() > 1_700_000_000);
 }

--- a/specs/021-memory-crate/contracts/public-api.md
+++ b/specs/021-memory-crate/contracts/public-api.md
@@ -192,7 +192,7 @@ pub struct LoadOptions {
 // Not public, but behavior is part of the contract:
 // - Rejects IDs containing: '/', '\', "..", '\0'
 // - Returns io::Error with ErrorKind::InvalidInput
-// - Auto-generated IDs use format: YYYYMMDD_HHMMSS
+// - Auto-generated IDs use format: YYYYMMDD_HHMMSS_<random-hex>
 ```
 
 ---
@@ -201,7 +201,7 @@ pub struct LoadOptions {
 
 ```rust
 pub fn now_utc() -> DateTime<Utc>;
-pub fn format_session_id() -> String;  // YYYYMMDD_HHMMSS
+pub fn format_session_id() -> String;  // YYYYMMDD_HHMMSS_<random-hex>
 ```
 
 ---

--- a/specs/021-memory-crate/data-model.md
+++ b/specs/021-memory-crate/data-model.md
@@ -10,7 +10,7 @@ Descriptive information about a persisted session.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `id` | `String` | Unique session identifier. Validated: no `/`, `\`, `..`, null bytes. Auto-generated format: `YYYYMMDD_HHMMSS`. |
+| `id` | `String` | Unique session identifier. Validated: no `/`, `\`, `..`, null bytes. Auto-generated format: `YYYYMMDD_HHMMSS_<random-hex>`. |
 | `title` | `String` | Human-readable session title. |
 | `created_at` | `DateTime<Utc>` | Timestamp when the session was first created. |
 | `updated_at` | `DateTime<Utc>` | Timestamp of the most recent save. Updated on every save. |

--- a/specs/021-memory-crate/quickstart.md
+++ b/specs/021-memory-crate/quickstart.md
@@ -21,7 +21,7 @@ use swink_agent_memory::{
 let store = JsonlSessionStore::new("./sessions".into())?;
 
 // Build session metadata
-let id = format_session_id(); // e.g., "20260320_143000"
+let id = format_session_id(); // e.g., "20260320_143000_6f00bfe3f7c54b2f86d780df58ccf0a1"
 let meta = SessionMeta {
     id: id.clone(),
     title: "Debug session".into(),

--- a/specs/021-memory-crate/research.md
+++ b/specs/021-memory-crate/research.md
@@ -55,7 +55,7 @@
 
 ### 6. Session ID Validation
 
-**Decision**: Validate session IDs — reject `/`, `\`, `..`, and null bytes with a clear error. Auto-generated IDs use `YYYYMMDD_HHMMSS` format.
+**Decision**: Validate session IDs — reject `/`, `\`, `..`, and null bytes with a clear error. Auto-generated IDs use a readable UTC timestamp prefix plus random hex entropy (`YYYYMMDD_HHMMSS_<random-hex>`).
 
 **Rationale**: Session IDs map directly to filenames. Unsafe characters enable path traversal attacks or filesystem errors. Validation at the API boundary prevents these issues.
 


### PR DESCRIPTION
## What changed
- Replaced second-resolution auto-generated session IDs with `YYYYMMDD_HHMMSS_<uuid-v4-hex>` so concurrent session creation no longer collides on the same JSONL filename.
- Updated `JsonlSessionStore::new_session_id()` and the shared `format_session_id()` helper docs/tests to treat the ID as a readable timestamp prefix plus entropy suffix.
- Updated the memory crate’s public API regression and the 021 memory spec docs so the documented ID contract matches the shipped behavior.

## Why
Session IDs map directly to JSONL filenames. The old `YYYYMMDD_HHMMSS` generator could produce identical IDs for sessions created within the same second, which risks cross-session file reuse and optimistic-concurrency conflicts.

## Slice completed
- Completed the session-ID generation fix for issue #561.
- No follow-up implementation remains for this issue; existing session files remain loadable because file semantics and ID validation rules are unchanged.

## Validation
- `cargo test -p swink-agent-memory`
- `cargo clippy -p swink-agent-memory --tests --no-deps -- -D warnings`

## Pre-existing baseline failures
- `cargo clippy --workspace -- -D warnings` still fails in untouched `src/tools/edit_file.rs` on `clippy::format_collect`, `clippy::if_not_else`, `clippy::option_if_let_else`, and `clippy::cast_possible_wrap`.
- `cargo test --workspace --features testkit --no-fail-fast` still fails in untouched targets:
  - `swink-agent-plugin-web --lib`: `content::tests::truncate_content_multibyte_boundaries_are_utf8_safe`, `tools::fetch::tests::execute_rejects_body_that_exceeds_cap_before_extraction`, `tools::fetch::tests::execute_returns_readable_content_for_html_under_cap`
  - `swink-agent-tui --lib`: `editor::tests::open_editor_with_true_command_returns_none`

Closes #561