### PR TITLE
[codex] Add typed FnTool execute builder

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,6 +146,7 @@ MSRV **1.88** (edition 2024). Common workspace deps are centralized in root `Car
 - `AgentToolResult.is_error` replaces old `text.starts_with("error")` heuristic. Use `error()` / `text()` constructors.
 - `ToolCallTransformer` runs unconditionally (not gated by approval). Distinct from `ToolValidator` (rejects vs rewrites).
 - `#[tool]` macro param decoding must return `AgentToolResult::error("invalid parameters: ...")` on serde failures rather than panicking. The generated code still retries deserialization from `{}` so zero-param / all-optional tools can execute when appropriate.
+- `FnTool::with_execute_typed::<T>()` is the zero-boilerplate typed path: it derives the schema from `T` and must mirror the rest of the tool stack by returning `AgentToolResult::error("invalid parameters: ...")` on serde decode failures.
 
 ### Credential Management (`auth/`)
 

--- a/docs/architecture/tool-system/README.md
+++ b/docs/architecture/tool-system/README.md
@@ -272,6 +272,7 @@ flowchart TB
 | `.with_requires_approval(bool)` | Mark the tool as requiring user approval before execution. |
 | `.with_execute(closure)` | Full signature: `(tool_call_id, params, cancel, on_update) -> Future<AgentToolResult>`. |
 | `.with_execute_simple(closure)` | Simplified: `(params, cancel) -> Future<AgentToolResult>`. Ignores tool call ID and update callback. |
+| `.with_execute_typed::<T>(closure)` | Derive the schema from `T` and deserialize params into `T` before execution. Returns `invalid parameters` on serde decode failure. |
 
 ### Example
 
@@ -284,10 +285,8 @@ use swink_agent::{AgentToolResult, FnTool};
 struct Params { city: String }
 
 let tool = FnTool::new("get_weather", "Weather", "Get weather for a city.")
