### PR TITLE
[codex] Fix Gemini null tool-call snapshots

### DIFF
--- a/adapters/AGENTS.md
+++ b/adapters/AGENTS.md
@@ -43,6 +43,7 @@
 - **Mistral divergences from OpenAI** — Tool call IDs must be exactly 9-char `[a-zA-Z0-9]`. `stream_options` field rejected (usage comes in final chunk). Must use `max_tokens` not `max_completion_tokens`. `finish_reason: "model_length"` is Mistral-specific. User messages cannot immediately follow tool messages (synthetic assistant message inserted).
 - Any failure before the provider yields its first streaming payload must still emit `[Start, Error]`. Returning only a terminal `Error` makes `accumulate_message()` fail with `no Start event found`.
 - `finish_reason == "content_filter"` must be routed through `OaiSseStreamState.terminal_error`; emitting an inline error and then consuming a later `[DONE]` produces a duplicate terminal event that `accumulate_message` rejects.
+- In `src/google.rs`, `function_call.args` chunks are full snapshots, not deltas. Always overwrite the buffered args, including `null`, or a later empty snapshot can leave stale JSON from an earlier chunk.
 - In `src/ollama.rs`, the NDJSON parser must buffer raw bytes until it has a full newline-delimited record. Decoding each transport chunk independently with `from_utf8_lossy` corrupts split multibyte UTF-8.
 - In `src/openai_compat.rs`, buffer tool-call arguments and delay `ToolCallStart` until a non-empty `function.name` is known; some providers stream arguments before the name.
 - Runtime SSE adapters must thread `StreamOptions.on_raw_payload` into the callback-aware shared parser (`sse_data_lines_with_callback`). The callback-free helper silently disables payload observers.

--- a/adapters/src/google.rs
+++ b/adapters/src/google.rs
@@ -760,9 +760,7 @@ fn process_function_call(
         Value::Null => String::new(),
         value => value.to_string(),
     };
-    if !serialized_args.is_empty() {
-        entry.arguments = serialized_args;
-    }
+    entry.arguments = serialized_args;
 }
 
 fn map_finish_reason(finish_reason: &str, saw_tool_call: bool) -> StopReason {

--- a/adapters/tests/google.rs
+++ b/adapters/tests/google.rs
@@ -772,8 +772,8 @@ async fn gemini_two_tool_calls_have_sequential_content_indices() {
     assert_eq!(cis[1], cis[0] + 1, "content indices must be sequential");
 }
 
-/// When a tool call is emitted but finishReason is MAX_TOKENS, the stop reason
-/// must be Length — not ToolUse. Regression test for #273.
+/// When a tool call is emitted but finishReason is `MAX_TOKENS`, the stop
+/// reason must be `Length` and not `ToolUse`. Regression test for #273.
 #[tokio::test]
 async fn gemini_max_tokens_after_tool_call_reports_length() {
     let body = [
@@ -867,6 +867,52 @@ async fn gemini_non_prefix_arg_rewrite_produces_correct_json() {
         parsed,
         serde_json::json!({"b": 2}),
         "final args must match the last Gemini snapshot, got: {arguments}"
+    );
+}
+
+/// Regression test for #583: when Gemini rewrites a previously non-empty
+/// `function_call.args` snapshot to `null`, the buffered final args must clear
+/// instead of reusing stale JSON from the earlier chunk.
+#[tokio::test]
+async fn gemini_null_arg_rewrite_clears_buffered_args() {
+    let body = [
+        r#"data: {"candidates":[{"content":{"parts":[{"functionCall":{"id":"c1","name":"do_stuff","args":{"city":"Paris"}}}]}}]}"#,
+        "",
+        r#"data: {"candidates":[{"content":{"parts":[{"functionCall":{"id":"c1","name":"do_stuff","args":null}]}}]}"#,
+        "",
+        r#"data: {"candidates":[{"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":5,"totalTokenCount":10}}"#,
+        "",
+        "data: [DONE]",
+        "",
+    ]
+    .join("\n");
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(sse_response(&body))
+        .mount(&server)
+        .await;
+
+    let stream_fn = GeminiStreamFn::new(server.uri(), "test-key", ApiVersion::V1beta);
+    let events = collect_events(&stream_fn).await;
+
+    let arguments: String = events
+        .iter()
+        .filter_map(|event| match event {
+            AssistantMessageEvent::ToolCallDelta { delta, .. } => Some(delta.as_str()),
+            _ => None,
+        })
+        .collect();
+
+    assert!(
+        arguments.is_empty(),
+        "null rewrite must clear buffered args instead of keeping stale JSON: {arguments}"
+    );
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, AssistantMessageEvent::ToolCallStart { .. })),
+        "tool call should still start before the null rewrite is finalized"
     );
 }
 


### PR DESCRIPTION
## What changed and why
- Always replace the buffered Gemini `function_call.args` snapshot, including `null`, so a later empty snapshot clears stale JSON instead of reusing an earlier payload.
- Added a focused Gemini regression test for the `args: null` rewrite case.
- Recorded the adapter-specific lesson in `adapters/AGENTS.md`.

## Slice completed
- Completed the issue's narrow adapter fix for latest Gemini tool-call argument snapshots.
- Remaining work: none expected for this issue if review agrees with the `null`-snapshot contract.

## Validation output
- `cargo test -p swink-agent-adapters --features gemini --test google`
- `cargo clippy -p swink-agent-adapters --features gemini --test google -- -D warnings`

## Pre-existing baseline failures
- None observed in the scoped Gemini adapter checks run for this slice.
- Workspace-wide `cargo test` / `cargo clippy` were not rerun for this targeted issue fix.

Closes #583