### PR TITLE
[codex] Fix pre-start terminal adapter envelopes

### DIFF
--- a/adapters/src/bedrock.rs
+++ b/adapters/src/bedrock.rs
@@ -268,6 +268,22 @@ fn cancelled_event(message: &'static str) -> AssistantMessageEvent {
     }
 }
 
+fn prefix_pre_start_terminal_error(
+    events: Vec<AssistantMessageEvent>,
+    started: &mut bool,
+) -> Vec<AssistantMessageEvent> {
+    if *started || !matches!(events.as_slice(), [AssistantMessageEvent::Error { .. }]) {
+        return events;
+    }
+
+    *started = true;
+    let event = events
+        .into_iter()
+        .next()
+        .expect("matched single terminal error");
+    Vec::from(crate::base::pre_stream_error(event))
+}
+
 pub struct BedrockStreamFn {
     base_url: String,
     region: String,
@@ -499,6 +515,8 @@ impl BedrockStreamFn {
                                     events.push(AssistantMessageEvent::error_network(format!(
                                         "Bedrock event-stream decode error: {e}"
                                     )));
+                                    let events =
+                                        prefix_pre_start_terminal_error(events, &mut state.started);
                                     return Some((events, StreamUnfoldState::Done));
                                 }
                             }
@@ -509,6 +527,8 @@ impl BedrockStreamFn {
                                 () = cancellation_token.cancelled() => {
                                     let mut events = finalize::finalize_blocks(state.as_mut());
                                     events.push(cancelled_event("Bedrock stream cancelled"));
+                                    let events =
+                                        prefix_pre_start_terminal_error(events, &mut state.started);
                                     return Some((events, StreamUnfoldState::Done));
                                 }
                                 chunk = byte_stream.next() => {
@@ -522,6 +542,10 @@ impl BedrockStreamFn {
                                             events.push(AssistantMessageEvent::error_network(
                                                 format!("Bedrock stream read error: {e}"),
                                             ));
+                                            let events = prefix_pre_start_terminal_error(
+                                                events,
+                                                &mut state.started,
+                                            );
                                             return Some((events, StreamUnfoldState::Done));
                                         }
                                         None => {
@@ -549,6 +573,10 @@ impl BedrockStreamFn {
                                                     "Bedrock stream ended unexpectedly",
                                                 ));
                                             }
+                                            let events = prefix_pre_start_terminal_error(
+                                                events,
+                                                &mut state.started,
+                                            );
                                             return Some((events, StreamUnfoldState::Done));
                                         }
                                     }
@@ -635,7 +663,7 @@ fn process_smithy_message(
             warn!(event_type = %et, "Bedrock event deserialization failed for known event type");
             let mut events = finalize::finalize_blocks(state);
             events.push(AssistantMessageEvent::error_network(error_text));
-            events
+            prefix_pre_start_terminal_error(events, &mut state.started)
         }
     })
 }
