### PR TITLE
Align duplicate tool dispatch with public lookup

### DIFF
--- a/src/loop_/tool_dispatch/mod.rs
+++ b/src/loop_/tool_dispatch/mod.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::tool::{AgentTool, AgentToolResult};
 use crate::types::ToolResultMessage;
@@ -52,6 +52,30 @@ fn order_results_by_tool_calls(
         }
     }
     ordered
+}
+
+/// Build a tool lookup table that preserves the first registered tool for a
+/// given name.
+///
+/// Public lookup paths such as `Agent::find_tool()` return the first matching
+/// tool. Dispatch must use the same rule so duplicate tool names do not expose
+/// one tool to the model while executing another.
+fn build_tool_map(tools: &[Arc<dyn AgentTool>]) -> HashMap<&str, &Arc<dyn AgentTool>> {
+    let mut tool_map: HashMap<&str, &Arc<dyn AgentTool>> = HashMap::with_capacity(tools.len());
+
+    for tool in tools {
+        if tool_map.contains_key(tool.name()) {
+            warn!(
+                tool_name = %tool.name(),
+                "duplicate tool name detected during dispatch; keeping first registered tool"
+            );
+            continue;
+        }
+
+        tool_map.insert(tool.name(), tool);
+    }
+
+    tool_map
 }
 
 // ─── Public entry point ─────────────────────────────────────────────────────
@@ -97,8 +121,7 @@ pub async fn execute_tools_concurrently(
     let transfer_signal: Arc<Mutex<Option<crate::transfer::TransferSignal>>> =
         Arc::new(Mutex::new(None));
 
-    let tool_map: HashMap<&str, &Arc<dyn AgentTool>> =
-        config.tools.iter().map(|t| (t.name(), t)).collect();
+    let tool_map = build_tool_map(&config.tools);
 
     // Phase 1: Pre-process — policies, approval, argument rewriting.
     let preprocess::PreprocessResult {

--- a/tests/agent.rs
+++ b/tests/agent.rs
@@ -13,8 +13,9 @@ use common::{
 use futures::stream::StreamExt;
 
 use swink_agent::{
-    Agent, AgentError, AgentEvent, AgentMessage, AgentOptions, AgentTool, AssistantMessageEvent,
-    ContentBlock, DefaultRetryStrategy, LlmMessage, ModelSpec, StopReason, StreamFn,
+    Agent, AgentError, AgentEvent, AgentMessage, AgentOptions, AgentTool, AgentToolResult,
+    AssistantMessageEvent, ContentBlock, DefaultRetryStrategy, LlmMessage, ModelSpec, StopReason,
+    StreamFn,
 };
 
 // ─── Helpers ─────────────────────────────────────────────────────────────
@@ -252,6 +253,51 @@ async fn abort_during_tool_turn_keeps_single_turn_and_tool_payloads() {
     assert!(
         tool_text.contains("aborted") || tool_text.contains("cancelled"),
         "expected the preserved tool result to explain the abort, got: {tool_text}"
+    );
+}
+
+#[tokio::test]
+async fn duplicate_tool_names_dispatch_first_registered_tool() {
+    let stream_fn = Arc::new(MockStreamFn::new(vec![
+        tool_call_events("tc_dup", "dup_tool", "{}"),
+        text_only_events("done"),
+    ]));
+    let first = Arc::new(MockTool::new("dup_tool").with_result(AgentToolResult::text("first")));
+    let second = Arc::new(MockTool::new("dup_tool").with_result(AgentToolResult::text("second")));
+    let mut agent = make_agent_with_tools(
+        stream_fn,
+        vec![
+            Arc::clone(&first) as Arc<dyn AgentTool>,
+            Arc::clone(&second) as Arc<dyn AgentTool>,
+        ],
+    );
+
+    let resolved = agent
+        .find_tool("dup_tool")
+        .expect("duplicate tool name should still resolve");
+    assert!(
+        std::ptr::eq::<dyn AgentTool>(resolved.as_ref(), first.as_ref()),
+        "find_tool should expose the first registered tool"
+    );
+
+    let result = agent.prompt_async(vec![user_msg("go")]).await.unwrap();
+
+    assert_eq!(
+        first.execution_count(),
+        1,
+        "dispatch should execute the same first registered tool that lookup exposes"
+    );
+    assert_eq!(second.execution_count(), 0, "later duplicates must not run");
+    assert!(
+        result.messages.iter().any(|message| {
+            matches!(
+                message,
+                AgentMessage::Llm(LlmMessage::ToolResult(tool_result))
+                    if tool_result.tool_call_id == "tc_dup"
+                        && ContentBlock::extract_text(&tool_result.content) == "first"
+            )
+        }),
+        "the persisted tool result should come from the first registered tool"
     );
 }
 


### PR DESCRIPTION
## What changed and why
- Changed loop-time tool lookup to preserve the first registered tool when duplicate tool names exist.
- Added a regression test proving `Agent::find_tool()` and runtime dispatch resolve the same tool and persist the same tool-result payload.
- Logged a warning when duplicate names are encountered during dispatch so the ambiguity is visible without changing public registration APIs in this slice.

## Slice completed
This PR completes the dispatch-alignment slice of #582: duplicate names no longer expose one tool to the model while executing another.

## What remains
- Decide whether duplicate tool names should be rejected earlier during tool registration / merge time instead of only being handled deterministically at dispatch.
- If that broader fail-fast direction is chosen, add registration-time coverage around `with_tools`, `set_tools`, and any other merge paths that can admit duplicates.

## Validation output
- `cargo fmt --check`
- `cargo test --features testkit duplicate_tool_names_dispatch_first_registered_tool -- --exact --nocapture`
- `cargo test -p swink-agent --features testkit`

## Pre-existing baseline failures
- `cargo clippy -p swink-agent --all-targets --features testkit -- -D warnings` fails on unrelated existing lint debt in other tests and support modules (for example `tests/abort_turn_end_reason.rs`, `tests/tool_middleware.rs`, `src/agent/checkpointing.rs`, `src/checkpoint.rs`, `src/task_core.rs`).
- `cargo clippy --workspace -- -D warnings` and `cargo test --workspace --features testkit` are blocked in this environment by `llama-cpp-sys-2` needing `libclang` (`Unable to find libclang ... set the LIBCLANG_PATH environment variable`).

Ref #582