### PR TITLE
[codex] fix: export ToolMiddleware in prelude

### DIFF
--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,7 +1,11 @@
 //! Convenience re-exports for common Swink-Agent types.
 //!
 //! ```
+//! use std::sync::Arc;
 //! use swink_agent::prelude::*;
+//!
+//! let tool = Arc::new(FnTool::new("echo", "Echo", "Echoes input"));
+//! let _logged = ToolMiddleware::with_logging(tool, |_name, _id, _is_start| {});
 //! ```
 
 pub use crate::{
@@ -13,7 +17,7 @@ pub use crate::{
     FnTool, InMemoryVersionStore, IntoTool, LlmMessage, LoopCheckpoint, MetricsCollector,
     ModelConnection, ModelConnections, ModelConnectionsBuilder, ModelFallback, ModelSpec,
     StopReason, StreamErrorKind, StreamFn, StreamMiddleware, StreamOptions, SubAgent, TokenCounter,
-    Usage, UserMessage, VersioningTransformer,
+    ToolMiddleware, Usage, UserMessage, VersioningTransformer,
 };
 
 #[cfg(feature = "builtin-tools")]


### PR DESCRIPTION
## What changed
- added `ToolMiddleware` to `swink_agent::prelude` so middleware-heavy consumers can rely on the prelude without a separate explicit import
- strengthened the prelude rustdoc example to compile a `ToolMiddleware::with_logging(...)` usage through `swink_agent::prelude::*`, giving this export gap a public-surface regression

## Value
This removes a paper-cut in the public API: prelude-based consumers can now build wrapped tools without an extra root import, which matches the crate-root re-export and the expectations in issue #652.

## Slice completed
- completed the `ToolMiddleware` prelude export requested in #652
- did not broaden scope to other missing prelude exports such as `StreamMiddleware` follow-up candidates outside this issue

## Validation output
- `cargo fmt --all --check`
- `cargo test -p swink-agent --doc`
- `cargo test -p swink-agent --test tool_middleware --features testkit`

## Pre-existing baseline failures
- `cargo clippy -p swink-agent --all-targets --features testkit -- -D warnings` still fails on existing unrelated lint debt already present on `integration`, including examples in `tests/approval.rs`, `tests/abort_turn_end_reason.rs`, `tests/incomplete_tool_call_sanitize.rs`, `tests/pause_resume.rs`, `src/agent/checkpointing.rs`, `src/block_accumulator.rs`, `src/checkpoint.rs`, `src/loop_/tool_dispatch/mod.rs`, `src/task_core.rs`, `src/tool_middleware.rs`, and `src/types/message_codec.rs`
- this PR does not expand scope to clean up that pre-existing workspace/package lint backlog

## IPC contract changes
- None

Closes #652