### PR TITLE
fix(adapters): stop retrying parse and protocol faults

### DIFF
--- a/adapters/AGENTS.md
+++ b/adapters/AGENTS.md
@@ -45,6 +45,7 @@
 - `finish_reason == "content_filter"` must be routed through `OaiSseStreamState.terminal_error`; emitting an inline error and then consuming a later `[DONE]` produces a duplicate terminal event that `accumulate_message` rejects.
 - In `src/google.rs`, `function_call.args` chunks are full snapshots, not deltas. Always overwrite the buffered args, including `null`, or a later empty snapshot can leave stale JSON from an earlier chunk.
 - In `src/ollama.rs`, the NDJSON parser must buffer raw bytes until it has a full newline-delimited record. Decoding each transport chunk independently with `from_utf8_lossy` corrupts split multibyte UTF-8.
+- In `src/ollama.rs` and `src/proxy.rs`, deterministic parse/protocol faults (malformed NDJSON/SSE JSON, proxy terminal-frame violations, unexpected `done` EOF) must use `AssistantMessageEvent::error(...)`, not `error_network(...)`; only transport failures stay retryable.
 - In `src/openai_compat.rs`, buffer tool-call arguments and delay `ToolCallStart` until a non-empty `function.name` is known; some providers stream arguments before the name.
 - Runtime SSE adapters must thread `StreamOptions.on_raw_payload` into the callback-aware shared parser (`sse_data_lines_with_callback`). The callback-free helper silently disables payload observers.
 - In `src/proxy.rs`, treat transport `data: [DONE]` as a protocol error unless the proxy has already emitted a typed `done` or `error` JSON event.

--- a/adapters/src/ollama.rs
+++ b/adapters/src/ollama.rs
@@ -403,7 +403,7 @@ fn parse_ndjson_stream(
                             // Stream ended without done=true
                             done = true;
                             let mut events = crate::finalize::finalize_blocks(&mut state);
-                            events.push(AssistantMessageEvent::error_network("Ollama stream ended unexpectedly"));
+                            events.push(AssistantMessageEvent::error("Ollama stream ended unexpectedly"));
                             Some((events, (lines, token, state, done, false)))
                         }
                         Some(Err(err)) => {
@@ -424,7 +424,7 @@ fn parse_ndjson_stream(
                                     error!(error = %e, "Ollama JSON parse error");
                                     done = true;
                                     let mut events = crate::finalize::finalize_blocks(&mut state);
-                                    events.push(AssistantMessageEvent::error_network(format!("Ollama JSON parse error: {e}")));
+                                    events.push(AssistantMessageEvent::error(format!("Ollama JSON parse error: {e}")));
                                     return Some((events, (lines, token, state, done, false)));
                                 }
                             };

--- a/adapters/src/proxy.rs
+++ b/adapters/src/proxy.rs
@@ -293,20 +293,16 @@ fn parse_sse_stream(
                                 "network error: SSE stream ended unexpectedly",
                             )
                         }
-                        Some(SseLine::Done) => {
-                            AssistantMessageEvent::error_network(
-                                "network error: proxy SSE transport ended before protocol terminal event",
-                            )
-                        }
+                        Some(SseLine::Done) => AssistantMessageEvent::error(
+                            "proxy SSE transport ended before protocol terminal event",
+                        ),
                         Some(SseLine::Data(data)) => {
                             parse_sse_event_data(&data)
                         }
                         Some(SseLine::TransportError(message)) => AssistantMessageEvent::error_network(format!(
                                 "network error: {message}",
                             )),
-                        Some(_) => AssistantMessageEvent::error_network(
-                            "network error: unexpected non-data SSE line",
-                        ),
+                        Some(_) => AssistantMessageEvent::error("unexpected non-data SSE line"),
                     }
                 }
             };
