### PR TITLE
fix: export ApprovalMode in prelude

### DIFF
--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -6,18 +6,21 @@
 //!
 //! let tool = Arc::new(FnTool::new("echo", "Echo", "Echoes input"));
 //! let _logged = ToolMiddleware::with_logging(tool, |_name, _id, _is_start| {});
+//! // ApprovalMode is available via the prelude without a separate import
+//! let _mode: ApprovalMode = ApprovalMode::default();
 //! ```
 
 pub use crate::{
     Agent, AgentContext, AgentError, AgentEvent, AgentHandle, AgentId, AgentMailbox, AgentMessage,
     AgentOptions, AgentOrchestrator, AgentRef, AgentRegistry, AgentResult, AgentStatus, AgentTool,
-    AgentToolResult, AssistantMessage, AssistantMessageEvent, AsyncContextTransformer, Checkpoint,
-    CheckpointStore, ContentBlock, ContextSummarizer, ContextTransformer, ContextVersion,
-    ContextVersionMeta, ContextVersionStore, Cost, DefaultTokenCounter, Emission, EventForwarderFn,
-    FnTool, InMemoryVersionStore, IntoTool, LlmMessage, LoopCheckpoint, MetricsCollector,
-    ModelConnection, ModelConnections, ModelConnectionsBuilder, ModelFallback, ModelSpec,
-    StopReason, StreamErrorKind, StreamFn, StreamMiddleware, StreamOptions, SubAgent, TokenCounter,
-    ToolMiddleware, Usage, UserMessage, VersioningTransformer,
+    AgentToolResult, ApprovalMode, AssistantMessage, AssistantMessageEvent,
+    AsyncContextTransformer, Checkpoint, CheckpointStore, ContentBlock, ContextSummarizer,
+    ContextTransformer, ContextVersion, ContextVersionMeta, ContextVersionStore, Cost,
+    DefaultTokenCounter, Emission, EventForwarderFn, FnTool, InMemoryVersionStore, IntoTool,
+    LlmMessage, LoopCheckpoint, MetricsCollector, ModelConnection, ModelConnections,
+    ModelConnectionsBuilder, ModelFallback, ModelSpec, StopReason, StreamErrorKind, StreamFn,
+    StreamMiddleware, StreamOptions, SubAgent, TokenCounter, ToolMiddleware, Usage, UserMessage,
+    VersioningTransformer,
 };
 
 #[cfg(feature = "builtin-tools")]


### PR DESCRIPTION
## Summary
- Added `ApprovalMode` to `swink_agent::prelude`
- Prelude consumers no longer need a separate explicit import for this core agent-configuration type
- Added regression test proving `use swink_agent::prelude::*` resolves `ApprovalMode`

## Tasks completed
- Added ApprovalMode to prelude
- Added regression test

## Test plan
- [x] cargo test --workspace passes
- [x] cargo clippy --workspace -- -D warnings clean
- [x] No public API breakage

Closes #655
🤖 Generated with [Claude Code](https://claude.com/claude-code)