### PR TITLE
fix(tui): update catalog test gpt-4o → gpt-5.4

### DIFF
--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -309,8 +309,8 @@ mod tests {
             "catalog should have openai presets"
         );
         assert!(
-            openai_presets.iter().any(|p| p.model_id == "gpt-4o"),
-            "openai presets should contain gpt-4o"
+            openai_presets.iter().any(|p| p.model_id == "gpt-5.4"),
+            "openai presets should contain gpt-5.4"
         );
     }
 


### PR DESCRIPTION
## Summary
- Fix `catalog_presets_contain_expected_providers` test that still asserted `gpt-4o` exists in OpenAI presets after the model catalog was updated to remove <5 models
- Both `check (ubuntu)` and `all-features` CI jobs failed on this test

## Test plan
- [ ] `cargo nextest run --workspace` passes (check job)
- [ ] `cargo test --workspace --all-features --exclude swink-agent-local-llm` passes (all-features job)

🤖 Generated with [Claude Code](https://claude.com/claude-code)