### PR TITLE
fix(loop): emit one terminal event on overflow failure

### DIFF
--- a/src/loop_/AGENTS.md
+++ b/src/loop_/AGENTS.md
@@ -12,4 +12,5 @@
 - Pre-dispatch is batch-wide and two-pass. A later `PreDispatchVerdict::Stop` must prevent any earlier tool from emitting approval request/resolution side effects, so approval only starts after the entire batch clears pre-dispatch.
 - Cancellation has to be observed in preprocessing and before each execution group/tool dispatch, not just while collecting spawned handles. Otherwise approval waits can hang forever and later tools can still launch after the batch is already cancelled.
 - Overflow recovery cancellation must reuse a started-turn cancellation path. Calling the pre-turn helper after `TurnStart` has already been emitted duplicates `TurnStart` and breaks lifecycle ordering for the interrupted turn.
+- `handle_stream_error()` must not emit `MessageEnd` for context overflow. Overflow recovery owns the terminal message lifecycle, and unrecoverable overflow must still surface exactly one `MessageEnd`.
 - `LoopState.turn_index` must advance after every completed turn, not just tool-loop continuation. Text-only or other `BreakInner` turns still finish a turn before the outer loop polls follow-up messages.

--- a/src/loop_/stream.rs
+++ b/src/loop_/stream.rs
@@ -386,13 +386,6 @@ async fn handle_stream_error(
     // Context window overflow — signal and retry
     if matches!(harness_error, AgentError::ContextWindowOverflow { .. }) {
         warn!("context window overflow, signaling prune");
-        let _ = emit(
-            tx,
-            AgentEvent::MessageEnd {
-                message: build_error_message(model, &harness_error),
-            },
-        )
-        .await;
         return StreamErrorAction::ContextOverflow;
     }
 

--- a/tests/loop_overflow.rs
+++ b/tests/loop_overflow.rs
@@ -263,6 +263,15 @@ async fn double_overflow_surfaces_error() {
         }),
         "should have a TurnEnd with Error reason"
     );
+
+    let message_end_count = events
+        .iter()
+        .filter(|e| common::event_variant_name(e) == "MessageEnd")
+        .count();
+    assert_eq!(
+        message_end_count, 1,
+        "unrecoverable overflow should emit exactly one MessageEnd"
+    );
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## What changed
- stopped `handle_stream_error()` from emitting a provisional `MessageEnd` when the provider reports context overflow
- kept unrecoverable overflow termination in the dedicated overflow path so the turn still surfaces the final overflow error once
- tightened the overflow regression to assert that a double-overflow turn emits exactly one `MessageEnd`
- documented the ownership rule in `src/loop_/AGENTS.md`

## Why / value
Overflow recovery is supposed to keep the initial overflow internal to the turn. Emitting `MessageEnd` during classification leaked a terminal event before recovery completed, and a second terminal event could follow when recovery still failed. This restores the single-terminal-event lifecycle contract for unrecoverable overflow turns.

## Slice completed
Completed the overflow terminal-event sequencing slice for issue #633. No broader compaction behavior changes are included.

## Validation output
- `cargo test -p swink-agent --test loop_overflow --features testkit double_overflow_surfaces_error -- --exact`
- `cargo test -p swink-agent --test loop_overflow --features testkit`
- `cargo clippy -p swink-agent --test loop_overflow --features testkit -- -D warnings`
- `cargo fmt --all --check`

## Pre-existing baseline failures
- none encountered in this scoped loop validation
- workspace-wide validation was not rerun for this bounded slice

Closes #633
