### PR TITLE
feat(tui): click-drag text selection and copy in chat view

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -24,7 +24,7 @@ jobs:
         run: cargo bench -p swink-agent --bench context -- --save-baseline pr
 
       - name: Export PR baseline
-        run: critcmp --export pr > "$RUNNER_TEMP/pr.json"
+        run: "$CARGO_HOME/bin/critcmp" --export pr > "$RUNNER_TEMP/pr.json"
 
       - name: Add base worktree
         run: git worktree add ../bench-base ${{ github.event.pull_request.base.sha }}
@@ -35,10 +35,10 @@ jobs:
 
       - name: Export base baseline
         working-directory: ../bench-base
-        run: critcmp --export base > "$RUNNER_TEMP/base.json"
+        run: "$CARGO_HOME/bin/critcmp" --export base > "$RUNNER_TEMP/base.json"
 
       - name: Compare
-        run: critcmp "$RUNNER_TEMP/base.json" "$RUNNER_TEMP/pr.json" | tee bench-diff.txt
+        run: "$CARGO_HOME/bin/critcmp" "$RUNNER_TEMP/base.json" "$RUNNER_TEMP/pr.json" | tee bench-diff.txt
 
       - name: Post comment
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9

--- a/tui/src/app/event_loop.rs
+++ b/tui/src/app/event_loop.rs
@@ -3,13 +3,15 @@
 use std::io;
 use std::time::{Duration, Instant};
 
-use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
+use crossterm::event::{
+    Event, KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
+};
 use futures::StreamExt;
 use ratatui::{Terminal, backend::CrosstermBackend};
 
 use swink_agent::{ApprovalMode, ToolApproval};
 
-use super::state::TrustFollowUp;
+use super::state::{Selection, TrustFollowUp};
 use crate::commands::{self, ApprovalModeArg, ClipboardContent, CommandResult};
 use crate::theme;
 use crate::ui;
