### PR TITLE
fix: validate session_id and enforce canonical artifact root

### DIFF
--- a/artifacts/src/fs_store.rs
+++ b/artifacts/src/fs_store.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::error::Error;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
@@ -9,7 +9,7 @@ use tokio::sync::Mutex;
 
 use swink_agent::{
     ArtifactData, ArtifactError, ArtifactMeta, ArtifactStore, ArtifactVersion,
-    validate_artifact_name,
+    validate_artifact_name, validate_session_id,
 };
 
 // ─── Internal meta.json schema ─────────────────────────────────────────────
@@ -35,12 +35,62 @@ pub fn storage_err(e: impl Error + Send + Sync + 'static) -> ArtifactError {
     ArtifactError::Storage(Box::new(e))
 }
 
+/// Canonicalize `root`, creating it first if it does not already exist.
+///
+/// This returns an absolute, symlink-free path so later operations can prove
+/// their resolved target stays under it.
+fn canonicalize_root(root: &Path) -> std::io::Result<PathBuf> {
+    if !root.exists() {
+        std::fs::create_dir_all(root)?;
+    }
+    root.canonicalize()
+}
+
+/// Ensure `candidate` stays contained within `root` after canonicalization.
+///
+/// `candidate` need not exist yet. We canonicalize the longest existing
+/// ancestor and re-join the remaining components, so newly created
+/// subdirectories are still checked for containment once materialized.
+fn ensure_within_root(root: &Path, candidate: &Path) -> Result<PathBuf, ArtifactError> {
+    // Walk up until we find an existing ancestor we can canonicalize.
+    let mut existing = candidate;
+    let mut suffix: Vec<&std::ffi::OsStr> = Vec::new();
+    let canonical_anchor = loop {
+        if let Ok(canonical) = existing.canonicalize() {
+            break canonical;
+        }
+        let Some(name) = existing.file_name() else {
+            return Err(ArtifactError::PathOutsideRoot);
+        };
+        suffix.push(name);
+        let Some(parent) = existing.parent() else {
+            return Err(ArtifactError::PathOutsideRoot);
+        };
+        existing = parent;
+    };
+
+    let mut resolved = canonical_anchor;
+    for component in suffix.iter().rev() {
+        resolved.push(component);
+    }
+
+    if !resolved.starts_with(root) {
+        return Err(ArtifactError::PathOutsideRoot);
+    }
+    Ok(resolved)
+}
+
 // ─── FileArtifactStore ──────────────────────────────────────────────────────
 
 /// Filesystem-backed artifact store with per-artifact locking and atomic writes.
 ///
 /// Artifacts are stored under `{root}/{session_id}/{artifact_name}/` with a
 /// `meta.json` sidecar and versioned content files (`v1.bin`, `v2.bin`, ...).
