### PR TITLE
fix(adapters): gate Azure auth dependency

### DIFF
--- a/adapters/AGENTS.md
+++ b/adapters/AGENTS.md
@@ -10,6 +10,7 @@
 
 - `gemini` gates `mod google` — feature name matches public type `GeminiStreamFn`, not the file name.
 - `proxy` activates `eventsource-stream` dep. `bedrock` activates `sha2`/`hmac`/`chrono`/`aws-smithy-*` deps.
+- Provider-only support crates must stay optional and hang off the owning feature. In particular, `swink-agent-auth` belongs under `azure = ["dep:swink-agent-auth"]`; leaving it unconditional leaks Azure auth into non-Azure builds.
 - **Always compiled** (shared infra): `base`, `sse`, `classify`, `convert`, `finalize`, `openai_compat`, `remote_presets`.
 - `openai_compat` is shared by `openai`, `azure`, `mistral`, `xai` — compiles unconditionally but has `allow(dead_code)` when none enabled.
 - Portable CI must not run `--all-features` on a generic Linux runner — `metal`/`accelerate` pull Apple-only deps. Exclude `swink-agent-local-llm` or target explicit feature sets.
@@ -48,6 +49,7 @@
 - In `src/openai_compat.rs`, buffer tool-call arguments and delay `ToolCallStart` until a non-empty `function.name` is known; some providers stream arguments before the name.
 - Runtime SSE adapters must thread `StreamOptions.on_raw_payload` into the callback-aware shared parser (`sse_data_lines_with_callback`). The callback-free helper silently disables payload observers.
 - In `src/proxy.rs`, treat transport `data: [DONE]` as a protocol error unless the proxy has already emitted a typed `done` or `error` JSON event.
+- In `src/oai_transport.rs`, gate `OaiAdapterShell` helper methods to the provider features that actually call them. Azure-only builds reuse the request/parse pipeline but not the Bearer-auth convenience helpers, and otherwise `cargo clippy --no-default-features --features azure -D warnings` trips dead-code failures.
 
 ## Live Tests
 

--- a/adapters/Cargo.toml
+++ b/adapters/Cargo.toml
@@ -24,7 +24,7 @@ openai = ["openai-compat"]
 ollama = []
 gemini = []
 proxy = []
-azure = []
+azure = ["dep:swink-agent-auth"]
 bedrock = ["dep:aws-credential-types", "dep:aws-sigv4", "dep:aws-smithy-eventstream", "dep:aws-smithy-runtime-api", "dep:aws-smithy-types"]
 mistral = []
 xai = ["openai-compat"]
@@ -32,7 +32,7 @@ __no_default_features_sentinel = []
 
 [dependencies]
 swink-agent = { path = "..", version = "0.7.9", default-features = false }
-swink-agent-auth = { path = "../auth", version = "0.7.9" }
+swink-agent-auth = { path = "../auth", version = "0.7.9", optional = true }
 reqwest.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true

--- a/adapters/src/lib.rs
+++ b/adapters/src/lib.rs
@@ -2,19 +2,21 @@
 //! LLM provider adapters for [`swink-agent`](https://docs.rs/swink-agent).
 //!
 //! Provides [`StreamFn`](swink_agent::StreamFn) implementations for nine LLM providers.
-//! Each provider is behind a feature flag — enable only what you need:
+//! No provider is enabled by default; enable only what you need:
 //!
 //! | Feature | Provider |
 //! |---|---|
-//! | `anthropic` (default) | Anthropic Claude |
-//! | `openai` (default) | `OpenAI` GPT |
-//! | `ollama` (default) | `Ollama` (local) |
+//! | `anthropic` | Anthropic Claude |
+//! | `openai` | `OpenAI` GPT |
+//! | `ollama` | `Ollama` (local) |
 //! | `gemini` | Google Gemini |
 //! | `azure` | Azure `OpenAI` / AI Foundry |
 //! | `bedrock` | AWS Bedrock |
 //! | `mistral` | Mistral AI |
 //! | `xai` | xAI Grok |
 //! | `proxy` | Custom SSE proxy |
+//!
+//! Use `full` or `all` to compile every provider adapter.
 //!
 //! # Quick Start
 //!

--- a/adapters/src/oai_transport.rs
+++ b/adapters/src/oai_transport.rs
@@ -9,12 +9,15 @@
 //! Adapters that need provider-specific hooks (Azure auth, Mistral message
 //! ordering, etc.) apply those before or after calling into this module.
 
+#[cfg(feature = "openai-compat")]
 use std::pin::Pin;
 
 use futures::stream::{self, Stream, StreamExt as _};
-use tokio_util::sync::CancellationToken;
-use tracing::debug;
 use tracing::warn;
+#[cfg(feature = "openai-compat")]
+use tokio_util::sync::CancellationToken;
+#[cfg(feature = "openai-compat")]
+use tracing::debug;
 
 #[cfg(feature = "mistral")]
 use serde::Serialize;
