### PR TITLE
fix: sanitize incomplete tool_use arguments before adapter dispatch

### DIFF
--- a/adapters/src/anthropic.rs
+++ b/adapters/src/anthropic.rs
@@ -397,6 +397,13 @@ fn convert_messages(
                             arguments,
                             ..
                         } => {
+                            // Issue #619: loop-level scrub coerces incomplete tool-use
+                            // blocks into object-typed arguments before reaching here.
+                            // Debug builds assert the invariant to catch regressions.
+                            debug_assert!(
+                                arguments.is_object(),
+                                "anthropic adapter: tool_use arguments must be a JSON object (got {arguments:?}); loop-level sanitize_incomplete_tool_calls should have coerced this before dispatch"
+                            );
                             content.push(AnthropicContentBlock::ToolUse {
                                 id: id.clone(),
                                 name: name.clone(),
@@ -1276,5 +1283,56 @@ mod tests {
     fn no_trailing_slash_unchanged() {
         let anthropic = AnthropicStreamFn::new("https://api.anthropic.com", "key");
         assert_eq!(anthropic.base.base_url, "https://api.anthropic.com");
+    }
+
+    // ── Issue #619: incomplete tool_use sanitization ─────────────────────
+
+    /// Regression for #619: after the loop-level scrub runs, an assistant
+    /// message that originally carried `arguments: Null` with `partial_json`
+    /// set must serialize with `input: {}` so the Anthropic API accepts the
+    /// replayed history on the next turn.
+    #[test]
+    fn convert_messages_sanitized_tool_use_becomes_empty_object_input() {
+        use swink_agent::AssistantMessage;
+
+        let mut assistant = AssistantMessage {
+            content: vec![ContentBlock::ToolCall {
+                id: "toolu_01".into(),
+                name: "read_file".into(),
+                // Simulate an incomplete-tool-use block surviving Done(Length):
+                arguments: Value::Null,
+                partial_json: Some(r#"{"path": "/tm"#.into()),
+            }],
+            provider: "anthropic".into(),
+            model_id: "claude-sonnet-4-6".into(),
+            usage: Usage::default(),
+            cost: Cost::default(),
+            stop_reason: StopReason::Length,
+            error_message: None,
+            error_kind: None,
+            timestamp: 0,
+            cache_hint: None,
+        };
+
+        // Loop-level scrub runs before the adapter sees the history.
+        swink_agent::sanitize_incomplete_tool_calls(&mut assistant);
+
+        let messages = vec![AgentMessage::Llm(LlmMessage::Assistant(assistant))];
+        let (_system, converted) = convert_messages(&messages, "");
+
+        assert_eq!(converted.len(), 1);
+        assert_eq!(converted[0].role, "assistant");
+        let json = serde_json::to_value(&converted[0]).unwrap();
+        let block = &json["content"][0];
+        assert_eq!(block["type"], "tool_use");
+        assert_eq!(block["id"], "toolu_01");
+        assert_eq!(block["name"], "read_file");
+        // The critical assertion: input is a valid empty JSON object, NOT null.
+        assert!(
+            block["input"].is_object(),
+            "input must be a JSON object, got {:?}",
+            block["input"]
+        );
+        assert_eq!(block["input"].as_object().unwrap().len(), 0);
     }
 }

--- a/adapters/src/bedrock.rs
+++ b/adapters/src/bedrock.rs
@@ -898,14 +898,23 @@ fn convert_messages(messages: &[AgentMessage]) -> Vec<BedrockMessage> {
                             name,
                             arguments,
                             ..
-                        } => content.push(BedrockContentBlock {
-                            tool_use: Some(BedrockToolUse {
-                                tool_use_id: id.clone(),
-                                name: name.clone(),
-                                input: arguments.clone(),
-                            }),
-                            ..BedrockContentBlock::default()
-                        }),
+                        } => {
+                            // Issue #619: loop-level scrub coerces incomplete tool-use
+                            // blocks into object-typed arguments before reaching here.
+                            // Debug builds assert the invariant to catch regressions.
+                            debug_assert!(
+                                arguments.is_object(),
+                                "bedrock adapter: toolUse input must be a JSON object (got {arguments:?}); loop-level sanitize_incomplete_tool_calls should have coerced this before dispatch"
+                            );
+                            content.push(BedrockContentBlock {
+                                tool_use: Some(BedrockToolUse {
+                                    tool_use_id: id.clone(),
+                                    name: name.clone(),
+                                    input: arguments.clone(),
+                                }),
+                                ..BedrockContentBlock::default()
+                            });
+                        }
                         _ => {}
                     }
                 }
@@ -1838,5 +1847,50 @@ mod tests {
             AssistantMessageEvent::Error { error_message, .. }
                 if error_message.contains("Bedrock contentBlockDelta parse error")
         ));
