### PR TITLE
feat: ship built-in TiktokenCounter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,6 +197,7 @@ gh pr comment <number> --body-file /tmp/comment.md
 - Sliding window: anchor (first N) + tail (recent), middle removed to fit budget.
 - Tool-result pairs preserved together even if it exceeds budget. Correctness > token count.
 - Token estimation: chars/4 heuristic. CustomMessage = 100 tokens flat.
+- `TiktokenCounter` is feature-gated behind `tiktoken`; it keeps `CustomMessage` at the same flat 100-token estimate because those messages never reach provider tokenizers.
 
 ### Error / Retry
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ A pure-Rust library for building LLM-powered agentic loops. Provider-agnostic co
 - Errors stay in the message log — the loop keeps running. Typed `AgentError` variants for callers.
 - Events are push-only (`AgentEvent` stream). No inward mutation through events.
 - No `unsafe` code. No global mutable state.
+- Optional `tiktoken` support ships a built-in `TiktokenCounter` for more accurate context budgets.
 
 ## Quick Reference
 

--- a/specs/006-context-management/quickstart.md
+++ b/specs/006-context-management/quickstart.md
@@ -57,21 +57,19 @@ if let Some(report) = transformer.transform(&mut messages, false) {
 ### Custom token counter
 
 ```rust
-use swink_agent::{TokenCounter, SlidingWindowTransformer};
-use swink_agent::types::AgentMessage;
+use swink_agent::{SlidingWindowTransformer, TiktokenCounter};
 use std::sync::Arc;
 
-struct TiktokenCounter;
-
-impl TokenCounter for TiktokenCounter {
-    fn count_tokens(&self, message: &AgentMessage) -> usize {
-        // Use tiktoken or any tokenizer library here
-        todo!()
-    }
-}
-
 let transformer = SlidingWindowTransformer::new(100_000, 50_000, 2)
-    .with_token_counter(Arc::new(TiktokenCounter));
+    .with_token_counter(Arc::new(
+        TiktokenCounter::cl100k().expect("built-in cl100k tokenizer"),
+    ));
+```
+
+Enable the `tiktoken` feature to use the built-in wrapper:
+
+```bash
+cargo add swink-agent --features tiktoken
 ```
 
 ### Custom synchronous context transformer

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,8 @@ mod stream_error_kind;
 mod stream_middleware;
 mod sub_agent;
 mod task_core;
+#[cfg(feature = "tiktoken")]
+mod tiktoken_counter;
 pub(crate) mod tool;
 mod tool_execution_policy;
 pub(crate) mod tool_filter;
@@ -138,6 +140,8 @@ pub use stream::{
 };
 pub use stream_middleware::StreamMiddleware;
 pub use sub_agent::SubAgent;
+#[cfg(feature = "tiktoken")]
+pub use tiktoken_counter::{TiktokenCounter, TiktokenError};
 pub use tool::{
     AgentTool, AgentToolResult, ApprovalMode, IntoTool, ToolApproval, ToolApprovalRequest,
     ToolFuture, ToolMetadata, ToolParameters, redact_sensitive_values, selective_approve,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -23,5 +23,8 @@ pub use crate::{
     VersioningTransformer,
 };
 
+#[cfg(feature = "tiktoken")]
+pub use crate::{TiktokenCounter, TiktokenError};
+
 #[cfg(feature = "builtin-tools")]
 pub use crate::{BashTool, ReadFileTool, WriteFileTool, builtin_tools};

--- a/src/tiktoken_counter.rs
+++ b/src/tiktoken_counter.rs
@@ -1,0 +1,132 @@
+//! `tiktoken`-backed token counting for context management.
+
+use std::error::Error;
+use std::fmt;
+
+use crate::context::TokenCounter;
+use crate::types::{AgentMessage, ContentBlock, LlmMessage};
+
+/// Error returned when building a [`TiktokenCounter`] tokenizer.
+#[cfg_attr(docsrs, doc(cfg(feature = "tiktoken")))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TiktokenError {
+    message: String,
+}
+
+impl TiktokenError {
+    /// Create a new error with a caller-provided message.
+    #[must_use]
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for TiktokenError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl Error for TiktokenError {}
+
+/// [`TokenCounter`] implementation backed by `tiktoken-rs`.
+///
+/// This counts each text-bearing content block with the selected tokenizer
+/// instead of the default `chars / 4` heuristic. `CustomMessage` values stay at
+/// the existing flat 100-token estimate because they never reach the provider.
+#[cfg_attr(docsrs, doc(cfg(feature = "tiktoken")))]
+pub struct TiktokenCounter {
+    bpe: tiktoken_rs::CoreBPE,
+}
+
+impl TiktokenCounter {
+    /// Build a counter from an existing `tiktoken-rs` tokenizer.
+    #[must_use]
+    pub const fn new(bpe: tiktoken_rs::CoreBPE) -> Self {
+        Self { bpe }
+    }
+
+    /// Build a counter from the tokenizer mapped to a model name.
+    pub fn from_model(model: &str) -> Result<Self, TiktokenError> {
+        tiktoken_rs::get_bpe_from_model(model)
+            .map(Self::new)
+            .map_err(|err| TiktokenError::new(err.to_string()))
+    }
+
+    /// Build a counter using the `cl100k_base` tokenizer.
+    pub fn cl100k() -> Result<Self, TiktokenError> {
+        tiktoken_rs::cl100k_base()
+            .map(Self::new)
+            .map_err(|err| TiktokenError::new(err.to_string()))
+    }
+
+    /// Build a counter using the `o200k_base` tokenizer.
+    pub fn o200k() -> Result<Self, TiktokenError> {
+        tiktoken_rs::o200k_base()
+            .map(Self::new)
+            .map_err(|err| TiktokenError::new(err.to_string()))
+    }
+
+    /// Build a counter using the `p50k_base` tokenizer.
+    pub fn p50k_base() -> Result<Self, TiktokenError> {
+        tiktoken_rs::p50k_base()
+            .map(Self::new)
+            .map_err(|err| TiktokenError::new(err.to_string()))
+    }
+
+    /// Build a counter using the `p50k_edit` tokenizer.
+    pub fn p50k_edit() -> Result<Self, TiktokenError> {
+        tiktoken_rs::p50k_edit()
+            .map(Self::new)
+            .map_err(|err| TiktokenError::new(err.to_string()))
+    }
+
+    /// Build a counter using the `r50k_base` tokenizer.
+    pub fn r50k_base() -> Result<Self, TiktokenError> {
+        tiktoken_rs::r50k_base()
+            .map(Self::new)
+            .map_err(|err| TiktokenError::new(err.to_string()))
+    }
+
+    fn count_text(&self, text: &str) -> usize {
+        self.bpe.encode_with_special_tokens(text).len()
+    }
+}
+
+impl TokenCounter for TiktokenCounter {
+    fn count_tokens(&self, message: &AgentMessage) -> usize {
+        match message {
+            AgentMessage::Llm(llm) => content_blocks(llm)
+                .iter()
+                .map(|block| match block {
+                    ContentBlock::Text { text } => self.count_text(text),
+                    ContentBlock::Thinking { thinking, .. } => self.count_text(thinking),
+                    ContentBlock::ToolCall {
+                        name, arguments, ..
+                    } => self.count_text(name) + self.count_text(&arguments.to_string()),
+                    ContentBlock::Image { .. } => 0,
+                    ContentBlock::Extension { type_name, data } => {
+                        self.count_text(type_name) + self.count_text(&data.to_string())
+                    }
+                })
+                .sum(),
+            AgentMessage::Custom(_) => 100,
+        }
+    }
+}
+
+impl From<tiktoken_rs::CoreBPE> for TiktokenCounter {
+    fn from(bpe: tiktoken_rs::CoreBPE) -> Self {
+        Self::new(bpe)
+    }
+}
+
+fn content_blocks(msg: &LlmMessage) -> &[ContentBlock] {
+    match msg {
+        LlmMessage::User(m) => &m.content,
+        LlmMessage::Assistant(m) => &m.content,
+        LlmMessage::ToolResult(m) => &m.content,
+    }
+}

--- a/tests/tiktoken_counter.rs
+++ b/tests/tiktoken_counter.rs
@@ -1,0 +1,84 @@
+#![cfg(feature = "tiktoken")]
+
+use swink_agent::{
+    AgentMessage, AssistantMessage, ContentBlock, Cost, LlmMessage, StopReason, TiktokenCounter,
+    TokenCounter, Usage, UserMessage,
+};
+
+fn user_text_message(text: &str) -> AgentMessage {
+    AgentMessage::Llm(LlmMessage::User(UserMessage {
+        content: vec![ContentBlock::Text {
+            text: text.to_owned(),
+        }],
+        timestamp: 0,
+        cache_hint: None,
+    }))
+}
+
+fn assistant_tool_call_message(name: &str, arguments: serde_json::Value) -> AgentMessage {
+    AgentMessage::Llm(LlmMessage::Assistant(AssistantMessage {
+        content: vec![ContentBlock::ToolCall {
+            id: "tool-1".into(),
+            name: name.into(),
+            arguments,
+            partial_json: None,
+        }],
+        provider: "test".into(),
+        model_id: "test-model".into(),
+        usage: Usage::default(),
+        cost: Cost::default(),
+        stop_reason: StopReason::ToolUse,
+        error_message: None,
+        error_kind: None,
+        timestamp: 0,
+        cache_hint: None,
+    }))
+}
+
+#[test]
+fn cl100k_counts_text_with_tiktoken() {
+    let counter = TiktokenCounter::cl100k().unwrap();
+    let message = user_text_message("Swink Agent keeps context budgets honest.");
+    let expected = tiktoken_rs::cl100k_base()
+        .unwrap()
+        .encode_with_special_tokens("Swink Agent keeps context budgets honest.")
+        .len();
+
+    assert_eq!(counter.count_tokens(&message), expected);
+}
+
+#[test]
+fn tool_call_count_includes_name_and_arguments() {
+    let counter = TiktokenCounter::cl100k().unwrap();
+    let message = assistant_tool_call_message("lookup_docs", serde_json::json!({"topic": "mcp"}));
+    let bpe = tiktoken_rs::cl100k_base().unwrap();
+    let expected = bpe.encode_with_special_tokens("lookup_docs").len()
+        + bpe.encode_with_special_tokens("{\"topic\":\"mcp\"}").len();
+
+    assert_eq!(counter.count_tokens(&message), expected);
+}
+
+#[test]
+fn custom_messages_keep_flat_100_token_estimate() {
+    #[derive(Debug)]
+    struct TestCustom;
+
+    impl swink_agent::CustomMessage for TestCustom {
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    let counter = TiktokenCounter::cl100k().unwrap();
+    let message = AgentMessage::Custom(Box::new(TestCustom));
+
+    assert_eq!(counter.count_tokens(&message), 100);
+}
+
+#[test]
+fn from_model_builds_counter_for_known_model() {
+    let counter = TiktokenCounter::from_model("gpt-4o").unwrap();
+    let message = user_text_message("hello");
+
+    assert!(counter.count_tokens(&message) > 0);
+}


### PR DESCRIPTION
## What changed
- added a feature-gated `TiktokenCounter` and `TiktokenError` so `swink-agent` users can opt into a built-in `tiktoken`-backed `TokenCounter`
- re-exported the new counter from the crate root and `prelude`
- added focused integration coverage for text counting, tool-call counting, custom-message handling, and model-based tokenizer lookup
- updated the context-management quickstart and README to show the built-in wrapper instead of custom boilerplate

## Slice completed
- completed the built-in `TiktokenCounter` wrapper requested in this issue
- nothing else is required in this slice beyond review and merge

## Validation output
- `cargo clippy -p swink-agent --features tiktoken --test tiktoken_counter -- -D warnings`
- `cargo test -p swink-agent --features tiktoken --test tiktoken_counter`

## Pre-existing baseline failures
- `cargo clippy -p swink-agent --features tiktoken --tests -- -D warnings` still fails in unrelated existing files outside this slice: `tests/incomplete_tool_call_sanitize.rs`, `tests/pre_dispatch_panic_rollback.rs`, `src/block_accumulator.rs`, `src/atomic_fs.rs`, `src/checkpoint.rs`, `src/task_core.rs`, `src/tool_middleware.rs`, and `src/types/message_codec.rs`

## IPC contract changes
- none

Closes #651