### PR TITLE
[codex] add custom SSE MCP headers

### DIFF
--- a/mcp/src/config.rs
+++ b/mcp/src/config.rs
@@ -19,6 +19,8 @@ pub enum McpTransport {
     Sse {
         url: String,
         bearer_token: Option<String>,
+        #[serde(default)]
+        headers: HashMap<String, String>,
     },
 }
 

--- a/mcp/src/connection.rs
+++ b/mcp/src/connection.rs
@@ -5,8 +5,10 @@
 //! awaits the service lifecycle and emits a disconnect event when the
 //! underlying service stops running.
 
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex, PoisonError};
 
+use reqwest::header::{HeaderName, HeaderValue};
 use rmcp::model::{CallToolRequestParams, CallToolResult, ClientInfo, Implementation};
 use rmcp::service::{Peer, QuitReason, RoleClient, RunningService, ServiceExt};
 use rmcp::transport::TokioChildProcess;
@@ -178,9 +180,11 @@ impl McpConnection {
             McpTransport::Stdio { command, args, env } => {
                 Self::connect_stdio(command, args, env, &config.name).await?
             }
-            McpTransport::Sse { url, bearer_token } => {
-                Self::connect_sse(url, bearer_token.as_deref(), &config.name).await?
-            }
+            McpTransport::Sse {
+                url,
+                bearer_token,
+                headers,
+            } => Self::connect_sse(url, bearer_token.as_deref(), headers, &config.name).await?,
         };
 
         // Handshake succeeded, transport is live.
