### PR TITLE
[codex] redact OAuth2 refresh failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4953,6 +4953,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "uuid",
  "wiremock",
 ]

--- a/auth/AGENTS.md
+++ b/auth/AGENTS.md
@@ -16,6 +16,7 @@
 
 - `DefaultCredentialResolver` can reuse a per-key `SingleFlightTokenSource`, but the credential store remains the source of truth. Clear the token source's cached value before resolving an expired key from the store, or a previously refreshed token can mask later external store updates.
 - Adapters that need token caching should depend on `SingleFlightTokenSource` from this crate rather than rolling an adapter-local `RwLock<Option<_>>` cache, which does not deduplicate concurrent refreshes.
+- OAuth2 refresh failures must only surface `HTTP status + OAuth2 error code`; never include provider `error_description` text or raw token-endpoint bodies in debug logs, because those errors propagate into tool-visible output.
 
 ## Build & Test
 

--- a/auth/Cargo.toml
+++ b/auth/Cargo.toml
@@ -26,3 +26,4 @@ uuid.workspace = true
 wiremock.workspace = true
 pretty_assertions.workspace = true
 tokio = { workspace = true, features = ["full", "test-util"] }
+tracing-subscriber = { version = "0.3", features = ["fmt"] }

--- a/auth/src/oauth2.rs
+++ b/auth/src/oauth2.rs
@@ -20,60 +20,38 @@ pub struct TokenResponse {
 
 /// Standard OAuth2 error response body (RFC 6749 §5.2).
 ///
-/// Used to extract a stable `error` code (and optional `error_description`)
-/// from a token endpoint failure without surfacing the full raw body — which
-/// may contain provider-specific diagnostic data that should not leak into
-/// tool output or user-visible logs.
+/// Only the stable `error` code is surfaced from a token endpoint failure.
+/// `error_description` is intentionally ignored because providers can place
+/// sensitive details there.
 #[derive(Debug, Deserialize)]
 struct OAuth2ErrorBody {
     error: String,
     #[serde(default)]
-    error_description: Option<String>,
+    _error_description: Option<String>,
 }
 
 /// Build a sanitized refresh-failure reason string from the HTTP status and
 /// optional response body.
 ///
 /// The returned string NEVER includes the raw body verbatim. When the body
-/// parses as an RFC 6749 §5.2 OAuth2 error response, the stable `error` code
-/// (and a length-capped `error_description`, if present) is included. All
-/// other bodies are ignored and only the status appears in the surfaced
-/// reason.
+/// parses as an RFC 6749 §5.2 OAuth2 error response, only the stable `error`
+/// code is included. All other bodies are ignored and only the status appears
+/// in the surfaced reason.
 ///
-/// The full body is expected to be emitted separately via `tracing::debug!`
-/// by the caller so operators can still diagnose failures when debug logging
-/// is enabled — but it never reaches `CredentialError::RefreshFailed.reason`
-/// and therefore never propagates into tool output.
+/// The caller may emit redacted metadata such as body length via
+/// `tracing::debug!`, but the raw body never reaches
+/// `CredentialError::RefreshFailed.reason` and therefore never propagates into
+/// tool output.
 fn sanitize_refresh_reason(status: reqwest::StatusCode, body: &str) -> String {
     // Attempt to parse a standard OAuth2 error response. Anything else
     // (HTML error pages, opaque vendor JSON, plain text, empty) degrades to a
     // status-only reason.
     if let Ok(parsed) = serde_json::from_str::<OAuth2ErrorBody>(body) {
-        // Cap the description to prevent a pathological vendor from stuffing
-        // sensitive content into `error_description`.
-        const DESCRIPTION_MAX: usize = 200;
-        let trimmed_description = parsed.error_description.as_deref().map(|d| {
-            if d.len() > DESCRIPTION_MAX {
-                format!("{}…", &d[..DESCRIPTION_MAX])
-            } else {
-                d.to_string()
-            }
-        });
-
-        if let Some(desc) = trimmed_description {
-            format!(
-                "token refresh failed: HTTP {} ({}: {})",
-                status.as_u16(),
-                parsed.error,
-                desc
-            )
-        } else {
-            format!(
-                "token refresh failed: HTTP {} ({})",
-                status.as_u16(),
-                parsed.error
-            )
-        }
+        format!(
+            "token refresh failed: HTTP {} ({})",
+            status.as_u16(),
+            parsed.error
+        )
     } else {
         format!("token refresh failed: HTTP {}", status.as_u16())
     }
@@ -86,9 +64,9 @@ fn sanitize_refresh_reason(status: reqwest::StatusCode, body: &str) -> String {
 ///
 /// On failure, the returned [`CredentialError::RefreshFailed`] contains only
 /// a sanitized reason: HTTP status plus (if the body is a standard OAuth2
-/// error JSON) the stable `error` code and truncated description. The raw
-/// response body is NEVER included in the surfaced error — it is emitted only
-/// via `tracing::debug!` so it cannot leak into user-visible tool output.
+/// error JSON) the stable `error` code. The raw response body is NEVER
+/// included in the surfaced error, and debug logs only emit redacted metadata
+/// so body contents cannot leak into user-visible tool output.
 pub async fn refresh_token(
     client: &reqwest::Client,
     token_url: &str,
@@ -122,12 +100,7 @@ pub async fn refresh_token(
         let body = response.text().await.unwrap_or_default();
         // Raw body stays in debug tracing only; never surfaced in the error
         // reason to avoid leaking token-endpoint payloads into tool output.
-        debug!(
-            status = %status,
-            body_len = body.len(),
-            body = %body,
-            "OAuth2 token refresh failed; raw body held for debug only"
-        );
+        debug!(status = %status, body_len = body.len(), "OAuth2 token refresh failed; response body redacted");
         let reason = sanitize_refresh_reason(status, &body);
         return Err(CredentialError::RefreshFailed {
             key: String::new(),
@@ -146,31 +119,60 @@ pub async fn refresh_token(
 
 #[cfg(test)]
 mod tests {
+    use std::io::{self, Write};
+    use std::sync::{Arc, Mutex};
+
     use super::*;
     use reqwest::StatusCode;
+    use tracing_subscriber::fmt::MakeWriter;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     const LEAK_SENTINEL: &str = "LEAK_SENTINEL_ABC123";
 
+    #[derive(Clone, Default)]
+    struct SharedLogBuffer(Arc<Mutex<Vec<u8>>>);
+
+    impl SharedLogBuffer {
+        fn contents(&self) -> String {
+            let bytes = self.0.lock().unwrap().clone();
+            String::from_utf8(bytes).unwrap()
+        }
+    }
+
+    struct SharedLogWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for SharedLogWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> MakeWriter<'a> for SharedLogBuffer {
+        type Writer = SharedLogWriter;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            SharedLogWriter(Arc::clone(&self.0))
+        }
+    }
+
     #[test]
-    fn sanitized_reason_with_standard_oauth2_error_json() {
+    fn sanitized_reason_with_standard_oauth2_error_json_ignores_description() {
         let body = format!(
             r#"{{"error":"invalid_grant","error_description":"refresh token expired {LEAK_SENTINEL}"}}"#
         );
         let reason = sanitize_refresh_reason(StatusCode::UNAUTHORIZED, &body);
 
-        // Status and standard code are included.
-        assert!(reason.contains("401"), "reason missing status: {reason}");
+        assert_eq!(reason, "token refresh failed: HTTP 401 (invalid_grant)");
         assert!(
-            reason.contains("invalid_grant"),
-            "reason missing error code: {reason}"
+            !reason.contains(LEAK_SENTINEL),
+            "error_description leaked into reason: {reason}"
         );
-        // The description is preserved here because it is a stable field in
-        // the RFC 6749 §5.2 contract; callers are responsible for not
-        // stuffing secrets into `error_description`. The sentinel may appear
-        // because it lives inside the standard description field, which is
-        // intentionally surfaced — the leak test below uses a body OUTSIDE
-        // the standard schema to prove non-standard fields never leak.
-        assert!(reason.starts_with("token refresh failed:"));
     }
 
     #[test]
@@ -222,21 +224,6 @@ mod tests {
     }
 
     #[test]
-    fn sanitized_reason_caps_error_description_length() {
-        let long_desc = "x".repeat(500);
-        let body = format!(r#"{{"error":"invalid_grant","error_description":"{long_desc}"}}"#);
-        let reason = sanitize_refresh_reason(StatusCode::UNAUTHORIZED, &body);
-
-        // Cap is 200 chars + trailing ellipsis.
-        assert!(
-            reason.len() < 300,
-            "reason should be length-capped, got {} chars: {reason}",
-            reason.len()
-        );
-        assert!(reason.contains("…"), "reason missing truncation marker");
-    }
-
-    #[test]
     fn sanitized_reason_does_not_include_body_for_ignored_fields() {
         // A standard OAuth2 body with an extra sensitive field outside the
         // recognized schema. serde's default behavior ignores unknown fields,
@@ -250,5 +237,54 @@ mod tests {
             "non-standard field leaked into reason: {reason}"
         );
         assert!(reason.contains("invalid_grant"));
+    }
+
+    #[tokio::test]
+    async fn refresh_token_debug_log_redacts_response_body() {
+        let mock_server = MockServer::start().await;
+        let body = format!(
+            r#"{{"error":"invalid_grant","error_description":"refresh token expired {LEAK_SENTINEL}"}}"#
+        );
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(401).set_body_string(body))
+            .mount(&mock_server)
+            .await;
+
+        let logs = SharedLogBuffer::default();
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::DEBUG)
+            .without_time()
+            .with_writer(logs.clone())
+            .finish();
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let err = refresh_token(
+            &reqwest::Client::new(),
+            &format!("{}/token", mock_server.uri()),
+            "refresh-token",
+            "client-id",
+            Some("client-secret"),
+        )
+        .await
+        .unwrap_err();
+        let log_output = logs.contents();
+
+        assert!(
+            !format!("{err}").contains(LEAK_SENTINEL),
+            "refresh error leaked sentinel: {err}"
+        );
+        assert!(
+            !log_output.contains(LEAK_SENTINEL),
+            "debug log leaked response body: {log_output}"
+        );
+        assert!(
+            log_output.contains("body_len"),
+            "debug log should include body length metadata: {log_output}"
+        );
+        assert!(
+            log_output.contains("response body redacted"),
+            "debug log should state the body is redacted: {log_output}"
+        );
     }
 }

--- a/auth/tests/oauth2_tests.rs
+++ b/auth/tests/oauth2_tests.rs
@@ -234,6 +234,7 @@ async fn refresh_error_standard_oauth2_surface_includes_error_code_only() {
         .and(path("/token"))
         .respond_with(ResponseTemplate::new(400).set_body_json(serde_json::json!({
             "error": "invalid_grant",
+            "error_description": format!("refresh token expired {LEAK_SENTINEL}"),
         })))
         .mount(&mock_server)
         .await;
@@ -254,6 +255,10 @@ async fn refresh_error_standard_oauth2_surface_includes_error_code_only() {
     assert!(
         display.contains("invalid_grant"),
         "standard error code missing from Display: {display}"
+    );
+    assert!(
+        !display.contains(LEAK_SENTINEL),
+        "error_description leaked into Display: {display}"
     );
 }
 


### PR DESCRIPTION
## What changed
- removed `error_description` from surfaced OAuth2 refresh failure reasons so tool-visible errors now expose only the HTTP status plus the stable OAuth2 `error` code
- stopped debug tracing from recording raw token-endpoint response bodies and logged only redacted metadata (`status` and `body_len`)
- added regression coverage for both surfaces, including a log-capture test that proves sensitive body fragments never appear in debug output
- recorded the redaction rule in `auth/AGENTS.md`

## Why / value
OAuth2 token endpoints can return provider diagnostics or sensitive payload fragments in `error_description` and raw response bodies. Those values were propagating into tool-facing errors or debug logs; this change keeps the refresh flow diagnosable without leaking token-endpoint content.

## Slice completed
This PR completes the OAuth2 refresh redaction slice for issue #613.

## What remains
- none for this issue

## Validation output
- `cargo fmt --all`
- `cargo test -p swink-agent-auth`
- `cargo clippy -p swink-agent-auth -- -D warnings`

## Pre-existing baseline failures
- `cargo test --workspace` fails on this Windows runner while building `llama-cpp-sys-2` because `cmake` is not installed
- `cargo clippy --workspace -- -D warnings` fails on the same `llama-cpp-sys-2` / missing `cmake` environment prerequisite

## IPC contract changes
- none

Closes #613