### PR TITLE
feat: add FnTool with_execute_async alias

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,6 +210,7 @@ gh pr comment <number> --body-file /tmp/comment.md
 - `ToolCallTransformer` runs unconditionally (not gated by approval). Distinct from `ToolValidator` (rejects vs rewrites).
 - `#[tool]` macro param decoding must return `AgentToolResult::error("invalid parameters: ...")` on serde failures rather than panicking. The generated code still retries deserialization from `{}` so zero-param / all-optional tools can execute when appropriate.
 - `FnTool::with_execute_typed::<T>()` is the zero-boilerplate typed path: it derives the schema from `T` and must mirror the rest of the tool stack by returning `AgentToolResult::error("invalid parameters: ...")` on serde decode failures.
+- `FnTool::with_execute_simple()` already accepts async closures; `FnTool::with_execute_async()` is the explicit untyped async alias for discoverability, not a separate execution path.
 - `ToolApprovalRequest` debug output must keep `arguments` fully redacted and run `redact_sensitive_values()` over `context`. MCP tools intentionally pass raw params through `approval_context()` for policy/approval inspection, so the logging boundary is where sanitization has to happen.
 
 ### Credential Management (`auth/`)

--- a/docs/architecture/tool-system/README.md
+++ b/docs/architecture/tool-system/README.md
@@ -272,6 +272,7 @@ flowchart TB
 | `.with_requires_approval(bool)` | Mark the tool as requiring user approval before execution. |
 | `.with_execute(closure)` | Full signature: `(tool_call_id, params, cancel, on_update) -> Future<AgentToolResult>`. |
 | `.with_execute_simple(closure)` | Simplified: `(params, cancel) -> Future<AgentToolResult>`. Ignores tool call ID and update callback. |
+| `.with_execute_async(closure)` | Explicit untyped async alias for `.with_execute_simple(closure)`. |
 | `.with_execute_typed::<T>(closure)` | Derive the schema from `T` and deserialize params into `T` before execution. Returns `invalid parameters` on serde decode failure. |
 
 ### Example
