### PR TITLE
[codex] fix cache-miss retry strategy integration

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,8 @@
 //!
 //! All error conditions surfaced to the caller are represented as variants of
 //! [`AgentError`]. Transient failures (`ModelThrottled`, `NetworkError`) are
-//! retryable; all other variants are terminal for the current operation.
+//! retryable by the default strategy; all other variants are terminal for the
+//! current operation unless a custom retry strategy opts into retrying them.
 
 /// Error returned when downcasting an [`AgentMessage`](crate::types::AgentMessage) to a concrete
 /// custom message type fails.
@@ -83,8 +84,9 @@ pub enum AgentError {
 
     /// Provider-side context cache was not found (evicted or expired).
     ///
-    /// The framework resets [`CacheState`](crate::context_cache::CacheState) and
-    /// retries with `CacheHint::Write`.
+    /// The framework resets [`CacheState`](crate::context_cache::CacheState)
+    /// before consulting the configured retry strategy. Custom strategies can
+    /// choose to retry with `CacheHint::Write`.
     #[error("provider cache miss")]
     CacheMiss,
 
@@ -107,14 +109,11 @@ pub enum AgentError {
 }
 
 impl AgentError {
-    /// Returns `true` for error variants that are safe to retry
-    /// (`ModelThrottled`, `NetworkError`, and `CacheMiss`).
+    /// Returns `true` for error variants that are safe to retry by default
+    /// (`ModelThrottled` and `NetworkError`).
     #[must_use]
     pub const fn is_retryable(&self) -> bool {
-        matches!(
-            self,
-            Self::ModelThrottled | Self::NetworkError { .. } | Self::CacheMiss
-        )
+        matches!(self, Self::ModelThrottled | Self::NetworkError { .. })
     }
 
     /// Convenience constructor for [`AgentError::NetworkError`].

--- a/src/loop_/mod.rs
+++ b/src/loop_/mod.rs
@@ -389,7 +389,7 @@ mod tests {
                 matches!(err, AgentError::CacheMiss),
                 "expected CacheMiss for \"{msg}\", got {err:?}"
             );
-            assert!(err.is_retryable());
+            assert!(!err.is_retryable());
         }
     }
 

--- a/src/loop_/stream.rs
+++ b/src/loop_/stream.rs
@@ -397,6 +397,7 @@ async fn handle_stream_error(
     }
 
     // Cache miss — reset cache state so next attempt re-sends with Write hint
