### PR TITLE
[codex] harden composed tool name uniqueness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,7 +168,9 @@ gh pr comment <number> --body-file /tmp/comment.md
 - `PluginRegistry` deduplicates by name on `register()` — the new plugin **replaces** the old one (with a `tracing::warn`), not an error.
 - `list()` returns plugins sorted by priority descending; insertion order preserved for ties.
 - `NamespacedTool` prefixes as `"{plugin_name}_{tool_name}"` (underscore, not dot — Anthropic/Bedrock/OpenAI reject dots) and sanitizes both components to the common subset `^[a-zA-Z][a-zA-Z0-9_]{0,63}$` accepted by every provider. Prevents tool name collisions across plugins and guarantees wire-level validity.
+- Long namespaced tool names must keep a deterministic hash suffix when truncated; raw prefix truncation can collapse distinct plugin/tool pairs onto the same wire name.
 - Contributions merged in `Agent::new()`: plugin policies **prepended** (priority-sorted), direct policies appended; plugin tools appended after direct tools.
+- `Agent::new()` and `Agent::set_tools()` must reject duplicate final tool names after composition instead of relying on dispatch's "keep first" fallback; schema export and lookup need the same unique wire-name set.
 - `on_init(&self, &Agent)` dispatched in priority order, wrapped in `catch_unwind` — panicking `on_init` is logged and skipped, construction continues.
 - Entire module behind `#[cfg(feature = "plugins")]` — opt-in, not default-enabled, zero cost when disabled.
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -151,6 +151,27 @@ fn available_models_and_stream_fns(
     (available_models, model_stream_fns)
 }
 