@@ -115,19 +117,51 @@ impl App {
     }
 
     pub(super) fn handle_mouse_event(&mut self, mouse: MouseEvent) {
-        if !self.mouse_in_conversation(mouse.column, mouse.row) {
-            return;
-        }
-
         match mouse.kind {
             MouseEventKind::ScrollUp => {
+                if !self.mouse_in_conversation(mouse.column, mouse.row) {
+                    return;
+                }
+                self.selection = None;
                 self.conversation.scroll_up(MOUSE_SCROLL_STEP);
                 self.dirty = true;
             }
             MouseEventKind::ScrollDown => {
+                if !self.mouse_in_conversation(mouse.column, mouse.row) {
+                    return;
+                }
+                self.selection = None;
                 self.conversation
                     .scroll_down(MOUSE_SCROLL_STEP, self.conversation_page_height());
                 self.dirty = true;
+            }
+            MouseEventKind::Down(MouseButton::Left) => {
+                if !self.mouse_in_conversation(mouse.column, mouse.row) {
+                    self.selection = None;
+                    self.dirty = true;
+                    return;
+                }
+                if let Some((row, col)) = self.inner_conversation_coords(mouse.column, mouse.row) {
+                    self.selection = Some(Selection::new(row, col));
+                    self.dirty = true;
+                }
+            }
+            MouseEventKind::Drag(MouseButton::Left) => {
+                if self.selection.is_none() {
+                    return;
+                }
+                let (row, col) = self.clamped_conversation_coords(mouse.column, mouse.row);
+                if let Some(sel) = self.selection.as_mut() {
+                    sel.cursor = (row, col);
+                    sel.dragging = true;
+                }
+                self.dirty = true;
+            }
+            MouseEventKind::Up(MouseButton::Left) => {
+                if let Some(sel) = self.selection.as_mut() {
+                    sel.dragging = false;
+                }
+                self.copy_selection_to_clipboard();
             }
             _ => {}
         }
@@ -140,6 +174,57 @@ impl App {
         within_x && within_y
     }
 
+    /// Translate absolute terminal coordinates into `(row, col)` inside the
+    /// conversation's inner area (i.e. excluding the border). Returns `None`
+    /// if the position falls outside the inner area.
+    fn inner_conversation_coords(&self, column: u16, row: u16) -> Option<(u16, u16)> {
+        let area = self.conversation_area;
+        let inner_x = area.x.checked_add(1)?;
+        let inner_y = area.y.checked_add(1)?;
+        let inner_w = area.width.saturating_sub(2);
+        let inner_h = area.height.saturating_sub(2);
+        if column < inner_x || row < inner_y {
+            return None;
+        }
+        let col = column - inner_x;
+        let r = row - inner_y;
+        if col >= inner_w || r >= inner_h {
+            return None;
+        }
+        Some((r, col))
+    }
+
+    /// Like [`Self::inner_conversation_coords`] but clamps to the viewport
+    /// edges instead of returning `None` — used during drag so the selection
+    /// still extends when the cursor leaves the conversation area.
+    fn clamped_conversation_coords(&self, column: u16, row: u16) -> (u16, u16) {
+        let area = self.conversation_area;
+        let inner_x = area.x.saturating_add(1);
+        let inner_y = area.y.saturating_add(1);
+        let inner_w = area.width.saturating_sub(2);
+        let inner_h = area.height.saturating_sub(2);
+        let max_col = inner_w.saturating_sub(1);
+        let max_row = inner_h.saturating_sub(1);
+        let col = column.saturating_sub(inner_x).min(max_col);
+        let r = row.saturating_sub(inner_y).min(max_row);
+        (r, col)
+    }
+
+    /// Copy the current selection (if any) to the system clipboard.
+    pub(super) fn copy_selection_to_clipboard(&mut self) {
+        let Some(sel) = self.selection else { return };
+        let Some(text) = self.conversation.selection_text(&sel) else {
+            return;
+        };
+        match arboard::Clipboard::new().and_then(|mut cb| cb.set_text(text)) {
+            Ok(()) => {}
+            Err(error) => {
+                self.push_system_message(format!("Clipboard error: {error}"));
+            }
+        }
+        self.dirty = true;
+    }
+
     pub(super) fn handle_key_event(&mut self, key: KeyEvent) {
         match (key.modifiers, key.code) {
             (KeyModifiers::CONTROL, KeyCode::Char('q')) => {
@@ -148,11 +233,19 @@ impl App {
                 return;
             }
             (KeyModifiers::CONTROL, KeyCode::Char('c')) => {
-                if self.status == AgentStatus::Running {
+                if self.selection.is_some() {
+                    self.copy_selection_to_clipboard();
+                    self.selection = None;
+                } else if self.status == AgentStatus::Running {
                     self.abort_agent();
                 } else {
                     self.should_quit = true;
                 }
+                self.dirty = true;
+                return;
+            }
+            (_, KeyCode::Esc) if self.selection.is_some() => {
+                self.selection = None;
                 self.dirty = true;
                 return;
             }

--- a/tui/src/app/lifecycle.rs
+++ b/tui/src/app/lifecycle.rs
@@ -84,6 +84,7 @@ impl App {
             conversation_visible_height: 0,
             pending_steered: Vec::new(),
             steered_fade_ticks: 0,
+            selection: None,
         }
     }
 

--- a/tui/src/app/mod.rs
+++ b/tui/src/app/mod.rs
@@ -7,7 +7,7 @@ mod persistence;
 mod render_helpers;
 mod state;
 
-pub use state::{AgentStatus, App, DisplayMessage, Focus, MessageRole, OperatingMode};
+pub use state::{AgentStatus, App, DisplayMessage, Focus, MessageRole, OperatingMode, Selection};
 
 type AppResult<T> = Result<T, Box<dyn std::error::Error>>;
 

--- a/tui/src/app/state.rs
+++ b/tui/src/app/state.rs
@@ -53,6 +53,41 @@ pub struct TrustFollowUp {
     pub expires_at: Instant,
 }
 
+/// Click-drag text selection within the conversation viewport.
+///
+/// Coordinates are cell offsets inside the conversation's inner area (after
+/// the border): `(row, col)` where `(0, 0)` is the top-left visible cell.
+#[derive(Debug, Clone, Copy)]
+pub struct Selection {
+    pub anchor: (u16, u16),
+    pub cursor: (u16, u16),
+    pub dragging: bool,
+}
+
+impl Selection {
+    pub const fn new(row: u16, col: u16) -> Self {
+        Self {
+            anchor: (row, col),
+            cursor: (row, col),
+            dragging: true,
+        }
+    }
+
+    /// Return `(start, end)` with `start <= end` in row-major order.
+    pub fn normalized(&self) -> ((u16, u16), (u16, u16)) {
+        if (self.anchor.0, self.anchor.1) <= (self.cursor.0, self.cursor.1) {
+            (self.anchor, self.cursor)
+        } else {
+            (self.cursor, self.anchor)
+        }
+    }
+
+    /// True when the selection covers at least one cell.
+    pub fn is_empty(&self) -> bool {
+        self.anchor == self.cursor
+    }
+}
+
 /// Message role for display styling.
 ///
 /// Type alias for [`DisplayRole`] from the core crate. Kept as an alias
@@ -218,4 +253,6 @@ pub struct App {
     /// Ticks remaining for the fade-out animation after steered messages are
     /// consumed. Zero means the overlay is not visible.
     pub(crate) steered_fade_ticks: u8,
+    /// Active click-drag selection in the conversation viewport.
+    pub(crate) selection: Option<Selection>,
 }

--- a/tui/src/ui/conversation.rs
+++ b/tui/src/ui/conversation.rs
@@ -6,7 +6,7 @@ use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
 
-use crate::app::{DisplayMessage, MessageRole};
+use crate::app::{DisplayMessage, MessageRole, Selection};
 use crate::theme;
 use crate::ui::markdown;
 
@@ -18,6 +18,10 @@ pub struct ConversationView {
     pub auto_scroll: bool,
     /// Total rendered lines (computed each frame).
     rendered_lines: usize,
+    /// Per-row cell symbols captured from the last render pass, indexed
+    /// `[row][col]` over the conversation's inner area. Used by selection
+    /// copy to extract exactly what the user sees on screen.
+    pub(crate) visible_cells: Vec<Vec<String>>,
 }
 
 impl Default for ConversationView {
@@ -32,6 +36,54 @@ impl ConversationView {
             scroll_offset: 0,
             auto_scroll: true,
             rendered_lines: 0,
+            visible_cells: Vec::new(),
+        }
+    }
+
+    /// Extract the text inside `selection` from the last captured render.
+    /// Returns the selected text with a leading `"│ "` gutter stripped per
+    /// line and trailing whitespace removed. Returns `None` if the selection
+    /// is empty or out of bounds.
+    pub(crate) fn selection_text(&self, selection: &Selection) -> Option<String> {
+        if selection.is_empty() || self.visible_cells.is_empty() {
+            return None;
+        }
+        let (start, end) = selection.normalized();
+        let start_row = start.0 as usize;
+        let end_row = end.0 as usize;
+        let mut out = String::new();
+        for row_idx in start_row..=end_row {
+            let Some(row) = self.visible_cells.get(row_idx) else {
+                break;
+            };
+            let width = row.len();
+            let col_start = if row_idx == start_row {
+                start.1 as usize
+            } else {
+                0
+            };
+            let col_end = if row_idx == end_row {
+                end.1 as usize
+            } else {
+                width
+            };
+            let col_start = col_start.min(width);
+            let col_end = col_end.min(width).max(col_start);
+            let mut line: String = row[col_start..col_end].concat();
+            if line.starts_with("│ ") {
+                line.drain(.."│ ".len());
+            }
+            let trimmed = line.trim_end();
+            out.push_str(trimmed);
+            if row_idx != end_row {
+                out.push('\n');
+            }
+        }
+        let trimmed = out.trim_matches('\n').to_string();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed)
         }
     }
 
@@ -75,7 +127,7 @@ impl ConversationView {
     }
 
     /// Render the conversation view.
-    #[allow(clippy::too_many_lines)]
+    #[allow(clippy::too_many_lines, clippy::too_many_arguments)]
     pub fn render(
         &mut self,
         frame: &mut Frame,
@@ -84,6 +136,7 @@ impl ConversationView {
         focused: bool,
         blink_on: bool,
         selected_tool_block: Option<usize>,
+        selection: Option<&Selection>,
     ) {
         let border_color = if focused {
             theme::border_focused_color()
@@ -233,6 +286,50 @@ impl ConversationView {
             .scroll((u16::try_from(self.scroll_offset).unwrap_or(u16::MAX), 0));
 
         frame.render_widget(paragraph, area);
+
+        // Capture the inner-area cells so selection copy can extract exactly
+        // what the user sees (after wrapping). Then apply the selection
+        // highlight on top.
+        let inner_x = area.x.saturating_add(1);
+        let inner_y = area.y.saturating_add(1);
+        let inner_w = area.width.saturating_sub(2);
+        let inner_h = area.height.saturating_sub(2);
+        let buf = frame.buffer_mut();
+
+        let mut rows: Vec<Vec<String>> = Vec::with_capacity(inner_h as usize);
+        for y in 0..inner_h {
+            let mut row: Vec<String> = Vec::with_capacity(inner_w as usize);
+            for x in 0..inner_w {
+                let symbol = buf
+                    .cell((inner_x + x, inner_y + y))
+                    .map(|c| c.symbol().to_string())
+                    .unwrap_or_default();
+                row.push(symbol);
+            }
+            rows.push(row);
+        }
+        self.visible_cells = rows;
+
+        if let Some(sel) = selection
+            && !sel.is_empty()
+        {
+            let (start, end) = sel.normalized();
+            let highlight = Style::default().add_modifier(Modifier::REVERSED);
+            for row_idx in start.0..=end.0 {
+                if row_idx >= inner_h {
+                    break;
+                }
+                let col_start = if row_idx == start.0 { start.1 } else { 0 };
+                let col_end = if row_idx == end.0 { end.1 } else { inner_w };
+                let col_start = col_start.min(inner_w);
+                let col_end = col_end.min(inner_w).max(col_start);
+                for col in col_start..col_end {
+                    if let Some(cell) = buf.cell_mut((inner_x + col, inner_y + row_idx)) {
+                        cell.set_style(highlight);
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/tui/src/ui/help_panel.rs
+++ b/tui/src/ui/help_panel.rs
@@ -74,6 +74,8 @@ pub fn help_lines() -> Vec<Line<'static>> {
         key_line("Up/Down", "Scroll / History", normal),
         key_line("PgUp/PgDn", "Page scroll", normal),
         key_line("Mouse wheel", "Chat scroll", normal),
+        key_line("Click+drag", "Select / copy", normal),
+        key_line("Esc", "Clear selection", normal),
         key_line("F1", "Toggle help", normal),
         key_line("F2", "Collapse tool", normal),
         key_line("F3", "Color mode", normal),

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -130,6 +130,7 @@ pub fn render(frame: &mut Frame, app: &mut App) {
         app.focus == Focus::Conversation,
         app.blink_on,
         app.selected_tool_block,
+        app.selection.as_ref(),
     );
 
     // Render help panel


### PR DESCRIPTION
## Summary

- Click-drag inside the conversation viewport now anchors and extends an in-app selection; mouse-up copies the selected text to the system clipboard via `arboard`.
- Ctrl+C copies the active selection (falls through to the existing abort/quit behavior when no selection is active). Esc clears an active selection (falls through otherwise).
- Mouse capture stays enabled so scroll wheel still works. Scroll clears an active selection.

## Implementation notes

- Selection is cell-based, anchored in coordinates inside the conversation's inner area. `Selection::normalized()` yields row-major ordered `(start, end)`.
- Rendering: after the `Paragraph` draws, we capture the inner-area cells as `Vec<Vec<String>>` indexed `[row][col]`, then apply `Modifier::REVERSED` to the cells in the normalized selection. Copy text is extracted from that captured grid so it matches exactly what the user sees (wrapping included); the `│ ` gutter prefix is stripped per line.
- Drag clamps to the viewport edges so selection extends naturally even when the pointer leaves the area.
- On terminals that honor Shift/Option/Fn bypass (kitty, Alacritty, WezTerm, Ghostty, iTerm2 with Option, Terminal.app with Fn), native terminal selection continues to work unchanged.

## Test plan

- [x] `cargo build -p swink-agent-tui`
- [x] `cargo clippy -p swink-agent-tui --lib --tests --all-targets` (clean)
- [x] `cargo test -p swink-agent-tui` (288 lib + 22 integration + 1 doctest)
- [ ] Manual: click-drag a multi-line range, confirm highlight and clipboard contents
- [ ] Manual: Ctrl+C copies; Esc clears
- [ ] Manual: scroll wheel still scrolls and clears selection
- [ ] Manual: Shift/Option+drag (terminal-native) still works on kitty / iTerm2

🤖 Generated with [Claude Code](https://claude.com/claude-code)