### PR TITLE
fix(ci): force-reinstall binstalled tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: cargo-bins/cargo-binstall@f8ce4d55b131f4a1e373b8747ca6b6a54133ae5a # v1.18.0
 
-      - run: cargo binstall --no-confirm cargo-nextest
+      - run: cargo binstall --no-confirm --force cargo-nextest
 
       - run: cargo nextest run --workspace
 
@@ -62,7 +62,7 @@ jobs:
 
       - uses: cargo-bins/cargo-binstall@f8ce4d55b131f4a1e373b8747ca6b6a54133ae5a # v1.18.0
 
-      - run: cargo binstall --no-confirm cargo-hack
+      - run: cargo binstall --no-confirm --force cargo-hack
 
       # Exclude swink-agent-local-llm because its `metal` / `accelerate` / `mkl`
       # features activate Apple-only backends (objc2) and fail to compile on
@@ -131,7 +131,7 @@ jobs:
 
       - uses: cargo-bins/cargo-binstall@f8ce4d55b131f4a1e373b8747ca6b6a54133ae5a # v1.18.0
 
-      - run: cargo binstall --no-confirm cargo-semver-checks
+      - run: cargo binstall --no-confirm --force cargo-semver-checks
 
       - name: Fetch main branch for baseline
         run: git fetch origin main


### PR DESCRIPTION
## Summary
- Add `--force` to all `cargo binstall` invocations in `ci.yml` (nextest, cargo-hack, semver-checks)
- Fixes persistent "no such command" failures where binstall's cached metadata claims a tool is installed but the binary is missing/broken
- ~3s download cost per tool is negligible vs 10+ min build time

## Root cause
cargo-binstall writes a metadata file when it installs a binary. When GitHub Actions' Swatinem/rust-cache restores `~/.cargo`, the metadata file is restored but the binary may be stale, corrupted, or from a different arch. binstall sees the metadata, says "already installed", and skips the download. The subsequent `cargo hack`/`cargo nextest`/`cargo semver-checks` command then fails with "no such command."

## Test plan
- [ ] CI `features` job (cargo-hack) passes
- [ ] CI `check` jobs (cargo-nextest) pass on all 3 OSes
- [ ] CI `semver` job (cargo-semver-checks) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)