### PR TITLE
[codex] Avoid duplicate TurnStart on overflow cancellation

### DIFF
--- a/src/loop_/AGENTS.md
+++ b/src/loop_/AGENTS.md
@@ -10,5 +10,5 @@
 - `ToolExecutionStrategy::partition()` indices target the post-preprocessing `tool_calls` slice passed into the strategy, not the original LLM-emitted tool-call list. The dispatch layer must reject out-of-bounds, duplicate, or missing prepared indices with synthetic tool errors before any tool starts.
 - `PreDispatchVerdict::Stop` must synthesize one terminal error result for every unresolved tool call in the batch, including calls that already passed preprocessing before a later stop fires. Stop aborts dispatch, but it does not relax tool-result parity.
 - Cancellation has to be observed in preprocessing and before each execution group/tool dispatch, not just while collecting spawned handles. Otherwise approval waits can hang forever and later tools can still launch after the batch is already cancelled.
+- Overflow recovery cancellation must reuse a started-turn cancellation path. Calling the pre-turn helper after `TurnStart` has already been emitted duplicates `TurnStart` and breaks lifecycle ordering for the interrupted turn.
 - `LoopState.turn_index` must advance after every completed turn, not just tool-loop continuation. Text-only or other `BreakInner` turns still finish a turn before the outer loop polls follow-up messages.
-

