### PR TITLE
fix(tui): prevent #key secrets from entering input history

### DIFF
--- a/tui/src/app/event_loop.rs
+++ b/tui/src/app/event_loop.rs
@@ -455,7 +455,17 @@ impl App {
 
     #[allow(clippy::too_many_lines)]
     pub(super) fn submit_input(&mut self) {
-        let Some(text) = self.input.submit() else {
+        // Classify the pending input BEFORE draining the editor so that
+        // secret-bearing commands (e.g. `#key <provider> <api-key>`) can be
+        // submitted without entering the input history. See issue #614.
+        let pending = self.input.lines().join("\n");
+        let sensitive = commands::is_sensitive_input(&pending);
+        let submit_result = if sensitive {
+            self.input.submit_without_history()
+        } else {
+            self.input.submit()
+        };
+        let Some(text) = submit_result else {
             return;
         };
 

--- a/tui/src/app/tests/input_ui.rs
+++ b/tui/src/app/tests/input_ui.rs
@@ -518,3 +518,99 @@ async fn hash_help_toggles_panel() {
 
     assert!(app.help_panel.visible);
 }
+
+/// Helper: type a literal string into the input editor.
+fn type_input(app: &mut App, s: &str) {
+    for c in s.chars() {
+        app.input.insert_char(c);
+    }
+}
+
+/// Regression: secrets submitted via `#key <provider> <api-key>` must NOT
+/// be recallable via Up-arrow history navigation. Covers issue #614.
+#[tokio::test]
+async fn hash_key_submission_is_not_recallable_via_history() {
+    let mut app = App::new(TuiConfig::default());
+
+    type_input(&mut app, "#key openai sk-leak-sentinel-xyz");
+    app.submit_input();
+
+    // Navigate history up — nothing should come back.
+    app.input.history_prev();
+
+    assert_eq!(
+        app.input.lines(),
+        &[String::new()],
+        "sensitive `#key` submission must not be recallable via history"
+    );
+    for line in app.input.lines() {
+        assert!(
+            !line.contains("sk-leak-sentinel-xyz"),
+            "secret value leaked into recalled history line: {line}"
+        );
+    }
+}
+
+/// Regression: multi-line submissions containing a `#key` line must be
+/// withheld from history in full — not just the key line.
+#[tokio::test]
+async fn multiline_hash_key_submission_is_fully_redacted() {
+    let mut app = App::new(TuiConfig::default());
+
+    type_input(&mut app, "preamble");
+    app.input.insert_newline();
+    type_input(&mut app, "#key anthropic sk-ant-top-secret-multi");
+    app.input.insert_newline();
+    type_input(&mut app, "epilogue");
+
+    app.submit_input();
+
+    app.input.history_prev();
+
+    for line in app.input.lines() {
+        assert!(
+            !line.contains("sk-ant-top-secret-multi"),
+            "multi-line sensitive entry leaked into history: {line}"
+        );
+    }
+    assert_eq!(
+        app.input.lines(),
+        &[String::new()],
+        "multi-line sensitive entry must be fully absent from history"
+    );
+}
+
+/// Regression: non-sensitive commands must continue to enter history so
+/// users can recall them with Up-arrow.
+#[tokio::test]
+async fn non_sensitive_command_is_recallable_via_history() {
+    let mut app = App::new(TuiConfig::default());
+
+    type_input(&mut app, "/help");
+    app.submit_input();
+
+    app.input.history_prev();
+
+    assert_eq!(
+        app.input.lines(),
+        &["/help".to_string()],
+        "non-sensitive command should remain recallable via history"
+    );
+}
+
+/// Regression: plain text submissions continue to enter history.
+#[tokio::test]
+async fn plain_text_submission_is_recallable_via_history() {
+    let mut app = App::new(TuiConfig::default());
+
+    type_input(&mut app, "hello world");
+    app.submit_input();
+
+    app.input.history_prev();
+
+    assert_eq!(
+        app.input.lines(),
+        &["hello world".to_string()],
+        "plain text should remain recallable via history"
+    );
+}

--- a/tui/src/commands.rs
+++ b/tui/src/commands.rs
@@ -86,6 +86,37 @@ pub fn execute_command(input: &str) -> CommandResult {
     CommandResult::NotACommand
 }
 
+/// Classify whether the given input carries a user-supplied secret.
+///
+/// The classification runs BEFORE the input is persisted to the editor's
+/// history buffer, so that callers can skip history persistence for sensitive
+/// submissions. Currently this covers `#key <provider> <api-key>` entries;
+/// other hash/slash commands are treated as non-sensitive.
+///
+/// Detection is intentionally permissive: any line (in possibly multi-line
+/// input) whose trimmed content starts with `#key ` followed by both a
+/// provider and a key marks the whole submission as sensitive so that the
+/// full entry is withheld from history, not just the offending line.
+#[must_use]
+pub fn is_sensitive_input(input: &str) -> bool {
+    input.lines().any(|line| {
+        let Some(rest) = line.trim_start().strip_prefix('#') else {
+            return false;
+        };
+        let Some(after_key) = rest.trim_start().strip_prefix("key") else {
+            return false;
+        };
+        // Require whitespace after `key` so `#keys` is NOT flagged.
+        let Some(args) = after_key.strip_prefix(|c: char| c.is_whitespace()) else {
+            return false;
+        };
+        // Must contain both a provider and a key.
+        args.trim()
+            .split_once(char::is_whitespace)
+            .is_some_and(|(_, key)| !key.trim().is_empty())
+    })
+}
+
 fn execute_hash_command(cmd: &str) -> CommandResult {
     match cmd {
         "help" => CommandResult::ToggleHelp,
@@ -444,5 +475,49 @@ mod tests {
         assert_ne!(ApprovalModeArg::On, ApprovalModeArg::Off);
         // Ensure Debug is implemented
         let _ = format!("{:?}", ApprovalModeArg::On);
+    }
+
+    // --- Sensitive input classification ---
+
+    #[test]
+    fn hash_key_with_provider_and_key_is_sensitive() {
+        assert!(is_sensitive_input("#key openai sk-leak-sentinel-xyz"));
+    }
+
+    #[test]
+    fn hash_key_with_leading_whitespace_is_sensitive() {
+        assert!(is_sensitive_input("   #key anthropic sk-ant-xyz   "));
+    }
+
+    #[test]
+    fn hash_key_only_is_not_sensitive() {
+        // `#key` alone (no provider/key) exposes no secret.
+        assert!(!is_sensitive_input("#key"));
+    }
+
+    #[test]
+    fn hash_key_with_provider_only_is_not_sensitive() {
+        // No key present yet; treat as non-secret so the usage hint is
+        // recallable via history.
+        assert!(!is_sensitive_input("#key openai"));
+    }
+
+    #[test]
+    fn hash_keys_list_is_not_sensitive() {
+        // `#keys` lists provider names and carries no secret material.
+        assert!(!is_sensitive_input("#keys"));
+    }
+
+    #[test]
+    fn plain_text_is_not_sensitive() {
+        assert!(!is_sensitive_input("hello world"));
+        assert!(!is_sensitive_input("/help"));
+        assert!(!is_sensitive_input("#help"));
+    }
+
+    #[test]
+    fn multiline_with_embedded_key_is_sensitive() {
+        let input = "line one\n#key openai sk-embedded\nline three";
+        assert!(is_sensitive_input(input));
     }
 }

--- a/tui/src/ui/input.rs
+++ b/tui/src/ui/input.rs
@@ -203,16 +203,33 @@ impl InputEditor {
         self.cursor_col = Self::byte_to_char(&self.lines[self.cursor_row]);
     }
 
-    /// Submit the current input, returning the full text. Clears the editor.
-    /// Returns None if the input is empty/whitespace.
+    /// Submit the current input, returning the full text. Clears the editor
+    /// and pushes the submitted lines onto the history buffer.
+    ///
+    /// Returns `None` if the input is empty/whitespace.
     pub fn submit(&mut self) -> Option<String> {
+        self.submit_inner(true)
+    }
+
+    /// Submit the current input WITHOUT persisting the lines to history.
+    ///
+    /// Used for submissions that contain user-supplied secrets (e.g.
+    /// `#key <provider> <api-key>`) so that the value cannot be recalled
+    /// via history navigation. Returns `None` if the input is empty.
+    pub fn submit_without_history(&mut self) -> Option<String> {
+        self.submit_inner(false)
+    }
+
+    fn submit_inner(&mut self, push_to_history: bool) -> Option<String> {
         let text: String = self.lines.join("\n");
         let trimmed = text.trim().to_string();
         if trimmed.is_empty() {
             return None;
         }
-        // Save to history
-        self.history.push(self.lines.clone());
+        if push_to_history {
+            // Save to history
+            self.history.push(self.lines.clone());
+        }
         // Reset editor
         self.lines = vec![String::new()];
         self.cursor_row = 0;
@@ -506,6 +523,84 @@ mod tests {
         assert_eq!(editor.cursor_row, 0);
         assert_eq!(editor.cursor_col, 0);
         assert_eq!(editor.history.len(), 1);
+    }
+
+    #[test]
+    fn submit_without_history_clears_but_skips_history() {
+        let mut editor = InputEditor::new();
+        for c in "#key openai sk-leak-sentinel".chars() {
+            editor.insert_char(c);
+        }
+        let result = editor.submit_without_history();
+        assert_eq!(result.as_deref(), Some("#key openai sk-leak-sentinel"));
+        assert_eq!(editor.lines, vec![String::new()]);
+        assert_eq!(editor.cursor_row, 0);
+        assert_eq!(editor.cursor_col, 0);
+        assert!(
+            editor.history.is_empty(),
+            "submit_without_history must not push to history"
+        );
+    }
+
+    #[test]
+    fn submit_without_history_on_empty_returns_none() {
+        let mut editor = InputEditor::new();
+        assert_eq!(editor.submit_without_history(), None);
+        assert!(editor.history.is_empty());
+    }
+
+    #[test]
+    fn history_navigation_after_submit_without_history_is_empty() {
+        let mut editor = InputEditor::new();
+        for c in "#key openai sk-leak-sentinel-xyz".chars() {
+            editor.insert_char(c);
+        }
+        let submitted = editor.submit_without_history();
+        assert!(submitted.is_some());
+
+        // History is empty, so navigating backwards must not recall the key.
+        editor.history_prev();
+        assert_eq!(
+            editor.lines,
+            vec![String::new()],
+            "sensitive submission must not be recallable via history"
+        );
+        for line in &editor.lines {
+            assert!(
+                !line.contains("sk-leak-sentinel-xyz"),
+                "secret value leaked into history: {line}"
+            );
+        }
+    }
+
+    #[test]
+    fn multiline_sensitive_submission_does_not_enter_history() {
+        let mut editor = InputEditor::new();
+        editor.insert_char('p');
+        editor.insert_char('r');
+        editor.insert_char('e');
+        editor.insert_newline();
+        for c in "#key anthropic sk-ant-top-secret".chars() {
+            editor.insert_char(c);
+        }
+        editor.insert_newline();
+        editor.insert_char('p');
+        editor.insert_char('o');
+        editor.insert_char('s');
+        editor.insert_char('t');
+        let submitted = editor.submit_without_history();
+        assert!(submitted.is_some());
+
+        // Nothing should be recallable — the ENTIRE multi-line entry is
+        // withheld, not just the key line.
+        editor.history_prev();
+        for line in &editor.lines {
+            assert!(
+                !line.contains("sk-ant-top-secret"),
+                "multi-line sensitive entry leaked secret into history: {line}"
+            );
+        }
+        assert_eq!(editor.lines, vec![String::new()]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Classifies sensitive commands (currently `#key`) before `input.submit()` pushes to history, so secrets are never recalled via history navigation.
- Adds regression tests for history navigation after key submission and confirms non-sensitive commands still persist.

## Test plan
- [x] cargo fmt --all -- --check
- [x] cargo clippy --workspace -- -D warnings clean
- [x] cargo test --workspace passes
- [x] History-navigation regression tests for #key and non-sensitive commands

Closes #614

🤖 Generated with [Claude Code](https://claude.com/claude-code)