### PR TITLE
refactor(core): break types/stream import cycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,6 +177,7 @@ gh pr comment <number> --body-file /tmp/comment.md
 
 ### Streaming (`src/stream.rs`)
 
+- `StreamErrorKind` lives in `src/stream_error_kind.rs`; `stream.rs` re-exports it so `AssistantMessageEvent` helpers and the crate root keep the same public API while `types` stays decoupled from `stream`.
 - `accumulate_message` enforces strict ordering: one Start, indexed content blocks, one terminal (Done/Error).
 - `partial_json` consumed on `ToolCallEnd` — parsed once. Empty string → `{}`, not null.
 - `Done(Length)` tolerance is only for unfinished `ToolCall` blocks that preserve `partial_json` for `recover_incomplete_tool_calls`; unterminated text/thinking blocks must still be rejected as malformed.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@ mod schema;
 mod state;
 pub(crate) mod stream;
 pub mod stream_assembly;
+mod stream_error_kind;
 mod stream_middleware;
 mod sub_agent;
 mod task_core;

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio_util::sync::CancellationToken;
 
+pub use crate::stream_error_kind::StreamErrorKind;
 use crate::types::{
     AgentContext, AssistantMessage, ContentBlock, Cost, ModelSpec, StopReason, Usage,
 };
@@ -99,28 +100,6 @@ impl std::fmt::Debug for StreamOptions {
             )
             .finish()
     }
-}
-
-// ─── StreamErrorKind ─────────────────────────────────────────────────────────
-
-/// Structured classification of stream errors.
-///
-/// Adapters can attach a `StreamErrorKind` to an `Error` event so the agent
-/// loop can classify errors structurally instead of relying on string matching.
-#[non_exhaustive]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum StreamErrorKind {
-    /// The provider throttled the request (HTTP 429 / rate limit).
-    Throttled,
-    /// The request exceeded the model's context window.
-    ContextWindowExceeded,
-    /// Authentication or authorization failure (HTTP 401/403).
-    Auth,
-    /// Transient network or server error (connection drop, 5xx, etc.).
-    Network,
-    /// Provider safety/content filter blocked the response.
-    ContentFiltered,
 }
 
 // ─── AssistantMessageEvent ───────────────────────────────────────────────────

--- a/src/stream_error_kind.rs
+++ b/src/stream_error_kind.rs
@@ -1,0 +1,21 @@
+use serde::{Deserialize, Serialize};
+
+/// Structured classification of stream errors.
+///
+/// Adapters can attach a `StreamErrorKind` to an `Error` event so the agent
+/// loop can classify errors structurally instead of relying on string matching.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StreamErrorKind {
+    /// The provider throttled the request (HTTP 429 / rate limit).
+    Throttled,
+    /// The request exceeded the model's context window.
+    ContextWindowExceeded,
+    /// Authentication or authorization failure (HTTP 401/403).
+    Auth,
+    /// Transient network or server error (connection drop, 5xx, etc.).
+    Network,
+    /// Provider safety/content filter blocked the response.
+    ContentFiltered,
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -124,7 +124,7 @@ pub struct AssistantMessage {
     /// When present, the agent loop uses this to classify the error without
     /// falling back to string matching on `error_message`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub error_kind: Option<crate::stream::StreamErrorKind>,
+    pub error_kind: Option<crate::stream_error_kind::StreamErrorKind>,
     pub timestamp: u64,
     /// Provider-agnostic cache hint for this message.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -35,6 +35,7 @@ fn stream_types_re_exported() {
     let _ = swink_agent::StreamOptions::default();
     let _ = std::any::type_name::<swink_agent::AssistantMessageEvent>();
     let _ = std::any::type_name::<swink_agent::AssistantMessageDelta>();
+    let _ = std::any::type_name::<swink_agent::StreamErrorKind>();
 }
 
 #[test]


### PR DESCRIPTION
## What changed
- moved `StreamErrorKind` into a dedicated low-level `src/stream_error_kind.rs` module
- made `src/types/mod.rs` depend on that shared module directly instead of pointing at `crate::stream::StreamErrorKind`
- kept the existing crate-root API stable by re-exporting `StreamErrorKind` through `stream.rs` and locking that in with the public API test
- recorded the module-boundary rule in `AGENTS.md`

## Why / value
This removes the `types` ↔ `stream` internal cycle called out in #624 without changing stream behavior or the public `swink_agent::StreamErrorKind` surface.

## Slice completed
Completed the bounded refactor to break the internal `src/types/mod.rs` ↔ `src/stream.rs` dependency cycle while preserving the current public API. No additional behavior changes are included.

## Validation output
- `cargo fmt --all`
- `cargo test -p swink-agent --lib error_throttled_constructor_sets_kind`
- `cargo test -p swink-agent --test public_api`
- `cargo clippy -p swink-agent --lib --test public_api -- -D warnings`

## Pre-existing baseline failures
- none encountered in this scoped core refactor validation
- workspace-wide validation was not rerun for this bounded slice

Closes #624