@@ -266,11 +270,15 @@ impl McpConnection {
     async fn connect_sse(
         url: &str,
         bearer_token: Option<&str>,
+        headers: &HashMap<String, String>,
         server_name: &str,
     ) -> Result<RunningService<RoleClient, ClientInfo>, McpError> {
         let mut config = StreamableHttpClientTransportConfig::with_uri(url);
         if let Some(token) = bearer_token {
-            config = config.auth_header(format!("Bearer {token}"));
+            config = config.auth_header(token.to_owned());
+        }
+        if !headers.is_empty() {
+            config = config.custom_headers(parse_custom_headers(headers, server_name)?);
         }
 
         let transport = StreamableHttpClientTransport::from_config(config);
@@ -354,6 +362,29 @@ impl McpConnection {
             let _ = monitor.await;
         }
     }
+}
+
+fn parse_custom_headers(
+    headers: &HashMap<String, String>,
+    server_name: &str,
+) -> Result<HashMap<HeaderName, HeaderValue>, McpError> {
+    headers
+        .iter()
+        .map(|(name, value)| {
+            let header_name = HeaderName::from_bytes(name.as_bytes()).map_err(|error| {
+                McpError::ConnectionFailed {
+                    server: server_name.to_string(),
+                    reason: format!("invalid SSE header name `{name}`: {error}"),
+                }
+            })?;
+            let header_value =
+                HeaderValue::from_str(value).map_err(|error| McpError::ConnectionFailed {
+                    server: server_name.to_string(),
+                    reason: format!("invalid SSE header value for `{name}`: {error}"),
+                })?;
+            Ok((header_name, header_value))
+        })
+        .collect()
 }
 
 impl Drop for McpConnection {

--- a/mcp/tests/config_test.rs
+++ b/mcp/tests/config_test.rs
@@ -2,6 +2,8 @@
 
 mod common;
 
+use std::collections::HashMap;
+
 use swink_agent_mcp::{McpServerConfig, McpTransport, ToolFilter};
 
 #[test]
@@ -30,6 +32,7 @@ fn sse_transport_construction() {
         transport: McpTransport::Sse {
             url: "http://localhost:8080/sse".into(),
             bearer_token: Some("secret".into()),
+            headers: HashMap::from([("x-api-key".into(), "abc123".into())]),
         },
         tool_prefix: None,
         tool_filter: None,
@@ -38,6 +41,36 @@ fn sse_transport_construction() {
 
     assert_eq!(config.name, "remote");
     assert!(!config.requires_approval);
+}
+
+#[test]
+fn sse_transport_deserialization_defaults_headers() {
+    let json = r#"{
+        "name": "remote",
+        "transport": {
+            "type": "sse",
+            "url": "http://localhost:8080/sse",
+            "bearer_token": "secret"
+        },
+        "tool_prefix": null,
+        "tool_filter": null,
+        "requires_approval": false
+    }"#;
+
+    let config: McpServerConfig = serde_json::from_str(json).expect("deserialize");
+
+    match config.transport {
+        McpTransport::Sse {
+            url,
+            bearer_token,
+            headers,
+        } => {
+            assert_eq!(url, "http://localhost:8080/sse");
+            assert_eq!(bearer_token.as_deref(), Some("secret"));
+            assert!(headers.is_empty(), "legacy configs should default headers");
+        }
+        other @ McpTransport::Stdio { .. } => panic!("expected SSE transport, got {other:?}"),
+    }
 }
 
 #[test]
@@ -111,4 +144,45 @@ fn config_serialization_roundtrip() {
     assert_eq!(roundtrip.name, config.name);
     assert_eq!(roundtrip.tool_prefix, config.tool_prefix);
     assert!(roundtrip.requires_approval);
+}
+
+#[test]
+fn sse_config_serialization_roundtrip_preserves_headers() {
+    let config = McpServerConfig {
+        name: "remote".into(),
+        transport: McpTransport::Sse {
+            url: "https://example.com/mcp".into(),
+            bearer_token: Some("secret".into()),
+            headers: HashMap::from([
+                ("x-api-key".into(), "key-123".into()),
+                ("x-trace-id".into(), "trace-abc".into()),
+            ]),
+        },
+        tool_prefix: Some("remote".into()),
+        tool_filter: None,
+        requires_approval: false,
+    };
+
+    let json = serde_json::to_string(&config).expect("serialize");
+    let roundtrip: McpServerConfig = serde_json::from_str(&json).expect("deserialize");
+
+    match roundtrip.transport {
+        McpTransport::Sse {
+            url,
+            bearer_token,
+            headers,
+        } => {
+            assert_eq!(url, "https://example.com/mcp");
+            assert_eq!(bearer_token.as_deref(), Some("secret"));
+            assert_eq!(
+                headers.get("x-api-key").map(String::as_str),
+                Some("key-123")
+            );
+            assert_eq!(
+                headers.get("x-trace-id").map(String::as_str),
+                Some("trace-abc")
+            );
+        }
+        other @ McpTransport::Stdio { .. } => panic!("expected SSE transport, got {other:?}"),
+    }
 }

--- a/mcp/tests/connection_test.rs
+++ b/mcp/tests/connection_test.rs
@@ -2,7 +2,61 @@
 
 mod common;
 
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, PoisonError};
+use std::time::Duration;
+
+use axum::Router;
+use axum::extract::State;
+use axum::http::header::AUTHORIZATION;
+use axum::http::{HeaderMap, StatusCode};
+use axum::routing::post;
+use tokio::sync::oneshot;
+
 use swink_agent_mcp::{McpConnection, McpServerConfig, McpTransport};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CapturedHeaders {
+    authorization: Option<String>,
+    api_key: Option<String>,
+    trace_id: Option<String>,
+}
+
+#[derive(Clone)]
+struct HeaderCaptureState {
+    sender: Arc<Mutex<Option<oneshot::Sender<CapturedHeaders>>>>,
+}
+
+async fn capture_headers(
+    State(state): State<HeaderCaptureState>,
+    headers: HeaderMap,
+) -> StatusCode {
+    let captured = CapturedHeaders {
+        authorization: headers
+            .get(AUTHORIZATION)
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_owned),
+        api_key: headers
+            .get("x-api-key")
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_owned),
+        trace_id: headers
+            .get("x-trace-id")
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_owned),
+    };
+
+    let sender = state
+        .sender
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner)
+        .take();
+    if let Some(sender) = sender {
+        let _ = sender.send(captured);
+    }
+
+    StatusCode::INTERNAL_SERVER_ERROR
+}
 
 /// T010: Connect to mock stdio MCP server, verify connection succeeds
 /// and tools are discovered.
