### PR TITLE
[codex] fix(tool): redact approval debug context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,6 +210,7 @@ gh pr comment <number> --body-file /tmp/comment.md
 - `ToolCallTransformer` runs unconditionally (not gated by approval). Distinct from `ToolValidator` (rejects vs rewrites).
 - `#[tool]` macro param decoding must return `AgentToolResult::error("invalid parameters: ...")` on serde failures rather than panicking. The generated code still retries deserialization from `{}` so zero-param / all-optional tools can execute when appropriate.
 - `FnTool::with_execute_typed::<T>()` is the zero-boilerplate typed path: it derives the schema from `T` and must mirror the rest of the tool stack by returning `AgentToolResult::error("invalid parameters: ...")` on serde decode failures.
+- `ToolApprovalRequest` debug output must keep `arguments` fully redacted and run `redact_sensitive_values()` over `context`. MCP tools intentionally pass raw params through `approval_context()` for policy/approval inspection, so the logging boundary is where sanitization has to happen.
 
 ### Credential Management (`auth/`)
 

--- a/mcp/tests/policy_test.rs
+++ b/mcp/tests/policy_test.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 
 use serde_json::Value;
 use swink_agent::AgentTool;
+use swink_agent::ToolApprovalRequest;
 use swink_agent_mcp::{McpConnection, McpServerConfig, McpTool, McpTransport};
 
 /// Helper to create a disconnected McpConnection for metadata-only tests.
@@ -86,6 +87,39 @@ async fn mcp_tool_approval_context_returns_params_for_policy_inspection() {
         params,
         "approval context should be the full params so policies can inspect arguments"
     );
+}
+
+/// Debug output must sanitize MCP approval context even though the raw params
+/// stay available to approval and policy code.
+#[tokio::test]
+async fn mcp_tool_approval_context_is_redacted_in_tool_approval_request_debug() {
+    let config = common::MockServerConfig::new(vec![]);
+    let client = common::spawn_mock_server_with_client(&config).await;
+    let tools = client.peer().list_all_tools().await.unwrap();
+    let echo_def = tools.iter().find(|t| t.name == "echo").unwrap();
+
+    let (_, conn) = disconnected_connection(true);
+    let tool = McpTool::new(echo_def, None, "policy-test-server", true, conn);
+
+    let params = serde_json::json!({
+        "Authorization": "Bearer top-secret",
+        "path": "/tmp/output.txt",
+        "text": "${API_KEY}"
+    });
+    let request = ToolApprovalRequest {
+        tool_call_id: "call_1".into(),
+        tool_name: tool.name().into(),
+        arguments: params.clone(),
+        requires_approval: true,
+        context: tool.approval_context(&params),
+    };
+
+    let debug = format!("{request:?}");
+
+    assert!(!debug.contains("top-secret"));
+    assert!(!debug.contains("${API_KEY}"));
+    assert!(debug.contains("/tmp/output.txt"));
+    assert!(debug.contains("[REDACTED]"));
 }
 
 /// T026: approval_context is non-None — policies receive params for inspection.

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -339,8 +339,9 @@ pub enum ToolApproval {
 
 /// Information about a tool call pending approval.
 ///
-/// The [`Debug`] implementation redacts the `arguments` field to prevent
-/// sensitive values from leaking into logs and debug output.
+/// The [`Debug`] implementation redacts the `arguments` field and sanitizes
+/// `context` to prevent sensitive values from leaking into logs and debug
+/// output.
 #[derive(Clone)]
 pub struct ToolApprovalRequest {
     /// The unique ID of this tool call.
@@ -357,12 +358,13 @@ pub struct ToolApprovalRequest {
 
 impl fmt::Debug for ToolApprovalRequest {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let redacted_context = self.context.as_ref().map(redact_sensitive_values);
         f.debug_struct("ToolApprovalRequest")
             .field("tool_call_id", &self.tool_call_id)
             .field("tool_name", &self.tool_name)
             .field("arguments", &"[REDACTED]")
             .field("requires_approval", &self.requires_approval)
-            .field("context", &self.context)
+            .field("context", &redacted_context)
             .finish()
     }
 }
@@ -521,19 +523,24 @@ mod tests {
     // ─── ToolApprovalRequest Debug ──────────────────────────────────────────
 
     #[test]
-    fn approval_request_debug_redacts_arguments() {
+    fn approval_request_debug_redacts_arguments_and_context() {
         let req = ToolApprovalRequest {
             tool_call_id: "call_1".into(),
             tool_name: "bash".into(),
             arguments: json!({"command": "echo secret"}),
             requires_approval: true,
-            context: None,
+            context: Some(json!({
+                "Authorization": "Bearer top-secret",
+                "path": "/tmp/output.txt",
+            })),
         };
         let debug = format!("{req:?}");
         assert!(debug.contains("tool_call_id: \"call_1\""));
         assert!(debug.contains("tool_name: \"bash\""));
         assert!(debug.contains("[REDACTED]"));
         assert!(!debug.contains("echo secret"));
+        assert!(!debug.contains("top-secret"));
+        assert!(debug.contains("/tmp/output.txt"));
     }
 
     // ─── redact_sensitive_values ────────────────────────────────────────────


### PR DESCRIPTION
## What changed
- sanitized `ToolApprovalRequest` debug output so approval `context` goes through `redact_sensitive_values()` before formatting while `arguments` remain fully redacted
- expanded the core regression to cover both argument and context redaction in `src/tool.rs`
- added an MCP regression proving MCP tools can still expose raw approval context to policy/approval code while the logging boundary redacts secrets
- recorded the logging-boundary rule in `AGENTS.md`

## Value
Approval requests no longer leak sensitive MCP or tool input values through debug/log formatting when tools attach rich approval context.

## Slice completed
- completed the approval-logging redaction slice for issue #635
- no approval UI schema redesign or MCP context-shape changes are included

## Validation output
- `cargo fmt --all --check`
- `cargo test -p swink-agent approval_request_debug_redacts_arguments_and_context --lib`
- `cargo test -p swink-agent-mcp --test policy_test mcp_tool_approval_context_is_redacted_in_tool_approval_request_debug`

## Pre-existing baseline failures
- `cargo clippy --workspace -- -D warnings` is still blocked on this Windows runner by the existing `llama-cpp-sys-2` / `bindgen` environment prerequisite: `Unable to find libclang ... set the LIBCLANG_PATH environment variable`
- `cargo test --workspace` stops at the same pre-existing `libclang` blocker before the full workspace completes

## IPC contract changes
- None

Closes #635