@@ -344,7 +340,7 @@ fn prepare_stream_event(
 fn parse_sse_event_data(data: &str) -> AssistantMessageEvent {
     match serde_json::from_str::<SseEventData>(data) {
         Ok(event) => convert_sse_event(event),
-        Err(e) => AssistantMessageEvent::error_network(format!("malformed SSE event JSON: {e}")),
+        Err(e) => AssistantMessageEvent::error(format!("malformed SSE event JSON: {e}")),
     }
 }
 

--- a/adapters/tests/ollama.rs
+++ b/adapters/tests/ollama.rs
@@ -580,16 +580,68 @@ async fn ollama_unexpected_stream_end() {
     let ollama = OllamaStreamFn::new(server.uri());
     let events = collect_events(&ollama).await;
 
-    let has_unexpected_end = events.iter().any(|e| match e {
-        AssistantMessageEvent::Error { error_message, .. } => error_message
-            .to_lowercase()
-            .contains("stream ended unexpectedly"),
-        _ => false,
-    });
-    assert!(
-        has_unexpected_end,
-        "expected error about 'stream ended unexpectedly', got: {events:?}"
-    );
+    let error = events
+        .iter()
+        .find(|event| matches!(event, AssistantMessageEvent::Error { .. }))
+        .expect("expected terminal error");
+    match error {
+        AssistantMessageEvent::Error {
+            error_message,
+            error_kind,
+            ..
+        } => {
+            assert!(
+                error_message
+                    .to_lowercase()
+                    .contains("stream ended unexpectedly"),
+                "expected error about 'stream ended unexpectedly', got: {error_message}"
+            );
+            assert_eq!(
+                *error_kind, None,
+                "unexpected Ollama EOF should not be marked retryable network error"
+            );
+        }
+        other => panic!("expected Error event, got {other:?}"),
+    }
+}
+
+/// 15. Malformed NDJSON should surface as a non-network terminal stream error.
+#[tokio::test]
+async fn ollama_malformed_ndjson_is_non_network_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/chat"))
+        .respond_with(ndjson_response(&[
+            r#"{"message":{"role":"assistant","content":"partial"},"done":false}"#,
+            "{not valid json at all!!!}",
+        ]))
+        .mount(&server)
+        .await;
+
+    let ollama = OllamaStreamFn::new(server.uri());
+    let events = collect_events(&ollama).await;
+
+    let error = events
+        .iter()
+        .find(|event| matches!(event, AssistantMessageEvent::Error { .. }))
+        .expect("expected terminal error");
+    match error {
+        AssistantMessageEvent::Error {
+            error_message,
+            error_kind,
+            ..
+        } => {
+            assert!(
+                error_message.contains("Ollama JSON parse error"),
+                "expected parse diagnostic, got: {error_message}"
+            );
+            assert_eq!(
+                *error_kind, None,
+                "malformed Ollama NDJSON should not be marked retryable network error"
+            );
+        }
+        other => panic!("expected Error event, got {other:?}"),
+    }
 }
 
 /// 15. A chunk with an empty thinking string should be skipped — no `ThinkingStart`

--- a/adapters/tests/proxy_http.rs
+++ b/adapters/tests/proxy_http.rs
@@ -367,16 +367,27 @@ async fn malformed_sse_event_produces_stream_error() {
     let proxy = ProxyStreamFn::new(server.uri(), "token");
     let events = collect_events(&proxy).await;
 
-    let has_malformed_error = events.iter().any(|e| match e {
-        AssistantMessageEvent::Error { error_message, .. } => {
-            error_message.contains("malformed SSE event JSON")
+    let error = events
+        .iter()
+        .find(|event| matches!(event, AssistantMessageEvent::Error { .. }))
+        .expect("expected terminal error");
+    match error {
+        AssistantMessageEvent::Error {
+            error_message,
+            error_kind,
+            ..
+        } => {
+            assert!(
+                error_message.contains("malformed SSE event JSON"),
+                "expected malformed-JSON diagnostic, got: {error_message}"
+            );
+            assert_eq!(
+                *error_kind, None,
+                "malformed proxy payloads must not be marked retryable network errors"
+            );
         }
-        _ => false,
-    });
-    assert!(
-        has_malformed_error,
-        "expected an error containing 'malformed SSE event JSON', got: {events:?}"
-    );
+        other => panic!("expected Error event, got {other:?}"),
+    }
 }
 
 // ── 5.9: Mid-stream disconnect produces network error ───────────────────
@@ -425,7 +436,7 @@ async fn mid_stream_disconnect_produces_network_error() {
 }
 
 #[tokio::test]
-async fn done_sentinel_without_protocol_terminal_produces_network_error() {
+async fn done_sentinel_without_protocol_terminal_produces_stream_error() {
     let body = [
         r#"data: {"type":"start"}"#,
         "",
@@ -463,12 +474,17 @@ async fn done_sentinel_without_protocol_terminal_produces_network_error() {
         AssistantMessageEvent::Error {
             error_message,
             stop_reason,
+            error_kind,
             ..
         } => {
             assert_eq!(*stop_reason, StopReason::Error);
             assert!(
                 error_message.contains("protocol terminal event"),
                 "expected terminal-event diagnostic, got: {error_message}"
+            );
+            assert_eq!(
+                *error_kind, None,
+                "protocol faults must not be marked retryable network errors"
             );
         }
         other => panic!("expected terminal Error event, got {other:?}"),


### PR DESCRIPTION
## What changed
- reclassified deterministic Proxy protocol faults so malformed SSE JSON and premature proxy transport `[DONE]` frames emit generic terminal stream errors instead of retryable network errors
- reclassified deterministic Ollama protocol faults so unexpected `done: false` EOF and malformed NDJSON emit generic terminal stream errors instead of retryable network errors
- added focused regressions in the public adapter test suites and documented the rule in `adapters/AGENTS.md`

## Slice completed
- completed the parse/protocol classification slice for issue #612 across `ProxyStreamFn` and `OllamaStreamFn`
- remaining work: none identified within the scoped issue description

## Validation output
- `cargo fmt --all`
- `cargo test -p swink-agent-adapters --features "proxy ollama" --test proxy_http --test ollama`
- `cargo clippy -p swink-agent-adapters --features "proxy ollama" --test proxy_http --test ollama -- -D warnings`

## Pre-existing baseline failures
- none encountered in the targeted adapter validation above
- full workspace validation was not run for this bounded adapter slice

Closes #612