### PR TITLE
[codex] preserve one retry message lifecycle

### DIFF
--- a/src/loop_/AGENTS.md
+++ b/src/loop_/AGENTS.md
@@ -17,3 +17,4 @@
 - `LoopState.turn_index` must advance after every completed turn, not just tool-loop continuation. Text-only or other `BreakInner` turns still finish a turn before the outer loop polls follow-up messages.
 - First-turn `PreTurn` policies must receive the initial prompt batch in `PolicyContext::new_messages`; only `agent_loop_continue()` resumes with an empty initial batch.
 - Text-only turns cannot break the inner loop while `pending_messages` is non-empty. Post-turn or post-loop injections queued for the next turn must continue loop processing before follow-up polling or `AgentEnd`.
+- Retry attempts share one logical assistant-message lifecycle. Emit `MessageStart` once per turn, buffer attempt-local deltas until the terminal attempt is known, and never leak failed-attempt partials into downstream `MessageUpdate` streams.

--- a/src/loop_/stream.rs
+++ b/src/loop_/stream.rs
@@ -183,24 +183,39 @@ async fn stream_with_retry_single(
         let mut stream_options = config.stream_options.clone();
         stream_options.api_key = api_key.clone();
 
-        // Emit MessageStart
-        if !emit(tx, AgentEvent::MessageStart).await {
+        // Emit MessageStart once for the logical turn. Attempt-local deltas are
+        // buffered until the terminal attempt so retries do not leak stale
+        // partials or duplicate lifecycle starts.
+        if attempt == 1 && !emit(tx, AgentEvent::MessageStart).await {
             return StreamResult::ChannelClosed;
         }
 
-        // Stream from the provider and collect events + emit deltas
+        // Stream from the provider and collect attempt-local events. Deltas are
+        // only replayed once a terminal attempt is known.
         let attempt_result = stream_single_attempt(
             model,
             stream_fn,
             &call_context,
             &stream_options,
             cancellation_token,
-            tx,
         )
         .await;
 
         let (events, had_error) = match attempt_result {
-            StreamAttemptResult::EarlyExit(result) => return result,
+            StreamAttemptResult::EarlyExit { result, events } => {
+                if let Some(exit) = emit_attempt_deltas(&events, tx).await {
+                    return exit;
+                }
+
+                if matches!(result, StreamResult::Aborted) {
+                    let abort_msg = build_abort_message(model);
+                    if !emit(tx, AgentEvent::MessageEnd { message: abort_msg }).await {
+                        return StreamResult::ChannelClosed;
+                    }
+                }
+
+                return result;
+            }
             StreamAttemptResult::Collected { events, error } => (events, error),
         };
 
@@ -209,28 +224,34 @@ async fn stream_with_retry_single(
             let retry_result = handle_stream_error(
                 model,
                 config,
-                &stop_reason,
+                stop_reason,
                 &error_message,
                 error_kind,
                 attempt,
-                tx,
-            )
-            .await;
+            );
             match retry_result {
                 StreamErrorAction::ContextOverflow => return StreamResult::ContextOverflow,
                 StreamErrorAction::Retry(delay) => {
                     tokio::time::sleep(delay).await;
                     continue;
                 }
-                StreamErrorAction::FatalError(msg) => {
+                StreamErrorAction::FatalError { result, message } => {
+                    if let Some(exit) = emit_attempt_deltas(&events, tx).await {
+                        return exit;
+                    }
+                    if !emit(tx, AgentEvent::MessageEnd { message }).await {
+                        return StreamResult::ChannelClosed;
+                    }
                     llm_span.record("otel.status_code", "ERROR");
-                    return msg;
+                    return result;
                 }
-                StreamErrorAction::ChannelClosed => return StreamResult::ChannelClosed,
             }
         }
 
         // Success: accumulate and emit
+        if let Some(exit) = emit_attempt_deltas(&events, tx).await {
+            return exit;
+        }
         let result = finalize_stream_message(model, events, tx).await;
         if let StreamResult::Message(ref msg) = result {
             llm_span.record("agent.tokens.input", msg.usage.input);
@@ -248,8 +269,10 @@ async fn stream_with_retry_single(
 enum StreamErrorAction {
     ContextOverflow,
     Retry(std::time::Duration),
-    FatalError(StreamResult),
-    ChannelClosed,
+    FatalError {
+        result: StreamResult,
+        message: AssistantMessage,
+    },
 }
 
 /// Result of streaming a single attempt from the provider.
@@ -265,10 +288,13 @@ enum StreamAttemptResult {
         )>,
     },
     /// Early exit due to cancellation or channel close.
-    EarlyExit(StreamResult),
+    EarlyExit {
+        result: StreamResult,
+        events: Vec<AssistantMessageEvent>,
+    },
 }
 
-/// Stream a single attempt from the provider, emitting delta events.
+/// Stream a single attempt from the provider.
 /// Collects all events and captures any error info for the caller.
 async fn stream_single_attempt(
     model: &ModelSpec,
@@ -276,7 +302,6 @@ async fn stream_single_attempt(
     call_context: &AgentContext,
     stream_options: &StreamOptions,
     cancellation_token: &CancellationToken,
-    tx: &mpsc::Sender<AgentEvent>,
 ) -> StreamAttemptResult {
     // Apply capability overrides (e.g. disable thinking for models that
     // don't support it) before handing the spec to the provider.
@@ -299,13 +324,10 @@ async fn stream_single_attempt(
 
     while let Some(event) = stream.next().await {
         if cancellation_token.is_cancelled() {
-            let abort_msg = build_abort_message(model);
-            let _ = emit(tx, AgentEvent::MessageEnd { message: abort_msg }).await;
-            return StreamAttemptResult::EarlyExit(StreamResult::Aborted);
-        }
-
-        if let Some(early_exit) = emit_delta_event(&event, tx).await {
-            return StreamAttemptResult::EarlyExit(early_exit);
+            return StreamAttemptResult::EarlyExit {
+                result: StreamResult::Aborted,
+                events,
+            };
         }
 
         if let AssistantMessageEvent::Error {
@@ -330,6 +352,19 @@ async fn stream_single_attempt(
         events,
         error: had_error,
     }
+}
+
+/// Replay deltas from the terminal attempt only.
+async fn emit_attempt_deltas(
+    events: &[AssistantMessageEvent],
+    tx: &mpsc::Sender<AgentEvent>,
+) -> Option<StreamResult> {
+    for event in events {
+        if let Some(early_exit) = emit_delta_event(event, tx).await {
+            return Some(early_exit);
+        }
+    }
+    None
 }
 
 /// Emit a delta event for a single stream event. Returns `Some(StreamResult)`
@@ -372,16 +407,15 @@ async fn emit_delta_event(
 }
 
 /// Handle a stream error: classify it, check retryability, return action.
-async fn handle_stream_error(
+fn handle_stream_error(
     model: &ModelSpec,
     config: &Arc<AgentLoopConfig>,
-    stop_reason: &StopReason,
+    stop_reason: StopReason,
     error_message: &str,
     error_kind: Option<crate::stream::StreamErrorKind>,
     attempt: u32,
-    tx: &mpsc::Sender<AgentEvent>,
 ) -> StreamErrorAction {
-    let harness_error = classify_stream_error(error_message, *stop_reason, error_kind);
+    let harness_error = classify_stream_error(error_message, stop_reason, error_kind);
 
     // Context window overflow — signal and retry
     if matches!(harness_error, AgentError::ContextWindowOverflow { .. }) {
@@ -417,10 +451,10 @@ async fn handle_stream_error(
     // TurnEndReason::Aborted instead of TurnEndReason::Error (#438).
     if matches!(harness_error, AgentError::Aborted) {
         let abort_msg = build_abort_message(model);
-        if !emit(tx, AgentEvent::MessageEnd { message: abort_msg }).await {
-            return StreamErrorAction::ChannelClosed;
-        }
-        return StreamErrorAction::FatalError(StreamResult::Aborted);
+        return StreamErrorAction::FatalError {
+            result: StreamResult::Aborted,
+            message: abort_msg,
+        };
     }
 
     // Check if retryable — RetryStrategy is the sole decision point
@@ -433,17 +467,10 @@ async fn handle_stream_error(
     // Non-retryable error
     error!(error = %harness_error, "non-retryable stream error");
     let error_msg = build_error_message(model, &harness_error);
-    if !emit(
-        tx,
-        AgentEvent::MessageEnd {
-            message: error_msg.clone(),
-        },
-    )
-    .await
-    {
-        return StreamErrorAction::ChannelClosed;
+    StreamErrorAction::FatalError {
+        result: StreamResult::Message(error_msg.clone()),
+        message: error_msg,
     }
-    StreamErrorAction::FatalError(StreamResult::Message(error_msg))
 }
 
 /// Return a model spec with capability-based overrides applied.

--- a/tests/agent_loop.rs
+++ b/tests/agent_loop.rs
@@ -1095,6 +1095,85 @@ async fn retry_success() {
     );
 }
 
+#[tokio::test]
+async fn retry_success_emits_one_logical_message_lifecycle() {
+    let stream_fn = Arc::new(MockStreamFn::new(vec![
+        vec![
+            AssistantMessageEvent::Start,
+            AssistantMessageEvent::TextStart { content_index: 0 },
+            AssistantMessageEvent::TextDelta {
+                content_index: 0,
+                delta: "stale partial".to_string(),
+            },
+            AssistantMessageEvent::TextEnd { content_index: 0 },
+            AssistantMessageEvent::Error {
+                stop_reason: StopReason::Error,
+                error_message: "rate limit exceeded (429)".to_string(),
+                usage: None,
+                error_kind: None,
+            },
+        ],
+        text_only_events("retried successfully"),
+    ]));
+
+    let mut config = default_config(stream_fn);
+    config.retry_strategy = Box::new(
+        DefaultRetryStrategy::default()
+            .with_max_attempts(3)
+            .with_jitter(false)
+            .with_base_delay(Duration::from_millis(1)),
+    );
+
+    let events = collect_events(agent_loop(
+        vec![],
+        "system".to_string(),
+        config,
+        CancellationToken::new(),
+    ))
+    .await;
+
+    assert_eq!(
+        count_events(&events, "MessageStart"),
+        1,
+        "retry should preserve a single logical MessageStart"
+    );
+    assert_eq!(
+        count_events(&events, "MessageEnd"),
+        1,
+        "retry should preserve a single logical MessageEnd"
+    );
+
+    let update_text = events
+        .iter()
+        .filter_map(|event| match event {
+            AgentEvent::MessageUpdate { delta } => Some(format!("{delta:?}")),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(
+        !update_text.contains("stale partial"),
+        "failed-attempt partials should not leak into the logical message lifecycle: {update_text}"
+    );
+
+    let final_text = events.iter().find_map(|event| match event {
+        AgentEvent::MessageEnd { message } => Some(
+            message
+                .content
+                .iter()
+                .filter_map(|block| match block {
+                    ContentBlock::Text { text } => Some(text.as_str()),
+                    _ => None,
+                })
+                .collect::<String>(),
+        ),
+        _ => None,
+    });
+
+    assert_eq!(final_text.as_deref(), Some("retried successfully"));
+}
+
 // ─── 3.12: Non-retryable error ──────────────────────────────────────────
 
 #[tokio::test]


### PR DESCRIPTION
## What changed
- buffered attempt-local `MessageUpdate` deltas inside `src/loop_/stream.rs` until the terminal retry attempt is known
- kept `MessageStart`/`MessageEnd` as a single logical lifecycle for retryable provider failures instead of re-emitting them per attempt
- added a focused regression in `tests/agent_loop.rs` proving failed-attempt partial text does not leak into the final message lifecycle
- recorded the retry lifecycle rule in `src/loop_/AGENTS.md`

## Why / value
Retryable stream failures were emitting a fresh `MessageStart` plus partial deltas on each attempt. Downstream consumers could observe stale partial content before the eventual successful retry, which violated the loop's per-turn message lifecycle contract.

## Slice completed
Completed the retry-stream lifecycle fix for issue #668.

## What remains
- none for this issue

## Validation output
- `cargo fmt --all --check`
- `cargo test -p swink-agent --features testkit --test agent_loop retry_success`
- `cargo clippy -p swink-agent --lib -- -D warnings`
- `git diff --check`

## Pre-existing baseline failures
- `cargo clippy -p swink-agent --features testkit --test agent_loop -- -D warnings` still fails in unchanged sections of `tests/agent_loop.rs` due existing `clippy::unnecessary_literal_bound` and `clippy::doc_markdown` findings at lines 275, 296, 1663, 1664, 1670, 1695, and 1908

## IPC contract changes
- none

Closes #668