### PR TITLE
[codex] Preserve local LLM length stop reasons

### DIFF
--- a/local-llm/AGENTS.md
+++ b/local-llm/AGENTS.md
@@ -33,6 +33,7 @@
 - **Gemma 4 thinking output** — `ChannelThoughtParser` in `stream.rs` handles cross-chunk `<|channel>thought\n...<channel|>` delimiters. Stateful 4-state machine (Normal → PartialOpen → InThinking → PartialClose).
 - **Gemma 4 tool calls** — `ToolCallParser` in `stream.rs` handles cross-chunk `<|tool_call>call:{name}{args}<tool_call|>` format. IDs are generated as UUIDs. `Gemma4LocalConverter` wraps tool results as `<|tool_result>{tool_call_id}\n{text}<tool_result|>`.
 - **Gemma 4 partial delimiter matching must be UTF-8 safe** — when scanning for split `<|channel>thought\n` and `<tool_call|>` delimiters, only slice `&str` values at character boundaries. Reuse the shared suffix helper in `stream.rs`; raw byte-offset suffix slicing can panic on multibyte output.
+- **Local stream finish reasons must survive finalization** — `runner.rs` must propagate whether generation ended naturally or because it exhausted `max_tokens`, and `stream.rs` must preserve `Length` ahead of synthesized `ToolUse` so the core loop can recover incomplete tool-call JSON.
 - **Two converter types** — `LocalConverter` (SmolLM3) and `Gemma4LocalConverter` (Gemma 4) both implement `MessageConverter`. `convert_context_messages` dispatches based on `config.is_gemma4()`.
 - **LazyLoader waiters must treat `Unloaded` as terminal for the current attempt** — `wait_until_ready()` now returns on `Unloaded`/`Failed` as well as `Ready`, and `ensure_ready()` re-checks loader state after every wakeup so an `unload()` during another caller's load does not strand waiters forever.
 