@@ -103,6 +157,7 @@ async fn connect_sse_to_unreachable_url_returns_error() {
         transport: McpTransport::Sse {
             url: "http://127.0.0.1:1/mcp".into(),
             bearer_token: Some("test-bearer-token-123".into()),
+            headers: HashMap::new(),
         },
         tool_prefix: None,
         tool_filter: None,
@@ -111,4 +166,61 @@ async fn connect_sse_to_unreachable_url_returns_error() {
 
     let result = McpConnection::connect(config, None).await;
     assert!(result.is_err(), "connecting to unreachable URL should fail");
+}
+
+#[tokio::test]
+async fn connect_sse_sends_bearer_and_custom_headers() {
+    let (sender, receiver) = oneshot::channel();
+    let state = HeaderCaptureState {
+        sender: Arc::new(Mutex::new(Some(sender))),
+    };
+
+    let app = Router::new()
+        .route("/mcp", post(capture_headers))
+        .with_state(state);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test server");
+    let address = listener.local_addr().expect("listener address");
+
+    let server = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+
+    let config = McpServerConfig {
+        name: "sse-header-test".into(),
+        transport: McpTransport::Sse {
+            url: format!("http://{address}/mcp"),
+            bearer_token: Some("test-bearer-token-123".into()),
+            headers: HashMap::from([
+                ("x-api-key".into(), "custom-key-456".into()),
+                ("x-trace-id".into(), "trace-789".into()),
+            ]),
+        },
+        tool_prefix: None,
+        tool_filter: None,
+        requires_approval: false,
+    };
+
+    let result = McpConnection::connect(config, None).await;
+    assert!(
+        result.is_err(),
+        "the mock HTTP server should reject the handshake"
+    );
+
+    let captured = tokio::time::timeout(Duration::from_secs(5), receiver)
+        .await
+        .expect("timed out waiting for header capture")
+        .expect("header capture channel closed");
+
+    assert_eq!(
+        captured.authorization.as_deref(),
+        Some("Bearer test-bearer-token-123")
+    );
+    assert_eq!(captured.api_key.as_deref(), Some("custom-key-456"));
+    assert_eq!(captured.trace_id.as_deref(), Some("trace-789"));
+
+    server.abort();
+    let _ = server.await;
 }

--- a/mcp/tests/lifecycle_test.rs
+++ b/mcp/tests/lifecycle_test.rs
@@ -272,6 +272,7 @@ async fn sse_session_expiry_recovers_without_wrapper_disconnect() {
             transport: McpTransport::Sse {
                 url: format!("http://{addr}/mcp"),
                 bearer_token: None,
+                headers: HashMap::new(),
             },
             tool_prefix: None,
             tool_filter: None,

--- a/specs/038-mcp-integration/contracts/public-api.md
+++ b/specs/038-mcp-integration/contracts/public-api.md
@@ -50,6 +50,7 @@ pub enum McpTransport {
     Sse {
         url: String,
         bearer_token: Option<String>,
+        headers: HashMap<String, String>,
     },
 }
 ```

--- a/specs/038-mcp-integration/data-model.md
+++ b/specs/038-mcp-integration/data-model.md
@@ -12,7 +12,7 @@ Describes how to connect to an MCP server.
 | Variant | Fields | Description |
 |---------|--------|-------------|
 | Stdio | `command: String`, `args: Vec<String>`, `env: HashMap<String, String>` | Subprocess spawned with stdin/stdout communication. `env` merges with (and overrides) parent process environment. |
-| Sse | `url: String`, `bearer_token: Option<String>` | HTTP connection using Server-Sent Events. Optional bearer token for `Authorization` header. |
+| Sse | `url: String`, `bearer_token: Option<String>`, `headers: HashMap<String, String>` | HTTP connection using Server-Sent Events. Optional bearer token for `Authorization` plus additional custom headers on every request. |
 
 ### McpServerConfig
 

--- a/specs/038-mcp-integration/quickstart.md
+++ b/specs/038-mcp-integration/quickstart.md
@@ -74,6 +74,7 @@ let configs = vec![
         transport: McpTransport::Sse {
             url: "https://mcp.example.com/sse".into(),
             bearer_token: Some("sk-...".into()),
+            headers: [("x-api-key".into(), "api-key-123".into())].into(),
         },
         tool_prefix: None,
         tool_filter: None,

--- a/specs/038-mcp-integration/spec.md
+++ b/specs/038-mcp-integration/spec.md
@@ -10,7 +10,7 @@
 ### Session 2026-04-01
 
 - Q: Should MCP operations emit events through the existing AgentEvent system? → A: Yes — MCP emits events for connect, disconnect, tool discovery, and tool call forwarded/completed via the existing AgentEvent system.
-- Q: How should the agent authenticate to remote SSE MCP servers? → A: Optional bearer token (API key or OAuth2 token) per SSE connection, integrated with the credential resolver (spec 035).
+- Q: How should the agent authenticate to remote SSE MCP servers? → A: Optional bearer token (API key or OAuth2 token) plus optional additional HTTP headers per SSE connection, with bearer-token support integrated with the credential resolver (spec 035).
 - Q: Can consumers pass environment variables and working directory to MCP subprocess? → A: Command, arguments, and optional environment variable overrides — no working directory config.
 
 ## User Scenarios & Testing *(mandatory)*
@@ -140,12 +140,12 @@ A library consumer configures an MCP server that runs as a subprocess (stdio tra
 - **FR-014**: System MUST detect and report tool name collisions across MCP servers at connection time.
 - **FR-015**: System MUST be feature-gated so that projects not using MCP incur no compilation or runtime cost.
 - **FR-016**: System MUST emit events through the existing agent event system for MCP lifecycle operations: server connect, server disconnect, tool discovery completed, tool call forwarded, and tool call completed.
-- **FR-017**: System MUST support optional bearer token authentication for SSE transport connections, integrated with the credential resolver (spec 035).
+- **FR-017**: System MUST support optional bearer token authentication and optional additional HTTP headers for SSE transport connections, integrated with the credential resolver (spec 035) for bearer-token resolution.
 - **FR-018**: System MUST support optional environment variable overrides when spawning MCP server subprocesses (stdio transport).
 
 ### Key Entities
 
-- **MCP Connection**: Represents a configured connection to an MCP server — transport type (stdio or SSE), connection parameters (command + args + optional env vars for stdio; URL + optional bearer token for SSE), optional name prefix, and optional tool filters.
+- **MCP Connection**: Represents a configured connection to an MCP server — transport type (stdio or SSE), connection parameters (command + args + optional env vars for stdio; URL + optional bearer token + optional custom headers for SSE), optional name prefix, and optional tool filters.
 - **MCP Tool**: A tool discovered from an MCP server — wraps the MCP tool definition and implements the agent's standard tool interface, routing execution calls to the originating MCP server.
 - **Tool Filter**: A configuration that controls which tools from an MCP server are exposed to the agent — supports allow-list and deny-list patterns.
 


### PR DESCRIPTION
## What changed
- added an optional `headers: HashMap<String, String>` field to `McpTransport::Sse` with backward-compatible serde defaults
- threaded custom SSE headers through the rmcp streamable HTTP client setup so they are sent on initialize, stream, and session-cleanup requests
- added focused regression coverage for SSE config deserialization/round-tripping and for outgoing bearer/custom headers
- updated the MCP integration spec contract, data model, and quickstart so the public API matches the shipped behavior
- corrected the existing bearer-token wiring to send `Authorization: Bearer <token>` instead of duplicating the prefix

## Why / value
Some remote MCP servers require non-standard authentication headers such as `x-api-key`. This change makes those servers usable without forking `swink-agent-mcp`, while preserving the existing bearer-token path.

## Slice completed
This PR completes issue #654 by adding configurable custom SSE headers end-to-end.

## What remains
- none for #654

## Validation output
- `cargo fmt --all --check`
- `cargo test -p swink-agent-mcp`
- `cargo clippy -p swink-agent-mcp --test config_test --test connection_test -- -D warnings`
- `git diff --check`

## Pre-existing baseline failures
- `cargo clippy -p swink-agent-mcp --tests -- -D warnings` still fails in unchanged files due existing `clippy::doc_markdown` and `clippy::default_trait_access` findings in `mcp/tests/filter_test.rs`, `mcp/tests/manager_test.rs`, `mcp/tests/policy_test.rs`, and `mcp/tests/lifecycle_test.rs`

## IPC contract changes
- none

Closes #654