### PR TITLE
[codex] fix pre-turn pending batch continuity

### DIFF
--- a/src/loop_/AGENTS.md
+++ b/src/loop_/AGENTS.md
@@ -15,3 +15,5 @@
 - Overflow recovery cancellation must reuse a started-turn cancellation path. Calling the pre-turn helper after `TurnStart` has already been emitted duplicates `TurnStart` and breaks lifecycle ordering for the interrupted turn.
 - `handle_stream_error()` must not emit `MessageEnd` for context overflow. Overflow recovery owns the terminal message lifecycle, and unrecoverable overflow must still surface exactly one `MessageEnd`.
 - `LoopState.turn_index` must advance after every completed turn, not just tool-loop continuation. Text-only or other `BreakInner` turns still finish a turn before the outer loop polls follow-up messages.
+- First-turn `PreTurn` policies must receive the initial prompt batch in `PolicyContext::new_messages`; only `agent_loop_continue()` resumes with an empty initial batch.
+- Text-only turns cannot break the inner loop while `pending_messages` is non-empty. Post-turn or post-loop injections queued for the next turn must continue loop processing before follow-up polling or `AgentEnd`.

--- a/src/loop_/mod.rs
+++ b/src/loop_/mod.rs
@@ -58,7 +58,14 @@ pub fn agent_loop(
     config: AgentLoopConfig,
     cancellation_token: CancellationToken,
 ) -> Pin<Box<dyn Stream<Item = AgentEvent> + Send>> {
-    run_loop(prompt_messages, system_prompt, config, cancellation_token)
+    let initial_new_messages_len = prompt_messages.len();
+    run_loop(
+        prompt_messages,
+        initial_new_messages_len,
+        system_prompt,
+        config,
+        cancellation_token,
+    )
 }
 
 /// Resume an agent loop from existing messages.
@@ -72,7 +79,7 @@ pub fn agent_loop_continue(
     config: AgentLoopConfig,
     cancellation_token: CancellationToken,
 ) -> Pin<Box<dyn Stream<Item = AgentEvent> + Send>> {
-    run_loop(messages, system_prompt, config, cancellation_token)
+    run_loop(messages, 0, system_prompt, config, cancellation_token)
 }
 
 // ─── Internal Loop ───────────────────────────────────────────────────────────