+fn assert_unique_tool_names(tools: &[Arc<dyn AgentTool>]) {
+    let mut seen = HashSet::with_capacity(tools.len());
+    let mut duplicates = Vec::new();
+
+    for tool in tools {
+        let name = tool.name();
+        if !seen.insert(name.to_owned()) {
+            duplicates.push(name.to_owned());
+        }
+    }
+
+    if !duplicates.is_empty() {
+        duplicates.sort();
+        duplicates.dedup();
+        panic!(
+            "duplicate tool names are not allowed after composition: {}",
+            duplicates.join(", ")
+        );
+    }
+}
+
 #[cfg(feature = "plugins")]
 fn dispatch_plugin_on_init(agent: &Agent) {
     // Dispatch on_init to each plugin in priority order (already sorted).
@@ -268,6 +289,8 @@ impl Agent {
         // Merge plugin contributions (policies, tools, event observers) into options.
         #[cfg(feature = "plugins")]
         let options = merge_plugin_contributions(options);
+
+        assert_unique_tool_names(&options.tools);
 
         // Compute the effective system prompt before partial moves.
         let effective_prompt = options.effective_system_prompt().to_owned();
@@ -504,5 +527,32 @@ impl RetryStrategy for SharedRetryStrategy {
 
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+}
+
+#[cfg(all(test, feature = "plugins"))]
+mod tests {
+    use std::sync::Arc;
+
+    use crate::testing::{MockPlugin, MockTool, SimpleMockStreamFn};
+
+    use super::*;
+
+    #[test]
+    #[should_panic(expected = "duplicate tool names are not allowed after composition")]
+    fn agent_new_rejects_duplicate_names_after_plugin_composition() {
+        let stream_fn = Arc::new(SimpleMockStreamFn::from_text("ok"));
+        let options = AgentOptions::new(
+            "test",
+            crate::testing::default_model(),
+            stream_fn,
+            crate::testing::default_convert,
+        )
+        .with_tools(vec![
+            Arc::new(MockTool::new("my_web_search")) as Arc<dyn AgentTool>
+        ])
+        .with_plugin(Arc::new(MockPlugin::new("my-web").with_tools(&["search"])));
+
+        let _agent = Agent::new(options);
     }
 }

--- a/src/agent/mutation.rs
+++ b/src/agent/mutation.rs
@@ -57,6 +57,7 @@ impl Agent {
 
     /// Replace the tool set.
     pub fn set_tools(&mut self, tools: Vec<Arc<dyn AgentTool>>) {
+        super::assert_unique_tool_names(&tools);
         self.state.tools = tools;
     }
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -155,6 +155,8 @@ impl Default for PluginRegistry {
 /// Maximum length for a composed tool name (the tightest cap across providers:
 /// `OpenAI`, Bedrock, and Gemini all cap at 64; Anthropic allows 128).
 const MAX_TOOL_NAME_LEN: usize = 64;
+/// Hex characters preserved from the stable hash when truncation is required.
+const TOOL_NAME_HASH_HEX_LEN: usize = 16;
 
 /// Sanitize a single component (plugin name or inner tool name) to the common
 /// subset of characters accepted by every provider's tool-name grammar.
@@ -191,8 +193,9 @@ fn sanitize_tool_name_component(input: &str) -> String {
 /// Joins `plugin_name` and `tool_name` with `_`, sanitizes each half, prepends
 /// `t_` if the result would start with a non-letter (Bedrock/Gemini require a
 /// leading letter or underscore — we pick letter for maximum safety), and
-/// truncates to [`MAX_TOOL_NAME_LEN`]. Truncation preserves the plugin prefix
-/// where possible so distinct plugins keep distinct names.
+/// truncates to [`MAX_TOOL_NAME_LEN`]. When truncation is required, a stable
+/// hash suffix is appended so long names do not silently collapse onto the same
+/// dispatch key.
 fn compose_namespaced_name(plugin_name: &str, tool_name: &str) -> String {
     let plugin = sanitize_tool_name_component(plugin_name);
     let tool = sanitize_tool_name_component(tool_name);
@@ -204,11 +207,20 @@ fn compose_namespaced_name(plugin_name: &str, tool_name: &str) -> String {
     if with_leading_letter.len() <= MAX_TOOL_NAME_LEN {
         with_leading_letter
     } else {
-        with_leading_letter
-            .chars()
-            .take(MAX_TOOL_NAME_LEN)
-            .collect()
+        let hash_suffix = stable_name_hash_hex(&with_leading_letter);
+        let prefix_len = MAX_TOOL_NAME_LEN - TOOL_NAME_HASH_HEX_LEN - 1;
+        let prefix: String = with_leading_letter.chars().take(prefix_len).collect();
+        format!("{prefix}_{hash_suffix}")
     }
+}
+
+fn stable_name_hash_hex(input: &str) -> String {
+    let mut hash = 0xcbf2_9ce4_8422_2325_u64;
+    for byte in input.bytes() {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    format!("{hash:0TOOL_NAME_HASH_HEX_LEN$x}")
 }
 
 // ─── NamespacedTool ────────────────────────────────────────────────────────
@@ -408,6 +420,33 @@ mod tests {
         assert_eq!(result.len(), MAX_TOOL_NAME_LEN);
         // Prefix is preserved (plugin name survives at the front).
         assert!(result.starts_with(&long_plugin));
+        assert_eq!(result.chars().filter(|c| *c == '_').count(), 2);
+        assert_eq!(
+            result.rsplit_once('_').unwrap().1.len(),
+            TOOL_NAME_HASH_HEX_LEN
+        );
+    }
+
+    #[test]
+    fn compose_namespaced_name_long_collisions_get_distinct_hash_suffixes() {
+        let long_plugin = "a".repeat(40);
+        let first_tool = format!("{}x", "b".repeat(40));
+        let second_tool = format!("{}y", "b".repeat(40));
+
+        let first = compose_namespaced_name(&long_plugin, &first_tool);
+        let second = compose_namespaced_name(&long_plugin, &second_tool);
+
+        assert_eq!(first.len(), MAX_TOOL_NAME_LEN);
+        assert_eq!(second.len(), MAX_TOOL_NAME_LEN);
+        assert_ne!(first, second);
+        assert_eq!(
+            first[..MAX_TOOL_NAME_LEN - TOOL_NAME_HASH_HEX_LEN - 1],
+            second[..MAX_TOOL_NAME_LEN - TOOL_NAME_HASH_HEX_LEN - 1]
+        );
+        assert_ne!(
+            first.rsplit_once('_').unwrap().1,
+            second.rsplit_once('_').unwrap().1
+        );
     }
 
     #[test]

--- a/tests/agent.rs
+++ b/tests/agent.rs
@@ -256,49 +256,45 @@ async fn abort_during_tool_turn_keeps_single_turn_and_tool_payloads() {
     );
 }
 
-#[tokio::test]
-async fn duplicate_tool_names_dispatch_first_registered_tool() {
+#[test]
+fn duplicate_tool_names_are_rejected_during_agent_construction() {
     let stream_fn = Arc::new(MockStreamFn::new(vec![
         tool_call_events("tc_dup", "dup_tool", "{}"),
         text_only_events("done"),
     ]));
     let first = Arc::new(MockTool::new("dup_tool").with_result(AgentToolResult::text("first")));
     let second = Arc::new(MockTool::new("dup_tool").with_result(AgentToolResult::text("second")));
-    let mut agent = make_agent_with_tools(
-        stream_fn,
-        vec![
-            Arc::clone(&first) as Arc<dyn AgentTool>,
-            Arc::clone(&second) as Arc<dyn AgentTool>,
-        ],
-    );
+    let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let _agent = make_agent_with_tools(
+            stream_fn,
+            vec![
+                Arc::clone(&first) as Arc<dyn AgentTool>,
+                Arc::clone(&second) as Arc<dyn AgentTool>,
+            ],
+        );
+    }))
+    .expect_err("duplicate tool names should be rejected during construction");
 
-    let resolved = agent
-        .find_tool("dup_tool")
-        .expect("duplicate tool name should still resolve");
+    let panic_message = panic
+        .downcast_ref::<String>()
+        .cloned()
+        .or_else(|| {
+            panic
+                .downcast_ref::<&str>()
+                .map(|message| (*message).to_owned())
+        })
+        .expect("panic should carry a message");
+
     assert!(
-        std::ptr::eq::<dyn AgentTool>(resolved.as_ref(), first.as_ref()),
-        "find_tool should expose the first registered tool"
+        panic_message.contains("duplicate tool names are not allowed after composition: dup_tool"),
+        "unexpected panic message: {panic_message}"
     );
-
-    let result = agent.prompt_async(vec![user_msg("go")]).await.unwrap();
-
     assert_eq!(
         first.execution_count(),
-        1,
-        "dispatch should execute the same first registered tool that lookup exposes"
+        0,
+        "duplicate tools should be rejected before any execution can happen"
     );
-    assert_eq!(second.execution_count(), 0, "later duplicates must not run");
-    assert!(
-        result.messages.iter().any(|message| {
-            matches!(
-                message,
-                AgentMessage::Llm(LlmMessage::ToolResult(tool_result))
-                    if tool_result.tool_call_id == "tc_dup"
-                        && ContentBlock::extract_text(&tool_result.content) == "first"
-            )
-        }),
-        "the persisted tool result should come from the first registered tool"
-    );
+    assert_eq!(second.execution_count(), 0);
 }
 
 // ─── Regression: abort path emits TurnEndReason::Aborted (#438) ──────────

--- a/tests/plugin_integration.rs
+++ b/tests/plugin_integration.rs
@@ -682,14 +682,14 @@ fn two_plugins_same_tool_names_distinct_namespaces() {
     );
 }
 
-// ─── T037: Direct tool takes precedence over namespaced plugin tool ─────
+// ─── T037: Duplicate composed tool names are rejected ───────────────────
 
 #[test]
-fn direct_tool_found_first_over_namespaced_plugin_tool() {
+fn duplicate_composed_tool_names_are_rejected() {
     use swink_agent::AgentTool;
 
     // Create a direct tool named "myns_fetch" and a plugin named "myns" contributing "fetch".
-    // Both resolve to the same public name — the direct tool should be found first.
+    // Both resolve to the same public name, so construction must fail fast.
     let direct_tool: Arc<dyn AgentTool> =
         Arc::new(swink_agent::testing::MockTool::new("myns_fetch"));
     let plugin: Arc<dyn Plugin> = Arc::new(MockPlugin::new("myns").with_tools(&["fetch"]));
@@ -699,35 +699,23 @@ fn direct_tool_found_first_over_namespaced_plugin_tool() {
         .with_tools(vec![direct_tool])
         .with_plugin(plugin);
 
-    let agent = Agent::new(options);
+    let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let _agent = Agent::new(options);
+    }))
+    .expect_err("duplicate composed tool names should be rejected");
 
-    // The direct tool is first in the list (direct tools before plugin tools).
-    let tool_names: Vec<&str> = agent.state().tools.iter().map(|t| t.name()).collect();
-    // Both should exist.
-    let count = tool_names.iter().filter(|&&n| n == "myns_fetch").count();
-    assert_eq!(
-        count, 2,
-        "both direct and namespaced tool should be present, got {count}"
-    );
-
-    // find_tool returns the first match — should be the direct tool.
-    let found = agent.find_tool("myns_fetch");
-    assert!(found.is_some(), "find_tool should find 'myns_fetch'");
-
-    // Verify it's the direct tool (not the NamespacedTool wrapper).
-    // NamespacedTool has description "plugin stub tool" and label "myns_fetch" (overridden).
-    // Direct MockTool has label "myns_fetch" (set in constructor).
-    // Both have the same description, so check order by position.
-    let first_idx = tool_names.iter().position(|&n| n == "myns_fetch").unwrap();
-    assert_eq!(
-        first_idx, 0,
-        "direct tool should be at index 0 (before plugin tools), got {first_idx}"
+    let panic_message = panic
+        .downcast_ref::<String>()
+        .cloned()
+        .or_else(|| panic.downcast_ref::<&str>().map(|message| (*message).to_owned()))
+        .expect("panic should carry a message");
+    assert!(
+        panic_message.contains("duplicate tool names are not allowed after composition: myns_fetch"),
+        "unexpected panic message: {panic_message}"
     );
 }
 
 // ─── T038: Verify tool merge order — direct first, then plugin ──────────
-// (Already confirmed by T037 above: direct tools at lower indices,
-//  plugin tools appended after.)
 
 // ─── Phase 9: User Story 6 — Plugin Removal ────────────────────────────
 

--- a/tests/plugin_integration.rs
+++ b/tests/plugin_integration.rs
@@ -707,10 +707,15 @@ fn duplicate_composed_tool_names_are_rejected() {
     let panic_message = panic
         .downcast_ref::<String>()
         .cloned()
-        .or_else(|| panic.downcast_ref::<&str>().map(|message| (*message).to_owned()))
+        .or_else(|| {
+            panic
+                .downcast_ref::<&str>()
+                .map(|message| (*message).to_owned())
+        })
         .expect("panic should carry a message");
     assert!(
-        panic_message.contains("duplicate tool names are not allowed after composition: myns_fetch"),
+        panic_message
+            .contains("duplicate tool names are not allowed after composition: myns_fetch"),
         "unexpected panic message: {panic_message}"
     );
 }


### PR DESCRIPTION
## What changed
- replaced raw prefix truncation for plugin-contributed tool wire names with deterministic hash-tail truncation so long plugin/tool pairs stay distinct after sanitization
- added merged-tool duplicate validation in `Agent::new()` and `Agent::set_tools()` so schema export, lookup, and dispatch all operate on one unique final tool-name set
- added focused regression coverage for long-name collision cases and for plugin/direct-tool composition collisions, and recorded the rule in `AGENTS.md`

## Why / value
Issue #582 identified a correctness gap where distinct long plugin tool names could truncate to the same 64-character routing key, and duplicate final tool names were only handled by dispatch's "keep first" fallback. This change makes the public wire names collision-resistant and fails fast when the composed tool set is ambiguous.

## Slice completed
This PR completes the tool-name uniqueness hardening requested in #582.

## What remains
- none for #582

## Validation output
- `cargo fmt --all --check`
- `cargo test -p swink-agent --features plugins,testkit --lib compose_namespaced_name`
- `cargo test -p swink-agent --features plugins,testkit --lib agent_new_rejects_duplicate_names_after_plugin_composition`
- `cargo clippy -p swink-agent --features plugins,testkit --lib -- -D warnings`
- `git diff --check`

## Pre-existing baseline failures
- broader workspace `cargo test --workspace` / `cargo clippy --workspace -- -D warnings` were not rerun for this narrow slice
- recent automation runs on this Windows runner still show the existing `swink-agent-local-llm` / `llama-cpp-sys-2` environment blocker when `cmake` / libclang prerequisites are missing

## IPC contract changes
- none

Closes #582