@@ -40,6 +43,7 @@ pub struct OaiAdapterShell {
 }
 
 impl OaiAdapterShell {
+    #[cfg(any(feature = "openai-compat", feature = "mistral"))]
     pub(crate) fn new(
         provider: &'static str,
         base_url: impl Into<String>,
@@ -76,6 +80,7 @@ impl OaiAdapterShell {
         &self.base.client
     }
 
+    #[cfg(any(feature = "openai-compat", feature = "mistral"))]
     pub(crate) fn fmt_debug(
         &self,
         name: &'static str,
@@ -96,6 +101,7 @@ impl OaiAdapterShell {
         format!("{}{}", self.base.base_url, self.chat_completions_path)
     }
 
+    #[cfg(any(feature = "openai-compat", feature = "mistral"))]
     pub(crate) fn api_key<'a>(&'a self, options: &'a StreamOptions) -> &'a str {
         options.api_key.as_deref().unwrap_or(&self.base.api_key)
     }
@@ -114,6 +120,7 @@ impl OaiAdapterShell {
             .json(body)
     }
 
+    #[cfg(feature = "openai-compat")]
     pub(crate) fn stream<'a>(
         &'a self,
         model: &'a ModelSpec,

--- a/adapters/src/oai_transport.rs
+++ b/adapters/src/oai_transport.rs
@@ -13,11 +13,11 @@
 use std::pin::Pin;
 
 use futures::stream::{self, Stream, StreamExt as _};
-use tracing::warn;
 #[cfg(feature = "openai-compat")]
 use tokio_util::sync::CancellationToken;
 #[cfg(feature = "openai-compat")]
 use tracing::debug;
+use tracing::warn;
 
 #[cfg(feature = "mistral")]
 use serde::Serialize;

--- a/adapters/tests/cargo_manifest.rs
+++ b/adapters/tests/cargo_manifest.rs
@@ -1,0 +1,73 @@
+use std::process::Command;
+
+use serde_json::Value;
+
+fn adapters_package_metadata() -> Value {
+    let manifest_path = format!("{}/Cargo.toml", env!("CARGO_MANIFEST_DIR"));
+    let output = Command::new("cargo")
+        .args(["metadata", "--format-version", "1", "--no-deps"])
+        .arg("--manifest-path")
+        .arg(&manifest_path)
+        .output()
+        .expect("cargo metadata should run for adapters manifest");
+
+    assert!(
+        output.status.success(),
+        "cargo metadata failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let metadata: Value =
+        serde_json::from_slice(&output.stdout).expect("cargo metadata should emit valid JSON");
+
+    metadata["packages"]
+        .as_array()
+        .and_then(|packages| {
+            packages
+                .iter()
+                .find(|package| package["name"].as_str() == Some("swink-agent-adapters"))
+        })
+        .cloned()
+        .expect("swink-agent-adapters package metadata should be present")
+}
+
+#[test]
+fn azure_feature_owns_auth_dependency() {
+    let package = adapters_package_metadata();
+    let dependencies = package["dependencies"]
+        .as_array()
+        .expect("package dependencies should be an array");
+    let auth_dependency = dependencies
+        .iter()
+        .find(|dependency| dependency["name"].as_str() == Some("swink-agent-auth"))
+        .expect("swink-agent-auth dependency should be present");
+
+    assert_eq!(
+        auth_dependency["optional"].as_bool(),
+        Some(true),
+        "swink-agent-auth should stay optional so non-Azure builds do not pull it in"
+    );
+
+    let azure_feature = package["features"]["azure"]
+        .as_array()
+        .expect("azure feature should be declared");
+    assert!(
+        azure_feature
+            .iter()
+            .any(|entry| entry.as_str() == Some("dep:swink-agent-auth")),
+        "azure feature should own swink-agent-auth"
+    );
+}
+
+#[test]
+fn default_profile_enables_no_provider_features() {
+    let package = adapters_package_metadata();
+    let default_feature = package["features"]["default"]
+        .as_array()
+        .expect("default feature should be declared");
+
+    assert!(
+        default_feature.is_empty(),
+        "swink-agent-adapters should not enable providers by default"
+    );
+}


### PR DESCRIPTION
## What changed
- made `swink-agent-auth` optional in `swink-agent-adapters` and wired it through `azure = ["dep:swink-agent-auth"]` so non-Azure builds do not pull Azure auth support
- fixed the crate-level feature docs to match the actual `default = []` adapter profile
- added a manifest-contract regression test for the Azure auth gate and tightened `OaiAdapterShell` helper cfgs so `--no-default-features --features azure` lints clean
- recorded the feature-gate lessons in `adapters/AGENTS.md`

## Slice completed
- completed the feature/dependency gating and docs-parity slice for Azure auth in the adapters crate
- remaining work: none identified within issue #616 scope

## Validation output
- `cargo clippy -p swink-agent-adapters --no-default-features --features azure --test azure --test cargo_manifest -- -D warnings`
- `cargo test -p swink-agent-adapters --test cargo_manifest`
- `cargo test -p swink-agent-adapters --no-default-features --features __no_default_features_sentinel --test no_default_features`
- `cargo test -p swink-agent-adapters --no-default-features --features azure --test azure`

## Pre-existing baseline failures
- none encountered in the scoped adapter validation above
- full workspace validation was not run for this bounded crate slice

Closes #616