@@ -330,7 +331,7 @@ let tool = FnTool::new("lookup", "Lookup", "Look up a term in the glossary.")
     });
 ```
 
-For tools that need the full call context, use `.with_execute()` instead of `.with_execute_simple()` — it receives `(tool_call_id, params, cancellation_token, on_update)`.
+For tools that need the full call context, use `.with_execute()` instead of `.with_execute_simple()` / `.with_execute_async()` — it receives `(tool_call_id, params, cancellation_token, on_update)`.
 
 ### Struct-based `impl AgentTool` pattern
 

--- a/specs/007-tool-system-extensions/contracts/public-api.md
+++ b/specs/007-tool-system-extensions/contracts/public-api.md
@@ -185,6 +185,10 @@ impl FnTool {
     where
         F: Fn(Value, CancellationToken) -> Fut + Send + Sync + 'static,
         Fut: Future<Output = AgentToolResult> + Send + 'static;
+    pub fn with_execute_async<F, Fut>(self, f: F) -> Self
+    where
+        F: Fn(Value, CancellationToken) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = AgentToolResult> + Send + 'static;
     pub fn with_execute_typed<T, F, Fut>(mut self, f: F) -> Self
     where
         T: DeserializeOwned + JsonSchema + Send + 'static,

--- a/specs/007-tool-system-extensions/data-model.md
+++ b/specs/007-tool-system-extensions/data-model.md
@@ -140,7 +140,7 @@ Closure-based tool builder. Implements `AgentTool`.
 
 **Type alias**: `ExecuteFn = dyn Fn(String, Value, CancellationToken, Option<Box<dyn Fn(AgentToolResult) + Send + Sync>>) -> Pin<Box<dyn Future<Output = AgentToolResult> + Send>> + Send + Sync`
 
-**Builders**: `new(name, label, description)`, `with_schema_for::<T>()`, `with_schema(Value)`, `with_requires_approval(bool)`, `with_execute(closure)`, `with_execute_simple(closure)`, `with_execute_typed::<T>(closure)`
+**Builders**: `new(name, label, description)`, `with_schema_for::<T>()`, `with_schema(Value)`, `with_requires_approval(bool)`, `with_execute(closure)`, `with_execute_simple(closure)`, `with_execute_async(closure)`, `with_execute_typed::<T>(closure)`
 
 ---
 

--- a/specs/007-tool-system-extensions/quickstart.md
+++ b/specs/007-tool-system-extensions/quickstart.md
@@ -40,7 +40,7 @@ struct WeatherParams {
 
 let tool = FnTool::new("get_weather", "Weather", "Get weather for a city.")
     .with_schema_for::<WeatherParams>()
-    .with_execute_simple(|params, _cancel| async move {
+    .with_execute_async(|params, _cancel| async move {
         let city = params["city"].as_str().unwrap_or("unknown");
         AgentToolResult::text(format!("72F in {city}"))
     });

--- a/src/fn_tool.rs
+++ b/src/fn_tool.rs
@@ -147,6 +147,19 @@ impl FnTool {
         self
     }
 
+    /// Set the execution function using an explicit untyped async signature.
+    ///
+    /// This is equivalent to [`Self::with_execute_simple`] and exists as a
+    /// discoverability alias for callers looking for an untyped async builder.
+    #[must_use]
+    pub fn with_execute_async<F, Fut>(self, f: F) -> Self
+    where
+        F: Fn(Value, CancellationToken) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = AgentToolResult> + Send + 'static,
+    {
+        self.with_execute_simple(f)
+    }
+
     /// Set the execution function using a typed parameter struct.
     ///
     /// This derives the schema from `T` and deserializes validated params into
@@ -314,6 +327,29 @@ mod tests {
             .await;
         assert!(!result.is_error);
         assert_eq!(result.content.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn async_execute_receives_params() {
+        let tool = FnTool::new("echo", "Echo", "Echo params.").with_execute_async(
+            |params, _cancel| async move {
+                let msg = params["msg"].as_str().unwrap_or("none").to_owned();
+                AgentToolResult::text(msg)
+            },
+        );
+
+        let result = tool
+            .execute(
+                "id",
+                json!({"msg": "hello"}),
+                CancellationToken::new(),
+                None,
+                test_state(),
+                None,
+            )
+            .await;
+        assert!(!result.is_error);
+        assert_eq!(ContentBlock::extract_text(&result.content), "hello");
     }
 
     #[derive(Deserialize, JsonSchema)]

--- a/tests/fn_tool.rs
+++ b/tests/fn_tool.rs
@@ -16,7 +16,7 @@ use serde_json::json;
 use swink_agent::{Agent, AgentOptions, AgentToolResult, DefaultRetryStrategy, FnTool};
 
 #[tokio::test]
-async fn fn_tool_executes_in_agent_loop() {
+async fn fn_tool_async_executes_in_agent_loop() {
     let tool = FnTool::new("greet", "Greet", "Greet a person.")
         .with_schema(json!({
             "type": "object",
@@ -26,7 +26,7 @@ async fn fn_tool_executes_in_agent_loop() {
             "required": ["name"],
             "additionalProperties": false
         }))
-        .with_execute_simple(|params, _cancel| async move {
+        .with_execute_async(|params, _cancel| async move {
             let name = params["name"].as_str().unwrap_or("world");
             AgentToolResult::text(format!("Hello, {name}!"))
         });


### PR DESCRIPTION
## What changed
- added `FnTool::with_execute_async(...)` as an explicit untyped async builder alias that forwards to `with_execute_simple(...)`
- added focused unit and agent-loop integration coverage for the new alias
- updated the tool-system docs/spec notes and quickstart so the untyped async path is discoverable

## Why / value
- issue #653 came from discoverability: `with_execute_simple(...)` already accepts async closures, but callers looking for an untyped async builder had no obvious API to reach for
- this keeps the existing execution path unchanged while making the intended usage explicit

## Slice completed
- completed the explicit untyped async `FnTool` builder requested in this issue
- no additional implementation work remains for this slice beyond review and merge

## Validation output
- `cargo fmt --all --check`
- `cargo test -p swink-agent async_execute_receives_params --lib`
- `cargo test -p swink-agent --features testkit --test fn_tool`
- `cargo clippy -p swink-agent --lib -- -D warnings`
- `cargo clippy -p swink-agent --test fn_tool --features testkit -- -D warnings`
- `git diff --check`

## Pre-existing baseline failures
- none observed in the focused validation above
- broader workspace `cargo clippy --workspace -- -D warnings` and `cargo test --workspace` were not rerun for this narrow slice

## IPC contract changes
- none

Closes #653