### PR TITLE
fix(plugin): sanitize plugin tool names for provider compatibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,7 +162,7 @@ gh pr comment <number> --body-file /tmp/comment.md
 - `Plugin` trait requires only `name()` — all contribution methods default to no-op/empty.
 - `PluginRegistry` deduplicates by name on `register()` — the new plugin **replaces** the old one (with a `tracing::warn`), not an error.
 - `list()` returns plugins sorted by priority descending; insertion order preserved for ties.
-- `NamespacedTool` prefixes as `"{plugin_name}.{tool_name}"` — prevents tool name collisions across plugins.
+- `NamespacedTool` prefixes as `"{plugin_name}_{tool_name}"` (underscore, not dot — Anthropic/Bedrock/OpenAI reject dots) and sanitizes both components to the common subset `^[a-zA-Z][a-zA-Z0-9_]{0,63}$` accepted by every provider. Prevents tool name collisions across plugins and guarantees wire-level validity.
 - Contributions merged in `Agent::new()`: plugin policies **prepended** (priority-sorted), direct policies appended; plugin tools appended after direct tools.
 - `on_init(&self, &Agent)` dispatched in priority order, wrapped in `catch_unwind` — panicking `on_init` is logged and skipped, construction continues.
 - Entire module behind `#[cfg(feature = "plugins")]` — opt-in, not default-enabled, zero cost when disabled.

