### PR TITLE
refactor: centralize workspace metadata with version.workspace = true

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,13 @@
 members = [".", "adapters", "artifacts", "auth", "eval", "local-llm", "macros", "mcp", "memory", "patterns", "plugins/web", "policies", "tui", "xtask"]
 resolver = "2"
 
+[workspace.package]
+version = "0.7.8"
+edition = "2024"
+rust-version = "1.88"
+license = "MIT"
+repository = "https://github.com/SuperSwinkAI/Swink-Agent"
+
 [workspace.dependencies]
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
@@ -42,12 +49,12 @@ aws-smithy-runtime-api = { version = "1.11.6", features = ["client"] }
 
 [package]
 name = "swink-agent"
-version = "0.7.8"
-edition = "2024"
-rust-version = "1.88"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 description = "Core scaffolding for running LLM-powered agentic loops"
-license = "MIT"
-repository = "https://github.com/SuperSwinkAI/Swink-Agent"
+license.workspace = true
+repository.workspace = true
 readme = "README.md"
 keywords = ["llm", "agent", "ai", "streaming", "tools"]
 categories = ["development-tools", "api-bindings", "asynchronous"]

--- a/adapters/Cargo.toml
+++ b/adapters/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "swink-agent-adapters"
-version = "0.7.8"
-edition = "2024"
-rust-version = "1.88"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 description = "LLM provider adapters for swink-agent"
-license = "MIT"
-repository = "https://github.com/SuperSwinkAI/Swink-Agent"
+license.workspace = true
+repository.workspace = true
 readme = "../README.md"
 keywords = ["llm", "anthropic", "openai", "adapter", "streaming"]
 categories = ["development-tools", "api-bindings", "asynchronous"]

--- a/artifacts/Cargo.toml
+++ b/artifacts/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "swink-agent-artifacts"
-version = "0.7.8"
-edition = "2024"
-rust-version = "1.88"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 description = "Versioned artifact storage for swink-agent sessions"
-license = "MIT"
-repository = "https://github.com/SuperSwinkAI/Swink-Agent"
+license.workspace = true
+repository.workspace = true
 keywords = ["llm", "agent", "artifacts", "storage", "versioned"]
 categories = ["development-tools", "filesystem"]
 readme = "../README.md"

--- a/auth/Cargo.toml
+++ b/auth/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "swink-agent-auth"
-version = "0.7.8"
-edition = "2024"
-rust-version = "1.88"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 description = "Credential management and OAuth2 support for swink-agent"
-license = "MIT"
-repository = "https://github.com/SuperSwinkAI/Swink-Agent"
+license.workspace = true
+repository.workspace = true
 keywords = ["llm", "agent", "oauth2", "credentials", "auth"]
 categories = ["development-tools", "authentication"]
 readme = "../README.md"

--- a/eval/Cargo.toml
+++ b/eval/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "swink-agent-eval"
-version = "0.7.8"
-edition = "2024"
-rust-version = "1.88"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 description = "Evaluation framework for swink-agent: trajectory tracing, golden path verification, and cost governance"
-license = "MIT"
-repository = "https://github.com/SuperSwinkAI/Swink-Agent"
+license.workspace = true
+repository.workspace = true
 readme = "../README.md"
 keywords = ["llm", "agent", "eval", "benchmark", "testing"]
 categories = ["development-tools", "development-tools::testing"]

--- a/local-llm/Cargo.toml
+++ b/local-llm/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "swink-agent-local-llm"
-version = "0.7.8"
-edition = "2024"
-rust-version = "1.88"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 description = "Local on-device LLM inference for swink-agent using mistral.rs"
-license = "MIT"
-repository = "https://github.com/SuperSwinkAI/Swink-Agent"
+license.workspace = true
+repository.workspace = true
 readme = "../README.md"
 keywords = ["llm", "local", "inference", "gguf", "embedding"]
 categories = ["development-tools", "science"]

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "swink-agent-macros"
-version = "0.7.8"
-edition = "2024"
-rust-version = "1.88"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 description = "Proc macros for swink-agent: #[derive(ToolSchema)] and #[tool]"
-license = "MIT"
-repository = "https://github.com/SuperSwinkAI/Swink-Agent"
+license.workspace = true
+repository.workspace = true
 keywords = ["llm", "agent", "macros", "proc-macro", "tools"]
 categories = ["development-tools", "development-tools::procedural-macro-helpers"]
 readme = "../README.md"

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "swink-agent-mcp"
-version = "0.7.8"
-edition = "2024"
-rust-version = "1.88"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 description = "MCP (Model Context Protocol) integration for swink-agent"
-license = "MIT"
-repository = "https://github.com/SuperSwinkAI/Swink-Agent"
+license.workspace = true
+repository.workspace = true
 keywords = ["llm", "agent", "mcp", "tools", "protocol"]
 categories = ["development-tools", "network-programming"]
 readme = "../README.md"

