### PR TITLE
docs: document ScriptTool TOML schema

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,6 +214,7 @@ gh pr comment <number> --body-file /tmp/comment.md
 - `#[tool]` macro param decoding must return `AgentToolResult::error("invalid parameters: ...")` on serde failures rather than panicking. The generated code still retries deserialization from `{}` so zero-param / all-optional tools can execute when appropriate.
 - `FnTool::with_execute_typed::<T>()` is the zero-boilerplate typed path: it derives the schema from `T` and must mirror the rest of the tool stack by returning `AgentToolResult::error("invalid parameters: ...")` on serde decode failures.
 - `ToolApprovalRequest` debug output must keep `arguments` fully redacted and run `redact_sensitive_values()` over `context`. MCP tools intentionally pass raw params through `approval_context()` for policy/approval inspection, so the logging boundary is where sanitization has to happen.
+- `ScriptTool` TOML definitions use a top-level `[parameters_schema]` section, not a legacy `[parameters]` table. Keep rustdoc and examples aligned with `src/hot_reload.rs` so hot-reload tool authors do not have to reverse-engineer the format from source.
 
 ### Credential Management (`auth/`)
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,26 @@ cargo test --workspace             # run all tests
 
 Workspace-wide `cargo build/test/clippy` commands also compile `swink-agent-local-llm`. That crate currently depends on `llama-cpp-sys-2`, so contributor machines need LLVM/libclang available for `bindgen`; if auto-discovery fails, set `LIBCLANG_PATH` to the LLVM `bin` directory before running workspace checks.
 
+## Hot-Reloaded Script Tools
+
+When the `hot-reload` feature is enabled, `ScriptTool` definitions use a
+top-level `[parameters_schema]` TOML section, and `command` interpolates
+runtime arguments with `{param}` placeholders:
+
+```toml
+name = "greet"
+description = "Greet a person by name"
+command = "echo 'Hello, {name}!'"
+
+[parameters_schema]
+type = "object"
+required = ["name"]
+
+[parameters_schema.properties.name]
+type = "string"
+description = "The name to greet"
+```
+
 ## Example: Build a Custom Agent
 
 Wire up an LLM provider, register tools, and launch the interactive TUI — all in one file:

--- a/specs/007-tool-system-extensions/data-model.md
+++ b/specs/007-tool-system-extensions/data-model.md
@@ -298,10 +298,14 @@ A tool loaded from a TOML/YAML/JSON definition file that executes a shell comman
 name = "list_files"
 description = "List files in a directory"
 command = "ls -la {path}"
-requires_approval = false
 
-[parameters]
-path = { type = "string", description = "Directory path" }
+[parameters_schema]
+type = "object"
+required = ["path"]
+
+[parameters_schema.properties.path]
+type = "string"
+description = "Directory path"
 ```
 
 Implements `AgentTool`. The `execute()` method interpolates parameters into the command template and runs it via `sh -c`.

--- a/specs/007-tool-system-extensions/quickstart.md
+++ b/specs/007-tool-system-extensions/quickstart.md
@@ -241,10 +241,14 @@ Example tool definition (`tools/list_files.toml`):
 name = "list_files"
 description = "List files in a directory"
 command = "ls -la {path}"
-requires_approval = false
 
-[parameters]
-path = { type = "string", description = "Directory path" }
+[parameters_schema]
+type = "object"
+required = ["path"]
+
+[parameters_schema.properties.path]
+type = "string"
+description = "Directory path"
 ```
 
 ### Noop Tool for Session Compatibility

--- a/src/hot_reload.rs
+++ b/src/hot_reload.rs
@@ -6,14 +6,17 @@
 //! # Definition file format (TOML)
 //!
 //! ```toml
-//! name = "my_tool"
-//! description = "Does something useful"
-//! command = "echo {message}"
+//! name = "greet"
+//! description = "Greet a person by name"
+//! command = "echo 'Hello, {name}!'"
 //!
 //! [parameters_schema]
 //! type = "object"
-//! [parameters_schema.properties.message]
+//! required = ["name"]
+//!
+//! [parameters_schema.properties.name]
 //! type = "string"
+//! description = "The name to greet"
 //! ```
 
 use std::collections::HashMap;
@@ -63,6 +66,24 @@ pub struct ScriptTool {
 impl ScriptTool {
     /// Parse a tool definition from TOML content.
     ///
+    /// TOML definitions use a top-level `[parameters_schema]` section for the
+    /// optional JSON Schema payload, and command templates interpolate
+    /// arguments with `{param_name}` placeholders.
+    ///
+    /// ```toml
+    /// name = "greet"
+    /// description = "Greet a person by name"
+    /// command = "echo 'Hello, {name}!'"
+    ///
+    /// [parameters_schema]
+    /// type = "object"
+    /// required = ["name"]
+    ///
+    /// [parameters_schema.properties.name]
+    /// type = "string"
+    /// description = "The name to greet"
+    /// ```
+    ///
     /// # Errors
     ///
     /// Returns `Err` if the TOML is invalid or missing required fields.
@@ -88,6 +109,10 @@ impl ScriptTool {
     }
 
     /// Load from a file, auto-detecting format by extension.
+    ///
+    /// `.toml` files use the same top-level `[parameters_schema]` section as
+    /// [`Self::from_toml`], and `command` values interpolate runtime arguments
+    /// with `{param_name}` placeholders.
     ///
     /// # Errors
     ///
@@ -374,6 +399,30 @@ command = "echo Hello {name}"
         assert_eq!(tool.name(), "greet");
         assert_eq!(tool.description(), "Greet someone");
         assert!(tool.requires_approval());
+    }
+
+    #[test]
+    fn script_tool_from_toml_with_parameter_schema_section() {
+        let toml = r#"
+name = "greet"
+description = "Greet a person by name"
+command = "echo 'Hello, {name}!'"
+
+[parameters_schema]
+type = "object"
+required = ["name"]
+
+[parameters_schema.properties.name]
+type = "string"
+description = "The name to greet"
+"#;
+
+        let tool = ScriptTool::from_toml(toml).unwrap();
+        assert_eq!(tool.parameters_schema()["required"], json!(["name"]));
+        assert_eq!(
+            tool.parameters_schema()["properties"]["name"]["description"],
+            json!("The name to greet")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- document `ScriptTool::from_toml` and `ScriptTool::from_file` with a full TOML example that shows the top-level `[parameters_schema]` section and `{param}` interpolation
- align the hot-reload module docs, README, and spec examples with the actual `ScriptTool` parser shape
- add a focused regression test that parses the documented TOML schema example

## Slice completed
This PR completes the documentation slice for `ScriptTool` TOML definitions requested in #656.

## What remains
- none for #656

## Validation
- `cargo fmt --all --check`
- `cargo test -p swink-agent --features hot-reload --lib script_tool_from_toml_with_parameter_schema_section`
- `cargo clippy -p swink-agent --features hot-reload --lib -- -D warnings`
- `git diff --check`

## Pre-existing baseline failures
- none observed in the focused validation above

Closes #656