-    .with_schema_for::<Params>()
-    .with_execute_simple(|params, _cancel| async move {
-        let city = params["city"].as_str().unwrap_or("unknown");
-        AgentToolResult::text(format!("72F in {city}"))
+    .with_execute_typed(|params: Params, _cancel| async move {
+        AgentToolResult::text(format!("72F in {}", params.city))
     });
 ```
 
@@ -326,10 +325,8 @@ struct LookupParams {
 }
 
 let tool = FnTool::new("lookup", "Lookup", "Look up a term in the glossary.")
-    .with_schema_for::<LookupParams>()
-    .with_execute_simple(|params, _cancel| async move {
-        let term = params["term"].as_str().unwrap_or("");
-        AgentToolResult::text(format!("Definition of '{term}': ..."))
+    .with_execute_typed(|params: LookupParams, _cancel| async move {
+        AgentToolResult::text(format!("Definition of '{}': ...", params.term))
     });
 ```
 

--- a/specs/007-tool-system-extensions/contracts/public-api.md
+++ b/specs/007-tool-system-extensions/contracts/public-api.md
@@ -185,6 +185,11 @@ impl FnTool {
     where
         F: Fn(Value, CancellationToken) -> Fut + Send + Sync + 'static,
         Fut: Future<Output = AgentToolResult> + Send + 'static;
+    pub fn with_execute_typed<T, F, Fut>(mut self, f: F) -> Self
+    where
+        T: DeserializeOwned + JsonSchema + Send + 'static,
+        F: Fn(T, CancellationToken) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = AgentToolResult> + Send + 'static;
 }
 
 impl AgentTool for FnTool { ... }

--- a/specs/007-tool-system-extensions/data-model.md
+++ b/specs/007-tool-system-extensions/data-model.md
@@ -140,7 +140,7 @@ Closure-based tool builder. Implements `AgentTool`.
 
 **Type alias**: `ExecuteFn = dyn Fn(String, Value, CancellationToken, Option<Box<dyn Fn(AgentToolResult) + Send + Sync>>) -> Pin<Box<dyn Future<Output = AgentToolResult> + Send>> + Send + Sync`
 
-**Builders**: `new(name, label, description)`, `with_schema_for::<T>()`, `with_schema(Value)`, `with_requires_approval(bool)`, `with_execute(closure)`, `with_execute_simple(closure)`
+**Builders**: `new(name, label, description)`, `with_schema_for::<T>()`, `with_schema(Value)`, `with_requires_approval(bool)`, `with_execute(closure)`, `with_execute_simple(closure)`, `with_execute_typed::<T>(closure)`
 
 ---
 

--- a/src/fn_tool.rs
+++ b/src/fn_tool.rs
@@ -12,10 +12,8 @@
 //! struct Params { city: String }
 //!
 //! let tool = FnTool::new("get_weather", "Weather", "Get weather for a city.")
-//!     .with_schema_for::<Params>()
-//!     .with_execute_simple(|params, _cancel| async move {
-//!         let city = params["city"].as_str().unwrap_or("unknown");
-//!         AgentToolResult::text(format!("72F in {city}"))
+//!     .with_execute_typed(|params: Params, _cancel| async move {
+//!         AgentToolResult::text(format!("72F in {}", params.city))
 //!     });
 //!
 //! assert_eq!(swink_agent::AgentTool::name(&tool), "get_weather");
@@ -24,6 +22,7 @@
 use std::future::Future;
 use std::sync::Arc;
 
+use serde::de::DeserializeOwned;
 use serde_json::Value;
 use tokio_util::sync::CancellationToken;
 
@@ -148,6 +147,33 @@ impl FnTool {
         self
     }
 
+    /// Set the execution function using a typed parameter struct.
+    ///
+    /// This derives the schema from `T` and deserializes validated params into
+    /// `T` before calling the closure. On deserialization failure, execution
+    /// returns `AgentToolResult::error("invalid parameters: ...")`.
+    #[must_use]
+    pub fn with_execute_typed<T, F, Fut>(mut self, f: F) -> Self
+    where
+        T: DeserializeOwned + schemars::JsonSchema + Send + 'static,
+        F: Fn(T, CancellationToken) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = AgentToolResult> + Send + 'static,
+    {
+        self.schema = validated_schema_for::<T>();
+        self.execute_fn = Arc::new(move |_id, params, cancel, _on_update| {
+            let parsed: T = match serde_json::from_value(params) {
+                Ok(parsed) => parsed,
+                Err(err) => {
+                    return Box::pin(async move {
+                        AgentToolResult::error(format!("invalid parameters: {err}"))
+                    });
+                }
+            };
+            Box::pin(f(parsed, cancel))
+        });
+        self
+    }
+
     /// Set a closure that provides rich context for the approval UI.
     ///
     /// When the tool requires approval, this closure is called to produce
@@ -232,6 +258,7 @@ mod tests {
     use tokio_util::sync::CancellationToken;
 
     use super::*;
+    use crate::ContentBlock;
 
     fn test_state() -> std::sync::Arc<std::sync::RwLock<crate::SessionState>> {
         std::sync::Arc::new(std::sync::RwLock::new(crate::SessionState::new()))
@@ -334,5 +361,63 @@ mod tests {
             )
             .await;
         assert!(!result.is_error);
+    }
+
+    #[derive(Deserialize, JsonSchema)]
+    struct TypedParams {
+        city: String,
+    }
+
+    #[tokio::test]
+    async fn typed_execute_deserializes_params_and_sets_schema() {
+        let tool = FnTool::new("typed", "Typed", "Typed params.").with_execute_typed(
+            |params: TypedParams, _cancel| async move { AgentToolResult::text(params.city) },
+        );
+
+        let schema = tool.parameters_schema();
+        assert_eq!(schema["type"], "object");
+        assert!(
+            schema["required"]
+                .as_array()
+                .unwrap()
+                .contains(&json!("city"))
+        );
+
+        let result = tool
+            .execute(
+                "id",
+                json!({"city": "Chicago"}),
+                CancellationToken::new(),
+                None,
+                test_state(),
+                None,
+            )
+            .await;
+        assert!(!result.is_error);
+        assert_eq!(ContentBlock::extract_text(&result.content), "Chicago");
+    }
+
+    #[tokio::test]
+    async fn typed_execute_reports_deserialization_errors() {
+        let tool = FnTool::new("typed", "Typed", "Typed params.").with_execute_typed(
+            |params: TypedParams, _cancel| async move { AgentToolResult::text(params.city) },
+        );
+
+        let result = tool
+            .execute(
+                "id",
+                json!({"city": 42}),
+                CancellationToken::new(),
+                None,
+                test_state(),
+                None,
+            )
+            .await;
+        assert!(result.is_error);
+        assert!(
+            ContentBlock::extract_text(&result.content).contains("invalid parameters"),
+            "expected invalid parameters error, got: {:?}",
+            result.content
+        );
     }
 }

--- a/tests/fn_tool.rs
+++ b/tests/fn_tool.rs
@@ -9,6 +9,8 @@ use std::time::Duration;
 use common::{
     MockStreamFn, default_convert, default_model, text_only_events, tool_call_events, user_msg,
 };
+use schemars::JsonSchema;
+use serde::Deserialize;
 use serde_json::json;
 
 use swink_agent::{Agent, AgentOptions, AgentToolResult, DefaultRetryStrategy, FnTool};
@@ -48,6 +50,42 @@ async fn fn_tool_executes_in_agent_loop() {
     let result = agent.prompt_async(vec![user_msg("hi")]).await.unwrap();
 
     // The agent completed both turns — tool execution + final response.
+    assert!(
+        !result.messages.is_empty(),
+        "agent should have produced messages"
+    );
+}
+
+#[derive(Deserialize, JsonSchema)]
+struct TypedParams {
+    name: String,
+}
+
+#[tokio::test]
+async fn fn_tool_typed_executes_in_agent_loop() {
+    let tool = FnTool::new("greet", "Greet", "Greet a person.").with_execute_typed(
+        |params: TypedParams, _cancel| async move {
+            AgentToolResult::text(format!("Hello, {}!", params.name))
+        },
+    );
+
+    let stream_fn = Arc::new(MockStreamFn::new(vec![
+        tool_call_events("call_1", "greet", r#"{"name":"Alice"}"#),
+        text_only_events("Done greeting."),
+    ]));
+
+    let mut agent = Agent::new(
+        AgentOptions::new("test", default_model(), stream_fn, default_convert)
+            .with_tools(vec![Arc::new(tool)])
+            .with_retry_strategy(Box::new(
+                DefaultRetryStrategy::default()
+                    .with_jitter(false)
+                    .with_base_delay(Duration::from_millis(1)),
+            )),
+    );
+
+    let result = agent.prompt_async(vec![user_msg("hi")]).await.unwrap();
+
     assert!(
         !result.messages.is_empty(),
         "agent should have produced messages"


### PR DESCRIPTION
## Summary
- add `FnTool::with_execute_typed::<T>()`, which derives the tool schema from `T` and deserializes validated params into `T` before executing the closure
- return the same `invalid parameters: ...` error shape used elsewhere when typed deserialization fails
- cover the new typed path in `src/fn_tool.rs` and `tests/fn_tool.rs`, and update the public `FnTool` docs/spec entries plus the tool-system lesson in `AGENTS.md`

## Slice Completed
Completed the typed simple-execute slice for issue #574 so `with_schema_for::<T>()` users can move to a single typed builder instead of keeping dead-code-only param structs plus manual `serde_json::Value` extraction.

No additional typed full-signature builder was added in this PR; that can be a follow-up only if callers need `tool_call_id` / `on_update` on the typed path.

## Validation
- `cargo test -p swink-agent --features testkit fn_tool -- --nocapture`

## Pre-existing Baseline Failures
- `cargo clippy -p swink-agent --lib --test fn_tool --features testkit -- -D warnings` still fails on unrelated existing lints in `src/tools/edit_file.rs` (`clippy::format_collect`, `clippy::if_not_else`, `clippy::option_if_let_else`, `clippy::cast_possible_wrap`)

Closes #574