### PR TITLE
Add resolver-backed SSE MCP auth bootstrap

### DIFF
--- a/mcp/src/config.rs
+++ b/mcp/src/config.rs
@@ -3,6 +3,16 @@
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
+use swink_agent::CredentialType;
+
+/// Resolver-backed bearer auth for SSE MCP transports.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SseBearerAuth {
+    /// Credential store key resolved before establishing the connection.
+    pub credential_key: String,
+    /// Expected resolved credential type for this bearer header.
+    pub credential_type: CredentialType,
+}
 
 /// Transport type for MCP server communication.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -19,6 +29,8 @@ pub enum McpTransport {
     Sse {
         url: String,
         bearer_token: Option<String>,
+        #[serde(default)]
+        bearer_auth: Option<SseBearerAuth>,
         #[serde(default)]
         headers: HashMap<String, String>,
     },

--- a/mcp/src/connection.rs
+++ b/mcp/src/connection.rs
@@ -7,6 +7,7 @@
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, PoisonError};
+use std::time::Duration;
 
 use reqwest::header::{HeaderName, HeaderValue};
 use rmcp::model::{CallToolRequestParams, CallToolResult, ClientInfo, Implementation};
@@ -16,12 +17,12 @@ use rmcp::transport::streamable_http_client::{
     StreamableHttpClientTransport, StreamableHttpClientTransportConfig,
 };
 use serde_json::Value;
-use swink_agent::AgentEvent;
+use swink_agent::{AgentEvent, CredentialResolver, CredentialType, ResolvedCredential};
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::task::JoinHandle;
 use tracing::{info, warn};
 
-use crate::config::{McpServerConfig, McpTransport};
+use crate::config::{McpServerConfig, McpTransport, SseBearerAuth};
 use crate::error::McpError;
 
 /// Status of an MCP server connection.
@@ -176,6 +177,16 @@ impl McpConnection {
         config: McpServerConfig,
         event_tx: Option<UnboundedSender<AgentEvent>>,
     ) -> Result<Self, McpError> {
+        Self::connect_with_resolver(config, None, event_tx).await
+    }
+
+    /// Connect to an MCP server using the configured transport and optional
+    /// credential resolver for SSE bearer auth.
+    pub async fn connect_with_resolver(
+        config: McpServerConfig,
+        credential_resolver: Option<Arc<dyn CredentialResolver>>,
+        event_tx: Option<UnboundedSender<AgentEvent>>,
+    ) -> Result<Self, McpError> {
         let service = match &config.transport {
             McpTransport::Stdio { command, args, env } => {
                 Self::connect_stdio(command, args, env, &config.name).await?
@@ -183,8 +194,18 @@ impl McpConnection {
             McpTransport::Sse {
                 url,
                 bearer_token,
+                bearer_auth,
                 headers,
-            } => Self::connect_sse(url, bearer_token.as_deref(), headers, &config.name).await?,
+            } => {
+                let resolved_bearer = resolve_sse_bearer_token(
+                    bearer_token.as_deref(),
+                    bearer_auth.as_ref(),
+                    credential_resolver.as_deref(),
+                    &config.name,
+                )
+                .await?;
+                Self::connect_sse(url, resolved_bearer.as_deref(), headers, &config.name).await?
+            }
         };
 
         // Handshake succeeded, transport is live.
@@ -361,6 +382,72 @@ impl McpConnection {
             monitor.abort();
             let _ = monitor.await;
         }
+    }
+}
+
+async fn resolve_sse_bearer_token(
+    bearer_token: Option<&str>,
+    bearer_auth: Option<&SseBearerAuth>,
+    credential_resolver: Option<&dyn CredentialResolver>,
+    server_name: &str,
+) -> Result<Option<String>, McpError> {
+    let Some(bearer_auth) = bearer_auth else {
+        return Ok(bearer_token.map(str::to_owned));
+    };
+
+    let resolver = credential_resolver.ok_or_else(|| McpError::ConnectionFailed {
+        server: server_name.to_string(),
+        reason: format!(
+            "SSE bearer auth for credential `{}` requires a credential resolver",
+            bearer_auth.credential_key
+        ),
+    })?;
+
+    let resolve_future = resolver.resolve(&bearer_auth.credential_key);
+    let credential = tokio::time::timeout(Duration::from_secs(30), resolve_future)
+        .await
+        .map_err(|_| McpError::ConnectionFailed {
+            server: server_name.to_string(),
+            reason: format!(
+                "timed out resolving SSE credential `{}`",
+                bearer_auth.credential_key
+            ),
+        })?
+        .map_err(|error| McpError::ConnectionFailed {
+            server: server_name.to_string(),
+            reason: format!(
+                "failed to resolve SSE credential `{}`: {error}",
+                bearer_auth.credential_key
+            ),
+        })?;
+
+    let actual_type = resolved_credential_type(&credential);
+    if actual_type != bearer_auth.credential_type {
+        return Err(McpError::ConnectionFailed {
+            server: server_name.to_string(),
+            reason: format!(
+                "SSE credential type mismatch for `{}`: expected {:?}, got {:?}",
+                bearer_auth.credential_key, bearer_auth.credential_type, actual_type
+            ),
+        });
+    }
+
+    Ok(Some(resolved_credential_secret(&credential).to_string()))
+}
+
+const fn resolved_credential_type(credential: &ResolvedCredential) -> CredentialType {
+    match credential {
+        ResolvedCredential::ApiKey(_) => CredentialType::ApiKey,
+        ResolvedCredential::Bearer(_) => CredentialType::Bearer,
+        ResolvedCredential::OAuth2AccessToken(_) => CredentialType::OAuth2,
+    }
+}
+
+fn resolved_credential_secret(credential: &ResolvedCredential) -> &str {
+    match credential {
+        ResolvedCredential::ApiKey(secret)
+        | ResolvedCredential::Bearer(secret)
+        | ResolvedCredential::OAuth2AccessToken(secret) => secret,
     }
 }
 