+    }
+
+    // ── Issue #619: incomplete tool_use sanitization ─────────────────────
+
+    /// Regression for #619: after the loop-level scrub runs, an assistant
+    /// message that originally carried `arguments: Null` with `partial_json`
+    /// set must serialize with `toolUse.input: {}` so Bedrock Converse accepts
+    /// the replayed history on the next turn.
+    #[test]
+    fn convert_messages_sanitized_tool_use_becomes_empty_object_input() {
+        use swink_agent::AssistantMessage as HarnessAssistantMessage;
+
+        let mut assistant = HarnessAssistantMessage {
+            content: vec![ContentBlock::ToolCall {
+                id: "tooluse_abc".into(),
+                name: "read_file".into(),
+                arguments: serde_json::Value::Null,
+                partial_json: Some(r#"{"path": "/tm"#.into()),
+            }],
+            provider: "bedrock".into(),
+            model_id: "anthropic.claude-3-sonnet".into(),
+            usage: Usage::default(),
+            cost: Cost::default(),
+            stop_reason: StopReason::Length,
+            error_message: None,
+            error_kind: None,
+            timestamp: 0,
+            cache_hint: None,
+        };
+
+        swink_agent::sanitize_incomplete_tool_calls(&mut assistant);
+
+        let messages = vec![AgentMessage::Llm(LlmMessage::Assistant(assistant))];
+        let converted = convert_messages(&messages);
+
+        assert_eq!(converted.len(), 1);
+        assert_eq!(converted[0].role, "assistant");
+        let json = serde_json::to_value(&converted[0]).unwrap();
+        let block = &json["content"][0];
+        let input = &block["toolUse"]["input"];
+        assert!(
+            input.is_object(),
+            "toolUse.input must be a JSON object, got {input:?}"
+        );
+        assert_eq!(input.as_object().unwrap().len(), 0);
     }
 }