--- a/local-llm/src/runner.rs
+++ b/local-llm/src/runner.rs
@@ -49,8 +49,15 @@ pub enum TokenEvent {
     Done {
         prompt_tokens: u32,
         completion_tokens: u32,
+        finish_reason: FinishReason,
     },
     Error(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FinishReason {
+    Stop,
+    Length,
 }
 
 // ─── LlamaRunner ───────────────────────────────────────────────────────────
@@ -247,6 +254,7 @@ fn run_inference(
         let _ = tx.blocking_send(TokenEvent::Done {
             prompt_tokens: 0,
             completion_tokens: 0,
+            finish_reason: FinishReason::Stop,
         });
         return Ok(());
     }
@@ -276,6 +284,11 @@ fn run_inference(
     let prompt_len_u32 = u32::try_from(prompt_len).unwrap_or(u32::MAX);
     let max_tokens = config.context_length.saturating_sub(prompt_len_u32);
     let mut n_cur = prompt_len;
+    let mut finish_reason = if max_tokens == 0 {
+        FinishReason::Length
+    } else {
+        FinishReason::Stop
+    };
 
     debug!(
         max_tokens,
@@ -283,7 +296,7 @@ fn run_inference(
         "entering generation loop"
     );
 
-    for _ in 0..max_tokens {
+    for step in 0..max_tokens {
         if cancel.is_cancelled() {
             debug!("inference cancelled");
             break;
@@ -332,6 +345,10 @@ fn run_inference(
         ctx.decode(&mut batch).map_err(|e| {
             LocalModelError::inference(format!("decode failed at position {n_cur}: {e}"))
         })?;
+
+        if step + 1 == max_tokens {
+            finish_reason = FinishReason::Length;
+        }
     }
 
     debug!(completion_tokens, "inference complete");
@@ -339,6 +356,7 @@ fn run_inference(
     let _ = tx.blocking_send(TokenEvent::Done {
         prompt_tokens: prompt_len_u32,
         completion_tokens,
+        finish_reason,
     });
 
     Ok(())

--- a/local-llm/src/stream.rs
+++ b/local-llm/src/stream.rs
@@ -22,7 +22,7 @@ use swink_agent::{
 
 use crate::loader::LoaderState;
 use crate::model::LocalModel;
-use crate::runner::TokenEvent;
+use crate::runner::{FinishReason, TokenEvent};
 
 // ─── LocalStreamFn ──────────────────────────────────────────────────────────
 
@@ -419,6 +419,7 @@ struct StreamState {
     prompt_tokens: u32,
     completion_tokens: u32,
     has_tool_calls: bool,
+    finish_reason: FinishReason,
     saw_done: bool,
     #[cfg(feature = "gemma4")]
     channel_parser: Option<channel_thought::ChannelThoughtParser>,
@@ -437,6 +438,7 @@ impl StreamState {
             prompt_tokens: 0,
             completion_tokens: 0,
             has_tool_calls: false,
+            finish_reason: FinishReason::Stop,
             saw_done: false,
             #[cfg(feature = "gemma4")]
             channel_parser: if is_gemma4 {
@@ -524,10 +526,10 @@ impl StreamState {
     fn finalize(mut self) -> Vec<AssistantMessageEvent> {
         self.events.extend(finalize_blocks(&mut self.blocks));
 
-        let stop_reason = if self.has_tool_calls {
-            StopReason::ToolUse
-        } else {
-            StopReason::Stop
+        let stop_reason = match self.finish_reason {
+            FinishReason::Length => StopReason::Length,
+            FinishReason::Stop if self.has_tool_calls => StopReason::ToolUse,
+            FinishReason::Stop => StopReason::Stop,
         };
 
         self.events.push(AssistantMessageEvent::Done {
@@ -699,9 +701,11 @@ fn local_stream<'a>(
                 TokenEvent::Done {
                     prompt_tokens,
                     completion_tokens,
+                    finish_reason,
                 } => {
                     state.prompt_tokens = prompt_tokens;
                     state.completion_tokens = completion_tokens;
+                    state.finish_reason = finish_reason;
                     state.saw_done = true;
                     break;
                 }
@@ -848,12 +852,29 @@ mod tests {
     fn finalize_keeps_tool_use_stop_reason() {
         let mut state = StreamState::new(false);
         state.has_tool_calls = true;
+        state.finish_reason = FinishReason::Stop;
 
         let events = state.finalize();
         let terminal = events.last().expect("at least one event");
         match terminal {
             AssistantMessageEvent::Done { stop_reason, .. } => {
                 assert_eq!(*stop_reason, StopReason::ToolUse);
+            }
+            other => panic!("expected Done terminal, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn finalize_preserves_length_stop_reason_over_tool_use() {
+        let mut state = StreamState::new(false);
+        state.has_tool_calls = true;
+        state.finish_reason = FinishReason::Length;
+
+        let events = state.finalize();
+        let terminal = events.last().expect("at least one event");
+        match terminal {
+            AssistantMessageEvent::Done { stop_reason, .. } => {
+                assert_eq!(*stop_reason, StopReason::Length);
             }
             other => panic!("expected Done terminal, got {other:?}"),
         }


### PR DESCRIPTION
## What changed
- threaded a local generation finish reason from `local-llm/src/runner.rs` into `local-llm/src/stream.rs`
- preserve `StopReason::Length` ahead of synthesized `ToolUse` when a local response truncates after starting tool calls
- added focused stream-finalization coverage for both natural tool-call turns and truncated tool-call turns
- recorded the invariant in `local-llm/AGENTS.md`

## Why / value
This keeps truncated local tool-call JSON visible to the core loop's existing recovery path instead of masking it as a completed `ToolUse` turn.

## Slice completed
Completed the issue's core stop-reason propagation and stream finalization fix for local-LLM tool-call truncation.

## What remains
If maintainers want broader end-to-end coverage after CI/tooling is restored, a higher-level local inference regression could still be added later. The functional bug in this issue is addressed in this slice.

## Validation output
- `cargo fmt --all --check`
- `cargo test -p swink-agent-local-llm finalize_ -- --nocapture` -> blocked in this environment while building `llama-cpp-sys-2`: bindgen could not find `libclang.dll` / `clang.dll` and requested `LIBCLANG_PATH`
- `cargo clippy -p swink-agent-local-llm --lib --tests -- -D warnings` -> blocked by the same pre-existing `libclang` toolchain gap

## Pre-existing baseline failures
- Local-LLM package builds are currently blocked in this environment by the existing missing-`libclang` setup tracked in issue #603.

Closes #344