### PR TITLE
[codex] docs: align TUI command and integration-test quickstarts

### DIFF
--- a/docs/testing_setup.md
+++ b/docs/testing_setup.md
@@ -157,11 +157,11 @@ Once the TUI is running, test each configured provider:
 #info
 ```
 
-**Switch model within the current provider:**
+**Cycle available models in the TUI:**
 ```
-/model claude-sonnet-4-6
+Press F4
 ```
-Note: `/model` changes the model ID on the active provider. To test a different provider, update `.env` and restart the TUI.
+Note: `F4` cycles the models currently available to the TUI and applies the selected model on the next prompt. Use `#info` to confirm the active model. To test a different provider, update `.env` and restart the TUI.
 
 **Test basic conversation:**
 ```
@@ -201,7 +201,7 @@ Thinking mode availability by provider:
 | Long output | Conversation scrolls, manual scroll with arrow keys works |
 | Session save/load | `#save` then `#load <id>` restores conversation |
 | Error recovery | Send a prompt that exceeds context window — agent should recover |
-| Model switching | `/model <id>` changes model within current provider, `#info` confirms |
+| Model switching | Press `F4` to cycle available models; `#info` confirms the active model |
 
 ## 9. Logs
 

--- a/specs/030-integration-tests/quickstart.md
+++ b/specs/030-integration-tests/quickstart.md
@@ -16,51 +16,60 @@
 cargo test --workspace
 ```
 
-### Run only integration tests in the core crate
+### Run the core-crate integration tests
 
 ```bash
-cargo test --test ac_lifecycle --test ac_tools --test ac_context --test ac_resilience --test ac_structured --test ac_tui
+cargo test -p swink-agent --test ac_lifecycle --test ac_tools --test ac_context --test ac_resilience --test ac_structured
+```
+
+### Run the TUI integration tests
+
+```bash
+cargo test -p swink-agent-tui --test ac_tui
 ```
 
 ### Run a specific test file
 
 ```bash
-cargo test --test ac_lifecycle
+cargo test -p swink-agent --test ac_lifecycle
 ```
 
 ### Run a specific test by name
 
 ```bash
-cargo test --test ac_tools concurrent_tool_execution
+cargo test -p swink-agent --test ac_tools concurrent_tool_execution
 ```
 
 ### Run with output visible
 
 ```bash
-cargo test --test ac_lifecycle -- --nocapture
+cargo test -p swink-agent --test ac_lifecycle -- --nocapture
 ```
 
 ## Project Layout
 
-```
+```text
 tests/
 ├── common/
 │   └── mod.rs           # Shared mocks and helpers (MockStreamFn, MockTool, etc.)
 ├── integration.rs       # Existing integration tests
-├── ac_lifecycle.rs      # AC 1–5:  Agent lifecycle and events
-├── ac_tools.rs          # AC 6–12: Tool execution and validation
-├── ac_context.rs        # AC 13–16: Context management and overflow
-├── ac_resilience.rs     # AC 17–22: Retry, steering, abort
-├── ac_structured.rs     # AC 23–25: Structured output, proxy reconstruction
-└── ac_tui.rs            # AC 26–30: TUI rendering and interaction
+├── ac_lifecycle.rs      # AC 1-5: Agent lifecycle and events
+├── ac_tools.rs          # AC 6-12: Tool execution and validation
+├── ac_context.rs        # AC 13-16: Context management and overflow
+├── ac_resilience.rs     # AC 17-22: Retry, steering, abort
+└── ac_structured.rs     # AC 23-25: Structured output, proxy reconstruction
+
+tui/tests/
+├── ac_tui.rs            # AC 26-30: TUI rendering and interaction
+└── public_api.rs        # TUI public API integration coverage
 ```
 
 ## Writing a New Test
 
 1. Identify which acceptance criterion the test covers.
-2. Open the corresponding `ac_*.rs` file.
-3. Add `mod common;` if not already present (all files need it).
-4. Use shared helpers:
+2. Open the corresponding `ac_*.rs` file in `tests/` or `tui/tests/`.
+3. For core integration tests under `tests/`, add `mod common;` if the file uses the shared helpers.
+4. Use shared helpers in the core test suite when needed:
 
 ```rust
 mod common;


### PR DESCRIPTION
## What changed
- replaced the unsupported `/model` walkthrough in `docs/testing_setup.md` with the actual TUI model-switch flow (`F4` + `#info`)
- corrected `specs/030-integration-tests/quickstart.md` so the TUI acceptance test runs from `swink-agent-tui` instead of the core crate
- updated the quickstart layout/examples to show `tui/tests/ac_tui.rs` separately from the root `tests/` suite

## Why / value
Contributors following the docs now get the commands and package paths that match the current implementation, which removes two false-negative onboarding failures without changing runtime behavior.

## Slice completed
Completed the docs-parity slice for issue #618 across the TUI testing guide and the integration-test quickstart. No remaining work is expected for this issue.

## Validation output
- `cargo fmt --all --check`
- `cargo test -p swink-agent --test ac_lifecycle -- --list`
- `cargo test -p swink-agent-tui --test ac_tui -- --list`

## Pre-existing baseline failures
- none encountered in this docs-focused validation slice
- no workspace-wide `cargo test --workspace` / `cargo clippy --workspace -- -D warnings` run was attempted for this change set

Closes #618