@@ -1755,11 +1783,30 @@ mod tests {
         let mut state = BedrockStreamState::new();
         let msg = make_event_message("metadata", br#"{"usage":"bad"}"#);
         let events = process_smithy_message(&msg, &mut state);
-        assert_eq!(events.len(), 1);
+        assert_eq!(events.len(), 2);
+        assert!(matches!(events[0], AssistantMessageEvent::Start));
         assert!(matches!(
-            &events[0],
+            &events[1],
             AssistantMessageEvent::Error { error_message, .. }
                 if error_message.contains("Bedrock metadata parse error")
+        ));
+    }
+
+    #[test]
+    fn pre_start_terminal_error_is_prefixed() {
+        let mut started = false;
+        let events = prefix_pre_start_terminal_error(
+            vec![AssistantMessageEvent::error_network("boom")],
+            &mut started,
+        );
+
+        assert!(started);
+        assert!(matches!(
+            events.as_slice(),
+            [
+                AssistantMessageEvent::Start,
+                AssistantMessageEvent::Error { .. }
+            ]
         ));
     }
 

--- a/adapters/src/proxy.rs
+++ b/adapters/src/proxy.rs
@@ -264,61 +264,80 @@ fn parse_sse_stream(
     let sse_stream = sse_data_lines_with_callback(response.bytes_stream(), on_raw_payload);
 
     stream::unfold(
-        (Box::pin(sse_stream), cancellation_token, false),
-        |(mut sse, token, mut done)| async move {
+        (Box::pin(sse_stream), cancellation_token, false, false, None),
+        |(mut sse, token, done, started, pending)| async move {
+            if let Some(event) = pending {
+                return Some((event, (sse, token, true, started, None)));
+            }
+
             if done {
                 return None;
             }
 
-            tokio::select! {
+            let raw_event = tokio::select! {
                 biased;
                 () = token.cancelled() => {
-                    Some((AssistantMessageEvent::Error {
+                    AssistantMessageEvent::Error {
                         stop_reason: StopReason::Aborted,
                         error_message: "operation cancelled".to_owned(),
                         usage: None,
                         error_kind: None,
-                    }, (sse, token, true)))
+                    }
                 }
                 item = sse.next() => {
                     match item {
                         None => {
                             // Stream ended without a Done/Error event — treat as
                             // connection drop.
-                            done = true;
-                            Some((
-                                AssistantMessageEvent::error_network("network error: SSE stream ended unexpectedly"),
-                                (sse, token, done),
-                            ))
+                            AssistantMessageEvent::error_network(
+                                "network error: SSE stream ended unexpectedly",
+                            )
                         }
                         Some(SseLine::Done) => {
-                            done = true;
-                            Some((
-                                AssistantMessageEvent::error_network(
-                                    "network error: proxy SSE transport ended before protocol terminal event",
-                                ),
-                                (sse, token, done),
-                            ))
+                            AssistantMessageEvent::error_network(
+                                "network error: proxy SSE transport ended before protocol terminal event",
+                            )
                         }
                         Some(SseLine::Data(data)) => {
-                            let parsed = parse_sse_event_data(&data);
-                            done = is_terminal_event(&parsed);
-                            Some((parsed, (sse, token, done)))
+                            parse_sse_event_data(&data)
                         }
-                        Some(SseLine::TransportError(message)) => Some((
-                            AssistantMessageEvent::error_network(format!(
+                        Some(SseLine::TransportError(message)) => AssistantMessageEvent::error_network(format!(
                                 "network error: {message}",
                             )),
-                            (sse, token, true),
-                        )),
-                        Some(_) => Some((AssistantMessageEvent::error_network(
+                        Some(_) => AssistantMessageEvent::error_network(
                             "network error: unexpected non-data SSE line",
-                        ), (sse, token, true))),
+                        ),
                     }
                 }
-            }
+            };
+
+            let (event, started, pending, done) = prepare_stream_event(raw_event, started);
+            Some((event, (sse, token, done, started, pending)))
         },
     )
+}
+
+fn prepare_stream_event(
+    event: AssistantMessageEvent,
+    started: bool,
+) -> (
+    AssistantMessageEvent,
+    bool,
+    Option<AssistantMessageEvent>,
+    bool,
+) {
+    if matches!(
+        event,
+        AssistantMessageEvent::Done { .. } | AssistantMessageEvent::Error { .. }
+    ) && !started
+    {
+        let [start, terminal] = crate::base::pre_stream_error(event);
+        return (start, true, Some(terminal), false);
+    }
+
+    let started = started || matches!(event, AssistantMessageEvent::Start);
+    let done = is_terminal_event(&event);
+    (event, started, None, done)
 }
 
 /// Parse a single SSE event's `data` field into an `AssistantMessageEvent`.
@@ -656,6 +675,28 @@ mod tests {
 
         let start = AssistantMessageEvent::Start;
         assert!(!is_terminal_event(&start));
+    }
+
+    #[test]
+    fn terminal_error_before_start_is_prefixed() {
+        let (first, started, pending, done) =
+            prepare_stream_event(AssistantMessageEvent::error_network("boom"), false);
+
+        assert!(matches!(first, AssistantMessageEvent::Start));
+        assert!(started);
+        assert!(!done);
+        assert!(matches!(pending, Some(AssistantMessageEvent::Error { .. })));
+    }
+
+    #[test]
+    fn terminal_error_after_start_is_not_prefixed() {
+        let error = AssistantMessageEvent::error_network("boom");
+        let (event, started, pending, done) = prepare_stream_event(error.clone(), true);
+
+        assert!(matches!(event, AssistantMessageEvent::Error { .. }));
+        assert!(started);
+        assert!(done);
+        assert!(pending.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## What changed and why
- Proxy streaming now synthesizes `AssistantMessageEvent::Start` before any terminal `Error` that occurs before the stream has emitted a start event.
- Bedrock now prefixes pure early terminal errors the same way in its decode/read/cancellation/parse-error paths.
- Added focused regression tests covering the new pre-start terminal wrapping behavior and the Bedrock malformed-event path.

## Slice completed; what remains
- Completed the `#581` adapter-contract slice for proxy and Bedrock early terminal errors.
- No further code changes are planned for this issue in this PR.

## Validation output
- `cargo test -p swink-agent-adapters`
- `cargo fmt --all`

## Pre-existing baseline failures
- `cargo clippy --workspace -- -D warnings` fails in this environment while building `llama-cpp-sys-2` because `libclang` is unavailable (`Unable to find libclang`; `LIBCLANG_PATH` unset).
- `cargo test --workspace` fails for the same environment/build blocker before reaching full workspace execution.

Closes #581