### PR TITLE
[codex] Increment turn index after no-tool turns

### DIFF
--- a/src/loop_/AGENTS.md
+++ b/src/loop_/AGENTS.md
@@ -10,3 +10,5 @@
 - `ToolExecutionStrategy::partition()` indices target the post-preprocessing `tool_calls` slice passed into the strategy, not the original LLM-emitted tool-call list. The dispatch layer must reject out-of-bounds, duplicate, or missing prepared indices with synthetic tool errors before any tool starts.
 - `PreDispatchVerdict::Stop` must synthesize one terminal error result for every unresolved tool call in the batch, including calls that already passed preprocessing before a later stop fires. Stop aborts dispatch, but it does not relax tool-result parity.
 - Cancellation has to be observed in preprocessing and before each execution group/tool dispatch, not just while collecting spawned handles. Otherwise approval waits can hang forever and later tools can still launch after the batch is already cancelled.
+- `LoopState.turn_index` must advance after every completed turn, not just tool-loop continuation. Text-only or other `BreakInner` turns still finish a turn before the outer loop polls follow-up messages.
+

--- a/src/loop_/mod.rs
+++ b/src/loop_/mod.rs
@@ -177,7 +177,10 @@ async fn run_loop_inner(
                         state.turn_index += 1;
                         false
                     }
-                    TurnOutcome::BreakInner => true,
+                    TurnOutcome::BreakInner => {
+                        state.turn_index += 1;
+                        true
+                    }
                     TurnOutcome::Return => return,
                 };
 

--- a/tests/agent_loop.rs
+++ b/tests/agent_loop.rs
@@ -1499,6 +1499,56 @@ async fn turn_snapshot_accumulates_across_tool_turns() {
 }
 
 #[tokio::test]
+async fn follow_up_turn_after_no_tool_turn_advances_turn_index() {
+    let stream_fn = Arc::new(MockStreamFn::new(vec![
+        text_only_events("first response"),
+        text_only_events("second response"),
+    ]));
+
+    let follow_up_count = Arc::new(AtomicU32::new(0));
+    let follow_up_clone = Arc::clone(&follow_up_count);
+
+    let mut config = default_config(stream_fn);
+    config.message_provider = Some(Arc::new(MockMessageProvider::follow_up_only(move || {
+        let count = follow_up_clone.fetch_add(1, Ordering::SeqCst);
+        if count == 0 {
+            vec![AgentMessage::Llm(LlmMessage::User(UserMessage {
+                content: vec![ContentBlock::Text {
+                    text: "follow up question".to_string(),
+                }],
+                timestamp: 0,
+                cache_hint: None,
+            }))]
+        } else {
+            vec![]
+        }
+    })));
+
+    let events = collect_events(agent_loop(
+        vec![],
+        "system".to_string(),
+        config,
+        CancellationToken::new(),
+    ))
+    .await;
+
+    let snapshots: Vec<TurnSnapshot> = events
+        .iter()
+        .filter_map(|event| match event {
+            AgentEvent::TurnEnd { snapshot, .. } => Some(snapshot.clone()),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(snapshots.len(), 2, "should have two completed turns");
+    assert_eq!(snapshots[0].turn_index, 0);
+    assert_eq!(
+        snapshots[1].turn_index, 1,
+        "the follow-up turn should observe the incremented turn index"
+    );
+}
+
+#[tokio::test]
 async fn turn_snapshot_serializes_to_json() {
     let snapshot = TurnSnapshot {
         turn_index: 3,


### PR DESCRIPTION
## What changed and why
- increment `LoopState.turn_index` after `BreakInner` as well as `ContinueInner`, so text-only/no-tool turns advance loop state before follow-up polling starts
- add a regression that drives two text-only turns through follow-up polling and asserts the second `TurnEnd` snapshot sees `turn_index == 1`
- record the invariant in `src/loop_/AGENTS.md`

## Slice completed / remaining
- Completed the issue's loop bookkeeping fix for no-tool turns.
- No additional work is planned for this issue in this PR.

## Validation output
- `cargo fmt --all --check`
- `cargo test -p swink-agent --test agent_loop --features testkit follow_up_turn_after_no_tool_turn_advances_turn_index -- --exact --nocapture`
- `cargo test -p swink-agent --test agent_loop follow_up --features testkit -- --exact --nocapture`

## Pre-existing baseline failures
- `cargo clippy -p swink-agent --test agent_loop --features testkit -- -D warnings` still fails in untouched existing `tests/agent_loop.rs` items due prior `clippy::unnecessary_literal_bound` and `clippy::doc_markdown` warnings at lines 275, 296, 1584, 1585, 1591, 1616, and 1829.

Closes #579