+///
+/// The `root` is canonicalized on construction (creating the directory if it
+/// does not yet exist). Every operation validates `session_id` and verifies
+/// that the resolved target path remains under the canonical root, so a
+/// crafted `session_id` cannot escape the artifact root.
 type LockMap = HashMap<(String, String), Arc<Mutex<()>>>;
 
 pub struct FileArtifactStore {
@@ -51,12 +101,26 @@ pub struct FileArtifactStore {
 impl FileArtifactStore {
     /// Create a new file artifact store rooted at the given directory.
     ///
-    /// The directory does not need to exist yet — it will be created on first save.
+    /// The directory does not need to exist yet — it will be created.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the directory cannot be created or canonicalized. Most
+    /// callers want [`Self::try_new`] instead, which surfaces I/O errors
+    /// as a `Result`.
     pub fn new(root: impl Into<PathBuf>) -> Self {
-        Self {
-            root: root.into(),
+        Self::try_new(root).expect("failed to canonicalize artifact root")
+    }
+
+    /// Fallible constructor: returns an error if the root cannot be created
+    /// or canonicalized.
+    pub fn try_new(root: impl Into<PathBuf>) -> Result<Self, ArtifactError> {
+        let root = root.into();
+        let canonical = canonicalize_root(&root).map_err(storage_err)?;
+        Ok(Self {
+            root: canonical,
             locks: Arc::new(Mutex::new(HashMap::new())),
-        }
+        })
     }
 
     /// Get or create the per-artifact lock for a (session, name) pair.
@@ -85,12 +149,34 @@ impl FileArtifactStore {
             .join(format!("v{version}.bin"))
     }
 
+    /// Validate `session_id` and confirm that the resolved `session_dir`
+    /// stays beneath the canonical root. Returns the resolved session dir.
+    pub(crate) fn resolve_session_dir(&self, session_id: &str) -> Result<PathBuf, ArtifactError> {
+        validate_session_id(session_id)?;
+        let candidate = self.root.join(session_id);
+        ensure_within_root(&self.root, &candidate)
+    }
+
+    /// Validate `session_id`/`name` and resolve the artifact directory,
+    /// enforcing root containment.
+    pub(crate) fn resolve_artifact_dir(
+        &self,
+        session_id: &str,
+        name: &str,
+    ) -> Result<PathBuf, ArtifactError> {
+        validate_session_id(session_id)?;
+        validate_artifact_name(name)?;
+        let candidate = self.artifact_dir(session_id, name);
+        ensure_within_root(&self.root, &candidate)
+    }
+
     /// Read meta.json, returning an empty `MetaFile` if it doesn't exist.
     pub(crate) async fn read_meta(
         &self,
         session_id: &str,
         name: &str,
     ) -> Result<MetaFile, ArtifactError> {
+        self.resolve_artifact_dir(session_id, name)?;
         let path = self.meta_path(session_id, name);
         match tokio::fs::read_to_string(&path).await {
             Ok(contents) => serde_json::from_str(&contents).map_err(storage_err),
@@ -108,6 +194,7 @@ impl FileArtifactStore {
         name: &str,
         meta: &MetaFile,
     ) -> Result<(), ArtifactError> {
+        self.resolve_artifact_dir(session_id, name)?;
         let meta_path = self.meta_path(session_id, name);
         let json = serde_json::to_string_pretty(meta).map_err(storage_err)?;
         let bytes = json.into_bytes();
@@ -124,7 +211,7 @@ impl FileArtifactStore {
     /// Recursively discovers artifact directories (those containing `meta.json`),
     /// returning artifact names relative to the session directory.
     async fn discover_artifacts(&self, session_id: &str) -> Result<Vec<String>, ArtifactError> {
-        let session_dir = self.root.join(session_id);
+        let session_dir = self.resolve_session_dir(session_id)?;
         if !session_dir.exists() {
             return Ok(Vec::new());
         }
@@ -164,12 +251,11 @@ impl ArtifactStore for FileArtifactStore {
         name: &str,
         data: ArtifactData,
     ) -> Result<ArtifactVersion, ArtifactError> {
-        validate_artifact_name(name)?;
+        let dir = self.resolve_artifact_dir(session_id, name)?;
 
         let lock = self.artifact_lock(session_id, name).await;
         let _guard = lock.lock().await;
 
-        let dir = self.artifact_dir(session_id, name);
         tokio::fs::create_dir_all(&dir).await.map_err(storage_err)?;
 
         // Read or create meta
@@ -226,6 +312,7 @@ impl ArtifactStore for FileArtifactStore {
         session_id: &str,
         name: &str,
     ) -> Result<Option<(ArtifactData, ArtifactVersion)>, ArtifactError> {
+        self.resolve_artifact_dir(session_id, name)?;
         let meta = self.read_meta(session_id, name).await?;
         let Some(record) = meta.versions.last() else {
             tracing::debug!(session_id, name, "artifact not found");
@@ -275,6 +362,7 @@ impl ArtifactStore for FileArtifactStore {
         name: &str,
         version: u32,
     ) -> Result<Option<(ArtifactData, ArtifactVersion)>, ArtifactError> {
+        self.resolve_artifact_dir(session_id, name)?;
         let meta = self.read_meta(session_id, name).await?;
         let Some(record) = meta.versions.iter().find(|r| r.version == version) else {
             tracing::debug!(session_id, name, version, "version not found");
@@ -330,7 +418,7 @@ impl ArtifactStore for FileArtifactStore {
     }
 
     async fn delete(&self, session_id: &str, name: &str) -> Result<(), ArtifactError> {
-        let dir = self.artifact_dir(session_id, name);
+        let dir = self.resolve_artifact_dir(session_id, name)?;
         match tokio::fs::remove_dir_all(&dir).await {
             Ok(()) => {
                 tracing::debug!(session_id, name, "artifact deleted");

--- a/artifacts/src/streaming.rs
+++ b/artifacts/src/streaming.rs
@@ -7,10 +7,7 @@ use futures::{StreamExt, stream};
 use tokio::fs::OpenOptions;
 use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader, BufWriter};
 
-use swink_agent::{
-    ArtifactByteStream, ArtifactError, ArtifactVersion, StreamingArtifactStore,
-    validate_artifact_name,
-};
+use swink_agent::{ArtifactByteStream, ArtifactError, ArtifactVersion, StreamingArtifactStore};
 
 use crate::fs_store::{FileArtifactStore, VersionRecord, storage_err};
 
@@ -88,12 +85,11 @@ impl StreamingArtifactStore for FileArtifactStore {
         metadata: HashMap<String, String>,
         stream: ArtifactByteStream,
     ) -> Result<ArtifactVersion, ArtifactError> {
-        validate_artifact_name(name)?;
+        let dir = self.resolve_artifact_dir(session_id, name)?;
 
         let lock = self.artifact_lock(session_id, name).await;
         let _guard = lock.lock().await;
 
-        let dir = self.artifact_dir(session_id, name);
         tokio::fs::create_dir_all(&dir).await.map_err(storage_err)?;
 
         let mut meta = self.read_meta(session_id, name).await?;
@@ -145,6 +141,8 @@ impl StreamingArtifactStore for FileArtifactStore {
         name: &str,
         version: Option<u32>,
     ) -> Result<Option<ArtifactByteStream>, ArtifactError> {
+        self.resolve_artifact_dir(session_id, name)?;
+
         // Resolve the target version number.
         let target_version = if let Some(v) = version {
             v

--- a/artifacts/tests/fs_store_session_id.rs
+++ b/artifacts/tests/fs_store_session_id.rs
@@ -1,0 +1,283 @@
+//! Regression tests for `session_id` validation and canonical-root
+//! containment in `FileArtifactStore`. These guard against path-traversal
+//! attacks via a crafted `session_id` (see issue #609).
+
+use std::collections::HashMap;
+
+use bytes::Bytes;
+use futures::stream;
+
+use swink_agent::{ArtifactData, ArtifactError, ArtifactStore, StreamingArtifactStore};
+use swink_agent_artifacts::FileArtifactStore;
+
+fn text_data(content: &str) -> ArtifactData {
+    ArtifactData {
+        content: content.as_bytes().to_vec(),
+        content_type: "text/plain".to_string(),
+        metadata: HashMap::new(),
+    }
+}
+
+fn stream_of(bytes: &'static [u8]) -> swink_agent::ArtifactByteStream {
+    Box::pin(stream::iter(vec![Ok(Bytes::from_static(bytes))]))
+}
+
+fn assert_invalid_session_id(err: ArtifactError) {
+    match err {
+        ArtifactError::InvalidSessionId { .. } => {}
+        other => panic!("expected InvalidSessionId, got: {other:?}"),
+    }
+}
+
+// ─── Save: malicious session_id rejected ───────────────────────────────────
+
+#[tokio::test]
+async fn save_rejects_session_id_with_dotdot() {
+    let tmpdir = tempfile::TempDir::new().unwrap();
+    let store = FileArtifactStore::new(tmpdir.path());
+
+    let err = store
+        .save("../escape", "report.md", text_data("pwn"))
+        .await
+        .unwrap_err();
+    assert_invalid_session_id(err);
+
+    // Nothing escaped the tmp dir.
+    let parent = tmpdir.path().parent().unwrap();
+    let escape_path = parent.join("escape");
+    assert!(
+        !escape_path.exists(),
+        "save with '../escape' must not materialize {escape_path:?}"
+    );
+}
+
+#[tokio::test]
+async fn save_rejects_session_id_with_forward_slash() {
+    let tmpdir = tempfile::TempDir::new().unwrap();
+    let store = FileArtifactStore::new(tmpdir.path());
+
+    let err = store
+        .save("nested/path", "report.md", text_data("nope"))
+        .await
+        .unwrap_err();
+    assert_invalid_session_id(err);
+}
+
+#[tokio::test]
+async fn save_rejects_session_id_with_backslash() {
+    let tmpdir = tempfile::TempDir::new().unwrap();
+    let store = FileArtifactStore::new(tmpdir.path());
+
+    let err = store
+        .save("windows\\path", "report.md", text_data("nope"))
+        .await
+        .unwrap_err();
+    assert_invalid_session_id(err);
+}
+
+#[tokio::test]
+async fn save_rejects_absolute_session_id() {
+    let tmpdir = tempfile::TempDir::new().unwrap();
+    let store = FileArtifactStore::new(tmpdir.path());
+
+    // Leading `/` tripping absolute-path interpretation on Unix.
+    let err = store
+        .save("/tmp/absolute", "report.md", text_data("nope"))
+        .await
+        .unwrap_err();
+    assert_invalid_session_id(err);
+
+    // Windows-style drive prefix.
+    let err = store
+        .save("C:\\absolute", "report.md", text_data("nope"))
+        .await
+        .unwrap_err();
+    assert_invalid_session_id(err);
+}
+
+#[tokio::test]
+async fn save_rejects_session_id_with_null_byte() {
+    let tmpdir = tempfile::TempDir::new().unwrap();
+    let store = FileArtifactStore::new(tmpdir.path());
+
+    let err = store
+        .save("has\0null", "report.md", text_data("nope"))
+        .await
+        .unwrap_err();
+    assert_invalid_session_id(err);
+}
+
+#[tokio::test]
+async fn save_rejects_session_id_with_control_chars() {
+    let tmpdir = tempfile::TempDir::new().unwrap();
+    let store = FileArtifactStore::new(tmpdir.path());
+
+    let err = store
+        .save("has\ttab", "report.md", text_data("nope"))
+        .await
+        .unwrap_err();
+    assert_invalid_session_id(err);
+
+    let err = store
+        .save("has\nnewline", "report.md", text_data("nope"))
+        .await
+        .unwrap_err();
+    assert_invalid_session_id(err);
+}
+
+#[tokio::test]
+async fn save_rejects_empty_session_id() {
+    let tmpdir = tempfile::TempDir::new().unwrap();
+    let store = FileArtifactStore::new(tmpdir.path());
+
+    let err = store
+        .save("", "report.md", text_data("nope"))
+        .await
+        .unwrap_err();
+    assert_invalid_session_id(err);
+}
+
+// ─── Load / list / delete also validate ────────────────────────────────────
+
+#[tokio::test]
+async fn load_rejects_malicious_session_id() {
+    let tmpdir = tempfile::TempDir::new().unwrap();
+    let store = FileArtifactStore::new(tmpdir.path());
+
+    let err = store.load("../etc", "passwd").await.unwrap_err();
+    assert_invalid_session_id(err);
+}
+
+#[tokio::test]
+async fn load_version_rejects_malicious_session_id() {
+    let tmpdir = tempfile::TempDir::new().unwrap();
+    let store = FileArtifactStore::new(tmpdir.path());
+
+    let err = store.load_version("../etc", "passwd", 1).await.unwrap_err();
+    assert_invalid_session_id(err);
+}
+
+#[tokio::test]
+async fn list_rejects_malicious_session_id() {
+    let tmpdir = tempfile::TempDir::new().unwrap();
+    let store = FileArtifactStore::new(tmpdir.path());
+
+    let err = store.list("../etc").await.unwrap_err();
+    assert_invalid_session_id(err);
+}
+
+#[tokio::test]
+async fn delete_rejects_malicious_session_id() {
+    let tmpdir = tempfile::TempDir::new().unwrap();
+    let store = FileArtifactStore::new(tmpdir.path());
+
+    let err = store.delete("../etc", "passwd").await.unwrap_err();
+    assert_invalid_session_id(err);
+}
+
+// ─── Streaming APIs enforce the same validation ────────────────────────────
+
+#[tokio::test]
+async fn save_stream_rejects_malicious_session_id() {
+    let tmpdir = tempfile::TempDir::new().unwrap();
+    let store = FileArtifactStore::new(tmpdir.path());
+
+    let err = store
+        .save_stream(
+            "../pwn",
+            "evil.bin",
+            "application/octet-stream".to_string(),
+            HashMap::new(),
+            stream_of(b"data"),
+        )
+        .await
+        .unwrap_err();
+    assert_invalid_session_id(err);
+
+    // Ensure nothing landed on disk outside the artifact root.
+    let parent = tmpdir.path().parent().unwrap();
+    let escape_path = parent.join("pwn");
+    assert!(
+        !escape_path.exists(),
+        "save_stream with '../pwn' must not materialize {escape_path:?}"
+    );
+}
+
+#[tokio::test]
+async fn load_stream_rejects_malicious_session_id() {
+    let tmpdir = tempfile::TempDir::new().unwrap();
+    let store = FileArtifactStore::new(tmpdir.path());
+
+    let err = match store.load_stream("../etc", "passwd", None).await {
+        Ok(_) => panic!("load_stream should reject traversal session id"),
+        Err(e) => e,
+    };
+    assert_invalid_session_id(err);
+}
+
+// ─── Happy path: a well-formed session_id still works across all APIs ──────
+
+#[tokio::test]
+async fn valid_session_id_round_trips() {
+    let tmpdir = tempfile::TempDir::new().unwrap();
+    let store = FileArtifactStore::new(tmpdir.path());
+    let session = "20260417_120000_abc123";
+
+    // save
+    store
+        .save(session, "notes.md", text_data("v1"))
+        .await
+        .unwrap();
+
+    // load
+    let (data, version) = store.load(session, "notes.md").await.unwrap().unwrap();
+    assert_eq!(data.content, b"v1");
+    assert_eq!(version.version, 1);
+
+    // load_version
+    let (data_v1, _) = store
+        .load_version(session, "notes.md", 1)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(data_v1.content, b"v1");
+
+    // list
+    let metas = store.list(session).await.unwrap();
+    assert_eq!(metas.len(), 1);
+    assert_eq!(metas[0].name, "notes.md");
+
+    // delete
+    store.delete(session, "notes.md").await.unwrap();
+    assert!(store.load(session, "notes.md").await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn valid_session_id_round_trips_via_streaming() {
+    let tmpdir = tempfile::TempDir::new().unwrap();
+    let store = FileArtifactStore::new(tmpdir.path());
+    let session = "session_abc_123";
+
+    let version = store
+        .save_stream(
+            session,
+            "big.bin",
+            "application/octet-stream".to_string(),
+            HashMap::new(),
+            stream_of(b"streamed-content"),
+        )
+        .await
+        .unwrap();
+    assert_eq!(version.version, 1);
+
+    let loaded = store
+        .load_stream(session, "big.bin", None)
+        .await
+        .unwrap()
+        .unwrap();
+
+    use futures::StreamExt;
+    let chunks: Vec<_> = loaded.map(|r| r.unwrap()).collect().await;
+    let bytes: Vec<u8> = chunks.into_iter().flat_map(|b| b.to_vec()).collect();
+    assert_eq!(bytes, b"streamed-content");
+}

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -15,6 +15,12 @@ pub enum ArtifactError {
     #[error("invalid artifact name '{name}': {reason}")]
     InvalidName { name: String, reason: String },
 
+    #[error("invalid session id '{session_id}': {reason}")]
+    InvalidSessionId { session_id: String, reason: String },
+
+    #[error("resolved artifact path escapes the artifact root")]
+    PathOutsideRoot,
+
     #[error("artifact storage error: {0}")]
     Storage(#[from] Box<dyn std::error::Error + Send + Sync>),
 
@@ -189,6 +195,75 @@ pub fn validate_artifact_name(name: &str) -> Result<(), ArtifactError> {
             name: name.to_string(),
             reason: "name contains invalid characters (allowed: alphanumeric, -, _, ., /)"
                 .to_string(),
+        });
+    }
+
+    Ok(())
+}
+
+/// Validate a session ID for use in filesystem-backed artifact stores.
+///
+/// Session IDs are embedded directly in filesystem paths, so they must not
+/// contain characters that can alter path resolution. This rejects:
+///
+/// - Empty strings
+/// - Path separators (`/` and `\`)
+/// - Path traversal sequences (any occurrence of `..`)
+/// - Null bytes and ASCII control characters
+/// - Windows drive prefixes (e.g. `C:`) — by virtue of the `:` control filter
+/// - Leading/trailing whitespace
+///
+/// The rules match the stricter-than-default filter used by
+/// `swink-agent-memory`'s `JsonlSessionStore`, extended to also reject
+/// other ASCII control characters.
+pub fn validate_session_id(session_id: &str) -> Result<(), ArtifactError> {
+    if session_id.is_empty() {
+        return Err(ArtifactError::InvalidSessionId {
+            session_id: session_id.to_string(),
+            reason: "session id must not be empty".to_string(),
+        });
+    }
+
+    if session_id.trim() != session_id {
+        return Err(ArtifactError::InvalidSessionId {
+            session_id: session_id.to_string(),
+            reason: "session id must not contain leading or trailing whitespace".to_string(),
+        });
+    }
+
+    if session_id.contains('/') || session_id.contains('\\') {
+        return Err(ArtifactError::InvalidSessionId {
+            session_id: session_id.to_string(),
+            reason: "session id must not contain path separators".to_string(),
+        });
+    }
+
+    if session_id.contains("..") {
+        return Err(ArtifactError::InvalidSessionId {
+            session_id: session_id.to_string(),
+            reason: "session id must not contain path traversal".to_string(),
+        });
+    }
+
+    if session_id
+        .chars()
+        .any(|c| c == '\0' || c.is_ascii_control())
+    {
+        return Err(ArtifactError::InvalidSessionId {
+            session_id: session_id.to_string(),
+            reason: "session id must not contain control characters".to_string(),
+        });
+    }
+
+    // Reject anything that would be interpreted as an absolute path on either
+    // platform (Unix starts with `/`, Windows drive prefixes like `C:\`).
+    // Path separators and control chars above cover `\` and `\0`; the only
+    // remaining absolute-path shape is a single-letter drive prefix such as
+    // `C:` — reject any occurrence of `:` to be safe.
+    if session_id.contains(':') {
+        return Err(ArtifactError::InvalidSessionId {
+            session_id: session_id.to_string(),
+            reason: "session id must not contain ':'".to_string(),
         });
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,7 +165,7 @@ pub use util::{now_timestamp, prefix_chars, suffix_chars};
 #[cfg(feature = "artifact-store")]
 pub use artifact::{
     ArtifactByteStream, ArtifactData, ArtifactError, ArtifactMeta, ArtifactStore, ArtifactVersion,
-    StreamingArtifactStore, validate_artifact_name,
+    StreamingArtifactStore, validate_artifact_name, validate_session_id,
 };
 pub use display::{CoreDisplayMessage, DisplayRole, IntoDisplayMessages};
 #[cfg(feature = "plugins")]

--- a/src/tools/save_artifact.rs
+++ b/src/tools/save_artifact.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 use serde_json::Value;
 use tokio_util::sync::CancellationToken;
 
-use crate::artifact::{ArtifactData, ArtifactStore};
+use crate::artifact::{ArtifactData, ArtifactStore, validate_session_id};
 use crate::tool::{AgentTool, AgentToolResult, ToolFuture, validated_schema_for};
 
 /// Built-in tool that saves content as a versioned artifact.
@@ -85,6 +85,10 @@ impl<S: ArtifactStore + 'static> AgentTool for SaveArtifactTool<S> {
                     None => return AgentToolResult::error("no session_id in state"),
                 }
             };
+
+            if let Err(e) = validate_session_id(&session_id) {
+                return AgentToolResult::error(format!("{e}"));
+            }
 
             let content_type = parsed
                 .content_type


### PR DESCRIPTION
## Summary
- Reuses swink-agent-memory's strict session-id validator across FileArtifactStore save/load/list/delete and streaming APIs.
- Canonicalizes the artifact root on construction and rejects any resolved path that escapes it.
- Adds regression tests for traversal/absolute/invalid session_ids.

## Test plan
- [x] cargo fmt --all -- --check
- [x] cargo clippy --workspace -- -D warnings clean
- [x] cargo test --workspace passes
- [x] New traversal/validation regression tests

Closes #609

Generated with Claude Code