+    let mut retry_strategy_consulted = false;
     if matches!(harness_error, AgentError::CacheMiss) {
         warn!("provider cache miss, resetting cache state for retry");
         {
@@ -406,7 +407,17 @@ async fn handle_stream_error(
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
             cache_state.reset();
         }
-        return StreamErrorAction::Retry(std::time::Duration::ZERO);
+        retry_strategy_consulted = true;
+        if config.retry_strategy.should_retry(&harness_error, attempt) {
+            let delay = config.retry_strategy.delay(attempt);
+            warn!(
+                attempt,
+                ?delay,
+                error = %harness_error,
+                "retrying after cache miss"
+            );
+            return StreamErrorAction::Retry(delay);
+        }
     }
 
     // Aborted — preserve as StreamResult::Aborted so the turn emits
@@ -420,7 +431,7 @@ async fn handle_stream_error(
     }
 
     // Check if retryable — RetryStrategy is the sole decision point
-    if config.retry_strategy.should_retry(&harness_error, attempt) {
+    if !retry_strategy_consulted && config.retry_strategy.should_retry(&harness_error, attempt) {
         let delay = config.retry_strategy.delay(attempt);
         warn!(attempt, ?delay, error = %harness_error, "retrying after transient error");
         return StreamErrorAction::Retry(delay);

--- a/tests/ac_resilience.rs
+++ b/tests/ac_resilience.rs
@@ -6,6 +6,7 @@
 mod common;
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Duration;
 
 use common::{
@@ -15,9 +16,9 @@ use common::{
 use futures::stream::StreamExt;
 
 use swink_agent::{
-    Agent, AgentEvent, AgentMessage, AgentOptions, ContentBlock, CustomMessage,
-    DefaultRetryStrategy, LlmMessage, PolicyContext, PolicyVerdict, PreTurnPolicy, StopReason,
-    StreamErrorKind,
+    Agent, AgentError, AgentEvent, AgentMessage, AgentOptions, ContentBlock, CustomMessage,
+    DefaultRetryStrategy, LlmMessage, PolicyContext, PolicyVerdict, PreTurnPolicy, RetryStrategy,
+    StopReason, StreamErrorKind,
 };
 
 /// Inline max-turns policy for this test (the real one lives in swink-agent-policies).
@@ -46,6 +47,31 @@ impl PreTurnPolicy for MaxTurnsPolicy {
         } else {
             PolicyVerdict::Continue
         }
+    }
+}
+
+#[derive(Debug)]
+struct CountingRetryStrategy {
+    calls: Arc<AtomicU32>,
+    allow_retry: bool,
+}
+
+impl RetryStrategy for CountingRetryStrategy {
+    fn should_retry(&self, error: &AgentError, _attempt: u32) -> bool {
+        if matches!(error, AgentError::CacheMiss) {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            return self.allow_retry;
+        }
+
+        false
+    }
+
+    fn delay(&self, _attempt: u32) -> Duration {
+        Duration::ZERO
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
     }
 }
 
@@ -505,6 +531,46 @@ async fn retry_exhaustion_surfaces_error() {
             assert!(
                 r.error.is_some() || r.stop_reason == StopReason::Error,
                 "exhausted retries should surface an error in the result"
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn cache_miss_denied_by_retry_strategy_surfaces_cache_miss_error() {
+    let strategy_calls = Arc::new(AtomicU32::new(0));
+    let stream_fn = Arc::new(MockStreamFn::new(vec![error_events("cache miss", None)]));
+
+    let mut agent = Agent::new(
+        AgentOptions::new("test", default_model(), stream_fn, default_convert).with_retry_strategy(
+            Box::new(CountingRetryStrategy {
+                calls: Arc::clone(&strategy_calls),
+                allow_retry: false,
+            }),
+        ),
+    );
+
+    let result = agent.prompt_async(vec![user_msg("hello")]).await;
+
+    assert_eq!(
+        strategy_calls.load(Ordering::SeqCst),
+        1,
+        "cache miss should consult RetryStrategy exactly once"
+    );
+
+    match result {
+        Err(err) => assert!(
+            err.to_string().contains("cache miss"),
+            "expected cache miss error, got {err}"
+        ),
+        Ok(run) => {
+            assert_eq!(run.stop_reason, StopReason::Error);
+            assert!(
+                run.error
+                    .as_deref()
+                    .is_some_and(|error| error.contains("cache miss")),
+                "expected cache miss error, got {:?}",
+                run.error
             );
         }
     }

--- a/tests/error.rs
+++ b/tests/error.rs
@@ -71,6 +71,7 @@ fn retryable_classification() {
 
     assert!(!AgentError::Aborted.is_retryable());
     assert!(!AgentError::AlreadyRunning.is_retryable());
+    assert!(!AgentError::CacheMiss.is_retryable());
     assert!(!AgentError::NoMessages.is_retryable());
     assert!(!AgentError::InvalidContinue.is_retryable());
     assert!(!AgentError::context_overflow("x").is_retryable());
@@ -250,6 +251,7 @@ fn error_retryable_classification() {
     assert!(AgentError::ModelThrottled.is_retryable());
     assert!(AgentError::network(io::Error::other("x")).is_retryable());
 
+    assert!(!AgentError::CacheMiss.is_retryable());
     assert!(!AgentError::context_overflow("m").is_retryable());
     assert!(!AgentError::structured_output_failed(1, "e").is_retryable());
     assert!(!AgentError::AlreadyRunning.is_retryable());

--- a/tests/retry.rs
+++ b/tests/retry.rs
@@ -48,6 +48,7 @@ fn does_not_retry_non_retryable_variants() {
 
     assert!(!strategy.should_retry(&AgentError::Aborted, 1));
     assert!(!strategy.should_retry(&AgentError::AlreadyRunning, 1));
+    assert!(!strategy.should_retry(&AgentError::CacheMiss, 1));
     assert!(!strategy.should_retry(&AgentError::NoMessages, 1));
     assert!(!strategy.should_retry(&AgentError::InvalidContinue, 1));
     assert!(!strategy.should_retry(&AgentError::structured_output_failed(3, "bad"), 1));


### PR DESCRIPTION
## What changed
- route `AgentError::CacheMiss` through the configured `RetryStrategy` after resetting cache state instead of forcing an unconditional zero-delay retry
- align default retry classification so `CacheMiss` is terminal unless a custom retry strategy explicitly opts in
- add a regression test that proves a denied cache-miss retry surfaces the cache-miss error instead of silently retrying into a different failure

## Why this changed
A provider cache miss was bypassing the normal retry policy path in `src/loop_/stream.rs`, which could ignore caller retry limits and backoff behavior. This patch restores the single retry decision point and keeps cache-state reset semantics available for custom strategies that still want to retry.

## Slice completed
Completed the cache-miss retry-policy integration for issue #632.

## Validation
- `cargo clippy -p swink-agent --lib --features testkit -- -D warnings`
- `cargo test -p swink-agent --features testkit`
- `cargo test -p swink-agent --test ac_resilience --features testkit cache_miss_denied_by_retry_strategy_surfaces_cache_miss_error -- --exact`

## Pre-existing baseline failures
- `cargo clippy --workspace --features testkit -- -D warnings` is still blocked in `swink-agent-local-llm` because `llama-cpp-sys-2` cannot find `libclang` in this environment.
- `cargo test --workspace --features testkit` hits the same `swink-agent-local-llm` `libclang` toolchain blocker before the full workspace can complete.

Closes #632