### PR TITLE
[codex] Surface tool execution updates in TUI

### DIFF
--- a/tui/src/app/agent_bridge.rs
+++ b/tui/src/app/agent_bridge.rs
@@ -134,6 +134,9 @@ impl App {
             AgentEvent::ToolExecutionStart { id, name, .. } => {
                 self.tool_panel.start_tool(id, name);
             }
+            AgentEvent::ToolExecutionUpdate { id, name, partial } => {
+                self.tool_panel.update_tool(&id, &name, &partial);
+            }
             AgentEvent::ToolExecutionEnd { id, is_error, .. } => {
                 self.tool_panel.end_tool(&id, is_error);
             }

--- a/tui/src/app/tests/agent_bridge.rs
+++ b/tui/src/app/tests/agent_bridge.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use swink_agent::testing::ScriptedStreamFn;
 use swink_agent::testing::text_events;
 use swink_agent::{
-    AgentEvent, AssistantMessage, AssistantMessageEvent, ContentBlock, Cost, LlmMessage, ModelSpec,
-    StopReason, StreamFn, ToolResultMessage, TurnSnapshot, Usage,
+    AgentEvent, AgentToolResult, AssistantMessage, AssistantMessageEvent, ContentBlock, Cost,
+    LlmMessage, ModelSpec, StopReason, StreamFn, ToolResultMessage, TurnSnapshot, Usage,
 };
 
 use crate::config::TuiConfig;
@@ -387,4 +387,33 @@ async fn turn_end_renders_tool_results_with_diff_data_and_trims_old_turns() {
     assert!(!diff.is_new_file);
     assert_eq!(diff.old_content, "before\nvalue");
     assert_eq!(diff.new_content, "after\nvalue");
+}
+
+#[test]
+fn tool_execution_update_surfaces_live_tool_output() {
+    let mut app = App::new(TuiConfig::default());
+
+    app.handle_agent_event(AgentEvent::ToolExecutionStart {
+        id: "call_1".to_string(),
+        name: "bash".to_string(),
+        arguments: serde_json::json!({
+            "command": "cargo test -p swink-agent-tui",
+        }),
+    });
+    app.handle_agent_event(AgentEvent::ToolExecutionUpdate {
+        id: "call_1".to_string(),
+        name: "bash".to_string(),
+        partial: AgentToolResult::text("Compiling swink-agent-tui\n"),
+    });
+    app.handle_agent_event(AgentEvent::ToolExecutionUpdate {
+        id: "call_1".to_string(),
+        name: "bash".to_string(),
+        partial: AgentToolResult::text("Finished test profile"),
+    });
+
+    assert_eq!(app.tool_panel.active.len(), 1);
+    assert_eq!(
+        app.tool_panel.active[0].streamed_output,
+        "Compiling swink-agent-tui\nFinished test profile"
+    );
 }

--- a/tui/src/ui/tool_panel.rs
+++ b/tui/src/ui/tool_panel.rs
@@ -8,7 +8,7 @@ use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph};
 use serde_json::Value;
-use swink_agent::redact_sensitive_values;
+use swink_agent::{AgentToolResult, ContentBlock, redact_sensitive_values};
 
 use crate::theme;
 
