### PR TITLE
[codex] Document local-LLM libclang prerequisite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,8 @@ cargo clippy --workspace -- -D warnings           # zero warnings policy
 cargo run -p swink-agent-tui                      # launch TUI (.env auto-loaded)
 ```
 
+Workspace-wide `build` / `test` / `clippy` commands compile `swink-agent-local-llm`, which currently pulls `llama-cpp-sys-2` and its `bindgen` build step. Install LLVM/libclang first and set `LIBCLANG_PATH` if your platform does not auto-discover the shared library (especially common on Windows).
+
 MSRV **1.88** (edition 2024). Common workspace deps are centralized in root `Cargo.toml`, with a few crate-specific dependencies declared locally where needed.
 
 ## Branch Model

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ cargo run -p swink-agent-tui --features local  # include bundled local-LLM suppo
 cargo test --workspace             # run all tests
 ```
 
+Workspace-wide `cargo build/test/clippy` commands also compile `swink-agent-local-llm`. That crate currently depends on `llama-cpp-sys-2`, so contributor machines need LLVM/libclang available for `bindgen`; if auto-discovery fails, set `LIBCLANG_PATH` to the LLVM `bin` directory before running workspace checks.
+
 ## Example: Build a Custom Agent
 
 Wire up an LLM provider, register tools, and launch the interactive TUI — all in one file:

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -3,6 +3,7 @@
 ## Prerequisites
 
 - **Rust 1.88+** (edition 2024)
+- **LLVM/libclang** available for workspace-wide `cargo build/test/clippy` commands because `swink-agent-local-llm` builds `llama-cpp-sys-2` via `bindgen`
 - At least one LLM provider:
   - [Ollama](https://ollama.ai) running locally (no key required)
   - An Anthropic API key
@@ -21,6 +22,8 @@
 git clone <repo-url> && cd swink-agent
 cargo build --workspace
 ```
+
+If `cargo build --workspace` fails with `Unable to find libclang` or asks for `LIBCLANG_PATH`, install LLVM and point `LIBCLANG_PATH` at the directory containing `libclang` (`bin` on Windows LLVM installs).
 
 ## Configure a Provider
 
@@ -82,6 +85,12 @@ Keys can also be stored in the OS keychain instead of env vars — the first-run
 |---|---|
 | `OLLAMA_HOST` | `http://localhost:11434` |
 | `OLLAMA_MODEL` | `llama3.2` |
+
+**Local build prerequisite**
+
+| Variable | Default | Description |
+|---|---|---|
+| `LIBCLANG_PATH` | auto-discovered | Directory containing `libclang` / `clang.dll` when `llama-cpp-sys-2` bindgen cannot find LLVM automatically |
 
 ## Run the TUI
 

--- a/docs/testing_setup.md
+++ b/docs/testing_setup.md
@@ -20,6 +20,8 @@ cargo build --workspace
 
 This compiles all workspace crates: core library, adapters, local-llm, memory, eval, and TUI. First build pulls dependencies and takes a few minutes.
 
+`swink-agent-local-llm` currently builds `llama-cpp-sys-2`, which runs `bindgen` during compilation. Install LLVM/libclang before running workspace-wide commands; if the build reports `Unable to find libclang`, set `LIBCLANG_PATH` to the LLVM directory that contains the shared library (`bin` on Windows).
+
 ## 3. Run Unit Tests
 
 Verify everything compiles and passes before connecting to live APIs:
@@ -70,6 +72,8 @@ Ollama runs entirely on your machine — no account, no API key, no cost.
 ### Local On-Device (swink-agent-local-llm)
 
 No API key needed. Models are lazily downloaded from HuggingFace on first use and cached in `~/.cache/huggingface/hub/`.
+
+Build prerequisite: local-LLM compilation currently requires LLVM/libclang because `llama-cpp-sys-2` uses `bindgen`. On Windows, the usual fix is installing LLVM and setting `LIBCLANG_PATH` to something like `C:\Program Files\LLVM\bin` before running `cargo build/test/clippy --workspace`.
 
 - **SmolLM3-3B** (GGUF Q4_K_M, ~1.92 GB) — text generation, tool use, reasoning
 - **EmbeddingGemma-300M** (<200 MB) — text vectorization/embeddings

--- a/local-llm/AGENTS.md
+++ b/local-llm/AGENTS.md
@@ -35,6 +35,7 @@
 - **Gemma 4 partial delimiter matching must be UTF-8 safe** — when scanning for split `<|channel>thought\n` and `<tool_call|>` delimiters, only slice `&str` values at character boundaries. Reuse the shared suffix helper in `stream.rs`; raw byte-offset suffix slicing can panic on multibyte output.
 - **Two converter types** — `LocalConverter` (SmolLM3) and `Gemma4LocalConverter` (Gemma 4) both implement `MessageConverter`. `convert_context_messages` dispatches based on `config.is_gemma4()`.
 - **LazyLoader waiters must treat `Unloaded` as terminal for the current attempt** — `wait_until_ready()` now returns on `Unloaded`/`Failed` as well as `Ready`, and `ensure_ready()` re-checks loader state after every wakeup so an `unload()` during another caller's load does not strand waiters forever.
+- Workspace-wide `cargo build` / `test` / `clippy` now compile `llama-cpp-sys-2` through this crate, so contributors need LLVM/libclang installed and Windows contributors commonly need `LIBCLANG_PATH` pointed at the LLVM `bin` directory.
 
 ## Design Decisions
 


### PR DESCRIPTION
## What changed
- documented in the root contributor guide that workspace-wide `cargo build/test/clippy` commands now compile `swink-agent-local-llm` and therefore require LLVM/libclang
- added the same prerequisite and `LIBCLANG_PATH` guidance to the README, `docs/getting_started.md`, and `docs/testing_setup.md`
- recorded the crate-local lesson in `local-llm/AGENTS.md` so future local-LLM work keeps the prerequisite visible

## Why / value
Workspace-wide quality commands currently fail on default Windows setups with a bindgen panic when `libclang` is missing. This patch makes the prerequisite explicit where contributors first look, so the failure is actionable instead of surprising.

## Slice completed
Completed the documentation slice of issue #603: contributor-facing guidance now calls out the LLVM/libclang prerequisite and the `LIBCLANG_PATH` fallback.

## What remains
If maintainers want a code-level ergonomics improvement later, the separate follow-up would be to make workspace QA paths optionally exclude local inference builds when LLVM is unavailable. That behavior change is not part of this docs-only PR.

## Validation output
- `git diff --check`
- `cargo build --workspace` -> fails in `llama-cpp-sys-2` build script with `Unable to find libclang ... set the LIBCLANG_PATH environment variable`
- `cargo test --workspace --features testkit` -> fails at the same `llama-cpp-sys-2` / `bindgen` step with the same missing-`libclang` error
- `cargo clippy --workspace -- -D warnings` -> fails at the same `llama-cpp-sys-2` / `bindgen` step with the same missing-`libclang` error

## Pre-existing baseline failures
- This environment does not have LLVM/libclang configured for `llama-cpp-sys-2`, so current workspace-wide build/test/clippy commands fail before reaching unrelated crates.

Closes #603