### PR TITLE
fix(auth): redact OAuth2 refresh error bodies

### DIFF
--- a/auth/src/oauth2.rs
+++ b/auth/src/oauth2.rs
@@ -18,10 +18,77 @@ pub struct TokenResponse {
     pub token_type: Option<String>,
 }
 
+/// Standard OAuth2 error response body (RFC 6749 §5.2).
+///
+/// Used to extract a stable `error` code (and optional `error_description`)
+/// from a token endpoint failure without surfacing the full raw body — which
+/// may contain provider-specific diagnostic data that should not leak into
+/// tool output or user-visible logs.
+#[derive(Debug, Deserialize)]
+struct OAuth2ErrorBody {
+    error: String,
+    #[serde(default)]
+    error_description: Option<String>,
+}
+
+/// Build a sanitized refresh-failure reason string from the HTTP status and
+/// optional response body.
+///
+/// The returned string NEVER includes the raw body verbatim. When the body
+/// parses as an RFC 6749 §5.2 OAuth2 error response, the stable `error` code
+/// (and a length-capped `error_description`, if present) is included. All
+/// other bodies are ignored and only the status appears in the surfaced
+/// reason.
+///
+/// The full body is expected to be emitted separately via `tracing::debug!`
+/// by the caller so operators can still diagnose failures when debug logging
+/// is enabled — but it never reaches `CredentialError::RefreshFailed.reason`
+/// and therefore never propagates into tool output.
+fn sanitize_refresh_reason(status: reqwest::StatusCode, body: &str) -> String {
+    // Attempt to parse a standard OAuth2 error response. Anything else
+    // (HTML error pages, opaque vendor JSON, plain text, empty) degrades to a
+    // status-only reason.
+    if let Ok(parsed) = serde_json::from_str::<OAuth2ErrorBody>(body) {
+        // Cap the description to prevent a pathological vendor from stuffing
+        // sensitive content into `error_description`.
+        const DESCRIPTION_MAX: usize = 200;
+        let trimmed_description = parsed.error_description.as_deref().map(|d| {
+            if d.len() > DESCRIPTION_MAX {
+                format!("{}…", &d[..DESCRIPTION_MAX])
+            } else {
+                d.to_string()
+            }
+        });
+
+        if let Some(desc) = trimmed_description {
+            format!(
+                "token refresh failed: HTTP {} ({}: {})",
+                status.as_u16(),
+                parsed.error,
+                desc
+            )
+        } else {
+            format!(
+                "token refresh failed: HTTP {} ({})",
+                status.as_u16(),
+                parsed.error
+            )
+        }
+    } else {
+        format!("token refresh failed: HTTP {}", status.as_u16())
+    }
+}
+
 /// Perform an OAuth2 token refresh via the token endpoint.
 ///
 /// Sends a POST request with `grant_type=refresh_token` to the given
 /// `token_url`. Returns the parsed token response on success.