@@ -20,6 +20,7 @@ const SPINNER: &[char] = &['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧
 pub struct ToolExecution {
     pub id: String,
     pub name: String,
+    pub streamed_output: String,
     pub started_at: Instant,
     pub completed_at: Option<Instant>,
     pub is_error: bool,
@@ -70,10 +71,35 @@ impl ToolPanel {
         self.active.push(ToolExecution {
             id,
             name,
+            streamed_output: String::new(),
             started_at: Instant::now(),
             completed_at: None,
             is_error: false,
         });
+    }
+
+    /// Append a partial output update for an active tool.
+    pub fn update_tool(&mut self, id: &str, name: &str, partial: &AgentToolResult) {
+        let update = ContentBlock::extract_text(&partial.content);
+        if update.is_empty() {
+            return;
+        }
+
+        let Some(tool) = self.active.iter_mut().find(|tool| tool.id == id) else {
+            self.start_tool(id.to_string(), name.to_string());
+            let tool = self
+                .active
+                .last_mut()
+                .expect("start_tool should add the missing tool");
+            tool.streamed_output = update;
+            return;
+        };
+
+        if update.starts_with(&tool.streamed_output) {
+            tool.streamed_output = update;
+        } else {
+            tool.streamed_output.push_str(&update);
+        }
     }
 
     /// Mark a tool as completed, moving it from active to completed.
@@ -250,7 +276,14 @@ impl ToolPanel {
         for tool in &self.active {
             let elapsed = tool.started_at.elapsed().as_secs();
             let spinner = SPINNER[self.spinner_frame % SPINNER.len()];
-            lines.push(Line::from(vec![
+            let preview = tool
+                .streamed_output
+                .lines()
+                .rev()
+                .find(|line| !line.trim().is_empty())
+                .unwrap_or(tool.streamed_output.trim());
+            let preview = truncate_preview(preview, 60);
+            let mut spans = vec![
                 Span::styled(
                     format!(" {spinner} "),
                     Style::default().fg(theme::tool_color()),
@@ -259,13 +292,22 @@ impl ToolPanel {
                     tool.name.clone(),
                     Style::default().add_modifier(Modifier::BOLD),
                 ),
-                Span::styled(
-                    format!("  {elapsed}s"),
+            ];
+            if !preview.is_empty() {
+                spans.push(Span::styled(
+                    format!(": {preview}"),
                     Style::default()
-                        .fg(theme::border_color())
+                        .fg(theme::border_focused_color())
                         .add_modifier(Modifier::DIM),
-                ),
-            ]));
+                ));
+            }
+            spans.push(Span::styled(
+                format!("  {elapsed}s"),
+                Style::default()
+                    .fg(theme::border_color())
+                    .add_modifier(Modifier::DIM),
+            ));
+            lines.push(Line::from(spans));
         }
 
         // Completed tools with check/cross
@@ -344,6 +386,15 @@ fn summarize_arguments(args: &Value) -> String {
     }
 }
 
+fn truncate_preview(text: &str, max_chars: usize) -> String {
+    let preview: String = text.chars().take(max_chars).collect();
+    if text.chars().count() > max_chars {
+        format!("{preview}...")
+    } else {
+        preview
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -355,6 +406,7 @@ mod tests {
         assert_eq!(panel.active.len(), 1);
         assert_eq!(panel.active[0].id, "t1");
         assert_eq!(panel.active[0].name, "bash");
+        assert!(panel.active[0].streamed_output.is_empty());
     }
 
     #[test]
@@ -443,6 +495,39 @@ mod tests {
         panel.end_tool("nonexistent", false);
         assert_eq!(panel.active.len(), 1);
         assert!(panel.completed.is_empty());
+    }
+
+    #[test]
+    fn update_tool_accumulates_incremental_output() {
+        let mut panel = ToolPanel::new();
+        panel.start_tool("t1".into(), "bash".into());
+
+        panel.update_tool("t1", "bash", &AgentToolResult::text("line 1\n"));
+        panel.update_tool("t1", "bash", &AgentToolResult::text("line 2"));
+
+        assert_eq!(panel.active[0].streamed_output, "line 1\nline 2");
+    }
+
+    #[test]
+    fn update_tool_replaces_with_latest_snapshot() {
+        let mut panel = ToolPanel::new();
+        panel.start_tool("t1".into(), "bash".into());
+
+        panel.update_tool("t1", "bash", &AgentToolResult::text("line 1"));
+        panel.update_tool("t1", "bash", &AgentToolResult::text("line 1\nline 2"));
+
+        assert_eq!(panel.active[0].streamed_output, "line 1\nline 2");
+    }
+
+    #[test]
+    fn update_tool_registers_missing_active_tool() {
+        let mut panel = ToolPanel::new();
+
+        panel.update_tool("t1", "bash", &AgentToolResult::text("working"));
+
+        assert_eq!(panel.active.len(), 1);
+        assert_eq!(panel.active[0].name, "bash");
+        assert_eq!(panel.active[0].streamed_output, "working");
     }
 
     #[test]


### PR DESCRIPTION
## What changed and why
- `tui/src/app/agent_bridge.rs` now handles `AgentEvent::ToolExecutionUpdate` instead of dropping it on the floor.
- `tui/src/ui/tool_panel.rs` now tracks per-tool streamed output and renders a truncated live preview on active tool rows.
- Added regression coverage for both the bridge wiring and the tool-panel accumulation logic.

## Slice completed
- Completed the TUI event-handling slice for issue #572 so long-running tools can surface incremental output while they are running.
- Remaining work, if desired, is broader UX polish around multi-line or richer streaming output presentation.

## Validation output
- `cargo test -p swink-agent-tui tool_execution_update -- --nocapture`
- `cargo test -p swink-agent-tui update_tool_ -- --nocapture`

## Pre-existing baseline failures
- `cargo test -p swink-agent-tui` still fails on `editor::tests::open_editor_with_true_command_returns_none` (unrelated to this slice).
- `cargo clippy --workspace --features testkit -- -D warnings` still fails on pre-existing findings in `src/tools/edit_file.rs` and `src/testing.rs`.
- `cargo test --workspace --features testkit` exceeded the 20-minute automation time budget.

Ref #572