### PR TITLE
[codex] docs: align local validation commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,10 +44,13 @@ Pure-Rust library for LLM-powered agentic loops. Provider-agnostic core with plu
 ## Build & Test
 
 ```bash
-cargo build --workspace
+cargo fmt --all --check                           # formatting
+cargo clippy --workspace -- -D warnings           # zero warnings policy
+cargo test --workspace                            # full workspace tests
+cargo build --workspace                           # full workspace build
 cargo test --workspace --features testkit         # testkit enables test helpers
 cargo test -p swink-agent --no-default-features   # verify builtin-tools disabled
-cargo clippy --workspace -- -D warnings           # zero warnings policy
+just validate                                     # same canonical gate via justfile
 cargo run -p swink-agent-tui                      # launch TUI (.env auto-loaded)
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,13 +71,17 @@ Link your PR to its issue using `Closes #<issue>` or `Related to #<issue>` in th
 Run this locally before opening:
 
 ```bash
-cargo fmt --check                                    # formatting
+cargo fmt --all --check                              # formatting
 cargo clippy --workspace -- -D warnings              # zero warnings
-cargo test --workspace                               # all tests
-cargo test -p swink-agent --no-default-features      # feature gate coverage
+cargo test --workspace                               # all workspace tests
+cargo build --workspace                              # full workspace build
+cargo test --workspace --features testkit            # testkit-enabled workspace tests
+cargo test -p swink-agent --no-default-features      # builtin-tools disabled coverage
 ```
 
-All four must pass. Do not edit `CHANGELOG.md` — entries are added by maintainers.
+`just validate` and `just check` run the same canonical gate.
+
+All six commands must pass. Do not edit `CHANGELOG.md` — entries are added by maintainers.
 
 Some tests hit live APIs and are `#[ignore]`. Run them with:
 ```bash

--- a/docs/testing_setup.md
+++ b/docs/testing_setup.md
@@ -22,13 +22,20 @@ This compiles all workspace crates: core library, adapters, local-llm, memory, e
 
 `swink-agent-local-llm` currently builds `llama-cpp-sys-2`, which runs `bindgen` during compilation. Install LLVM/libclang before running workspace-wide commands; if the build reports `Unable to find libclang`, set `LIBCLANG_PATH` to the LLVM directory that contains the shared library (`bin` on Windows).
 
-## 3. Run Unit Tests
+## 3. Run the Local Validation Gate
 
-Verify everything compiles and passes before connecting to live APIs:
+Verify the same local validation sequence required for PRs before connecting to live APIs:
 
 ```bash
+cargo fmt --all --check
+cargo clippy --workspace -- -D warnings
 cargo test --workspace
+cargo build --workspace
+cargo test --workspace --features testkit
+cargo test -p swink-agent --no-default-features
 ```
+
+`just validate` and `just check` run this exact command set.
 
 ## 4. Get API Keys
 

--- a/justfile
+++ b/justfile
@@ -9,6 +9,10 @@ set dotenv-load
 test:
     cargo nextest run --workspace
 
+# Run full workspace tests with testkit enabled
+test-testkit:
+    cargo test --workspace --features testkit
+
 # Run core crate tests with no default features (verifies builtin-tools disabled)
 test-no-features:
     cargo nextest run -p swink-agent --no-default-features
@@ -37,8 +41,17 @@ bench:
 tui:
     cargo run -p swink-agent-tui
 
-# Run all checks: lint, format check, docs
-check: lint fmt-check doc
+# Run the canonical local validation gate required before opening a PR
+validate:
+    cargo fmt --all --check
+    cargo clippy --workspace -- -D warnings
+    cargo test --workspace
+    cargo build --workspace
+    cargo test --workspace --features testkit
+    cargo test -p swink-agent --no-default-features
+
+# Backward-compatible alias for the canonical local validation gate
+check: validate
 
 # Build the entire workspace
 build:


### PR DESCRIPTION
## What changed
- added a canonical `just validate` recipe that runs the full local validation gate
- made `just check` a backward-compatible alias to that canonical gate
- updated `AGENTS.md`, `CONTRIBUTING.md`, and `docs/testing_setup.md` to reference the same six-command validation sequence

## Why / value
Local contributor guidance and the default task-runner path now point at the same required validation flow, which avoids false confidence from running only a partial local gate before opening a PR.

## Slice completed
Completed the local validation consistency slice for `justfile`, contributor docs, and testing setup docs. No CI workflow changes are included.

## Validation
- `cargo fmt --all --check`

## Pre-existing baseline failures
- None encountered in scope.
- `just` is not installed in this automation runner, so `just validate` / `just check` could not be executed locally here.

Closes #615