--- a/memory/Cargo.toml
+++ b/memory/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "swink-agent-memory"
-version = "0.7.8"
-edition = "2024"
-rust-version = "1.88"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 description = "Session persistence and memory management for swink-agent"
-license = "MIT"
-repository = "https://github.com/SuperSwinkAI/Swink-Agent"
+license.workspace = true
+repository.workspace = true
 readme = "../README.md"
 keywords = ["llm", "agent", "memory", "session", "context"]
 categories = ["development-tools", "data-structures"]

--- a/patterns/Cargo.toml
+++ b/patterns/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "swink-agent-patterns"
-version = "0.7.8"
-edition = "2024"
-rust-version = "1.88"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 description = "Multi-agent pipeline patterns for swink-agent"
-license = "MIT"
-repository = "https://github.com/SuperSwinkAI/Swink-Agent"
+license.workspace = true
+repository.workspace = true
 keywords = ["llm", "agent", "pipeline", "multi-agent", "orchestration"]
 categories = ["development-tools", "asynchronous"]
 readme = "../README.md"

--- a/plugins/web/Cargo.toml
+++ b/plugins/web/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "swink-agent-plugin-web"
-version = "0.7.8"
-edition = "2024"
-rust-version = "1.88"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 description = "Web browsing plugin for swink-agent: fetch, search, screenshot, extract"
-license = "MIT"
-repository = "https://github.com/SuperSwinkAI/Swink-Agent"
+license.workspace = true
+repository.workspace = true
 keywords = ["llm", "agent", "web", "browse", "search"]
 categories = ["development-tools", "web-programming"]
 

--- a/policies/Cargo.toml
+++ b/policies/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "swink-agent-policies"
-version = "0.7.8"
-edition = "2024"
-rust-version = "1.88"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 description = "Policy implementations for swink-agent"
-license = "MIT"
-repository = "https://github.com/SuperSwinkAI/Swink-Agent"
+license.workspace = true
+repository.workspace = true
 keywords = ["llm", "agent", "policy", "security", "audit"]
 categories = ["development-tools", "security"]
 readme = "../README.md"

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "swink-agent-tui"
-version = "0.7.8"
-edition = "2024"
-rust-version = "1.88"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 description = "Interactive terminal UI for swink-agent"
-license = "MIT"
-repository = "https://github.com/SuperSwinkAI/Swink-Agent"
+license.workspace = true
+repository.workspace = true
 readme = "../README.md"
 keywords = ["tui", "terminal", "llm", "agent", "chat"]
 categories = ["command-line-utilities", "development-tools"]


### PR DESCRIPTION
## Summary
- Add `[workspace.package]` with `version`, `edition`, `rust-version`, `license`, `repository`
- All 13 publishable member crates now inherit these via `version.workspace = true` (etc.)
- xtask retains its independent version (0.7.1)
- Future version bumps: **1 line instead of 14**

## What changed
| Field | Before | After |
|---|---|---|
| `version` | Repeated in 14 `Cargo.toml` files | `[workspace.package] version = "0.7.8"` + `version.workspace = true` in members |
| `edition` | Same | Same pattern |
| `rust-version` | Same | Same pattern |
| `license` | Same | Same pattern |
| `repository` | Same | Same pattern |

## Test plan
- [ ] `cargo check --workspace` passes
- [ ] `cargo publish --dry-run -p swink-agent --allow-dirty` resolves workspace version correctly
- [ ] CI check + features + deny pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)