### PR TITLE
fix(mcp): emit connect/discovery/call lifecycle events

### DIFF
--- a/mcp/src/connection.rs
+++ b/mcp/src/connection.rs
@@ -52,6 +52,12 @@ pub struct McpConnection {
     pub discovered_tools: Vec<rmcp::model::Tool>,
     /// Shared connection state used by callers, shutdown, and the monitor task.
     state: Arc<Mutex<McpConnectionState>>,
+    /// Optional event channel for emitting MCP lifecycle events such as
+    /// `McpToolCallStarted` / `McpToolCallCompleted`. Connect, discovery, and
+    /// disconnect events are emitted through this sender during
+    /// [`connect`](Self::connect) / [`from_service`](Self::from_service) and
+    /// the background monitor task respectively.
+    event_tx: Option<UnboundedSender<AgentEvent>>,
 }
 
 impl std::fmt::Debug for McpConnection {
@@ -86,7 +92,16 @@ impl McpConnection {
                 peer: None,
                 monitor: None,
             })),
+            event_tx: None,
         }
+    }
+
+    /// Shared reference to the optional event sender.
+    ///
+    /// Used by tool wrappers to emit `McpToolCallStarted` /
+    /// `McpToolCallCompleted` around forwarded calls.
+    pub(crate) const fn event_tx(&self) -> Option<&UnboundedSender<AgentEvent>> {
+        self.event_tx.as_ref()
     }
 
     /// Create a connection from a pre-established rmcp service.
@@ -100,6 +115,11 @@ impl McpConnection {
         event_tx: Option<UnboundedSender<AgentEvent>>,
     ) -> Result<Self, McpError> {
         let peer = service.peer().clone();
+
+        // Handshake already completed before we were given the service.
+        emit_event(event_tx.as_ref(), || {
+            crate::event::server_connected(&config.name)
+        });
 
         let discovered_tools =
             peer.list_all_tools()
@@ -115,18 +135,28 @@ impl McpConnection {
             "MCP server connected via provided service, tools discovered"
         );
 
+        emit_event(event_tx.as_ref(), || {
+            crate::event::tools_discovered(&config.name, discovered_tools.len())
+        });
+
         let state = Arc::new(Mutex::new(McpConnectionState {
             status: McpConnectionStatus::Connected,
             peer: Some(peer),
             monitor: None,
         }));
-        let monitor = spawn_monitor(service, Arc::clone(&state), config.name.clone(), event_tx);
+        let monitor = spawn_monitor(
+            service,
+            Arc::clone(&state),
+            config.name.clone(),
+            event_tx.clone(),
+        );
         state.lock().unwrap_or_else(PoisonError::into_inner).monitor = Some(monitor);
 
         Ok(Self {
             config,
             discovered_tools,
             state,
+            event_tx,
         })
     }
 
@@ -148,6 +178,11 @@ impl McpConnection {
             }
         };
 
+        // Handshake succeeded, transport is live.
+        emit_event(event_tx.as_ref(), || {
+            crate::event::server_connected(&config.name)
+        });
+
         let peer = service.peer().clone();
 
         // Discover tools from the server.
@@ -165,18 +200,28 @@ impl McpConnection {
             "MCP server connected, tools discovered"
         );
 
+        emit_event(event_tx.as_ref(), || {
+            crate::event::tools_discovered(&config.name, discovered_tools.len())
+        });
+
         let state = Arc::new(Mutex::new(McpConnectionState {
             status: McpConnectionStatus::Connected,
             peer: Some(peer),
             monitor: None,
         }));
-        let monitor = spawn_monitor(service, Arc::clone(&state), config.name.clone(), event_tx);
+        let monitor = spawn_monitor(
+            service,
+            Arc::clone(&state),
+            config.name.clone(),
+            event_tx.clone(),
+        );
         state.lock().unwrap_or_else(PoisonError::into_inner).monitor = Some(monitor);
 
         Ok(Self {
             config,
             discovered_tools,
             state,
+            event_tx,
         })
     }
 
