### PR TITLE
[codex] test(mcp): cover SSE session recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,6 +319,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.9.0",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper 1.0.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2618,6 +2670,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4504,6 +4562,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4946,6 +5015,7 @@ dependencies = [
 name = "swink-agent-mcp"
 version = "0.7.9"
 dependencies = [
+ "axum",
  "reqwest 0.13.2",
  "rmcp",
  "schemars",
@@ -5623,6 +5693,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/mcp/AGENTS.md
+++ b/mcp/AGENTS.md
@@ -17,6 +17,7 @@
 
 - `McpManager::shutdown()` must operate on shared connection-owned state, not `Arc::try_unwrap()`: exported `McpTool` handles keep `Arc<McpConnection>` clones alive, so deterministic disconnect has to clear the session/monitor even when callers still retain tool `Arc`s.
 - Tool discovery happens at `connect_all()` time. Tools added to a server after connection are not auto-refreshed; call `reconnect()` to rediscover.
+- SSE recovery is delegated to rmcp's streamable HTTP transport: transient stream drops and stale-session 404s are retried/re-initialized inside rmcp, so `McpConnection` should only flip to `Disconnected` after the underlying service fully exits.
 
 ## Build & Test
 

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -22,6 +22,7 @@ thiserror.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+axum = "0.8"
 rmcp = { version = "1.3", features = ["client", "server", "macros", "client-side-sse", "transport-streamable-http-client", "transport-streamable-http-client-reqwest", "transport-child-process", "transport-streamable-http-server"] }
 swink-agent = { path = "..", default-features = false }
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/mcp/src/connection.rs
+++ b/mcp/src/connection.rs
@@ -3,7 +3,7 @@
 //! Wraps an `rmcp` client session, handling tool discovery and providing
 //! access to the peer for tool call forwarding. A background monitor task
 //! awaits the service lifecycle and emits a disconnect event when the
-//! transport closes unexpectedly.
+//! underlying service stops running.
 
 use std::sync::{Arc, Mutex, PoisonError};
 
@@ -164,7 +164,12 @@ impl McpConnection {
     ///
     /// Supports stdio and SSE (HTTP) transports. Spawns a background lifecycle
     /// monitor that sends `AgentEvent::McpServerDisconnected` on `event_tx`
-    /// when the transport closes unexpectedly.
+    /// when the underlying service terminates.
+    ///
+    /// For SSE, transient stream drops and stale-session recovery are handled
+    /// by rmcp's streamable HTTP transport. This wrapper only transitions to
+    /// [`McpConnectionStatus::Disconnected`] once rmcp has given up and the
+    /// service itself exits.
     pub async fn connect(
         config: McpServerConfig,
         event_tx: Option<UnboundedSender<AgentEvent>>,
@@ -384,8 +389,8 @@ fn client_info() -> ClientInfo {
 
 /// Spawn a background task that awaits the service lifecycle.
 ///
-/// When the transport closes with `QuitReason::Closed` (remote disconnect or
-/// crash), the shared state is updated to `Disconnected` and
+/// When the underlying service exits with `QuitReason::Closed` or a join error,
+/// the shared state is updated to `Disconnected` and
 /// `McpServerDisconnected` is sent on `event_tx`. Voluntary cancellations
 /// (`QuitReason::Cancelled`) and join errors are silently ignored since they
 /// are initiated by the caller via `shutdown()`.

--- a/mcp/tests/lifecycle_test.rs
+++ b/mcp/tests/lifecycle_test.rs
@@ -6,6 +6,9 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
+use rmcp::transport::streamable_http_server::{
+    StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
+};
 use swink_agent::{AgentEvent, AgentTool, ContentBlock, SessionState};
 use swink_agent_mcp::{
     McpConnection, McpConnectionStatus, McpManager, McpServerConfig, McpTool, McpTransport,
@@ -196,6 +199,134 @@ async fn monitor_detects_transport_close_and_emits_event() {
         }
         other => panic!("unexpected event: {other:?}"),
     }
+}
+
+async fn current_session_id(session_manager: &Arc<LocalSessionManager>) -> String {
+    let sessions = session_manager.sessions.read().await;
+    sessions
+        .keys()
+        .next()
+        .map(std::string::ToString::to_string)
+        .expect("session should exist")
+}
+
+fn assert_mcp_event(
+    event: AgentEvent,
+    server_name: &str,
+    expect_discovery: bool,
+) {
+    match (expect_discovery, event) {
+        (
+            false,
+            AgentEvent::McpServerConnected {
+                server_name: actual,
+            },
+        ) => assert_eq!(actual, server_name),
+        (
+            true,
+            AgentEvent::McpToolsDiscovered {
+                server_name: actual,
+                tool_count,
+            },
+        ) => {
+            assert_eq!(actual, server_name);
+            assert!(tool_count >= 1, "expected at least one discovered tool");
+        }
+        (_, other) => panic!("unexpected MCP lifecycle event: {other:?}"),
+    }
+}
+
+/// SSE transport keeps the wrapper connected while rmcp transparently
+/// re-initializes after the server drops the active session.
+#[tokio::test]
+async fn sse_session_expiry_recovers_without_wrapper_disconnect() {
+    let (event_tx, mut event_rx) = unbounded_channel::<AgentEvent>();
+    let session_manager = Arc::new(LocalSessionManager::default());
+    let shutdown = tokio_util::sync::CancellationToken::new();
+
+    let mock_cfg = common::MockServerConfig::new(vec![]);
+    let server = common::MockMcpServer::from_config(&mock_cfg);
+    let service = StreamableHttpService::new(
+        move || Ok(server.clone()),
+        Arc::clone(&session_manager),
+        StreamableHttpServerConfig::default()
+            .with_sse_keep_alive(None)
+            .with_cancellation_token(shutdown.child_token()),
+    );
+
+    let router = axum::Router::new().nest_service("/mcp", service);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("listener should bind");
+    let addr = listener.local_addr().expect("listener should expose an addr");
+    let server_task = tokio::spawn({
+        let shutdown = shutdown.clone();
+        async move {
+            let _ = axum::serve(listener, router)
+                .with_graceful_shutdown(async move { shutdown.cancelled_owned().await })
+                .await;
+        }
+    });
+
+    let conn = McpConnection::connect(
+        McpServerConfig {
+            name: "sse-recovery-server".into(),
+            transport: McpTransport::Sse {
+                url: format!("http://{addr}/mcp"),
+                bearer_token: None,
+            },
+            tool_prefix: None,
+            tool_filter: None,
+            requires_approval: false,
+        },
+        Some(event_tx),
+    )
+    .await
+    .expect("SSE connection should succeed");
+
+    assert_mcp_event(event_rx.try_recv().expect("connect event"), "sse-recovery-server", false);
+    assert_mcp_event(
+        event_rx.try_recv().expect("discovery event"),
+        "sse-recovery-server",
+        true,
+    );
+
+    let original_session_id = current_session_id(&session_manager).await;
+
+    {
+        let mut sessions = session_manager.sessions.write().await;
+        sessions.clear();
+    }
+
+    let result = conn
+        .call_tool("echo", serde_json::json!({ "text": "reconnected" }))
+        .await
+        .expect("tool call should transparently recover after session expiry");
+    let agent_result = swink_agent_mcp::convert::call_result_to_agent_result(&result);
+    let text = ContentBlock::extract_text(&agent_result.content);
+    assert!(
+        text.contains("reconnected"),
+        "recovered call should still reach the server, got: {text}"
+    );
+    assert_eq!(
+        conn.status(),
+        McpConnectionStatus::Connected,
+        "wrapper should remain connected while rmcp re-establishes the session"
+    );
+
+    let replacement_session_id = current_session_id(&session_manager).await;
+    assert_ne!(
+        replacement_session_id, original_session_id,
+        "transport recovery should create a fresh server session"
+    );
+    assert!(
+        event_rx.try_recv().is_err(),
+        "wrapper monitor should not emit a disconnect for transparent SSE recovery"
+    );
+
+    conn.shutdown().await;
+    shutdown.cancel();
+    let _ = server_task.await;
 }
 
 /// Issue #611: `McpServerConnected` is emitted once the handshake completes.

--- a/mcp/tests/lifecycle_test.rs
+++ b/mcp/tests/lifecycle_test.rs
@@ -210,11 +210,7 @@ async fn current_session_id(session_manager: &Arc<LocalSessionManager>) -> Strin
         .expect("session should exist")
 }
 
-fn assert_mcp_event(
-    event: AgentEvent,
-    server_name: &str,
-    expect_discovery: bool,
-) {
+fn assert_mcp_event(event: AgentEvent, server_name: &str, expect_discovery: bool) {
     match (expect_discovery, event) {
         (
             false,
@@ -258,7 +254,9 @@ async fn sse_session_expiry_recovers_without_wrapper_disconnect() {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
         .expect("listener should bind");
-    let addr = listener.local_addr().expect("listener should expose an addr");
+    let addr = listener
+        .local_addr()
+        .expect("listener should expose an addr");
     let server_task = tokio::spawn({
         let shutdown = shutdown.clone();
         async move {
@@ -284,7 +282,11 @@ async fn sse_session_expiry_recovers_without_wrapper_disconnect() {
     .await
     .expect("SSE connection should succeed");
 
-    assert_mcp_event(event_rx.try_recv().expect("connect event"), "sse-recovery-server", false);
+    assert_mcp_event(
+        event_rx.try_recv().expect("connect event"),
+        "sse-recovery-server",
+        false,
+    );
     assert_mcp_event(
         event_rx.try_recv().expect("discovery event"),
         "sse-recovery-server",


### PR DESCRIPTION
## What changed
- added a real streamable-HTTP lifecycle regression that connects `McpConnection` over SSE, forces server-side session loss, and verifies a subsequent MCP tool call succeeds without the wrapper flipping to `Disconnected`
- clarified `mcp/src/connection.rs` so the lifecycle docs match the actual ownership boundary: rmcp handles transient SSE stream/session recovery, while `McpConnection` only marks the server disconnected when the underlying service exits
- recorded the same non-obvious SSE recovery rule in `mcp/AGENTS.md` and added the `axum` dev harness needed to exercise the HTTP transport in tests

## Value
This closes a coverage gap around the SSE acceptance contract from spec 038. The MCP wrapper now has an end-to-end regression proving that server-side session loss does not permanently strand tools, and the docs no longer imply that every transient SSE drop is terminal at the wrapper layer.

## Slice completed
- completed the verification/documentation slice for issue #634 by codifying the existing rmcp-managed recovery path at the `swink-agent-mcp` boundary
- no broader manager/tool-refresh redesign is included in this PR

## Validation output
- `cargo test -p swink-agent-mcp sse_session_expiry_recovers_without_wrapper_disconnect --test lifecycle_test -- --exact`
- `cargo test -p swink-agent-mcp`
- `cargo clippy -p swink-agent-mcp --lib -- -D warnings`

## Pre-existing baseline failures
- `cargo clippy --workspace --all-targets --features testkit -- -D warnings` is currently blocked by the existing `swink-agent-local-llm` toolchain prerequisite for `llama-cpp-sys-2`: this runner is missing `libclang` (`bindgen` cannot find `clang.dll` / `libclang.dll`)
- `cargo test --workspace --features testkit` stops at the same existing `llama-cpp-sys-2` / `libclang` environment blocker before reaching this slice
- `cargo clippy -p swink-agent-mcp --all-targets -- -D warnings` still reports pre-existing doc-markdown/default-style lint debt in existing MCP test files such as `mcp/tests/filter_test.rs`, `mcp/tests/lifecycle_test.rs`, `mcp/tests/manager_test.rs`, and `mcp/tests/policy_test.rs`; this PR keeps scope on the SSE recovery regression instead of sweeping that backlog

## IPC contract changes
- None

Closes #634