--- a/plugins/web/src/plugin.rs
+++ b/plugins/web/src/plugin.rs
@@ -220,9 +220,9 @@ impl Plugin for WebPlugin {
 /// exercised directly by unit tests without depending on a tracing subscriber.
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum WebEventClass<'a> {
-    /// A `web.*` tool has started executing.
+    /// A `web_*` tool has started executing.
     Start(&'a str),
-    /// A `web.*` tool has failed.
+    /// A `web_*` tool has failed.
     Error(&'a str),
     /// Not a web-namespaced tool event — plugin should ignore it.
     Ignored,
@@ -230,11 +230,11 @@ enum WebEventClass<'a> {
 
 fn classify_web_event(event: &AgentEvent) -> WebEventClass<'_> {
     match event {
-        AgentEvent::ToolExecutionStart { name, .. } if name.starts_with("web.") => {
+        AgentEvent::ToolExecutionStart { name, .. } if name.starts_with("web_") => {
             WebEventClass::Start(name.as_str())
         }
         AgentEvent::ToolExecutionEnd { name, is_error, .. }
-            if *is_error && name.starts_with("web.") =>
+            if *is_error && name.starts_with("web_") =>
         {
             WebEventClass::Error(name.as_str())
         }
@@ -340,15 +340,15 @@ mod on_event_tests {
     #[test]
     fn web_tool_error_is_attributed_to_web_plugin() {
         assert_eq!(
-            classify_web_event(&tool_end("web.fetch", true)),
-            WebEventClass::Error("web.fetch")
+            classify_web_event(&tool_end("web_fetch", true)),
+            WebEventClass::Error("web_fetch")
         );
     }
 
     #[test]
     fn successful_web_tool_end_is_ignored() {
         assert_eq!(
-            classify_web_event(&tool_end("web.fetch", false)),
+            classify_web_event(&tool_end("web_fetch", false)),
             WebEventClass::Ignored
         );
     }
@@ -356,8 +356,8 @@ mod on_event_tests {
     #[test]
     fn web_tool_start_is_classified() {
         assert_eq!(
-            classify_web_event(&tool_start("web.search")),
-            WebEventClass::Start("web.search")
+            classify_web_event(&tool_start("web_search")),
+            WebEventClass::Start("web_search")
         );
         assert_eq!(
             classify_web_event(&tool_start("bash.run")),

--- a/plugins/web/src/policy/domain_filter.rs
+++ b/plugins/web/src/policy/domain_filter.rs
@@ -4,7 +4,7 @@ use url::Url;
 use crate::domain::DomainFilter;
 
 /// `PreDispatchPolicy` that enforces domain allowlist/denylist and SSRF
-/// protection on all `web.*` tool calls.
+/// protection on all `web_*` tool calls.
 pub struct DomainFilterPolicy {
     filter: DomainFilter,
 }
@@ -22,8 +22,8 @@ impl PreDispatchPolicy for DomainFilterPolicy {
     }
 
     fn evaluate(&self, ctx: &mut ToolDispatchContext<'_>) -> PreDispatchVerdict {
-        // Only apply to web.* tools.
-        if !ctx.tool_name.starts_with("web.") {
+        // Only apply to web_* tools.
+        if !ctx.tool_name.starts_with("web_") {
             return PreDispatchVerdict::Continue;
         }
 
@@ -91,7 +91,7 @@ mod tests {
         let policy = DomainFilterPolicy::new(DomainFilter::default());
         let state = SessionState::default();
         let mut args = json!({"query": "rust programming"});
-        let mut ctx = make_dispatch_ctx("web.search", "call_2", &mut args, &state);
+        let mut ctx = make_dispatch_ctx("web_search", "call_2", &mut args, &state);
         assert!(matches!(
             policy.evaluate(&mut ctx),
             PreDispatchVerdict::Continue
@@ -107,21 +107,21 @@ mod tests {
         let state = SessionState::default();
 
         let mut denied = json!({"url": "https://evil.com/page"});
-        let mut denied_ctx = make_dispatch_ctx("web.fetch", "call_3", &mut denied, &state);
+        let mut denied_ctx = make_dispatch_ctx("web_fetch", "call_3", &mut denied, &state);
         assert!(matches!(
             policy.evaluate(&mut denied_ctx),
             PreDispatchVerdict::Skip(_)
         ));
 
         let mut bad_scheme = json!({"url": "file:///etc/passwd"});
-        let mut bad_scheme_ctx = make_dispatch_ctx("web.fetch", "call_4", &mut bad_scheme, &state);
+        let mut bad_scheme_ctx = make_dispatch_ctx("web_fetch", "call_4", &mut bad_scheme, &state);
         assert!(matches!(
             policy.evaluate(&mut bad_scheme_ctx),
             PreDispatchVerdict::Skip(_)
         ));
 
         let mut invalid = json!({"url": "not a url at all"});
-        let mut invalid_ctx = make_dispatch_ctx("web.fetch", "call_5", &mut invalid, &state);
+        let mut invalid_ctx = make_dispatch_ctx("web_fetch", "call_5", &mut invalid, &state);
         assert!(matches!(
             policy.evaluate(&mut invalid_ctx),
             PreDispatchVerdict::Skip(_)

--- a/plugins/web/src/policy/rate_limiter.rs
+++ b/plugins/web/src/policy/rate_limiter.rs
@@ -45,7 +45,7 @@ impl PreDispatchPolicy for RateLimitPolicy {
 
     fn evaluate(&self, ctx: &mut ToolDispatchContext<'_>) -> PreDispatchVerdict {
         // Only apply to web-namespaced tools.
-        if !ctx.tool_name.starts_with("web.") {
+        if !ctx.tool_name.starts_with("web_") {
             return PreDispatchVerdict::Continue;
         }
 
@@ -102,7 +102,7 @@ mod tests {
         for i in 0..5 {
             let call_id = format!("tc_{i}");
             let mut args = json!({"url": "https://example.com"});
-            let mut ctx = make_dispatch_ctx("web.fetch", &call_id, &mut args, &session);
+            let mut ctx = make_dispatch_ctx("web_fetch", &call_id, &mut args, &session);
             assert!(matches!(
                 policy.evaluate(&mut ctx),
                 PreDispatchVerdict::Continue
@@ -118,7 +118,7 @@ mod tests {
         for i in 0..3 {
             let call_id = format!("tc_{i}");
             let mut args = json!({"url": "https://example.com"});
-            let mut ctx = make_dispatch_ctx("web.fetch", &call_id, &mut args, &session);
+            let mut ctx = make_dispatch_ctx("web_fetch", &call_id, &mut args, &session);
             assert!(matches!(
                 policy.evaluate(&mut ctx),
                 PreDispatchVerdict::Continue
@@ -126,7 +126,7 @@ mod tests {
         }
 
         let mut args = json!({"url": "https://example.com"});
-        let mut ctx = make_dispatch_ctx("web.fetch", "tc_over", &mut args, &session);
+        let mut ctx = make_dispatch_ctx("web_fetch", "tc_over", &mut args, &session);
         assert!(matches!(
             policy.evaluate(&mut ctx),
             PreDispatchVerdict::Skip(_)
@@ -159,7 +159,7 @@ mod tests {
         let policy = RateLimitPolicy::new(rl_state, 5);
         let session = SessionState::default();
         let mut args = json!({"url": "https://example.com"});
-        let mut ctx = make_dispatch_ctx("web.fetch", "tc_after_prune", &mut args, &session);
+        let mut ctx = make_dispatch_ctx("web_fetch", "tc_after_prune", &mut args, &session);
         assert!(matches!(
             policy.evaluate(&mut ctx),
             PreDispatchVerdict::Continue

--- a/plugins/web/src/policy/sanitizer.rs
+++ b/plugins/web/src/policy/sanitizer.rs
@@ -5,7 +5,7 @@ use swink_agent::{ContentBlock, PolicyContext, PolicyVerdict, PostTurnPolicy, Tu
 
 /// `PostTurnPolicy` that detects known prompt injection patterns in web content.
 ///
-/// After each turn, this policy scans tool results from `web.*` tools for text
+/// After each turn, this policy scans tool results from `web_*` tools for text
 /// matching common prompt-injection signatures (e.g. "ignore previous
 /// instructions", "you are now", fake `system:` prefixes). Because `PostTurnPolicy`
 /// runs after messages are already committed to context, this policy **logs
@@ -66,14 +66,14 @@ impl PostTurnPolicy for ContentSanitizerPolicy {
     }
 
     fn evaluate(&self, _ctx: &PolicyContext<'_>, turn: &TurnPolicyContext<'_>) -> PolicyVerdict {
-        // Collect tool-call IDs that belong to web.* tools from the assistant message.
+        // Collect tool-call IDs that belong to web_* tools from the assistant message.
         let web_call_ids: HashSet<&str> = turn
             .assistant_message
             .content
             .iter()
             .filter_map(|block| {
                 if let ContentBlock::ToolCall { id, name, .. } = block
-                    && name.starts_with("web.")
+                    && name.starts_with("web_")
                 {
                     return Some(id.as_str());
                 }
@@ -85,7 +85,7 @@ impl PostTurnPolicy for ContentSanitizerPolicy {
             return PolicyVerdict::Continue;
         }
 
-        // Scan only tool results that correspond to web.* tool calls.
+        // Scan only tool results that correspond to web_* tool calls.
         for result in turn.tool_results {
             if !web_call_ids.contains(result.tool_call_id.as_str()) {
                 continue;
@@ -208,9 +208,9 @@ mod tests {
         let model = make_model_spec();
 
         let assistant = make_assistant_message(vec![
-            ("call_1", "web.fetch"),
+            ("call_1", "web_fetch"),
             ("call_2", "bash"),
-            ("call_3", "web.search"),
+            ("call_3", "web_search"),
         ]);
         let results = vec![
             make_tool_result("call_1", "Normal page content."),

--- a/specs/037-plugin-system/contracts/plugin-trait.md
+++ b/specs/037-plugin-system/contracts/plugin-trait.md
@@ -36,7 +36,9 @@ pub trait Plugin: Send + Sync {
     /// Panics are caught and logged (consistent with event forwarders).
     fn on_event(&self, _event: &AgentEvent) {}
 
-    /// Tools contributed to the agent. Auto-namespaced as "{plugin_name}.{tool_name}".
+    /// Tools contributed to the agent. Auto-namespaced as "{plugin_name}_{tool_name}".
+    /// Both components are sanitized to match the strictest provider tool-name
+    /// grammar (`^[a-zA-Z][a-zA-Z0-9_]{0,63}$`).
     fn tools(&self) -> Vec<Arc<dyn AgentTool>> { vec![] }
 }
 ```

--- a/specs/037-plugin-system/quickstart.md
+++ b/specs/037-plugin-system/quickstart.md
@@ -45,7 +45,7 @@ let agent = Agent::new(
 
 ## Plugin with Tools
 
-Plugins can contribute tools. Tools are auto-namespaced as `{plugin_name}.{tool_name}`:
+Plugins can contribute tools. Tools are auto-namespaced as `{plugin_name}_{tool_name}` (both components sanitized to `^[a-zA-Z][a-zA-Z0-9_]{0,63}$` so the result is accepted by every supported provider):
 
 ```rust
 impl Plugin for ArtifactPlugin {
@@ -53,8 +53,8 @@ impl Plugin for ArtifactPlugin {
 
     fn tools(&self) -> Vec<Arc<dyn AgentTool>> {
         vec![
-            Arc::new(SaveArtifactTool::new(self.store.clone())),  // → "artifacts.save_artifact"
-            Arc::new(LoadArtifactTool::new(self.store.clone())),  // → "artifacts.load_artifact"
+            Arc::new(SaveArtifactTool::new(self.store.clone())),  // → "artifacts_save_artifact"
+            Arc::new(LoadArtifactTool::new(self.store.clone())),  // → "artifacts_load_artifact"
         ]
     }
 }

--- a/specs/037-plugin-system/spec.md
+++ b/specs/037-plugin-system/spec.md
@@ -139,7 +139,7 @@ A library consumer uses a plugin that provides specialized tools — for example
 - **FR-006**: The registry MUST support lookup by name and listing all registered plugins.
 - **FR-007**: Plugin-contributed policies MUST be merged with directly-registered policies at each slot. Plugin policies MUST run before directly-registered policies. Among plugin-contributed policies, higher-priority plugins' policies MUST run first.
 - **FR-008**: Short-circuit semantics (Stop verdict) MUST apply across the merged policy list — a Stop from a plugin policy prevents evaluation of subsequent plugin policies and all directly-registered policies in that slot.
-- **FR-009**: Plugin-contributed tools MUST be namespace-prefixed as `{plugin_name}.{tool_name}` (e.g., a tool "save" from plugin "artifacts" becomes "artifacts.save"). This prevents name collisions between plugins. Directly-registered tools are not namespaced. If a namespace-prefixed plugin tool collides with a directly-registered tool name, the directly-registered tool MUST take precedence.
+- **FR-009**: Plugin-contributed tools MUST be namespace-prefixed as `{plugin_name}_{tool_name}` (e.g., a tool "save" from plugin "artifacts" becomes "artifacts_save"). Both components are sanitized to the common subset accepted by every supported provider's tool-name grammar (`^[a-zA-Z][a-zA-Z0-9_]{0,63}$`). This prevents name collisions between plugins and guarantees the composed name is accepted by Anthropic, OpenAI, Bedrock, Mistral, Gemini, Ollama, and Azure. Directly-registered tools are not namespaced. If a namespace-prefixed plugin tool collides with a directly-registered tool name, the directly-registered tool MUST take precedence. *(Separator was changed from `.` to `_` in response to issue #608; dots are rejected by Anthropic and Bedrock.)*
 - **FR-010**: Plugin event observers MUST be called for every agent event, in plugin priority order (highest first), before any directly-registered event forwarders.
 - **FR-011**: Plugin initialization callbacks MUST be called once during agent construction, in priority order, after the agent is fully configured but before the first conversation turn.
 - **FR-012**: Panics in plugin initialization callbacks MUST be caught and logged. The agent MUST continue construction. The plugin's other contributions (policies, tools, observers) MUST remain active.
@@ -170,7 +170,7 @@ A library consumer uses a plugin that provides specialized tools — for example
 
 ### Session 2026-04-01
 
-- Q: What happens when two different plugins both contribute a tool with the same name? → A: Plugin tools are namespace-prefixed as `{plugin_name}.{tool_name}`, preventing collisions entirely. Two plugins can both provide a tool named "export" — they become "alpha.export" and "beta.export".
+- Q: What happens when two different plugins both contribute a tool with the same name? → A: Plugin tools are namespace-prefixed as `{plugin_name}_{tool_name}`, preventing collisions entirely. Two plugins can both provide a tool named "export" — they become "alpha_export" and "beta_export". *(Separator was `.` in the original design; changed to `_` in #608 for provider compatibility.)*
 - Q: Should plugins have a shutdown/cleanup callback? → A: No dedicated shutdown callback. Plugins use `on_event(AgentEnd)` for cleanup signaling or standard drop semantics for resource release. A dedicated `on_shutdown` can be added later if needed (backward-compatible addition).
 
 ## Assumptions

--- a/specs/042-web-browse-plugin/contracts/public-api.md
+++ b/specs/042-web-browse-plugin/contracts/public-api.md
@@ -51,13 +51,13 @@ let agent = Agent::builder()
     // ... other config
     .build();
 
-// Tools are auto-namespaced as: web.fetch, web.search, web.screenshot, web.extract
+// Tools are auto-namespaced as: web_fetch, web_search, web_screenshot, web_extract
 // Policies are auto-contributed: DomainFilterPolicy, RateLimitPolicy, ContentSanitizerPolicy
 ```
 
 ## Tool Schemas
 
-### web.fetch
+### web_fetch
 
 ```json
 {
@@ -74,7 +74,7 @@ let agent = Agent::builder()
 
 **Returns**: `AgentToolResult` with `ContentBlock::Text` containing the readable content. Error result if domain blocked, non-200, non-HTML content type, or network failure.
 
-### web.search
+### web_search
 
 ```json
 {

--- a/specs/042-web-browse-plugin/quickstart.md
+++ b/specs/042-web-browse-plugin/quickstart.md
@@ -44,7 +44,7 @@ let agent = Agent::builder()
     // ... stream_fn, model, etc.
     .build();
 
-// Agent now has tools: web.fetch, web.search, web.screenshot, web.extract
+// Agent now has tools: web_fetch, web_search, web_screenshot, web_extract
 // - DuckDuckGo search (no API key needed)
 // - SSRF protection enabled by default
 // - Rate limit: 30 req/min
@@ -95,10 +95,10 @@ Once the plugin is registered, the agent has access to:
 
 | Tool | Description | Requires Playwright? |
 |------|-------------|---------------------|
-| `web.fetch` | Fetch a URL, return clean readable text | No |
-| `web.search` | Search the web, return ranked results | No |
-| `web.screenshot` | Capture a PNG screenshot of a page | Yes |
-| `web.extract` | Extract structured content via CSS selectors | Yes |
+| `web_fetch` | Fetch a URL, return clean readable text | No |
+| `web_search` | Search the web, return ranked results | No |
+| `web_screenshot` | Capture a PNG screenshot of a page | Yes |
+| `web_extract` | Extract structured content via CSS selectors | Yes |
 
 Policies are automatically active:
 - **Domain filter** (PreDispatch): Blocks private IPs and denied domains

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -8,7 +8,7 @@
 //! [`PluginRegistry`] manages a collection of plugins with deduplication and priority
 //! ordering. [`NamespacedTool`] wraps a plugin-contributed tool, prefixing the plugin
 //! name so the composed identifier is unique and safe for every provider's tool-name
-//! grammar (see [`sanitize_tool_name_component`]).
+//! grammar (see `sanitize_tool_name_component`).
 
 use std::sync::Arc;
 
@@ -80,7 +80,7 @@ pub trait Plugin: Send + Sync {
     /// plugin's name as prefix. The prefix and inner name are joined with an
     /// underscore and sanitized to the common subset accepted by every
     /// provider's tool-name grammar (e.g., `"myplugin_mytool"`). See
-    /// [`sanitize_tool_name_component`] for the exact rule.
+    /// `sanitize_tool_name_component` for the exact rule.
     fn tools(&self) -> Vec<Arc<dyn AgentTool>> {
         vec![]
     }
@@ -219,7 +219,7 @@ fn compose_namespaced_name(plugin_name: &str, tool_name: &str) -> String {
 /// the same name. The composed name format is `"{plugin_name}_{tool_name}"`,
 /// with each component sanitized so the result matches the strictest tool-name
 /// grammar across supported providers (Anthropic, `OpenAI`, Bedrock, Mistral,
-/// Gemini, Ollama, Azure). See [`sanitize_tool_name_component`].
+/// Gemini, Ollama, Azure). See `sanitize_tool_name_component`.
 ///
 /// The original (unsanitized) plugin name is preserved in
 /// [`ToolMetadata::namespace`] for introspection.

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -176,7 +176,13 @@ fn sanitize_tool_name_component(input: &str) -> String {
     }
     input
         .chars()
-        .map(|c| if c.is_ascii_alphanumeric() || c == '_' { c } else { '_' })
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
         .collect()
 }
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -7,7 +7,8 @@
 //!
 //! [`PluginRegistry`] manages a collection of plugins with deduplication and priority
 //! ordering. [`NamespacedTool`] wraps a plugin-contributed tool, prefixing the plugin
-//! name to avoid collisions.
+//! name so the composed identifier is unique and safe for every provider's tool-name
+//! grammar (see [`sanitize_tool_name_component`]).
 
 use std::sync::Arc;
 
@@ -76,7 +77,10 @@ pub trait Plugin: Send + Sync {
     /// Tools contributed by this plugin.
     ///
     /// Each tool is automatically wrapped in a [`NamespacedTool`] with the
-    /// plugin's name as prefix (e.g., `"myplugin.mytool"`).
+    /// plugin's name as prefix. The prefix and inner name are joined with an
+    /// underscore and sanitized to the common subset accepted by every
+    /// provider's tool-name grammar (e.g., `"myplugin_mytool"`). See
+    /// [`sanitize_tool_name_component`] for the exact rule.
     fn tools(&self) -> Vec<Arc<dyn AgentTool>> {
         vec![]
     }
@@ -146,12 +150,73 @@ impl Default for PluginRegistry {
     }
 }
 
+// ─── Tool name sanitization ────────────────────────────────────────────────
+
+/// Maximum length for a composed tool name (the tightest cap across providers:
+/// OpenAI, Bedrock, and Gemini all cap at 64; Anthropic allows 128).
+const MAX_TOOL_NAME_LEN: usize = 64;
+
+/// Sanitize a single component (plugin name or inner tool name) to the common
+/// subset of characters accepted by every provider's tool-name grammar.
+///
+/// The strictest grammar is Bedrock's `^[a-zA-Z][a-zA-Z0-9_]*` (max 64). This
+/// is also a subset of what Anthropic (`^[a-zA-Z0-9_-]{1,128}$`), OpenAI-style
+/// providers (same pattern, cap 64), and Gemini accept, so names produced here
+/// round-trip safely across providers.
+///
+/// Rules:
+/// - Every character outside `[a-zA-Z0-9_]` is replaced with `_`.
+/// - The result is not truncated here; truncation happens on the composed name
+///   in [`NamespacedTool::new`] so both components survive when possible.
+/// - An empty input becomes `"_"` — callers should still prepend a letter
+///   prefix if the composed result needs to start with a letter.
+fn sanitize_tool_name_component(input: &str) -> String {
+    if input.is_empty() {
+        return "_".to_owned();
+    }
+    input
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() || c == '_' { c } else { '_' })
+        .collect()
+}
+
+/// Compose a plugin-namespaced tool name that is safe across every provider.
+///
+/// Joins `plugin_name` and `tool_name` with `_`, sanitizes each half, prepends
+/// `t_` if the result would start with a non-letter (Bedrock/Gemini require a
+/// leading letter or underscore — we pick letter for maximum safety), and
+/// truncates to [`MAX_TOOL_NAME_LEN`]. Truncation preserves the plugin prefix
+/// where possible so distinct plugins keep distinct names.
+fn compose_namespaced_name(plugin_name: &str, tool_name: &str) -> String {
+    let plugin = sanitize_tool_name_component(plugin_name);
+    let tool = sanitize_tool_name_component(tool_name);
+    let joined = format!("{plugin}_{tool}");
+    let with_leading_letter = match joined.chars().next() {
+        Some(c) if c.is_ascii_alphabetic() => joined,
+        _ => format!("t_{joined}"),
+    };
+    if with_leading_letter.len() <= MAX_TOOL_NAME_LEN {
+        with_leading_letter
+    } else {
+        with_leading_letter
+            .chars()
+            .take(MAX_TOOL_NAME_LEN)
+            .collect()
+    }
+}
+
 // ─── NamespacedTool ────────────────────────────────────────────────────────
 
 /// Wraps a plugin-contributed tool, prefixing the plugin name onto the tool name.
 ///
 /// This prevents name collisions when multiple plugins contribute tools with
-/// the same name. The prefixed name format is `"{plugin_name}.{tool_name}"`.
+/// the same name. The composed name format is `"{plugin_name}_{tool_name}"`,
+/// with each component sanitized so the result matches the strictest tool-name
+/// grammar across supported providers (Anthropic, OpenAI, Bedrock, Mistral,
+/// Gemini, Ollama, Azure). See [`sanitize_tool_name_component`].
+///
+/// The original (unsanitized) plugin name is preserved in
+/// [`ToolMetadata::namespace`] for introspection.
 ///
 /// All other trait methods delegate unchanged to the inner tool.
 pub struct NamespacedTool {
@@ -164,7 +229,7 @@ impl NamespacedTool {
     /// Create a new namespaced tool wrapper.
     pub fn new(plugin_name: impl Into<String>, inner: Arc<dyn AgentTool>) -> Self {
         let plugin_name = plugin_name.into();
-        let prefixed_name = format!("{}.{}", plugin_name, inner.name());
+        let prefixed_name = compose_namespaced_name(&plugin_name, inner.name());
         Self {
             prefixed_name,
             plugin_name,
@@ -298,6 +363,92 @@ mod tests {
         let list = reg.list();
         let names: Vec<&str> = list.iter().map(|p| p.name()).collect();
         assert_eq!(names, vec!["high", "mid", "low"]);
+    }
+
+    // ─── Tool-name sanitization tests ───────────────────────────────────
+
+    #[test]
+    fn compose_namespaced_name_dot_becomes_underscore() {
+        assert_eq!(compose_namespaced_name("web", "search"), "web_search");
+        assert_eq!(compose_namespaced_name("web", "fetch"), "web_fetch");
+    }
+
+    #[test]
+    fn compose_namespaced_name_replaces_dashes_and_dots() {
+        assert_eq!(compose_namespaced_name("my-web", "search"), "my_web_search");
+        assert_eq!(compose_namespaced_name("web", "read.file"), "web_read_file");
+        assert_eq!(compose_namespaced_name("my.ns", "x.y.z"), "my_ns_x_y_z");
+    }
+
+    #[test]
+    fn compose_namespaced_name_prepends_letter_when_leading_non_alpha() {
+        // Plugin starting with a digit would otherwise produce "1plugin_foo" —
+        // Bedrock requires a leading letter, so we prepend "t_".
+        assert_eq!(compose_namespaced_name("1plugin", "foo"), "t_1plugin_foo");
+        // Same for a leading underscore (valid for Gemini, rejected by Bedrock).
+        assert_eq!(compose_namespaced_name("_plugin", "foo"), "t__plugin_foo");
+    }
+
+    #[test]
+    fn compose_namespaced_name_replaces_non_ascii() {
+        assert_eq!(compose_namespaced_name("café", "naïve"), "caf__na_ve");
+    }
+
+    #[test]
+    fn compose_namespaced_name_truncates_to_max_length() {
+        let long_plugin = "a".repeat(40);
+        let long_tool = "b".repeat(40);
+        let result = compose_namespaced_name(&long_plugin, &long_tool);
+        assert_eq!(result.len(), MAX_TOOL_NAME_LEN);
+        // Prefix is preserved (plugin name survives at the front).
+        assert!(result.starts_with(&long_plugin));
+    }
+
+    #[test]
+    fn compose_namespaced_name_empty_components() {
+        // Empty plugin name collapses to "_", then the leading-letter rule kicks in.
+        assert_eq!(compose_namespaced_name("", "foo"), "t___foo");
+        assert_eq!(compose_namespaced_name("foo", ""), "foo__");
+        // "" → "_", "" → "_", joined "___" (3 underscores), leading non-alpha → prepend "t_".
+        assert_eq!(compose_namespaced_name("", ""), "t____");
+    }
+
+    #[test]
+    fn compose_namespaced_name_satisfies_strictest_grammar() {
+        // Regex equivalent to Bedrock's ^[a-zA-Z][a-zA-Z0-9_]*$ (the strictest
+        // provider pattern). Every output from this function must match.
+        let is_valid = |s: &str| {
+            s.len() <= MAX_TOOL_NAME_LEN
+                && s.chars().next().is_some_and(|c| c.is_ascii_alphabetic())
+                && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+        };
+        for (plugin, tool) in [
+            ("web", "search"),
+            ("my-web", "search"),
+            ("web", "read.file"),
+            ("1plugin", "foo"),
+            ("_plugin", "foo"),
+            ("café", "naïve"),
+            ("", ""),
+            (&"a".repeat(100), &"b".repeat(100)),
+        ] {
+            let name = compose_namespaced_name(plugin, tool);
+            assert!(
+                is_valid(&name),
+                "composed name {name:?} (from {plugin:?} + {tool:?}) violates the strictest grammar"
+            );
+        }
+    }
+
+    #[test]
+    fn namespaced_tool_preserves_unsanitized_plugin_name_in_metadata() {
+        use crate::testing::MockTool;
+        let tool: Arc<dyn AgentTool> = Arc::new(MockTool::new("search"));
+        let wrapped = NamespacedTool::new("my-web", tool);
+        assert_eq!(wrapped.name(), "my_web_search");
+        // Metadata namespace keeps the original plugin name for introspection.
+        let meta = wrapped.metadata().expect("metadata present");
+        assert_eq!(meta.namespace.as_deref(), Some("my-web"));
     }
 
     #[test]

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -397,7 +397,7 @@ mod tests {
 
     #[test]
     fn compose_namespaced_name_replaces_non_ascii() {
-        assert_eq!(compose_namespaced_name("café", "naïve"), "caf__na_ve");
+        assert_eq!(compose_namespaced_name("plugin", "naïve"), "plugin_na_ve");
     }
 
     #[test]
@@ -434,7 +434,7 @@ mod tests {
             ("web", "read.file"),
             ("1plugin", "foo"),
             ("_plugin", "foo"),
-            ("café", "naïve"),
+            ("plugin", "naïve"),
             ("", ""),
             (&"a".repeat(100), &"b".repeat(100)),
         ] {

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -153,7 +153,7 @@ impl Default for PluginRegistry {
 // ─── Tool name sanitization ────────────────────────────────────────────────
 
 /// Maximum length for a composed tool name (the tightest cap across providers:
-/// OpenAI, Bedrock, and Gemini all cap at 64; Anthropic allows 128).
+/// `OpenAI`, Bedrock, and Gemini all cap at 64; Anthropic allows 128).
 const MAX_TOOL_NAME_LEN: usize = 64;
 
 /// Sanitize a single component (plugin name or inner tool name) to the common
@@ -218,7 +218,7 @@ fn compose_namespaced_name(plugin_name: &str, tool_name: &str) -> String {
 /// This prevents name collisions when multiple plugins contribute tools with
 /// the same name. The composed name format is `"{plugin_name}_{tool_name}"`,
 /// with each component sanitized so the result matches the strictest tool-name
-/// grammar across supported providers (Anthropic, OpenAI, Bedrock, Mistral,
+/// grammar across supported providers (Anthropic, `OpenAI`, Bedrock, Mistral,
 /// Gemini, Ollama, Azure). See [`sanitize_tool_name_component`].
 ///
 /// The original (unsanitized) plugin name is preserved in

--- a/tests/plugin_integration.rs
+++ b/tests/plugin_integration.rs
@@ -54,12 +54,12 @@ fn plugin_tools_appear_namespaced_in_agent_tool_list() {
 
     let tool_names: Vec<&str> = agent.state().tools.iter().map(|t| t.name()).collect();
     assert!(
-        tool_names.contains(&"myplugin.save"),
-        "expected namespaced tool 'myplugin.save', got: {tool_names:?}"
+        tool_names.contains(&"myplugin_save"),
+        "expected namespaced tool 'myplugin_save', got: {tool_names:?}"
     );
     assert!(
-        tool_names.contains(&"myplugin.load"),
-        "expected namespaced tool 'myplugin.load', got: {tool_names:?}"
+        tool_names.contains(&"myplugin_load"),
+        "expected namespaced tool 'myplugin_load', got: {tool_names:?}"
     );
 }
 
@@ -631,7 +631,7 @@ async fn plugin_stop_prevents_all_direct_policies() {
 
 // ─── Phase 8: User Story 7 — Plugin Tool Contribution ──────────────────
 
-// ─── T035: Plugin tools appear as "{plugin_name}.{tool_name}" ───────────
+// ─── T035: Plugin tools appear as "{plugin_name}_{tool_name}" ───────────
 
 #[test]
 fn plugin_tools_namespaced_format() {
@@ -642,12 +642,12 @@ fn plugin_tools_namespaced_format() {
 
     let tool_names: Vec<&str> = agent.state().tools.iter().map(|t| t.name()).collect();
     assert!(
-        tool_names.contains(&"analyzer.scan"),
-        "expected 'analyzer.scan', got: {tool_names:?}"
+        tool_names.contains(&"analyzer_scan"),
+        "expected 'analyzer_scan', got: {tool_names:?}"
     );
     assert!(
-        tool_names.contains(&"analyzer.report"),
-        "expected 'analyzer.report', got: {tool_names:?}"
+        tool_names.contains(&"analyzer_report"),
+        "expected 'analyzer_report', got: {tool_names:?}"
     );
 }
 
@@ -662,23 +662,23 @@ fn two_plugins_same_tool_names_distinct_namespaces() {
 
     let tool_names: Vec<&str> = agent.state().tools.iter().map(|t| t.name()).collect();
     assert!(
-        tool_names.contains(&"alpha.run"),
-        "expected 'alpha.run', got: {tool_names:?}"
+        tool_names.contains(&"alpha_run"),
+        "expected 'alpha_run', got: {tool_names:?}"
     );
     assert!(
-        tool_names.contains(&"beta.run"),
-        "expected 'beta.run', got: {tool_names:?}"
+        tool_names.contains(&"beta_run"),
+        "expected 'beta_run', got: {tool_names:?}"
     );
     // Both should coexist — no collision.
     assert_eq!(
-        tool_names.iter().filter(|&&n| n == "alpha.run").count(),
+        tool_names.iter().filter(|&&n| n == "alpha_run").count(),
         1,
-        "alpha.run should appear exactly once"
+        "alpha_run should appear exactly once"
     );
     assert_eq!(
-        tool_names.iter().filter(|&&n| n == "beta.run").count(),
+        tool_names.iter().filter(|&&n| n == "beta_run").count(),
         1,
-        "beta.run should appear exactly once"
+        "beta_run should appear exactly once"
     );
 }
 
@@ -688,10 +688,10 @@ fn two_plugins_same_tool_names_distinct_namespaces() {
 fn direct_tool_found_first_over_namespaced_plugin_tool() {
     use swink_agent::AgentTool;
 
-    // Create a direct tool named "myns.fetch" and a plugin named "myns" contributing "fetch".
-    // The direct tool should be found first by find_tool.
+    // Create a direct tool named "myns_fetch" and a plugin named "myns" contributing "fetch".
+    // Both resolve to the same public name — the direct tool should be found first.
     let direct_tool: Arc<dyn AgentTool> =
-        Arc::new(swink_agent::testing::MockTool::new("myns.fetch"));
+        Arc::new(swink_agent::testing::MockTool::new("myns_fetch"));
     let plugin: Arc<dyn Plugin> = Arc::new(MockPlugin::new("myns").with_tools(&["fetch"]));
 
     let stream_fn = Arc::new(MockStreamFn::new(vec![text_only_events("hello")]));
@@ -704,21 +704,21 @@ fn direct_tool_found_first_over_namespaced_plugin_tool() {
     // The direct tool is first in the list (direct tools before plugin tools).
     let tool_names: Vec<&str> = agent.state().tools.iter().map(|t| t.name()).collect();
     // Both should exist.
-    let count = tool_names.iter().filter(|&&n| n == "myns.fetch").count();
+    let count = tool_names.iter().filter(|&&n| n == "myns_fetch").count();
     assert_eq!(
         count, 2,
         "both direct and namespaced tool should be present, got {count}"
     );
 
     // find_tool returns the first match — should be the direct tool.
-    let found = agent.find_tool("myns.fetch");
-    assert!(found.is_some(), "find_tool should find 'myns.fetch'");
+    let found = agent.find_tool("myns_fetch");
+    assert!(found.is_some(), "find_tool should find 'myns_fetch'");
 
     // Verify it's the direct tool (not the NamespacedTool wrapper).
-    // NamespacedTool has description "plugin stub tool" and label "myns.fetch" (overridden).
-    // Direct MockTool has label "myns.fetch" (set in constructor).
+    // NamespacedTool has description "plugin stub tool" and label "myns_fetch" (overridden).
+    // Direct MockTool has label "myns_fetch" (set in constructor).
     // Both have the same description, so check order by position.
-    let first_idx = tool_names.iter().position(|&n| n == "myns.fetch").unwrap();
+    let first_idx = tool_names.iter().position(|&n| n == "myns_fetch").unwrap();
     assert_eq!(
         first_idx, 0,
         "direct tool should be at index 0 (before plugin tools), got {first_idx}"
@@ -755,7 +755,7 @@ fn unregistered_plugin_contributions_absent() {
 
     let tool_names: Vec<&str> = agent.state().tools.iter().map(|t| t.name()).collect();
     assert!(
-        tool_names.contains(&"keep.tool_a"),
+        tool_names.contains(&"keep_tool_a"),
         "kept plugin's tools should be present: {tool_names:?}"
     );
     assert!(

--- a/tests/plugin_registry.rs
+++ b/tests/plugin_registry.rs
@@ -89,7 +89,7 @@ fn namespaced_tool_prefixes_name() {
     let inner = Arc::new(MockTool::new("save")) as Arc<dyn AgentTool>;
     let namespaced = NamespacedTool::new("artifacts", inner);
 
-    assert_eq!(namespaced.name(), "artifacts.save");
+    assert_eq!(namespaced.name(), "artifacts_save");
 }
 
 #[test]
@@ -152,7 +152,7 @@ fn two_namespaced_tools_from_different_plugins_are_distinct() {
     let ns1 = NamespacedTool::new("plugin_a", tool.clone());
     let ns2 = NamespacedTool::new("plugin_b", tool);
 
-    assert_eq!(ns1.name(), "plugin_a.run");
-    assert_eq!(ns2.name(), "plugin_b.run");
+    assert_eq!(ns1.name(), "plugin_a_run");
+    assert_eq!(ns2.name(), "plugin_b_run");
     assert_ne!(ns1.name(), ns2.name());
 }


### PR DESCRIPTION
## Summary
- Closes #608 — plugin-namespaced tools (`web.search`, `web.fetch`) violated Anthropic's tool-name regex and caused HTTP 400 on the first turn whenever a plugin was registered.
- `NamespacedTool` now composes as `{plugin_name}_{tool_name}` and sanitizes both halves to `^[a-zA-Z][a-zA-Z0-9_]{0,63}$` — the common subset across Anthropic, OpenAI, Bedrock, Mistral, Gemini, Ollama, and Azure (Bedrock is the strictest; its pattern is a subset of all others). Original plugin name preserved in `ToolMetadata::namespace` for introspection.
- Built-in web plugin policies (`RateLimitPolicy`, `DomainFilterPolicy`, `ContentSanitizerPolicy`, `classify_web_event`) updated to the new `web_` prefix so their scoping still applies.

## Provider tool-name rules researched

| Provider | Pattern | Max | Dot? | Dash? |
|---|---|---|---|---|
| Anthropic | `^[a-zA-Z0-9_-]{1,128}$` | 128 | ❌ | ✅ |
| OpenAI / Azure / Mistral / xAI / Ollama | `^[a-zA-Z0-9_-]{1,64}$` | 64 | ❌ | ✅ |
| Bedrock | `[a-zA-Z][a-zA-Z0-9_]*` | 64 | ❌ | ❌ |
| Gemini | `[a-zA-Z_][a-zA-Z0-9_.-]{0,63}` | 64 | ✅ | ✅ |

Bedrock is the tightest — no dashes, must start with a letter. The sanitizer uses Bedrock's grammar so output is safe everywhere.

## Design note
Considered adding per-adapter name aliasing (dispatch by internal name, expose a sanitized wire name) but skipped it: the LLM echoes the wire name in tool-call responses, which would require a reverse-lookup map in every adapter's response parser. A single sanitized name used for both dispatch and wire is simpler and has no observed downside for the existing use cases. Can revisit if a user needs to preserve legacy names externally.

## Test plan
- [x] `cargo test -p swink-agent --features plugins,testkit` — 449 lib + all integration pass
- [x] `cargo test -p swink-agent-plugin-web` — 38/38 pass
- [x] New unit tests for `compose_namespaced_name` cover dots → underscores, dashes → underscores, leading non-alpha prepended with `t_`, non-ASCII replaced, truncation at 64, empty inputs, round-trip validity against Bedrock's grammar
- [x] `cargo clippy -p swink-agent --features plugins,testkit --tests` — clean on changes
- [x] Verified `NamespacedTool` preserves unsanitized plugin name in metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)