@@ -81,6 +88,7 @@ pub fn agent_loop_continue(
 /// events through an mpsc channel, returning a stream of events.
 fn run_loop(
     initial_messages: Vec<AgentMessage>,
+    initial_new_messages_len: usize,
     system_prompt: String,
     config: AgentLoopConfig,
     cancellation_token: CancellationToken,
@@ -90,6 +98,7 @@ fn run_loop(
     tokio::spawn(async move {
         run_loop_inner(
             initial_messages,
+            initial_new_messages_len,
             system_prompt,
             config,
             cancellation_token,
@@ -112,6 +121,7 @@ pub async fn emit(tx: &mpsc::Sender<AgentEvent>, event: AgentEvent) -> bool {
 #[allow(clippy::too_many_lines)]
 async fn run_loop_inner(
     initial_messages: Vec<AgentMessage>,
+    initial_new_messages_len: usize,
     system_prompt: String,
     config: AgentLoopConfig,
     cancellation_token: CancellationToken,
@@ -144,6 +154,7 @@ async fn run_loop_inner(
         let mut state = LoopState {
             context_messages: initial_messages,
             pending_messages: Vec::new(),
+            initial_new_messages_len,
             overflow_signal: false,
             overflow_recovery_attempted: false,
             turn_index: 0,

--- a/src/loop_/turn.rs
+++ b/src/loop_/turn.rs
@@ -42,10 +42,18 @@ pub async fn run_single_turn(
 
     // i. Inject any pending messages into context.
     // Track where new messages start so PreTurn policies only see the fresh batch.
-    let new_messages_start = state.context_messages.len();
+    let new_messages_start = if state.turn_index == 0 {
+        state
+            .context_messages
+            .len()
+            .saturating_sub(state.initial_new_messages_len)
+    } else {
+        state.context_messages.len()
+    };
     if !state.pending_messages.is_empty() {
         state.context_messages.append(&mut state.pending_messages);
     }
+    state.initial_new_messages_len = 0;
     clear_pending_message_snapshot(config);
     // Sync the full context (including newly consumed pending messages) to the
     // loop_context_snapshot so that a concurrent pause() call can reconstruct
@@ -849,7 +857,11 @@ async fn handle_no_tool_calls(
         return emit_agent_end(state, tx).await;
     }
 
-    TurnOutcome::BreakInner
+    if state.pending_messages.is_empty() {
+        TurnOutcome::BreakInner
+    } else {
+        TurnOutcome::ContinueInner
+    }
 }
 
 /// Handle tool calls: separate incomplete ones, execute the rest, collect results,

--- a/src/loop_/types.rs
+++ b/src/loop_/types.rs
@@ -13,6 +13,9 @@ pub type ConvertToLlmFn = dyn Fn(&AgentMessage) -> Option<LlmMessage> + Send + S
 pub struct LoopState {
     pub context_messages: Vec<AgentMessage>,
     pub pending_messages: Vec<AgentMessage>,
+    /// Initial prompt messages that should be exposed once as the first
+    /// pre-turn `new_messages` batch. `agent_loop_continue` resumes with 0.
+    pub initial_new_messages_len: usize,
     pub overflow_signal: bool,
     /// Whether emergency overflow recovery has already been attempted this turn.
     /// Resets to `false` at the start of each turn.

--- a/tests/agent_loop.rs
+++ b/tests/agent_loop.rs
@@ -19,9 +19,9 @@ use tokio_util::sync::CancellationToken;
 use swink_agent::{
     AgentEvent, AgentLoopConfig, AgentMessage, AgentTool, AgentToolResult, AssistantMessage,
     AssistantMessageEvent, ContentBlock, Cost, CustomMessage, DefaultRetryStrategy, LlmMessage,
-    MessageProvider, PolicyContext, PolicyVerdict, PostTurnPolicy, StopReason, StreamFn,
-    StreamOptions, ToolResultMessage, TurnPolicyContext, TurnSnapshot, Usage, UserMessage,
-    agent_loop,
+    MessageProvider, PolicyContext, PolicyVerdict, PostTurnPolicy, PreTurnPolicy, StopReason,
+    StreamFn, StreamOptions, ToolResultMessage, TurnPolicyContext, TurnSnapshot, Usage,
+    UserMessage, agent_loop,
 };
 
 // ─── MockUpdatingTool ─────────────────────────────────────────────────────────
@@ -272,7 +272,7 @@ fn count_events(events: &[AgentEvent], name: &str) -> usize {
 struct StoppingPostTurnPolicy;
 
 impl PostTurnPolicy for StoppingPostTurnPolicy {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         "stopping-post-turn"
     }
 
@@ -293,7 +293,7 @@ struct RecordingPostTurnPolicy {
 }
 
 impl PostTurnPolicy for RecordingPostTurnPolicy {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         "recording-post-turn"
     }
 
@@ -313,6 +313,76 @@ impl PostTurnPolicy for RecordingPostTurnPolicy {
         });
 
         PolicyVerdict::Continue
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct RecordedPreTurnBatch {
+    turn_index: usize,
+    message_count: usize,
+    new_messages: Vec<String>,
+}
+
+struct RecordingPreTurnPolicy {
+    observations: Arc<Mutex<Vec<RecordedPreTurnBatch>>>,
+}
+
+impl PreTurnPolicy for RecordingPreTurnPolicy {
+    fn name(&self) -> &'static str {
+        "recording-pre-turn"
+    }
+
+    fn evaluate(&self, ctx: &PolicyContext<'_>) -> PolicyVerdict {
+        let new_messages = ctx
+            .new_messages
+            .iter()
+            .filter_map(|message| match message {
+                AgentMessage::Llm(LlmMessage::User(user)) => {
+                    Some(ContentBlock::extract_text(&user.content))
+                }
+                AgentMessage::Llm(LlmMessage::Assistant(assistant)) => {
+                    Some(ContentBlock::extract_text(&assistant.content))
+                }
+                AgentMessage::Llm(LlmMessage::ToolResult(result)) => {
+                    Some(ContentBlock::extract_text(&result.content))
+                }
+                AgentMessage::Custom(_) => None,
+            })
+            .collect();
+        self.observations
+            .lock()
+            .unwrap()
+            .push(RecordedPreTurnBatch {
+                turn_index: ctx.turn_index,
+                message_count: ctx.message_count,
+                new_messages,
+            });
+        PolicyVerdict::Continue
+    }
+}
+
+struct InjectingOncePostTurnPolicy {
+    injected: AtomicBool,
+    text: String,
+}
+
+impl PostTurnPolicy for InjectingOncePostTurnPolicy {
+    fn name(&self) -> &'static str {
+        "injecting-once-post-turn"
+    }
+
+    fn evaluate(&self, _ctx: &PolicyContext<'_>, _turn: &TurnPolicyContext<'_>) -> PolicyVerdict {
+        if self.injected.swap(true, Ordering::SeqCst) {
+            PolicyVerdict::Continue
+        } else {
+            PolicyVerdict::Inject(vec![AgentMessage::Llm(LlmMessage::User(UserMessage {
+                content: vec![ContentBlock::Text {
+                    text: self.text.clone(),
+                }],
+                timestamp: 0,
+                cache_hint: None,
+            }))])
+        }
     }
 }
 
@@ -1549,6 +1619,73 @@ async fn follow_up_turn_after_no_tool_turn_advances_turn_index() {
 }
 
 #[tokio::test]
+async fn pre_turn_new_messages_include_initial_prompt_batch() {
+    let stream_fn = Arc::new(MockStreamFn::new(vec![text_only_events("ok")]));
+    let observations = Arc::new(Mutex::new(Vec::new()));
+
+    let mut config = default_config(stream_fn);
+    config.pre_turn_policies = vec![Arc::new(RecordingPreTurnPolicy {
+        observations: Arc::clone(&observations),
+    })];
+
+    let events = collect_events(agent_loop(
+        vec![common::user_msg("hello from prompt")],
+        "system".to_string(),
+        config,
+        CancellationToken::new(),
+    ))
+    .await;
+
+    assert!(has_event(&events, "AgentEnd"));
+    let recorded = observations.lock().unwrap().clone();
+    assert_eq!(recorded.len(), 1, "pre-turn policy should run once");
+    assert_eq!(
+        recorded[0],
+        RecordedPreTurnBatch {
+            turn_index: 0,
+            message_count: 1,
+            new_messages: vec!["hello from prompt".to_string()],
+        },
+        "first-turn pre-turn policies must see the initial prompt batch as new_messages"
+    );
+}
+
+#[tokio::test]
+async fn post_turn_inject_without_tool_calls_continues_inner_loop() {
+    let capturing_fn = Arc::new(MockContextCapturingStreamFn::new(vec![
+        text_only_events("first response"),
+        text_only_events("second response"),
+    ]));
+    let stream_fn: Arc<dyn StreamFn> = Arc::clone(&capturing_fn) as Arc<dyn StreamFn>;
+
+    let mut config = default_config(stream_fn);
+    config.post_turn_policies = vec![Arc::new(InjectingOncePostTurnPolicy {
+        injected: AtomicBool::new(false),
+        text: "policy follow-up".to_string(),
+    })];
+
+    let events = collect_events(agent_loop(
+        vec![common::user_msg("start")],
+        "system".to_string(),
+        config,
+        CancellationToken::new(),
+    ))
+    .await;
+
+    assert_eq!(
+        count_events(&events, "TurnStart"),
+        2,
+        "post-turn injections on text-only turns should schedule another inner-loop turn"
+    );
+    let counts = capturing_fn.captured_message_counts.lock().unwrap().clone();
+    assert_eq!(
+        counts,
+        vec![1, 3],
+        "second stream call should include the injected pending batch"
+    );
+}
+
+#[tokio::test]
 async fn turn_snapshot_serializes_to_json() {
     let snapshot = TurnSnapshot {
         turn_index: 3,
@@ -1581,14 +1718,14 @@ async fn turn_snapshot_serializes_to_json() {
 // ─── Post-turn policy replaces assistant message before TurnEnd ──────────
 
 /// A post-turn policy that replaces the assistant message text.
-/// Simulates what PiiRedactor does: returns Inject with a modified
-/// AssistantMessage to replace the original.
+/// Simulates what `PiiRedactor` does: returns `Inject` with a modified
+/// `AssistantMessage` to replace the original.
 struct ReplacingPostTurnPolicy {
     replacement_text: String,
 }
 
 impl PostTurnPolicy for ReplacingPostTurnPolicy {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         "replacing-post-turn"
     }
 
@@ -1613,7 +1750,7 @@ impl PostTurnPolicy for ReplacingPostTurnPolicy {
 }
 
 /// Regression test for #313: post-turn Inject verdicts must replace the
-/// assistant message in TurnEnd and context BEFORE the event is emitted.
+/// assistant message in `TurnEnd` and context BEFORE the event is emitted.
 #[tokio::test]
 async fn post_turn_inject_replaces_assistant_message_in_turn_end() {
     let stream_fn = Arc::new(MockStreamFn::new(vec![text_only_events(
@@ -1826,7 +1963,7 @@ async fn post_turn_policy_runs_before_transfer_termination() {
     );
 }
 
-/// Regression test: post-turn Stop verdict still emits TurnEnd before stopping.
+/// Regression test: post-turn Stop verdict still emits `TurnEnd` before stopping.
 #[tokio::test]
 async fn post_turn_stop_still_emits_turn_end() {
     let stream_fn = Arc::new(MockStreamFn::new(vec![text_only_events("Hello!")]));


### PR DESCRIPTION
## What changed
- taught the loop to expose the initial prompt batch as the first-turn `PreTurn` `new_messages` slice while keeping `agent_loop_continue()` resumptions unchanged
- kept text-only turns inside the inner loop whenever post-turn policies inject more pending work, so injected follow-up messages are processed before follow-up polling or `AgentEnd`
- added focused regression coverage for both loop contracts and recorded the behavior in `src/loop_/AGENTS.md`

## Why / value
Issue #667 reported two policy-slot contract regressions in loop control flow. This restores the documented `PreTurn` message-batch semantics and prevents post-turn injected messages from being dropped on text-only exits.

## Slice completed
This PR completes the loop message-batch continuity fix for #667.

## What remains
- none for #667

## Validation output
- `cargo fmt --all`
- `cargo test -p swink-agent --features testkit --test agent_loop`
- `cargo clippy -p swink-agent --features testkit --test agent_loop -- -D warnings`
- `cargo clippy -p swink-agent --lib -- -D warnings`
- `git diff --check`

## Pre-existing baseline failures
- broader workspace `cargo test --workspace` / `cargo clippy --workspace -- -D warnings` were not rerun for this narrow loop slice
- recent automation runs on this Windows runner still show the existing `swink-agent-local-llm` / `llama-cpp-sys-2` environment blocker when `cmake` / libclang prerequisites are missing

## IPC contract changes
- none

Closes #667