+///
+/// On failure, the returned [`CredentialError::RefreshFailed`] contains only
+/// a sanitized reason: HTTP status plus (if the body is a standard OAuth2
+/// error JSON) the stable `error` code and truncated description. The raw
+/// response body is NEVER included in the surfaced error — it is emitted only
+/// via `tracing::debug!` so it cannot leak into user-visible tool output.
 pub async fn refresh_token(
     client: &reqwest::Client,
     token_url: &str,
@@ -53,9 +120,18 @@ pub async fn refresh_token(
     if !response.status().is_success() {
         let status = response.status();
         let body = response.text().await.unwrap_or_default();
+        // Raw body stays in debug tracing only; never surfaced in the error
+        // reason to avoid leaking token-endpoint payloads into tool output.
+        debug!(
+            status = %status,
+            body_len = body.len(),
+            body = %body,
+            "OAuth2 token refresh failed; raw body held for debug only"
+        );
+        let reason = sanitize_refresh_reason(status, &body);
         return Err(CredentialError::RefreshFailed {
             key: String::new(),
-            reason: format!("token endpoint returned {status}: {body}"),
+            reason,
         });
     }
 
@@ -66,4 +142,113 @@ pub async fn refresh_token(
             key: String::new(),
             reason: format!("failed to parse token response: {e}"),
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reqwest::StatusCode;
+
+    const LEAK_SENTINEL: &str = "LEAK_SENTINEL_ABC123";
+
+    #[test]
+    fn sanitized_reason_with_standard_oauth2_error_json() {
+        let body = format!(
+            r#"{{"error":"invalid_grant","error_description":"refresh token expired {LEAK_SENTINEL}"}}"#
+        );
+        let reason = sanitize_refresh_reason(StatusCode::UNAUTHORIZED, &body);
+
+        // Status and standard code are included.
+        assert!(reason.contains("401"), "reason missing status: {reason}");
+        assert!(
+            reason.contains("invalid_grant"),
+            "reason missing error code: {reason}"
+        );
+        // The description is preserved here because it is a stable field in
+        // the RFC 6749 §5.2 contract; callers are responsible for not
+        // stuffing secrets into `error_description`. The sentinel may appear
+        // because it lives inside the standard description field, which is
+        // intentionally surfaced — the leak test below uses a body OUTSIDE
+        // the standard schema to prove non-standard fields never leak.
+        assert!(reason.starts_with("token refresh failed:"));
+    }
+
+    #[test]
+    fn sanitized_reason_with_oauth2_error_no_description() {
+        let body = r#"{"error":"invalid_grant"}"#;
+        let reason = sanitize_refresh_reason(StatusCode::BAD_REQUEST, body);
+        assert_eq!(
+            reason, "token refresh failed: HTTP 400 (invalid_grant)",
+            "unexpected reason format"
+        );
+    }
+
+    #[test]
+    fn sanitized_reason_redacts_non_standard_json_body() {
+        // Vendor JSON that is NOT an RFC 6749 §5.2 error response — contains
+        // a sentinel that must never reach the surfaced reason.
+        let body = format!(
+            r#"{{"trace_id":"abc","internal_message":"db lookup failed {LEAK_SENTINEL}"}}"#
+        );
+        let reason = sanitize_refresh_reason(StatusCode::INTERNAL_SERVER_ERROR, &body);
+
+        assert!(
+            !reason.contains(LEAK_SENTINEL),
+            "sentinel leaked into reason: {reason}"
+        );
+        assert_eq!(reason, "token refresh failed: HTTP 500");
+    }
+
+    #[test]
+    fn sanitized_reason_redacts_malformed_body() {
+        let body = format!("<html><body>internal error {LEAK_SENTINEL}</body></html>");
+        let reason = sanitize_refresh_reason(StatusCode::BAD_GATEWAY, &body);
+
+        assert!(
+            !reason.contains(LEAK_SENTINEL),
+            "sentinel leaked into reason: {reason}"
+        );
+        assert!(
+            !reason.contains("html"),
+            "body fragment leaked into reason: {reason}"
+        );
+        assert_eq!(reason, "token refresh failed: HTTP 502");
+    }
+
+    #[test]
+    fn sanitized_reason_redacts_empty_body() {
+        let reason = sanitize_refresh_reason(StatusCode::UNAUTHORIZED, "");
+        assert_eq!(reason, "token refresh failed: HTTP 401");
+    }
+
+    #[test]
+    fn sanitized_reason_caps_error_description_length() {
+        let long_desc = "x".repeat(500);
+        let body = format!(r#"{{"error":"invalid_grant","error_description":"{long_desc}"}}"#);
+        let reason = sanitize_refresh_reason(StatusCode::UNAUTHORIZED, &body);
+
+        // Cap is 200 chars + trailing ellipsis.
+        assert!(
+            reason.len() < 300,
+            "reason should be length-capped, got {} chars: {reason}",
+            reason.len()
+        );
+        assert!(reason.contains("…"), "reason missing truncation marker");
+    }
+
+    #[test]
+    fn sanitized_reason_does_not_include_body_for_ignored_fields() {
+        // A standard OAuth2 body with an extra sensitive field outside the
+        // recognized schema. serde's default behavior ignores unknown fields,
+        // so the sentinel in `debug_info` must NOT appear in the reason.
+        let body =
+            format!(r#"{{"error":"invalid_grant","debug_info":"raw token dump {LEAK_SENTINEL}"}}"#);
+        let reason = sanitize_refresh_reason(StatusCode::UNAUTHORIZED, &body);
+
+        assert!(
+            !reason.contains(LEAK_SENTINEL),
+            "non-standard field leaked into reason: {reason}"
+        );
+        assert!(reason.contains("invalid_grant"));
+    }
 }

--- a/auth/tests/oauth2_tests.rs
+++ b/auth/tests/oauth2_tests.rs
@@ -182,6 +182,187 @@ async fn refresh_per_key_independence() {
     // wiremock verifies exactly 2 requests
 }
 
+// Issue #613: the raw token-endpoint response body must never leak into the
+// surfaced `CredentialError::RefreshFailed` reason / Display output. The
+// tests below feed a unique sentinel string in the body and assert the
+// sentinel does NOT appear in the public-facing error text.
+const LEAK_SENTINEL: &str = "LEAK_SENTINEL_ABC123";
+
+#[tokio::test]
+async fn refresh_error_does_not_leak_non_standard_body() {
+    let mock_server = MockServer::start().await;
+
+    // Non-standard JSON body with a sensitive-looking sentinel field.
+    Mock::given(method("POST"))
+        .and(path("/token"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+            "trace_id": "t-42",
+            "internal_message": format!("raw token dump {LEAK_SENTINEL}"),
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let token_url = format!("{}/token", mock_server.uri());
+    let store = Arc::new(
+        InMemoryCredentialStore::empty().with_credential("oauth-key", expired_oauth2(&token_url)),
+    );
+    let resolver = DefaultCredentialResolver::new(store);
+
+    let err = resolver.resolve("oauth-key").await.unwrap_err();
+    let display = format!("{err}");
+    let debug = format!("{err:?}");
+
+    assert!(
+        !display.contains(LEAK_SENTINEL),
+        "sentinel leaked into Display: {display}"
+    );
+    assert!(
+        !debug.contains(LEAK_SENTINEL),
+        "sentinel leaked into Debug: {debug}"
+    );
+    assert!(
+        display.contains("401"),
+        "status missing from Display: {display}"
+    );
+}
+
+#[tokio::test]
+async fn refresh_error_standard_oauth2_surface_includes_error_code_only() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/token"))
+        .respond_with(ResponseTemplate::new(400).set_body_json(serde_json::json!({
+            "error": "invalid_grant",
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let token_url = format!("{}/token", mock_server.uri());
+    let store = Arc::new(
+        InMemoryCredentialStore::empty().with_credential("oauth-key", expired_oauth2(&token_url)),
+    );
+    let resolver = DefaultCredentialResolver::new(store);
+
+    let err = resolver.resolve("oauth-key").await.unwrap_err();
+    let display = format!("{err}");
+
+    assert!(
+        display.contains("400"),
+        "status missing from Display: {display}"
+    );
+    assert!(
+        display.contains("invalid_grant"),
+        "standard error code missing from Display: {display}"
+    );
+}
+
+#[tokio::test]
+async fn refresh_error_malformed_body_degrades_to_status_only() {
+    let mock_server = MockServer::start().await;
+
+    let html_body = format!("<html><body>boom {LEAK_SENTINEL}</body></html>");
+    Mock::given(method("POST"))
+        .and(path("/token"))
+        .respond_with(ResponseTemplate::new(502).set_body_string(html_body))
+        .mount(&mock_server)
+        .await;
+
+    let token_url = format!("{}/token", mock_server.uri());
+    let store = Arc::new(
+        InMemoryCredentialStore::empty().with_credential("oauth-key", expired_oauth2(&token_url)),
+    );
+    let resolver = DefaultCredentialResolver::new(store);
+
+    let err = resolver.resolve("oauth-key").await.unwrap_err();
+    let display = format!("{err}");
+
+    assert!(
+        !display.contains(LEAK_SENTINEL),
+        "sentinel leaked into Display: {display}"
+    );
+    assert!(
+        !display.contains("<html"),
+        "raw HTML leaked into Display: {display}"
+    );
+    assert!(
+        display.contains("502"),
+        "status missing from Display: {display}"
+    );
+}
+
+#[tokio::test]
+async fn refresh_error_standard_body_ignores_non_standard_fields() {
+    // A mostly-standard OAuth2 error body with an extra vendor diagnostic
+    // field that serde should ignore. The sentinel lives in the ignored
+    // field and must NOT leak.
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/token"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+            "error": "invalid_grant",
+            "debug_info": format!("diagnostic payload {LEAK_SENTINEL}"),
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let token_url = format!("{}/token", mock_server.uri());
+    let store = Arc::new(
+        InMemoryCredentialStore::empty().with_credential("oauth-key", expired_oauth2(&token_url)),
+    );
+    let resolver = DefaultCredentialResolver::new(store);
+
+    let err = resolver.resolve("oauth-key").await.unwrap_err();
+    let display = format!("{err}");
+
+    assert!(
+        !display.contains(LEAK_SENTINEL),
+        "non-standard field leaked into Display: {display}"
+    );
+    assert!(display.contains("invalid_grant"));
+    assert!(display.contains("401"));
+}
+
+#[tokio::test]
+async fn refresh_error_tool_output_path_does_not_leak_body() {
+    // Simulates the flow in `src/loop_/tool_dispatch/execute.rs` where a
+    // `CredentialError` is converted into tool output via
+    // `AgentToolResult::error(format!("{cred_error}"))`. This asserts that
+    // the tool-facing string carries no body fragments.
+    let mock_server = MockServer::start().await;
+
+    let vendor_body = serde_json::json!({
+        "internal_trace": format!("secret {LEAK_SENTINEL} fragment"),
+        "request_id": "req-1",
+    });
+    Mock::given(method("POST"))
+        .and(path("/token"))
+        .respond_with(ResponseTemplate::new(500).set_body_json(vendor_body))
+        .mount(&mock_server)
+        .await;
+
+    let token_url = format!("{}/token", mock_server.uri());
+    let store = Arc::new(
+        InMemoryCredentialStore::empty().with_credential("oauth-key", expired_oauth2(&token_url)),
+    );
+    let resolver = DefaultCredentialResolver::new(store);
+
+    let err = resolver.resolve("oauth-key").await.unwrap_err();
+    // Mirror execute.rs:203 exactly.
+    let tool_output_text = format!("{err}");
+
+    assert!(
+        !tool_output_text.contains(LEAK_SENTINEL),
+        "sentinel leaked into tool output: {tool_output_text}"
+    );
+    assert!(
+        !tool_output_text.contains("internal_trace"),
+        "vendor field name leaked into tool output: {tool_output_text}"
+    );
+    assert!(tool_output_text.contains("500"));
+}
+
 // T064: Pre-provisioned expired OAuth2 auto-refreshes without handler
 #[tokio::test]
 async fn pre_provisioned_expired_auto_refreshes() {


### PR DESCRIPTION
## Summary
- Sanitizes `CredentialError::RefreshFailed.reason` to use HTTP status + standard OAuth2 error code/description instead of the raw token endpoint body.
- Adds regression tests using a sentinel body string to prove no body fragments leak into the surfaced error.
- Full body remains available via debug tracing only (if needed).

## Test plan
- [x] cargo fmt --all -- --check
- [x] cargo clippy --workspace -- -D warnings clean
- [x] cargo test --workspace passes
- [x] Sentinel-leak regression tests

Closes #613

🤖 Generated with [Claude Code](https://claude.com/claude-code)