--- a/src/loop_/overflow.rs
+++ b/src/loop_/overflow.rs
@@ -15,7 +15,8 @@ use crate::types::{AgentMessage, LlmMessage, StopReason};
 
 use super::stream::stream_with_retry;
 use super::turn::{
-    build_snapshot, emit_turn_end_and_agent_end, handle_cancellation, run_context_transformers,
+    build_snapshot, emit_turn_end_and_agent_end, handle_started_turn_cancellation,
+    run_context_transformers,
 };
 use super::{
     AgentEvent, AgentLoopConfig, LoopState, StreamResult, TurnEndReason, TurnOutcome,
@@ -75,7 +76,9 @@ pub(super) async fn attempt_overflow_recovery(
 
     // Check cancellation before retrying.
     if cancellation_token.is_cancelled() {
-        return OverflowRecoveryResult::Failed(handle_cancellation(config, state, tx).await);
+        return OverflowRecoveryResult::Failed(
+            handle_started_turn_cancellation(config, state, tx).await,
+        );
     }
 
     // Re-run convert-to-LLM pipeline with compacted context.

--- a/src/loop_/turn.rs
+++ b/src/loop_/turn.rs
@@ -512,18 +512,18 @@ async fn flush_state_delta(
 
 // ─── run_single_turn helpers ─────────────────────────────────────────────────
 
-/// Emit cancellation events and return from the loop.
-pub(super) async fn handle_cancellation(
+async fn emit_cancellation_for_turn(
     config: &Arc<AgentLoopConfig>,
     state: &mut LoopState,
     tx: &mpsc::Sender<AgentEvent>,
+    emit_turn_start: bool,
 ) -> TurnOutcome {
     let abort_msg = build_abort_message(&config.model);
     let msg_for_event = abort_msg.clone();
     state
         .context_messages
         .push(AgentMessage::Llm(LlmMessage::Assistant(abort_msg)));
-    if !emit(tx, AgentEvent::TurnStart).await {
+    if emit_turn_start && !emit(tx, AgentEvent::TurnStart).await {
         return TurnOutcome::Return;
     }
     if !emit(tx, AgentEvent::MessageStart).await {
@@ -549,6 +549,24 @@ pub(super) async fn handle_cancellation(
         tx,
     )
     .await
+}
+
+/// Emit cancellation events and return before the turn has started.
+pub(super) async fn handle_cancellation(
+    config: &Arc<AgentLoopConfig>,
+    state: &mut LoopState,
+    tx: &mpsc::Sender<AgentEvent>,
+) -> TurnOutcome {
+    emit_cancellation_for_turn(config, state, tx, true).await
+}
+
+/// Emit cancellation events for a turn that already emitted `TurnStart`.
+pub(super) async fn handle_started_turn_cancellation(
+    config: &Arc<AgentLoopConfig>,
+    state: &mut LoopState,
+    tx: &mpsc::Sender<AgentEvent>,
+) -> TurnOutcome {
+    emit_cancellation_for_turn(config, state, tx, false).await
 }
 
 /// Process the `StreamResult`, returning the assistant message on success,

--- a/tests/loop_overflow.rs
+++ b/tests/loop_overflow.rs
@@ -12,16 +12,16 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use common::{
-    MockContextCapturingStreamFn, MockStreamFn, MockTool, default_model, next_response,
-    text_only_events, tool_call_events, user_msg,
+    MockContextCapturingStreamFn, MockStreamFn, MockTool, default_model, text_only_events,
+    tool_call_events, user_msg,
 };
 use futures::Stream;
 use futures::stream::StreamExt;
 use tokio_util::sync::CancellationToken;
 
 use swink_agent::{
-    AgentContext, AgentEvent, AgentLoopConfig, AgentMessage, AssistantMessageEvent, ContentBlock,
-    DefaultRetryStrategy, LlmMessage, ModelSpec, StreamFn, StreamOptions, UserMessage, agent_loop,
+    AgentEvent, AgentLoopConfig, AgentMessage, AssistantMessageEvent, ContentBlock,
+    DefaultRetryStrategy, LlmMessage, StreamFn, StreamOptions, UserMessage, agent_loop,
 };
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
@@ -441,53 +441,21 @@ async fn no_compaction_skip_surfaces_error() {
 // T073: Cancellation during emergency recovery aborts the loop
 // ═══════════════════════════════════════════════════════════════════════════════
 
-/// A `StreamFn` that cancels the token after the first overflow, before the retry.
-struct CancellingAfterOverflowStreamFn {
-    responses: Mutex<Vec<Vec<AssistantMessageEvent>>>,
-    cancel_token: CancellationToken,
-    call_count: std::sync::atomic::AtomicU32,
-}
-
-impl StreamFn for CancellingAfterOverflowStreamFn {
-    fn stream<'a>(
-        &'a self,
-        _model: &'a ModelSpec,
-        _context: &'a AgentContext,
-        _options: &'a StreamOptions,
-        _cancellation_token: CancellationToken,
-    ) -> Pin<Box<dyn Stream<Item = AssistantMessageEvent> + Send + 'a>> {
-        let count = self
-            .call_count
-            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-        if count == 0 {
-            // First call: return overflow and cancel the token so recovery
-            // detects cancellation before retry.
-            self.cancel_token.cancel();
-        }
-        let fallback = vec![AssistantMessageEvent::error("exhausted")];
-        let events = next_response(&self.responses, fallback);
-        Box::pin(futures::stream::iter(events))
-    }
-}
-
 #[tokio::test]
 async fn cancellation_during_recovery_aborts() {
     let cancel_token = CancellationToken::new();
+    let stream_fn = Arc::new(MockStreamFn::new(vec![
+        overflow_error_events(),
+        text_only_events("should not reach — cancelled"),
+    ]));
 
-    let stream_fn = Arc::new(CancellingAfterOverflowStreamFn {
-        responses: Mutex::new(vec![
-            overflow_error_events(),
-            text_only_events("should not reach — cancelled"),
-        ]),
-        cancel_token: cancel_token.clone(),
-        call_count: std::sync::atomic::AtomicU32::new(0),
-    });
-
-    let mut config = default_config(stream_fn as Arc<dyn StreamFn>);
+    let mut config = default_config(stream_fn);
+    let cancel_clone = cancel_token.clone();
 
     // Compacting transformer so recovery tries.
-    config.transform_context = Some(Arc::new(|msgs: &mut Vec<AgentMessage>, overflow: bool| {
+    config.transform_context = Some(Arc::new(move |msgs: &mut Vec<AgentMessage>, overflow: bool| {
         if overflow && msgs.len() > 1 {
+            cancel_clone.cancel();
             msgs.truncate(1);
         }
     }));
@@ -501,6 +469,11 @@ async fn cancellation_during_recovery_aborts() {
     .await;
 
     assert!(has_event(&events, "AgentEnd"), "loop should complete");
+    assert_eq!(
+        count_events(&events, "TurnStart"),
+        1,
+        "cancellation during overflow recovery must not emit a duplicate TurnStart"
+    );
 
     // Should have a TurnEnd with Cancelled or Aborted reason.
     assert!(


### PR DESCRIPTION
## What changed and why
- split cancellation emission into a pre-turn path and a started-turn path
- routed emergency overflow recovery cancellation through the started-turn path so it keeps the synthetic abort message flow without emitting a second `TurnStart`
- tightened the overflow regression to cancel during the actual recovery window and assert the turn emits exactly one `TurnStart`
- recorded the lifecycle invariant in `src/loop_/AGENTS.md`

## Slice completed; what remains
- Completed this run: the overflow-cancellation event-order fix for issue #580
- Remaining follow-up: none identified in the scoped issue body

## Validation output
- `cargo test -p swink-agent --test loop_overflow --features testkit cancellation_during_recovery_aborts -- --exact`
- `cargo test -p swink-agent --test loop_overflow --features testkit`
- `cargo clippy --workspace --features testkit -- -D warnings`
- `cargo test --workspace --features testkit`

## Pre-existing baseline failures
- `cargo test --workspace --features testkit` still fails in untouched `swink-agent-tui` at `editor::tests::open_editor_with_true_command_returns_none`
- rerunning `cargo test -p swink-agent-tui --lib` reproduces the same existing failure with 287 passing tests and 1 failing test

Closes #580