### PR TITLE
[codex] fix(tui): surface corrupted session state loads

### DIFF
--- a/memory/src/jsonl.rs
+++ b/memory/src/jsonl.rs
@@ -283,6 +283,39 @@ fn upsert_state_line(
     Ok(())
 }
 
+fn parse_state_line(line: &str, id: &str) -> io::Result<Option<serde_json::Value>> {
+    let value: serde_json::Value = match serde_json::from_str(line) {
+        Ok(value) => value,
+        Err(error) => {
+            if line.contains("\"_state\"") {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("corrupted state line in session {id}: {error}"),
+                ));
+            }
+            return Ok(None);
+        }
+    };
+
+    let Some(state_marker) = value.get("_state") else {
+        return Ok(None);
+    };
+
+    if state_marker.as_bool() != Some(true) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("invalid state marker in session {id}: expected `_state: true`"),
+        ));
+    }
+
+    Ok(Some(
+        value
+            .get("data")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null),
+    ))
+}
+
 fn append_records(
     path: &Path,
     id: &str,
@@ -567,7 +600,7 @@ impl SessionStore for JsonlSessionStore {
 
         let (_, lines) = read_meta_and_message_lines(&path, id)?;
         for line in lines {
-            if let Ok(SessionRecord::State(state)) = SessionRecord::parse(&line) {
+            if let Some(state) = parse_state_line(&line, id)? {
                 return Ok(Some(state));
             }
         }
@@ -1077,6 +1110,26 @@ mod tests {
 
         let (_, messages) = store.load("test-state", None).unwrap();
         assert_eq!(messages.len(), 2);
+    }
+
+    #[test]
+    fn load_state_errors_on_corrupted_state_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = JsonlSessionStore::new(dir.path().to_path_buf()).unwrap();
+
+        let meta = fresh_meta("corrupt-state");
+        store
+            .save("corrupt-state", &meta, &[user_msg("hello", 1)])
+            .unwrap();
+
+        let path = session_path(dir.path(), "corrupt-state");
+        let mut contents = std::fs::read_to_string(&path).unwrap();
+        contents.push_str("{\"_state\":true,\"data\":\n");
+        std::fs::write(&path, contents).unwrap();
+
+        let err = store.load_state("corrupt-state").unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("state line"));
     }
 
     #[test]

--- a/tui/AGENTS.md
+++ b/tui/AGENTS.md
@@ -30,3 +30,4 @@
 - **Smart approval mode auto-approves trusted tools only** — untrusted tools still prompt even if they are read-only.
 - **Panic hook restores terminal** — without it, a panic leaves terminal in raw mode.
 - **Credentials** — env var checked first, then keychain. Env always wins.
+- **Session restore must validate before mutating UI state** — `App::load_session()` should first load transcript + session-state snapshot into locals, then apply them to `self` only after both succeed. If `store.load_state()` / `SessionState::restore_from_snapshot()` use `?` inside the mutation path, corrupted state snapshots bypass the normal warning branch and can partially apply a failed load.

--- a/tui/src/app/persistence.rs
+++ b/tui/src/app/persistence.rs
@@ -89,20 +89,25 @@ impl App {
             .agent
             .as_ref()
             .and_then(|a| a.custom_message_registry());
-        match store.load(id, registry) {
-            Ok((meta, messages)) => {
-                let restored_state = match store.load_state(id)? {
-                    Some(snapshot) => {
-                        SessionState::restore_from_snapshot(snapshot).map_err(|error| {
-                            io::Error::new(
-                                io::ErrorKind::InvalidData,
-                                format!("invalid session state snapshot for session {id}: {error}"),
-                            )
-                        })?
-                    }
-                    None => SessionState::new(),
-                };
+        let result: io::Result<_> = (|| {
+            let (meta, messages) = store.load(id, registry)?;
+            let restored_state = match store.load_state(id)? {
+                Some(snapshot) => {
+                    SessionState::restore_from_snapshot(snapshot).map_err(|error| {
+                        io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            format!("invalid session state snapshot for session {id}: {error}"),
+                        )
+                    })?
+                }
+                None => SessionState::new(),
+            };
 
+            Ok((meta, messages, restored_state))
+        })();
+
+        match result {
+            Ok((meta, messages, restored_state)) => {
                 let mut display_messages = Vec::new();
                 for msg in &messages {
                     match msg {

--- a/tui/src/app/tests/persistence.rs
+++ b/tui/src/app/tests/persistence.rs
@@ -296,3 +296,57 @@ async fn load_session_without_saved_state_clears_existing_agent_session_state() 
     };
     assert!(is_empty, "loading should replace prior session state");
 }
+
+#[tokio::test]
+async fn load_session_with_corrupted_saved_state_keeps_in_memory_state_and_reports_error() {
+    let tempdir = tempdir().unwrap();
+    let store = JsonlSessionStore::new(tempdir.path().to_path_buf()).unwrap();
+    let session_id = "state-corrupt-session";
+    let now = swink_agent_memory::now_utc();
+    let meta = SessionMeta {
+        id: session_id.to_string(),
+        title: "mock-model".to_string(),
+        created_at: now,
+        updated_at: now,
+        version: 1,
+        sequence: 0,
+    };
+
+    store
+        .save(session_id, &meta, &[make_user_agent_message("hello")])
+        .unwrap();
+
+    let path = tempdir.path().join(format!("{session_id}.jsonl"));
+    let mut contents = std::fs::read_to_string(&path).unwrap();
+    contents.push_str("{\"_state\":true,\"data\":\n");
+    std::fs::write(&path, contents).unwrap();
+
+    let stream_fn = Arc::new(ScriptedStreamFn::new(vec![]));
+    let agent = make_test_agent(stream_fn);
+    agent
+        .session_state()
+        .write()
+        .unwrap()
+        .set("draft", "keep me")
+        .unwrap();
+
+    let mut app = App::new(TuiConfig::default());
+    app.session_store = Some(store);
+    app.set_agent(agent);
+
+    let err = app.load_session(session_id).unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+
+    let agent = app.agent.as_ref().unwrap();
+    let draft = {
+        let state = agent.session_state().read().unwrap();
+        state.get::<String>("draft")
+    };
+    assert_eq!(draft, Some("keep me".to_string()));
+    assert!(
+        app.messages
+            .iter()
+            .any(|message| message.content.contains("Failed to load session")),
+        "load failures should surface a user-visible system message"
+    );
+}


### PR DESCRIPTION
## What changed
- `JsonlSessionStore::load_state()` now treats malformed `_state` records as `InvalidData` instead of silently returning `None`.
- `App::load_session()` now validates the persisted transcript and session-state snapshot before mutating TUI/agent state, so corrupted state restores surface through the normal user-visible failure path and keep the in-memory state intact.
- Added regressions in `swink-agent-memory` and `swink-agent-tui`, plus a `tui/AGENTS.md` note for the two-phase restore requirement.

## Slice completed / what remains
- Completed the corruption-aware load slice for issue #637.
- The atomic transcript+state autosave path is already present on `integration`; this PR closes the remaining gap by making corrupted saved state fail loudly instead of looking like an empty snapshot.

## Validation
- `cargo clippy -p swink-agent-memory -p swink-agent-tui --tests -- -D warnings`
- `cargo test -p swink-agent-memory corrupted_state_line`
- `cargo test -p swink-agent-tui corrupted_saved_state`

## Pre-existing baseline failures
- `cargo test -p swink-agent-memory -p swink-agent-tui` still hits the existing unrelated `swink-agent-tui` failure in `editor::tests::open_editor_with_true_command_returns_none`.

Closes #637