--- a/mcp/src/lib.rs
+++ b/mcp/src/lib.rs
@@ -34,7 +34,7 @@ pub mod event;
 mod manager;
 mod tool;
 
-pub use config::{McpServerConfig, McpTransport, ToolFilter};
+pub use config::{McpServerConfig, McpTransport, SseBearerAuth, ToolFilter};
 pub use connection::{McpConnection, McpConnectionStatus};
 pub use error::McpError;
 pub use manager::McpManager;

--- a/mcp/src/manager.rs
+++ b/mcp/src/manager.rs
@@ -7,7 +7,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use swink_agent::{AgentEvent, AgentTool};
+use swink_agent::{AgentEvent, AgentTool, CredentialResolver};
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::warn;
 
@@ -55,6 +55,7 @@ pub struct McpManager {
     connections: Vec<Arc<McpConnection>>,
     tools: Vec<Arc<dyn AgentTool>>,
     event_tx: Option<UnboundedSender<AgentEvent>>,
+    credential_resolver: Option<Arc<dyn CredentialResolver>>,
 }
 
 impl McpManager {
@@ -68,6 +69,7 @@ impl McpManager {
             connections: Vec::new(),
             tools: Vec::new(),
             event_tx: None,
+            credential_resolver: None,
         }
     }
 
@@ -79,6 +81,13 @@ impl McpManager {
     #[must_use]
     pub fn with_event_tx(mut self, tx: UnboundedSender<AgentEvent>) -> Self {
         self.event_tx = Some(tx);
+        self
+    }
+
+    /// Wire up a credential resolver for SSE bearer auth.
+    #[must_use]
+    pub fn with_credential_resolver(mut self, resolver: Arc<dyn CredentialResolver>) -> Self {
+        self.credential_resolver = Some(resolver);
         self
     }
 
@@ -104,6 +113,7 @@ impl McpManager {
             connections: arc_connections,
             tools,
             event_tx: None,
+            credential_resolver: None,
         })
     }
 
