### PR TITLE
[codex] add file-backed checkpoint store

### DIFF
--- a/memory/AGENTS.md
+++ b/memory/AGENTS.md
@@ -3,3 +3,4 @@
 ## Lessons Learned
 
 - Session transcript saves and session-state saves must share one store-level write path when callers need a consistent snapshot. `SessionStore::save_full()` is the atomic seam for that contract; `JsonlSessionStore` must rewrite messages plus the `_state` line under one lock and one sequence bump so TUI autosave cannot persist mixed transcript/state snapshots.
+- File-backed checkpoint persistence must validate checkpoint IDs before turning them into filenames. Reject path separators, `..`, and null bytes so consumer-provided checkpoint IDs cannot escape the configured checkpoint root.

--- a/memory/src/checkpoint_store.rs
+++ b/memory/src/checkpoint_store.rs
@@ -1,0 +1,180 @@
+//! File-backed checkpoint persistence for [`swink_agent::CheckpointStore`].
+
+use std::io;
+use std::path::{Path, PathBuf};
+
+use swink_agent::atomic_fs::atomic_write;
+use swink_agent::{Checkpoint, CheckpointFuture, CheckpointStore};
+
+fn checkpoint_path(checkpoints_dir: &Path, id: &str) -> PathBuf {
+    checkpoints_dir.join(format!("{id}.json"))
+}
+
+fn validate_checkpoint_id(id: &str) -> io::Result<()> {
+    if id.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "checkpoint ID must not be empty",
+        ));
+    }
+    if id.contains('/') || id.contains('\\') || id.contains("..") || id.contains('\0') {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("checkpoint ID contains unsafe characters: {id:?}"),
+        ));
+    }
+    Ok(())
+}
+
+/// Durable checkpoint store that persists one checkpoint per JSON file.
+///
+/// Checkpoints are written atomically, so a failed save never leaves a partial
+/// or zero-length live file behind. Checkpoint IDs are validated before file
+/// access and therefore must not contain path separators, `..`, or null bytes.
+pub struct FileCheckpointStore {
+    checkpoints_dir: PathBuf,
+}
+
+impl FileCheckpointStore {
+    /// Create a new store rooted at the given directory.
+    ///
+    /// Creates the directory (and parents) if it does not already exist.
+    pub fn new(checkpoints_dir: PathBuf) -> io::Result<Self> {
+        std::fs::create_dir_all(&checkpoints_dir)?;
+        Ok(Self { checkpoints_dir })
+    }
+
+    /// Default checkpoints directory: `<config_dir>/swink-agent/checkpoints`.
+    pub fn default_dir() -> Option<PathBuf> {
+        dirs::config_dir().map(|dir| dir.join("swink-agent").join("checkpoints"))
+    }
+}
+
+impl CheckpointStore for FileCheckpointStore {
+    fn save_checkpoint(&self, checkpoint: Checkpoint) -> CheckpointFuture<'_, ()> {
+        Box::pin(async move {
+            validate_checkpoint_id(&checkpoint.id)?;
+            let path = checkpoint_path(&self.checkpoints_dir, &checkpoint.id);
+            atomic_write(&path, |writer| {
+                serde_json::to_writer_pretty(&mut *writer, &checkpoint).map_err(io::Error::other)
+            })
+        })
+    }
+
+    fn load_checkpoint(&self, id: &str) -> CheckpointFuture<'_, Option<Checkpoint>> {
+        let id = id.to_string();
+        Box::pin(async move {
+            validate_checkpoint_id(&id)?;
+            let path = checkpoint_path(&self.checkpoints_dir, &id);
+            if !path.exists() {
+                return Ok(None);
+            }
+
+            let contents = std::fs::read_to_string(path)?;
+            serde_json::from_str(&contents)
+                .map(Some)
+                .map_err(io::Error::other)
+        })
+    }
+
+    fn list_checkpoints(&self) -> CheckpointFuture<'_, Vec<String>> {
+        Box::pin(async move {
+            let mut checkpoints = Vec::new();
+
+            for entry in std::fs::read_dir(&self.checkpoints_dir)? {
+                let entry = entry?;
+                let path = entry.path();
+                if path.extension().and_then(|value| value.to_str()) != Some("json") {
+                    continue;
+                }
+
+                let contents = match std::fs::read_to_string(&path) {
+                    Ok(contents) => contents,
+                    Err(error) => {
+                        tracing::warn!(
+                            path = %path.display(),
+                            error = %error,
+                            "skipping unreadable checkpoint file"
+                        );
+                        continue;
+                    }
+                };
+
+                match serde_json::from_str::<Checkpoint>(&contents) {
+                    Ok(checkpoint) => checkpoints.push((checkpoint.created_at, checkpoint.id)),
+                    Err(error) => {
+                        tracing::warn!(
+                            path = %path.display(),
+                            error = %error,
+                            "skipping invalid checkpoint file"
+                        );
+                    }
+                }
+            }
+
+            checkpoints.sort_by(|left, right| right.cmp(left));
+            Ok(checkpoints.into_iter().map(|(_, id)| id).collect())
+        })
+    }
+
+    fn delete_checkpoint(&self, id: &str) -> CheckpointFuture<'_, ()> {
+        let id = id.to_string();
+        Box::pin(async move {
+            validate_checkpoint_id(&id)?;
+            let path = checkpoint_path(&self.checkpoints_dir, &id);
+            match std::fs::remove_file(path) {
+                Ok(()) => Ok(()),
+                Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+                Err(error) => Err(error),
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io;
+
+    use super::FileCheckpointStore;
+    use swink_agent::{Checkpoint, CheckpointStore};
+
+    #[tokio::test]
+    async fn file_checkpoint_store_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = FileCheckpointStore::new(dir.path().to_path_buf()).unwrap();
+        let checkpoint =
+            Checkpoint::new("cp-file", "prompt", "provider", "model", &[]).with_turn_count(3);
+
+        store.save_checkpoint(checkpoint).await.unwrap();
+
+        let loaded = store.load_checkpoint("cp-file").await.unwrap().unwrap();
+        assert_eq!(loaded.id, "cp-file");
+        assert_eq!(loaded.turn_count, 3);
+    }
+
+    #[tokio::test]
+    async fn file_checkpoint_store_lists_newest_first() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = FileCheckpointStore::new(dir.path().to_path_buf()).unwrap();
+
+        let mut older = Checkpoint::new("older", "prompt", "provider", "model", &[]);
+        older.created_at = 10;
+        let mut newer = Checkpoint::new("newer", "prompt", "provider", "model", &[]);
+        newer.created_at = 20;
+
+        store.save_checkpoint(older).await.unwrap();
+        store.save_checkpoint(newer).await.unwrap();
+
+        let ids = store.list_checkpoints().await.unwrap();
+        assert_eq!(ids, vec!["newer".to_string(), "older".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn file_checkpoint_store_rejects_unsafe_checkpoint_ids() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = FileCheckpointStore::new(dir.path().to_path_buf()).unwrap();
+
+        let err = store.load_checkpoint("../escape").await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
+}

--- a/memory/src/lib.rs
+++ b/memory/src/lib.rs
@@ -1,10 +1,11 @@
 #![forbid(unsafe_code)]
 //! Session persistence and memory management for swink-agent.
 //!
-//! This crate provides pluggable session storage and context compaction
-//! strategies for the swink-agent framework. It extracts session persistence
-//! from the TUI into a reusable library and lays the groundwork for
-//! multi-layer memory research (summarization, RAG, tool-aware compaction).
+//! This crate provides pluggable session storage, durable checkpoint storage,
+//! and context compaction strategies for the swink-agent framework. It
+//! extracts session persistence from the TUI into a reusable library and lays
+//! the groundwork for multi-layer memory research (summarization, RAG,
+//! tool-aware compaction).
 //!
 //! # Quick Start
 //!
@@ -26,7 +27,10 @@
 //! };
 //! store.save(&id, &meta, &messages)?;
 //! ```
+//!
+//! For durable agent checkpoints, use [`FileCheckpointStore`].
 
+mod checkpoint_store;
 mod codec;
 mod compaction;
 mod entry;
@@ -39,6 +43,7 @@ mod store;
 mod store_async;
 mod time;
 
+pub use checkpoint_store::FileCheckpointStore;
 pub use compaction::{CompactionResult, SummarizingCompactor};
 pub use entry::SessionEntry;
 pub use interrupt::{InterruptState, PendingToolCall};

--- a/memory/tests/public_api.rs
+++ b/memory/tests/public_api.rs
@@ -1,12 +1,13 @@
 use swink_agent_memory::{
-    BlockingSessionStore, CompactionResult, InterruptState, JsonlSessionStore, LoadOptions,
-    PendingToolCall, SessionEntry, SessionMeta, SessionMigrator, SessionStore, SessionStoreFuture,
-    SummarizingCompactor, format_session_id, now_utc,
+    BlockingSessionStore, CompactionResult, FileCheckpointStore, InterruptState, JsonlSessionStore,
+    LoadOptions, PendingToolCall, SessionEntry, SessionMeta, SessionMigrator, SessionStore,
+    SessionStoreFuture, SummarizingCompactor, format_session_id, now_utc,
 };
 
 #[test]
 fn memory_root_reexports_remain_consumable() {
     let _ = std::any::type_name::<JsonlSessionStore>();
+    let _ = std::any::type_name::<FileCheckpointStore>();
     let _ = std::any::type_name::<dyn SessionStore>();
     let _ = std::any::type_name::<SessionMeta>();
     let _ = std::any::type_name::<SessionEntry>();


### PR DESCRIPTION
## What changed
- added `FileCheckpointStore` to `swink-agent-memory` as a durable `CheckpointStore` implementation that persists one checkpoint per JSON file
- exported the new store from the crate root and documented it in the memory crate docs
- added focused tests for round-trip persistence, newest-first listing, and unsafe checkpoint-ID rejection
- recorded the filesystem-safety rule in `memory/AGENTS.md`

## Why
Issue #658 reported that users had no out-of-box durable checkpoint store for persisting agent loop checkpoints across process restarts. This adds the missing file-backed implementation in the natural home alongside the existing memory/session persistence crate.

## Slice completed
Completed the durable checkpoint-store slice by shipping a public `FileCheckpointStore` in `swink-agent-memory`.
Remaining work: none for this issue in the library; downstream examples can adopt the new store directly.

## Validation
- `cargo fmt --all --check`
- `cargo test -p swink-agent-memory`
- `cargo clippy -p swink-agent-memory --tests -- -D warnings`

## Baseline failures
- `cargo clippy --workspace -- -D warnings` fails in this Windows runner while building `llama-cpp-sys-2` because `cmake` is not installed
- `cargo test --workspace` fails on the same `llama-cpp-sys-2` / missing `cmake` environment prerequisite

Closes #658