@@ -314,6 +359,19 @@ impl Drop for McpConnection {
         if let Some(monitor) = state.monitor.take() {
             monitor.abort();
         }
+    }
+}
+
+/// Send an event on the optional channel, ignoring closed-receiver errors.
+///
+/// The emitter is lazy so we never allocate event payloads when no channel
+/// is wired.
+pub fn emit_event(
+    event_tx: Option<&UnboundedSender<AgentEvent>>,
+    build: impl FnOnce() -> AgentEvent,
+) {
+    if let Some(tx) = event_tx {
+        let _ = tx.send(build());
     }
 }
 

--- a/mcp/src/tool.rs
+++ b/mcp/src/tool.rs
@@ -123,7 +123,13 @@ impl AgentTool for McpTool {
     ) -> ToolFuture<'_> {
         let original_name = self.original_name.clone();
         Box::pin(async move {
-            tokio::select! {
+            // Emit call-started before forwarding so observers see the full
+            // lifecycle bracket even if the call never returns.
+            crate::connection::emit_event(self.connection.event_tx(), || {
+                crate::event::tool_call_started(&self.server_name, &original_name)
+            });
+
+            let agent_result = tokio::select! {
                 result = self.connection.call_tool(&original_name, params) => {
                     match result {
                         Ok(call_result) => convert::call_result_to_agent_result(&call_result),
@@ -133,7 +139,17 @@ impl AgentTool for McpTool {
                 () = cancellation_token.cancelled() => {
                     AgentToolResult::error("MCP tool call cancelled")
                 }
-            }
+            };
+
+            crate::connection::emit_event(self.connection.event_tx(), || {
+                crate::event::tool_call_completed(
+                    &self.server_name,
+                    &original_name,
+                    agent_result.is_error,
+                )
+            });
+
+            agent_result
         })
     }
 }

--- a/mcp/tests/lifecycle_test.rs
+++ b/mcp/tests/lifecycle_test.rs
@@ -161,6 +161,11 @@ async fn monitor_detects_transport_close_and_emits_event() {
         "should start Connected"
     );
 
+    // Drain the connect + discovery events emitted during construction so
+    // only the disconnect event remains to be asserted below.
+    let _connect = event_rx.try_recv().expect("connect event");
+    let _discovery = event_rx.try_recv().expect("discovery event");
+
     let _ = cancel_tx.send(());
     let _ = server_task.await;
 
@@ -190,6 +195,264 @@ async fn monitor_detects_transport_close_and_emits_event() {
             assert_eq!(server_name, "crash-test-server");
         }
         other => panic!("unexpected event: {other:?}"),
+    }
+}
+
+/// Issue #611: `McpServerConnected` is emitted once the handshake completes.
+///
+/// Uses `from_service` to take a pre-established rmcp service past the
+/// handshake boundary and asserts the connect event is the first lifecycle
+/// event observed.
+#[tokio::test]
+async fn connected_event_emitted_after_handshake() {
+    let (event_tx, mut event_rx) = unbounded_channel::<AgentEvent>();
+
+    let mock_cfg = common::MockServerConfig::new(vec![]);
+    let service = common::spawn_mock_server_with_client(&mock_cfg).await;
+
+    let config = McpServerConfig {
+        name: "connect-event-server".into(),
+        transport: McpTransport::Stdio {
+            command: "mock".into(),
+            args: vec![],
+            env: HashMap::default(),
+        },
+        tool_prefix: None,
+        tool_filter: None,
+        requires_approval: false,
+    };
+
+    let _conn = McpConnection::from_service(config, service, Some(event_tx))
+        .await
+        .expect("connection should succeed");
+
+    let first = event_rx.try_recv().expect("connect event should be queued");
+    match first {
+        AgentEvent::McpServerConnected { server_name } => {
+            assert_eq!(server_name, "connect-event-server");
+        }
+        other => panic!("expected McpServerConnected first, got: {other:?}"),
+    }
+}
+
+/// Issue #611: `McpToolsDiscovered` is emitted after the list_tools round trip
+/// and carries the discovered tool count.
+#[tokio::test]
+async fn tools_discovered_event_emitted_after_discovery() {
+    let (event_tx, mut event_rx) = unbounded_channel::<AgentEvent>();
+
+    let mock_cfg = common::MockServerConfig::new(vec![]);
+    let service = common::spawn_mock_server_with_client(&mock_cfg).await;
+
+    let config = McpServerConfig {
+        name: "discovery-event-server".into(),
+        transport: McpTransport::Stdio {
+            command: "mock".into(),
+            args: vec![],
+            env: HashMap::default(),
+        },
+        tool_prefix: None,
+        tool_filter: None,
+        requires_approval: false,
+    };
+
+    let conn = McpConnection::from_service(config, service, Some(event_tx))
+        .await
+        .expect("connection should succeed");
+
+    // Drain events in order and assert we see connect followed by discovery.
+    let connect_evt = event_rx.try_recv().expect("connect event should fire");
+    assert!(
+        matches!(connect_evt, AgentEvent::McpServerConnected { .. }),
+        "first event should be McpServerConnected, got: {connect_evt:?}"
+    );
+
+    let discovery_evt = event_rx.try_recv().expect("discovery event should fire");
+    match discovery_evt {
+        AgentEvent::McpToolsDiscovered {
+            server_name,
+            tool_count,
+        } => {
+            assert_eq!(server_name, "discovery-event-server");
+            assert_eq!(
+                tool_count,
+                conn.discovered_tools.len(),
+                "discovery event tool_count should match connection's discovered tool list"
+            );
+        }
+        other => panic!("expected McpToolsDiscovered after connect, got: {other:?}"),
+    }
+}
+
+/// Issue #611: Forwarded tool calls are bracketed by
+/// `McpToolCallStarted` / `McpToolCallCompleted`, with `is_error=false` for
+/// successful calls.
+#[tokio::test]
+async fn tool_call_events_bracket_successful_call() {
+    use swink_agent::AgentTool;
+
+    let (event_tx, mut event_rx) = unbounded_channel::<AgentEvent>();
+
+    let mock_cfg = common::MockServerConfig::new(vec![]);
+    let service = common::spawn_mock_server_with_client(&mock_cfg).await;
+
+    let config = McpServerConfig {
+        name: "call-event-server".into(),
+        transport: McpTransport::Stdio {
+            command: "mock".into(),
+            args: vec![],
+            env: HashMap::default(),
+        },
+        tool_prefix: None,
+        tool_filter: None,
+        requires_approval: false,
+    };
+
+    let conn = McpConnection::from_service(config, service, Some(event_tx))
+        .await
+        .expect("connection should succeed");
+
+    // Drain the connect + discovery events emitted during construction.
+    let _connect = event_rx.try_recv().expect("connect event");
+    let _discovery = event_rx.try_recv().expect("discovery event");
+
+    let echo_def = conn
+        .discovered_tools
+        .iter()
+        .find(|t| t.name == "echo")
+        .expect("mock server advertises echo tool")
+        .clone();
+    let conn = Arc::new(conn);
+    let tool = McpTool::new(
+        &echo_def,
+        None,
+        "call-event-server",
+        false,
+        Arc::clone(&conn),
+    );
+
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let state = Arc::new(std::sync::RwLock::new(SessionState::default()));
+    let result = tool
+        .execute(
+            "call-1",
+            serde_json::json!({"text": "hello"}),
+            cancel,
+            None,
+            state,
+            None,
+        )
+        .await;
+
+    assert!(!result.is_error, "echo call should succeed");
+
+    let started = event_rx.try_recv().expect("tool_call_started event");
+    match started {
+        AgentEvent::McpToolCallStarted {
+            server_name,
+            tool_name,
+        } => {
+            assert_eq!(server_name, "call-event-server");
+            assert_eq!(tool_name, "echo");
+        }
+        other => panic!("expected McpToolCallStarted first, got: {other:?}"),
+    }
+
+    let completed = event_rx.try_recv().expect("tool_call_completed event");
+    match completed {
+        AgentEvent::McpToolCallCompleted {
+            server_name,
+            tool_name,
+            is_error,
+        } => {
+            assert_eq!(server_name, "call-event-server");
+            assert_eq!(tool_name, "echo");
+            assert!(
+                !is_error,
+                "successful echo call should report is_error=false"
+            );
+        }
+        other => panic!("expected McpToolCallCompleted, got: {other:?}"),
+    }
+}
+
+/// Issue #611: A failing tool call still emits `McpToolCallCompleted` with
+/// `is_error=true` — the completion event is guaranteed even in the error
+/// path so observers never see an unclosed bracket.
+#[tokio::test]
+async fn tool_call_completed_event_reports_error_on_failure() {
+    use swink_agent::AgentTool;
+
+    let (event_tx, mut event_rx) = unbounded_channel::<AgentEvent>();
+
+    let mock_cfg = common::MockServerConfig::new(vec![]);
+    let service = common::spawn_mock_server_with_client(&mock_cfg).await;
+
+    let config = McpServerConfig {
+        name: "error-call-event-server".into(),
+        transport: McpTransport::Stdio {
+            command: "mock".into(),
+            args: vec![],
+            env: HashMap::default(),
+        },
+        tool_prefix: None,
+        tool_filter: None,
+        requires_approval: false,
+    };
+
+    let conn = McpConnection::from_service(config, service, Some(event_tx))
+        .await
+        .expect("connection should succeed");
+
+    // Drain connect + discovery events so only call-related events remain.
+    let _connect = event_rx.try_recv().expect("connect event");
+    let _discovery = event_rx.try_recv().expect("discovery event");
+
+    let echo_def = conn
+        .discovered_tools
+        .iter()
+        .find(|t| t.name == "echo")
+        .expect("echo tool")
+        .clone();
+
+    // Force the call to fail by shutting down the connection before invoking.
+    conn.shutdown().await;
+
+    let conn = Arc::new(conn);
+    let tool = McpTool::new(
+        &echo_def,
+        None,
+        "error-call-event-server",
+        false,
+        Arc::clone(&conn),
+    );
+
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let state = Arc::new(std::sync::RwLock::new(SessionState::default()));
+    let result = tool
+        .execute(
+            "call-err",
+            serde_json::json!({"text": "hello"}),
+            cancel,
+            None,
+            state,
+            None,
+        )
+        .await;
+
+    assert!(result.is_error, "disconnected call should error");
+
+    let started = event_rx.try_recv().expect("tool_call_started event");
+    assert!(
+        matches!(started, AgentEvent::McpToolCallStarted { .. }),
+        "first event should be McpToolCallStarted, got: {started:?}"
+    );
+    let completed = event_rx.try_recv().expect("tool_call_completed event");
+    match completed {
+        AgentEvent::McpToolCallCompleted { is_error, .. } => {
+            assert!(is_error, "failing call should report is_error=true");
+        }
+        other => panic!("expected McpToolCallCompleted, got: {other:?}"),
     }
 }
 


### PR DESCRIPTION
## Summary
- Emits McpServerConnected and McpToolsDiscovered after successful handshake/discovery in connection.rs.
- Emits McpToolCallStarted and McpToolCallCompleted around forwarded MCP tool calls in tool.rs.
- Disconnect emission unchanged.
- Adds regression tests for each event.

Restores parity with the public contract in specs/038-mcp-integration/spec.md.

## Test plan
- [x] cargo fmt --all -- --check
- [x] cargo clippy --workspace -- -D warnings clean
- [x] cargo test --workspace passes
- [x] Regression tests for connect/discovery/call-start/call-complete events

Closes #611

🤖 Generated with [Claude Code](https://claude.com/claude-code)