--- a/adapters/src/google.rs
+++ b/adapters/src/google.rs
@@ -511,6 +511,13 @@ fn assistant_parts(
                 arguments,
                 ..
             } => {
+                // Issue #619: loop-level scrub coerces incomplete tool-use blocks
+                // into object-typed arguments before reaching here. Debug builds
+                // assert the invariant to catch regressions.
+                debug_assert!(
+                    arguments.is_object(),
+                    "google adapter: function_call args must be a JSON object (got {arguments:?}); loop-level sanitize_incomplete_tool_calls should have coerced this before dispatch"
+                );
                 tool_names_by_id.insert(id.clone(), name.clone());
                 parts.push(GeminiPart {
                     function_call: Some(GeminiFunctionCall {
@@ -806,3 +813,49 @@ const _: () = {
     const fn assert_send_sync<T: Send + Sync>() {}
     assert_send_sync::<GeminiStreamFn>();
 };
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression for #619: after the loop-level scrub runs, an assistant
+    /// message that originally carried `arguments: Null` with `partial_json`
+    /// set must serialize with `args: {}` so the Gemini API accepts the
+    /// replayed history on the next turn.
+    #[test]
+    fn convert_messages_sanitized_tool_use_becomes_empty_object_args() {
+        let mut assistant = HarnessAssistantMessage {
+            content: vec![ContentBlock::ToolCall {
+                id: "call_1".into(),
+                name: "read_file".into(),
+                arguments: Value::Null,
+                partial_json: Some(r#"{"path": "/tm"#.into()),
+            }],
+            provider: "google".into(),
+            model_id: "gemini-2.0-flash".into(),
+            usage: Usage::default(),
+            cost: Cost::default(),
+            stop_reason: StopReason::Length,
+            error_message: None,
+            error_kind: None,
+            timestamp: 0,
+            cache_hint: None,
+        };
+
+        swink_agent::sanitize_incomplete_tool_calls(&mut assistant);
+
+        let messages = vec![AgentMessage::Llm(LlmMessage::Assistant(assistant))];
+        let converted = convert_messages(&messages);
+
+        assert_eq!(converted.len(), 1);
+        assert_eq!(converted[0].role, "model");
+        let json = serde_json::to_value(&converted[0]).unwrap();
+        let part = &json["parts"][0];
+        let args = &part["functionCall"]["args"];
+        assert!(
+            args.is_object(),
+            "functionCall.args must be a JSON object, got {args:?}"
+        );
+        assert_eq!(args.as_object().unwrap().len(), 0);
+    }
+}

--- a/adapters/src/openai_compat.rs
+++ b/adapters/src/openai_compat.rs
@@ -251,6 +251,16 @@ impl MessageConverter for OaiConverter {
                     arguments,
                     ..
                 } => {
+                    // Issue #619: loop-level scrub coerces incomplete tool-use blocks
+                    // into object-typed arguments before reaching here. Debug builds
+                    // assert the invariant to catch regressions. OpenAI-compat is the
+                    // most dangerous case: `Value::Null.to_string()` is the literal
+                    // string "null", which the provider accepts structurally but then
+                    // rejects when parsing arguments.
+                    debug_assert!(
+                        arguments.is_object(),
+                        "openai-compat adapter: function.arguments must stringify from a JSON object (got {arguments:?}); loop-level sanitize_incomplete_tool_calls should have coerced this before dispatch"
+                    );
                     tool_calls.push(OaiToolCallRequest {
                         id: id.clone(),
                         r#type: "function".to_string(),
@@ -899,5 +909,47 @@ mod tests {
             chunk.choices[0].delta.reasoning_content.as_deref(),
             Some("step by step")
         );
+    }
+
+    // ── Issue #619: incomplete tool_use sanitization ─────────────────────
+
+    /// Regression for #619: after the loop-level scrub runs, an assistant
+    /// message that originally carried `arguments: Null` with `partial_json`
+    /// set must serialize with `function.arguments: "{}"` (a stringified empty
+    /// object) rather than the literal string `"null"` that `Value::Null.to_string()`
+    /// would produce. Otherwise OpenAI-compatible providers reject the request
+    /// when they try to parse the arguments.
+    #[test]
+    fn assistant_message_sanitized_tool_call_serializes_empty_object_string() {
+        use swink_agent::AssistantMessage;
+
+        let mut assistant = AssistantMessage {
+            content: vec![ContentBlock::ToolCall {
+                id: "call_01".into(),
+                name: "read_file".into(),
+                arguments: Value::Null,
+                partial_json: Some(r#"{"path": "/tm"#.into()),
+            }],
+            provider: "openai".into(),
+            model_id: "gpt-4o-mini".into(),
+            usage: Usage::default(),
+            cost: Cost::default(),
+            stop_reason: StopReason::Length,
+            error_message: None,
+            error_kind: None,
+            timestamp: 0,
+            cache_hint: None,
+        };
+
+        swink_agent::sanitize_incomplete_tool_calls(&mut assistant);
+
+        let oai_msg = OaiConverter::assistant_message(&assistant);
+        assert_eq!(oai_msg.role, "assistant");
+        let tool_calls = oai_msg.tool_calls.expect("tool_calls must be Some");
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0].function.name, "read_file");
+        // Critical: the stringified arguments must be a valid JSON object, NOT
+        // the literal "null" that `Value::Null.to_string()` would produce.
+        assert_eq!(tool_calls[0].function.arguments, "{}");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,7 @@ pub use schemars::JsonSchema;
 pub use state::{SessionState, StateDelta};
 pub use stream::{
     AssistantMessageDelta, AssistantMessageEvent, CacheStrategy, OnRawPayload, StreamErrorKind,
-    StreamFn, StreamOptions, StreamTransport, accumulate_message,
+    StreamFn, StreamOptions, StreamTransport, accumulate_message, sanitize_incomplete_tool_calls,
 };
 pub use stream_middleware::StreamMiddleware;
 pub use sub_agent::SubAgent;

--- a/src/loop_/turn.rs
+++ b/src/loop_/turn.rs
@@ -267,7 +267,7 @@ pub async fn run_single_turn(
         stream_result
     };
 
-    let Some(assistant_message) = handle_stream_result(stream_result, config, state, tx).await
+    let Some(mut assistant_message) = handle_stream_result(stream_result, config, state, tx).await
     else {
         return TurnOutcome::Return;
     };
@@ -286,8 +286,23 @@ pub async fn run_single_turn(
         return handle_error_stop(assistant_message, state, tx).await;
     }
 
-    // viii. Extract tool calls from assistant message content
+    // viii. Extract tool calls from assistant message content. `extract_tool_calls`
+    // derives `is_incomplete` from `partial_json.is_some()`, so it must run BEFORE
+    // `sanitize_incomplete_tool_calls` clears that field.
     let tool_calls = extract_tool_calls(&assistant_message);
+
+    // Issue #619: coerce any `ToolCall` blocks with `partial_json.is_some()` or
+    // non-object `arguments` into a valid empty-object call before the assistant
+    // message reaches any adapter again. Pairs with `recover_incomplete_tool_calls`
+    // which inserts a matching synthetic error `ToolResult` for each incomplete
+    // call so the provider sees a well-formed tool_use / tool_result pair.
+    let fixed = crate::stream::sanitize_incomplete_tool_calls(&mut assistant_message);
+    if fixed > 0 {
+        debug!(
+            fixed,
+            "sanitized incomplete tool-use blocks before adapter dispatch"
+        );
+    }
 
     // ix. If no tool calls: emit TurnEnd, exit inner loop
     if tool_calls.is_empty() {
@@ -610,10 +625,15 @@ async fn handle_stream_result(
 
 /// Handle an error or aborted stop reason: emit `TurnEnd` + `AgentEnd` and return.
 async fn handle_error_stop(
-    assistant_message: AssistantMessage,
+    mut assistant_message: AssistantMessage,
     state: &mut LoopState,
     tx: &mpsc::Sender<AgentEvent>,
 ) -> TurnOutcome {
+    // Issue #619: scrub any incomplete tool-use blocks before we persist the
+    // message into `context_messages` — even on terminal error paths a resumed
+    // session (e.g. continuation) could replay this history to an adapter.
+    crate::stream::sanitize_incomplete_tool_calls(&mut assistant_message);
+
     let is_abort = assistant_message.stop_reason == StopReason::Aborted;
     if is_abort {
         warn!(

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -341,6 +341,48 @@ pub trait StreamFn: Send + Sync {
     ) -> Pin<Box<dyn Stream<Item = AssistantMessageEvent> + Send + 'a>>;
 }
 
+// ─── Tool-call sanitization ──────────────────────────────────────────────────
+
+/// Scrub incomplete `ToolCall` blocks in an assistant message so it can safely
+/// be replayed to a provider.
+///
+/// When a stream hits [`StopReason::Length`] mid tool-use, the resulting
+/// [`ContentBlock::ToolCall`] may carry `arguments: Value::Null` with
+/// `partial_json: Some(..)` (see `accumulate_message`). Provider adapters
+/// forward `arguments` verbatim; Anthropic/Google/Bedrock reject null inputs
+/// and OpenAI-compatible providers reject the literal string `"null"`. On the
+/// next turn this causes a 400.
+///
+/// This helper coerces any `ToolCall` block whose `partial_json` is still set
+/// OR whose `arguments` is not a JSON object into a valid empty-object call:
+/// `arguments = Value::Object({})` and `partial_json = None`. The loop pairs
+/// this with a synthetic tool-result message (see
+/// `recover_incomplete_tool_calls`) so the provider sees a well-formed pair.
+///
+/// Safe to call multiple times and safe to call on messages that contain no
+/// tool-use blocks. Returns the number of blocks modified.
+///
+/// See <https://github.com/SuperSwinkAI/Swink-Agent/issues/619>.
+pub fn sanitize_incomplete_tool_calls(message: &mut AssistantMessage) -> usize {
+    let mut fixed = 0;
+    for block in &mut message.content {
+        if let ContentBlock::ToolCall {
+            arguments,
+            partial_json,
+            ..
+        } = block
+        {
+            let needs_fix = partial_json.is_some() || !arguments.is_object();
+            if needs_fix {
+                *arguments = Value::Object(serde_json::Map::new());
+                *partial_json = None;
+                fixed += 1;
+            }
+        }
+    }
+    fixed
+}
+
 // ─── Delta Accumulation ──────────────────────────────────────────────────────
 
 /// Reconstruct a finalized `AssistantMessage` from a collected list of stream
@@ -1132,5 +1174,187 @@ mod tests {
 
         let err = accumulate_message(events, "test", "test").unwrap_err();
         assert_eq!(err, "ToolCallEnd: block at index 0 is already closed");
+    }
+
+    // ── sanitize_incomplete_tool_calls (#619) ──────────────────────────────
+
+    fn build_assistant_with_tool_call(
+        arguments: Value,
+        partial_json: Option<String>,
+    ) -> AssistantMessage {
+        AssistantMessage {
+            content: vec![ContentBlock::ToolCall {
+                id: "tc_1".into(),
+                name: "read_file".into(),
+                arguments,
+                partial_json,
+            }],
+            provider: "test".into(),
+            model_id: "test".into(),
+            usage: Usage::default(),
+            cost: Cost::default(),
+            stop_reason: StopReason::Length,
+            error_message: None,
+            error_kind: None,
+            timestamp: 0,
+            cache_hint: None,
+        }
+    }
+
+    #[test]
+    fn sanitize_null_arguments_with_partial_json_returns_empty_object() {
+        let mut msg = build_assistant_with_tool_call(Value::Null, Some("{\"path\": \"/tm".into()));
+        let fixed = sanitize_incomplete_tool_calls(&mut msg);
+        assert_eq!(fixed, 1);
+        match &msg.content[0] {
+            ContentBlock::ToolCall {
+                arguments,
+                partial_json,
+                ..
+            } => {
+                assert_eq!(*arguments, Value::Object(serde_json::Map::new()));
+                assert!(
+                    partial_json.is_none(),
+                    "partial_json must be cleared after scrub"
+                );
+            }
+            other => panic!("expected ToolCall, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sanitize_leaves_valid_object_arguments_untouched() {
+        let args = serde_json::json!({ "path": "/tmp/a" });
+        let mut msg = build_assistant_with_tool_call(args.clone(), None);
+        let fixed = sanitize_incomplete_tool_calls(&mut msg);
+        assert_eq!(fixed, 0);
+        match &msg.content[0] {
+            ContentBlock::ToolCall {
+                arguments,
+                partial_json,
+                ..
+            } => {
+                assert_eq!(*arguments, args);
+                assert!(partial_json.is_none());
+            }
+            other => panic!("expected ToolCall, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sanitize_coerces_non_object_arguments() {
+        // `Value::String` / arrays / numbers are all not objects — they would
+        // confuse downstream providers even if `partial_json` is absent.
+        let mut msg = build_assistant_with_tool_call(Value::String("truncated".into()), None);
+        let fixed = sanitize_incomplete_tool_calls(&mut msg);
+        assert_eq!(fixed, 1);
+        match &msg.content[0] {
+            ContentBlock::ToolCall { arguments, .. } => {
+                assert_eq!(*arguments, Value::Object(serde_json::Map::new()));
+            }
+            other => panic!("expected ToolCall, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sanitize_is_idempotent() {
+        let mut msg = build_assistant_with_tool_call(Value::Null, Some("{\"path\":".into()));
+        assert_eq!(sanitize_incomplete_tool_calls(&mut msg), 1);
+        // A second pass should be a no-op.
+        assert_eq!(sanitize_incomplete_tool_calls(&mut msg), 0);
+    }
+
+    #[test]
+    fn sanitize_preserves_non_tool_blocks() {
+        let mut msg = AssistantMessage {
+            content: vec![
+                ContentBlock::Text {
+                    text: "hello".into(),
+                },
+                ContentBlock::ToolCall {
+                    id: "tc_1".into(),
+                    name: "foo".into(),
+                    arguments: Value::Null,
+                    partial_json: Some("{".into()),
+                },
+                ContentBlock::Text {
+                    text: "world".into(),
+                },
+            ],
+            provider: "test".into(),
+            model_id: "test".into(),
+            usage: Usage::default(),
+            cost: Cost::default(),
+            stop_reason: StopReason::Length,
+            error_message: None,
+            error_kind: None,
+            timestamp: 0,
+            cache_hint: None,
+        };
+        let fixed = sanitize_incomplete_tool_calls(&mut msg);
+        assert_eq!(fixed, 1);
+        // Text blocks preserved in place.
+        match &msg.content[0] {
+            ContentBlock::Text { text } => assert_eq!(text, "hello"),
+            other => panic!("expected Text, got {other:?}"),
+        }
+        match &msg.content[2] {
+            ContentBlock::Text { text } => assert_eq!(text, "world"),
+            other => panic!("expected Text, got {other:?}"),
+        }
+    }
+
+    /// Regression for #619: the canned "Length + partial tool-call" stream from
+    /// the issue, when run through `accumulate_message` and then scrubbed,
+    /// produces a block suitable for replay to any provider adapter.
+    #[test]
+    fn accumulate_plus_sanitize_yields_adapter_safe_tool_call() {
+        let events = vec![
+            AssistantMessageEvent::Start,
+            AssistantMessageEvent::ToolCallStart {
+                content_index: 0,
+                id: "tc_1".into(),
+                name: "read_file".into(),
+            },
+            AssistantMessageEvent::ToolCallDelta {
+                content_index: 0,
+                delta: r#"{"path": "/tm"#.into(),
+            },
+            AssistantMessageEvent::Done {
+                stop_reason: StopReason::Length,
+                usage: Usage::default(),
+                cost: Cost::default(),
+            },
+        ];
+        let mut msg = accumulate_message(events, "test", "test")
+            .expect("Done(Length) with unterminated tool-call should accumulate");
+        // Pre-scrub: partial_json present, arguments null.
+        match &msg.content[0] {
+            ContentBlock::ToolCall {
+                arguments,
+                partial_json,
+                ..
+            } => {
+                assert!(partial_json.is_some());
+                assert!(arguments.is_null());
+            }
+            other => panic!("expected ToolCall, got {other:?}"),
+        }
+
+        sanitize_incomplete_tool_calls(&mut msg);
+
+        // Post-scrub: arguments is an empty object, partial_json cleared.
+        match &msg.content[0] {
+            ContentBlock::ToolCall {
+                arguments,
+                partial_json,
+                ..
+            } => {
+                assert!(arguments.is_object());
+                assert_eq!(arguments.as_object().unwrap().len(), 0);
+                assert!(partial_json.is_none());
+            }
+            other => panic!("expected ToolCall, got {other:?}"),
+        }
     }
 }

--- a/tests/incomplete_tool_call_sanitize.rs
+++ b/tests/incomplete_tool_call_sanitize.rs
@@ -1,0 +1,248 @@
+//! Regression tests for issue #619: provider adapters forward incomplete
+//! tool_use arguments after `StopReason::Length` truncation, causing API 400
+//! on the next turn.
+//!
+//! The loop-level scrub (`sanitize_incomplete_tool_calls`) runs before the
+//! assistant message is committed to `context_messages`. After it runs, every
+//! `ContentBlock::ToolCall` in the history must have an object-typed
+//! `arguments` field with no `partial_json` set.
+
+#![cfg(feature = "testkit")]
+mod common;
+
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
+
+use common::{MockStreamFn, default_model};
+use futures::Stream;
+use futures::stream::StreamExt;
+use serde_json::{Value, json};
+use tokio_util::sync::CancellationToken;
+
+use swink_agent::{
+    AgentEvent, AgentLoopConfig, AgentMessage, AgentTool, AgentToolResult, AssistantMessageEvent,
+    ContentBlock, Cost, DefaultRetryStrategy, LlmMessage, StopReason, StreamFn, StreamOptions,
+    Usage, UserMessage, agent_loop,
+};
+
+// ─── Minimal in-memory tool ────────────────────────────────────────────────
+
+struct EchoTool;
+
+impl AgentTool for EchoTool {
+    fn name(&self) -> &str {
+        "echo"
+    }
+
+    fn label(&self) -> &str {
+        "echo"
+    }
+
+    fn description(&self) -> &'static str {
+        "echoes its arguments"
+    }
+
+    fn parameters_schema(&self) -> &serde_json::Value {
+        static SCHEMA: std::sync::OnceLock<serde_json::Value> = std::sync::OnceLock::new();
+        SCHEMA.get_or_init(|| {
+            json!({
+                "type": "object",
+                "properties": {"msg": {"type": "string"}},
+                "additionalProperties": true
+            })
+        })
+    }
+
+    fn execute(
+        &self,
+        _tool_call_id: &str,
+        params: serde_json::Value,
+        _cancellation_token: CancellationToken,
+        _on_update: Option<Box<dyn Fn(AgentToolResult) + Send + Sync>>,
+        _state: Arc<std::sync::RwLock<swink_agent::SessionState>>,
+        _credential: Option<swink_agent::ResolvedCredential>,
+    ) -> Pin<Box<dyn std::future::Future<Output = AgentToolResult> + Send + '_>> {
+        Box::pin(async move { AgentToolResult::text(format!("echo: {params}")) })
+    }
+}
+
+type ConvertToLlmBoxed = Box<dyn Fn(&AgentMessage) -> Option<LlmMessage> + Send + Sync>;
+
+fn default_convert_to_llm() -> ConvertToLlmBoxed {
+    Box::new(|msg: &AgentMessage| match msg {
+        AgentMessage::Llm(llm) => Some(llm.clone()),
+        AgentMessage::Custom(_) => None,
+    })
+}
+
+fn loop_config(stream_fn: Arc<dyn StreamFn>, tool: Arc<dyn AgentTool>) -> AgentLoopConfig {
+    AgentLoopConfig {
+        agent_name: None,
+        transfer_chain: None,
+        model: default_model(),
+        stream_options: StreamOptions::default(),
+        retry_strategy: Box::new(
+            DefaultRetryStrategy::default()
+                .with_jitter(false)
+                .with_base_delay(Duration::from_millis(1)),
+        ),
+        stream_fn,
+        tools: vec![tool],
+        convert_to_llm: default_convert_to_llm(),
+        transform_context: None,
+        get_api_key: None,
+        message_provider: None,
+        pending_message_snapshot: Arc::default(),
+        loop_context_snapshot: Arc::default(),
+        approve_tool: None,
+        approval_mode: swink_agent::ApprovalMode::default(),
+        pre_turn_policies: vec![],
+        pre_dispatch_policies: vec![],
+        post_turn_policies: vec![],
+        post_loop_policies: vec![],
+        async_transform_context: None,
+        metrics_collector: None,
+        fallback: None,
+        tool_execution_policy: swink_agent::ToolExecutionPolicy::default(),
+        session_state: Arc::new(std::sync::RwLock::new(swink_agent::SessionState::new())),
+        credential_resolver: None,
+        cache_config: None,
+        cache_state: std::sync::Mutex::new(swink_agent::CacheState::default()),
+        dynamic_system_prompt: None,
+    }
+}
+
+async fn collect_events(stream: Pin<Box<dyn Stream<Item = AgentEvent> + Send>>) -> Vec<AgentEvent> {
+    stream.collect().await
+}
+
+fn user_msg(text: &str) -> AgentMessage {
+    AgentMessage::Llm(LlmMessage::User(UserMessage {
+        content: vec![ContentBlock::Text {
+            text: text.to_string(),
+        }],
+        timestamp: 0,
+        cache_hint: None,
+    }))
+}
+
+/// The canned truncation sequence from issue #619: a tool-use block starts
+/// streaming, the provider hits `max_tokens` mid-JSON, and emits `Done(Length)`
+/// without a matching `ToolCallEnd`.
+fn truncated_tool_call_events() -> Vec<AssistantMessageEvent> {
+    vec![
+        AssistantMessageEvent::Start,
+        AssistantMessageEvent::ToolCallStart {
+            content_index: 0,
+            id: "tc_truncated".into(),
+            name: "echo".into(),
+        },
+        AssistantMessageEvent::ToolCallDelta {
+            content_index: 0,
+            delta: r#"{"msg": "hel"#.into(),
+        },
+        AssistantMessageEvent::Done {
+            stop_reason: StopReason::Length,
+            usage: Usage::default(),
+            cost: Cost::default(),
+        },
+    ]
+}
+
+/// After the first truncated turn, the loop inserts a synthetic error tool
+/// result and runs a second turn. The follow-up turn just returns plain text.
+fn plain_text_done_events(text: &str) -> Vec<AssistantMessageEvent> {
+    vec![
+        AssistantMessageEvent::Start,
+        AssistantMessageEvent::TextStart { content_index: 0 },
+        AssistantMessageEvent::TextDelta {
+            content_index: 0,
+            delta: text.to_string(),
+        },
+        AssistantMessageEvent::TextEnd { content_index: 0 },
+        AssistantMessageEvent::Done {
+            stop_reason: StopReason::Stop,
+            usage: Usage::default(),
+            cost: Cost::default(),
+        },
+    ]
+}
+
+/// End-to-end: feed the canned truncation stream on turn 1 and a plain-text
+/// response on turn 2. Verify that the assistant message in the final
+/// `AgentEnd.messages` has its truncated tool-call block scrubbed: arguments
+/// is an empty object and `partial_json` is `None`.
+///
+/// Without the fix, the tool-use block in the history would carry
+/// `arguments: Null` + `partial_json: Some(..)`, which adapters forward
+/// verbatim and providers reject with HTTP 400 on the second turn.
+#[tokio::test]
+async fn loop_sanitizes_truncated_tool_call_before_adapter_replay() {
+    let stream = Arc::new(MockStreamFn::new(vec![
+        truncated_tool_call_events(),
+        plain_text_done_events("done"),
+    ]));
+    let tool: Arc<dyn AgentTool> = Arc::new(EchoTool);
+    let config = loop_config(stream, tool);
+    let cancel = CancellationToken::new();
+
+    let events = collect_events(agent_loop(
+        vec![user_msg("do thing")],
+        "sys".to_string(),
+        config,
+        cancel,
+    ))
+    .await;
+
+    // Grab the final history off AgentEnd.
+    let final_messages = events
+        .iter()
+        .rev()
+        .find_map(|e| match e {
+            AgentEvent::AgentEnd { messages } => Some(messages.clone()),
+            _ => None,
+        })
+        .expect("expected AgentEnd event");
+
+    // Collect every ToolCall block the adapter would see on replay.
+    let tool_call_blocks: Vec<&ContentBlock> = final_messages
+        .iter()
+        .filter_map(|m| match m {
+            AgentMessage::Llm(LlmMessage::Assistant(a)) => Some(a),
+            _ => None,
+        })
+        .flat_map(|a| a.content.iter())
+        .filter(|b| matches!(b, ContentBlock::ToolCall { .. }))
+        .collect();
+
+    assert!(
+        !tool_call_blocks.is_empty(),
+        "expected at least one tool_call block in committed history"
+    );
+
+    for block in &tool_call_blocks {
+        match block {
+            ContentBlock::ToolCall {
+                arguments,
+                partial_json,
+                ..
+            } => {
+                assert!(
+                    arguments.is_object(),
+                    "adapter replay invariant violated: arguments must be a JSON object, got {arguments:?}"
+                );
+                assert_ne!(
+                    *arguments,
+                    Value::Null,
+                    "adapter replay invariant violated: arguments is Null"
+                );
+                assert!(
+                    partial_json.is_none(),
+                    "adapter replay invariant violated: partial_json should be cleared, got {partial_json:?}"
+                );
+            }
+            _ => unreachable!(),
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Loop-level scrub coerces incomplete ToolCall blocks (partial_json set, or non-object arguments) into valid empty-object arguments before the assistant message reaches any adapter.
- Adds `debug_assert!` in Anthropic, Google, Bedrock, and OpenAI-compat adapters that incoming arguments is a JSON object.
- New per-adapter tests and a loop-level truncation-replay test.

## Implementation
- `src/stream.rs` — new `sanitize_incomplete_tool_calls(&mut AssistantMessage) -> usize` helper + 6 unit tests (incl. the canned truncation sequence from the issue).
- `src/lib.rs` — re-export.
- `src/loop_/turn.rs` — calls the scrub in `run_single_turn` and `handle_error_stop` before the history is replayed.
- `adapters/src/{anthropic,google,bedrock,openai_compat}.rs` — `debug_assert!(arguments.is_object())` before forwarding, plus one regression test each.
- `tests/incomplete_tool_call_sanitize.rs` — loop-level test feeding a canned truncation stream, driving a second turn, asserting every outbound ToolCall has object-typed arguments.

## Test plan
- [x] cargo fmt --all -- --check
- [x] cargo clippy --workspace -- -D warnings clean
- [x] cargo test --workspace passes
- [x] cargo test -p swink-agent --no-default-features passes (372 tests)
- [x] Per-adapter regression tests (anthropic, google, bedrock, openai_compat) pass
- [x] Loop-level truncation-replay regression test passes
- [x] No public API breakage

~721 insertions across 8 files.

Closes #619

🤖 Generated with [Claude Code](https://claude.com/claude-code)