@@ -116,7 +126,13 @@ impl McpManager {
         let mut all_tools: Vec<(String, String, Arc<dyn AgentTool>)> = Vec::new();
 
         for config in self.configs.clone() {
-            match McpConnection::connect(config.clone(), self.event_tx.clone()).await {
+            match McpConnection::connect_with_resolver(
+                config.clone(),
+                self.credential_resolver.clone(),
+                self.event_tx.clone(),
+            )
+            .await
+            {
                 Ok(connection) => {
                     let conn = Arc::new(connection);
                     all_tools.extend(build_tools_for_connection(&conn));
@@ -167,6 +183,7 @@ impl std::fmt::Debug for McpManager {
             .field("connections", &self.connections.len())
             .field("tools", &self.tools.len())
             .field("event_tx", &self.event_tx.is_some())
+            .field("credential_resolver", &self.credential_resolver.is_some())
             .finish()
     }
 }

--- a/mcp/tests/config_test.rs
+++ b/mcp/tests/config_test.rs
@@ -4,7 +4,8 @@ mod common;
 
 use std::collections::HashMap;
 
-use swink_agent_mcp::{McpServerConfig, McpTransport, ToolFilter};
+use swink_agent::CredentialType;
+use swink_agent_mcp::{McpServerConfig, McpTransport, SseBearerAuth, ToolFilter};
 
 #[test]
 fn server_config_construction() {
@@ -32,6 +33,7 @@ fn sse_transport_construction() {
         transport: McpTransport::Sse {
             url: "http://localhost:8080/sse".into(),
             bearer_token: Some("secret".into()),
+            bearer_auth: None,
             headers: HashMap::from([("x-api-key".into(), "abc123".into())]),
         },
         tool_prefix: None,
@@ -63,10 +65,15 @@ fn sse_transport_deserialization_defaults_headers() {
         McpTransport::Sse {
             url,
             bearer_token,
+            bearer_auth,
             headers,
         } => {
             assert_eq!(url, "http://localhost:8080/sse");
             assert_eq!(bearer_token.as_deref(), Some("secret"));
+            assert!(
+                bearer_auth.is_none(),
+                "legacy configs should default bearer auth"
+            );
             assert!(headers.is_empty(), "legacy configs should default headers");
         }
         other @ McpTransport::Stdio { .. } => panic!("expected SSE transport, got {other:?}"),
@@ -153,6 +160,10 @@ fn sse_config_serialization_roundtrip_preserves_headers() {
         transport: McpTransport::Sse {
             url: "https://example.com/mcp".into(),
             bearer_token: Some("secret".into()),
+            bearer_auth: Some(SseBearerAuth {
+                credential_key: "mcp-sse".into(),
+                credential_type: CredentialType::OAuth2,
+            }),
             headers: HashMap::from([
                 ("x-api-key".into(), "key-123".into()),
                 ("x-trace-id".into(), "trace-abc".into()),
@@ -170,10 +181,18 @@ fn sse_config_serialization_roundtrip_preserves_headers() {
         McpTransport::Sse {
             url,
             bearer_token,
+            bearer_auth,
             headers,
         } => {
             assert_eq!(url, "https://example.com/mcp");
             assert_eq!(bearer_token.as_deref(), Some("secret"));
+            assert_eq!(
+                bearer_auth,
+                Some(SseBearerAuth {
+                    credential_key: "mcp-sse".into(),
+                    credential_type: CredentialType::OAuth2,
+                })
+            );
             assert_eq!(
                 headers.get("x-api-key").map(String::as_str),
                 Some("key-123")

--- a/mcp/tests/connection_test.rs
+++ b/mcp/tests/connection_test.rs
@@ -11,9 +11,10 @@ use axum::extract::State;
 use axum::http::header::AUTHORIZATION;
 use axum::http::{HeaderMap, StatusCode};
 use axum::routing::post;
+use swink_agent::{CredentialFuture, CredentialResolver, CredentialType, ResolvedCredential};
 use tokio::sync::oneshot;
 
-use swink_agent_mcp::{McpConnection, McpServerConfig, McpTransport};
+use swink_agent_mcp::{McpConnection, McpServerConfig, McpTransport, SseBearerAuth};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct CapturedHeaders {
@@ -25,6 +26,32 @@ struct CapturedHeaders {
 #[derive(Clone)]
 struct HeaderCaptureState {
     sender: Arc<Mutex<Option<oneshot::Sender<CapturedHeaders>>>>,
+}
+
+struct StaticCredentialResolver {
+    expected_key: String,
+    credential: ResolvedCredential,
+}
+
+impl StaticCredentialResolver {
+    fn new(expected_key: impl Into<String>, credential: ResolvedCredential) -> Self {
+        Self {
+            expected_key: expected_key.into(),
+            credential,
+        }
+    }
+}
+
+impl CredentialResolver for StaticCredentialResolver {
+    fn resolve(&self, key: &str) -> CredentialFuture<'_, ResolvedCredential> {
+        let expected_key = self.expected_key.clone();
+        let actual_key = key.to_string();
+        let credential = self.credential.clone();
+        Box::pin(async move {
+            assert_eq!(actual_key, expected_key);
+            Ok(credential)
+        })
+    }
 }
 
 async fn capture_headers(
@@ -157,6 +184,7 @@ async fn connect_sse_to_unreachable_url_returns_error() {
         transport: McpTransport::Sse {
             url: "http://127.0.0.1:1/mcp".into(),
             bearer_token: Some("test-bearer-token-123".into()),
+            bearer_auth: None,
             headers: HashMap::new(),
         },
         tool_prefix: None,
@@ -193,6 +221,7 @@ async fn connect_sse_sends_bearer_and_custom_headers() {
         transport: McpTransport::Sse {
             url: format!("http://{address}/mcp"),
             bearer_token: Some("test-bearer-token-123".into()),
+            bearer_auth: None,
             headers: HashMap::from([
                 ("x-api-key".into(), "custom-key-456".into()),
                 ("x-trace-id".into(), "trace-789".into()),
@@ -223,4 +252,92 @@ async fn connect_sse_sends_bearer_and_custom_headers() {
 
     server.abort();
     let _ = server.await;
+}
+
+#[tokio::test]
+async fn connect_sse_uses_resolved_bearer_auth_over_static_token() {
+    let (sender, receiver) = oneshot::channel();
+    let state = HeaderCaptureState {
+        sender: Arc::new(Mutex::new(Some(sender))),
+    };
+
+    let app = Router::new()
+        .route("/mcp", post(capture_headers))
+        .with_state(state);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test server");
+    let address = listener.local_addr().expect("listener address");
+
+    let server = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+
+    let config = McpServerConfig {
+        name: "sse-resolver-auth".into(),
+        transport: McpTransport::Sse {
+            url: format!("http://{address}/mcp"),
+            bearer_token: Some("static-token".into()),
+            bearer_auth: Some(SseBearerAuth {
+                credential_key: "mcp-sse-token".into(),
+                credential_type: CredentialType::ApiKey,
+            }),
+            headers: HashMap::new(),
+        },
+        tool_prefix: None,
+        tool_filter: None,
+        requires_approval: false,
+    };
+
+    let resolver = Arc::new(StaticCredentialResolver::new(
+        "mcp-sse-token",
+        ResolvedCredential::ApiKey("resolved-token-789".into()),
+    ));
+
+    let result = McpConnection::connect_with_resolver(config, Some(resolver), None).await;
+    assert!(
+        result.is_err(),
+        "the mock HTTP server should reject the handshake"
+    );
+
+    let captured = tokio::time::timeout(Duration::from_secs(5), receiver)
+        .await
+        .expect("timed out waiting for header capture")
+        .expect("header capture channel closed");
+
+    assert_eq!(
+        captured.authorization.as_deref(),
+        Some("Bearer resolved-token-789")
+    );
+
+    server.abort();
+    let _ = server.await;
+}
+
+#[tokio::test]
+async fn connect_sse_with_resolver_auth_requires_resolver() {
+    let config = McpServerConfig {
+        name: "sse-missing-resolver".into(),
+        transport: McpTransport::Sse {
+            url: "http://127.0.0.1:1/mcp".into(),
+            bearer_token: None,
+            bearer_auth: Some(SseBearerAuth {
+                credential_key: "mcp-sse-token".into(),
+                credential_type: CredentialType::Bearer,
+            }),
+            headers: HashMap::new(),
+        },
+        tool_prefix: None,
+        tool_filter: None,
+        requires_approval: false,
+    };
+
+    let result = McpConnection::connect(config, None).await;
+    assert!(result.is_err(), "missing resolver should fail fast");
+    let error = result.unwrap_err().to_string();
+    assert!(
+        error.contains("mcp-sse-token"),
+        "error should mention the missing credential key, got: {error}"
+    );
 }

--- a/mcp/tests/lifecycle_test.rs
+++ b/mcp/tests/lifecycle_test.rs
@@ -272,6 +272,7 @@ async fn sse_session_expiry_recovers_without_wrapper_disconnect() {
             transport: McpTransport::Sse {
                 url: format!("http://{addr}/mcp"),
                 bearer_token: None,
+                bearer_auth: None,
                 headers: HashMap::new(),
             },
             tool_prefix: None,

--- a/src/credential.rs
+++ b/src/credential.rs
@@ -159,7 +159,8 @@ pub enum AuthScheme {
 // ─── CredentialType ─────────────────────────────────────────────────────────
 
 /// Credential type discriminant for mismatch checking (FR-018).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum CredentialType {
     /// Expects an API key credential.
     ApiKey,


### PR DESCRIPTION
## Summary
- add `SseBearerAuth` config so SSE MCP servers can source bearer auth from the credential resolver instead of only a static token
- thread an optional credential resolver through `McpManager` into `McpConnection::connect_with_resolver`
- resolve the configured credential before opening the SSE transport, validate the expected credential type, and keep legacy static `bearer_token` configs working
- add regression tests for config roundtrips, resolved-header precedence, and fast failure when resolver-backed auth is configured without a resolver

## Slice completed
This PR completes the connection/bootstrap slice of #669: resolver-backed SSE auth is now available when establishing MCP SSE connections.

## Remaining work
- follow up on any future reconnect/refresh behavior beyond the initial connection bootstrap if the MCP transport needs to re-resolve credentials after long-lived token rotation

## Validation
- `cargo fmt --all`
- `cargo test -p swink-agent-mcp`
- `cargo clippy -p swink-agent-mcp -- -D warnings`
- `cargo test --workspace` *(fails in existing `llama-cpp-sys-2` build because `cmake` is not installed in this environment)*
- `cargo test --workspace --exclude swink-agent-local-llm` *(still hits a pre-existing unrelated failure: `swink-agent-tui` `editor::tests::open_editor_with_true_command_returns_none`)*

## Baseline failures
- `cargo test --workspace` currently fails in `llama-cpp-sys-2` because `cmake` is missing on this host
- `cargo test --workspace --exclude swink-agent-local-llm` currently fails in `swink-agent-tui` at `editor::tests::open_editor_with_true_command_returns_none`

Ref #669