### PR TITLE
[codex] fix(mcp): refresh SSE resolver auth on recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5017,11 +5017,13 @@ name = "swink-agent-mcp"
 version = "0.7.9"
 dependencies = [
  "axum",
+ "futures",
  "reqwest 0.13.2",
  "rmcp",
  "schemars",
  "serde",
  "serde_json",
+ "sse-stream",
  "swink-agent",
  "thiserror 2.0.18",
  "tokio",

--- a/mcp/AGENTS.md
+++ b/mcp/AGENTS.md
@@ -18,6 +18,7 @@
 - `McpManager::shutdown()` must operate on shared connection-owned state, not `Arc::try_unwrap()`: exported `McpTool` handles keep `Arc<McpConnection>` clones alive, so deterministic disconnect has to clear the session/monitor even when callers still retain tool `Arc`s.
 - Tool discovery happens at `connect_all()` time. Tools added to a server after connection are not auto-refreshed; call `reconnect()` to rediscover.
 - SSE recovery is delegated to rmcp's streamable HTTP transport: transient stream drops and stale-session 404s are retried/re-initialized inside rmcp, so `McpConnection` should only flip to `Disconnected` after the underlying service fully exits.
+- rmcp stores SSE `auth_header` as a static string inside the transport config and reuses it for reconnect/re-init paths. Resolver-backed SSE auth that must survive token rotation therefore needs a custom `StreamableHttpClient` wrapper that resolves credentials per HTTP request instead of only at initial connect.
 
 ## Build & Test
 

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -14,12 +14,14 @@ readme = "../README.md"
 swink-agent = { path = "..", version = "0.7.9", default-features = false }
 rmcp = { version = "1.3", features = ["client", "client-side-sse", "transport-streamable-http-client", "transport-streamable-http-client-reqwest", "transport-child-process"] }
 reqwest = { workspace = true }
+futures.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+sse-stream = "0.2"
 
 [dev-dependencies]
 axum = "0.8"

--- a/mcp/src/connection.rs
+++ b/mcp/src/connection.rs
@@ -9,15 +9,20 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex, PoisonError};
 use std::time::Duration;
 
+use futures::stream::BoxStream;
 use reqwest::header::{HeaderName, HeaderValue};
 use rmcp::model::{CallToolRequestParams, CallToolResult, ClientInfo, Implementation};
 use rmcp::service::{Peer, QuitReason, RoleClient, RunningService, ServiceExt};
 use rmcp::transport::TokioChildProcess;
 use rmcp::transport::streamable_http_client::{
-    StreamableHttpClientTransport, StreamableHttpClientTransportConfig,
+    StreamableHttpClient, StreamableHttpClientTransport, StreamableHttpClientTransportConfig,
+    StreamableHttpError, StreamableHttpPostResponse,
 };
 use serde_json::Value;
-use swink_agent::{AgentEvent, CredentialResolver, CredentialType, ResolvedCredential};
+use sse_stream::{Error as SseError, Sse};
+use swink_agent::{
+    AgentEvent, CredentialError, CredentialResolver, CredentialType, ResolvedCredential,
+};
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::task::JoinHandle;
 use tracing::{info, warn};
@@ -38,6 +43,125 @@ struct McpConnectionState {
     status: McpConnectionStatus,
     peer: Option<Peer<RoleClient>>,
     monitor: Option<JoinHandle<()>>,
+}
+
+#[derive(Debug, thiserror::Error)]
+enum SseBearerResolutionError {
+    #[error("credential resolution timed out for {key}")]
+    Timeout { key: String },
+    #[error(transparent)]
+    Credential(#[from] CredentialError),
+    #[error("credential type mismatch for {key}: expected {expected:?}, got {actual:?}")]
+    TypeMismatch {
+        key: String,
+        expected: CredentialType,
+        actual: CredentialType,
+    },
+}
+
+#[derive(Debug, thiserror::Error)]
+enum ResolverBackedSseHttpClientError {
+    #[error(transparent)]
+    Credential(#[from] SseBearerResolutionError),
+    #[error(transparent)]
+    Http(#[from] reqwest::Error),
+}
+
+#[derive(Clone)]
+struct ResolverBackedSseHttpClient {
+    inner: reqwest::Client,
+    bearer_auth: SseBearerAuth,
+    credential_resolver: Arc<dyn CredentialResolver>,
+}
+
+impl ResolverBackedSseHttpClient {
+    fn new(bearer_auth: SseBearerAuth, credential_resolver: Arc<dyn CredentialResolver>) -> Self {
+        Self {
+            inner: reqwest::Client::default(),
+            bearer_auth,
+            credential_resolver,
+        }
+    }
+
+    async fn resolve_bearer_token(&self) -> Result<String, ResolverBackedSseHttpClientError> {
+        resolve_sse_bearer_secret(&self.bearer_auth, self.credential_resolver.as_ref())
+            .await
+            .map_err(ResolverBackedSseHttpClientError::from)
+    }
+}
+
+impl StreamableHttpClient for ResolverBackedSseHttpClient {
+    type Error = ResolverBackedSseHttpClientError;
+
+    async fn post_message(
+        &self,
+        uri: Arc<str>,
+        message: rmcp::model::ClientJsonRpcMessage,
+        session_id: Option<Arc<str>>,
+        _auth_header: Option<String>,
+        custom_headers: HashMap<HeaderName, HeaderValue>,
+    ) -> Result<StreamableHttpPostResponse, StreamableHttpError<Self::Error>> {
+        let bearer_token = self
+            .resolve_bearer_token()
+            .await
+            .map_err(StreamableHttpError::Client)?;
+        <reqwest::Client as StreamableHttpClient>::post_message(
+            &self.inner,
+            uri,
+            message,
+            session_id,
+            Some(bearer_token),
+            custom_headers,
+        )
+        .await
+        .map_err(map_reqwest_streamable_http_error)
+    }
+
+    async fn delete_session(
+        &self,
+        uri: Arc<str>,
+        session_id: Arc<str>,
+        _auth_header: Option<String>,
+        custom_headers: HashMap<HeaderName, HeaderValue>,
+    ) -> Result<(), StreamableHttpError<Self::Error>> {
+        let bearer_token = self
+            .resolve_bearer_token()
+            .await
+            .map_err(StreamableHttpError::Client)?;
+        <reqwest::Client as StreamableHttpClient>::delete_session(
+            &self.inner,
+            uri,
+            session_id,
+            Some(bearer_token),
+            custom_headers,
+        )
+        .await
+        .map_err(map_reqwest_streamable_http_error)
+    }
+
+    async fn get_stream(
+        &self,
+        uri: Arc<str>,
+        session_id: Arc<str>,
+        last_event_id: Option<String>,
+        _auth_header: Option<String>,
+        custom_headers: HashMap<HeaderName, HeaderValue>,
+    ) -> Result<BoxStream<'static, Result<Sse, SseError>>, StreamableHttpError<Self::Error>> {
+        let bearer_token = self
+            .resolve_bearer_token()
+            .await
+            .map_err(StreamableHttpError::Client)?;
+        <reqwest::Client as StreamableHttpClient>::get_stream(
+            &self.inner,
+            uri,
+            session_id,
+            last_event_id,
+            Some(bearer_token),
+            custom_headers,
+        )
+        .await
+        .map_err(map_reqwest_streamable_http_error)
+    }
 }
 
 /// A connection to a single MCP server.
@@ -196,16 +320,29 @@ impl McpConnection {
                 bearer_token,
                 bearer_auth,
                 headers,
-            } => {
-                let resolved_bearer = resolve_sse_bearer_token(
-                    bearer_token.as_deref(),
-                    bearer_auth.as_ref(),
-                    credential_resolver.as_deref(),
-                    &config.name,
-                )
-                .await?;
-                Self::connect_sse(url, resolved_bearer.as_deref(), headers, &config.name).await?
-            }
+            } => match bearer_auth.as_ref() {
+                Some(bearer_auth) => {
+                    let credential_resolver =
+                        credential_resolver.clone().ok_or_else(|| McpError::ConnectionFailed {
+                            server: config.name.clone(),
+                            reason: format!(
+                                "SSE bearer auth for credential `{}` requires a credential resolver",
+                                bearer_auth.credential_key
+                            ),
+                        })?;
+                    Self::connect_sse_with_resolver(
+                        url,
+                        bearer_auth,
+                        credential_resolver,
+                        headers,
+                        &config.name,
+                    )
+                    .await?
+                }
+                None => {
+                    Self::connect_sse(url, bearer_token.as_deref(), headers, &config.name).await?
+                }
+            },
         };
 
         // Handshake succeeded, transport is live.
@@ -313,6 +450,39 @@ impl McpConnection {
             })
     }
 
+    /// Connect to a remote MCP server via HTTP streaming transport, resolving
+    /// bearer auth on every HTTP request so rmcp reconnect/reinit paths can
+    /// pick up rotated credentials.
+    async fn connect_sse_with_resolver(
+        url: &str,
+        bearer_auth: &SseBearerAuth,
+        credential_resolver: Arc<dyn CredentialResolver>,
+        headers: &HashMap<String, String>,
+        server_name: &str,
+    ) -> Result<RunningService<RoleClient, ClientInfo>, McpError> {
+        resolve_sse_bearer_secret(bearer_auth, credential_resolver.as_ref())
+            .await
+            .map_err(|error| sse_bearer_resolution_error(error, server_name))?;
+
+        let mut config = StreamableHttpClientTransportConfig::with_uri(url);
+        if !headers.is_empty() {
+            config = config.custom_headers(parse_custom_headers(headers, server_name)?);
+        }
+
+        let transport = StreamableHttpClientTransport::with_client(
+            ResolverBackedSseHttpClient::new(bearer_auth.clone(), credential_resolver),
+            config,
+        );
+
+        client_info()
+            .serve(transport)
+            .await
+            .map_err(|e| McpError::ConnectionFailed {
+                server: server_name.to_string(),
+                reason: format!("HTTP streaming handshake failed: {e}"),
+            })
+    }
+
     /// Call a tool on the connected MCP server.
     ///
     /// Returns an error if the connection is disconnected.
@@ -385,54 +555,91 @@ impl McpConnection {
     }
 }
 
-async fn resolve_sse_bearer_token(
-    bearer_token: Option<&str>,
-    bearer_auth: Option<&SseBearerAuth>,
-    credential_resolver: Option<&dyn CredentialResolver>,
-    server_name: &str,
-) -> Result<Option<String>, McpError> {
-    let Some(bearer_auth) = bearer_auth else {
-        return Ok(bearer_token.map(str::to_owned));
-    };
-
-    let resolver = credential_resolver.ok_or_else(|| McpError::ConnectionFailed {
-        server: server_name.to_string(),
-        reason: format!(
-            "SSE bearer auth for credential `{}` requires a credential resolver",
-            bearer_auth.credential_key
-        ),
-    })?;
-
-    let resolve_future = resolver.resolve(&bearer_auth.credential_key);
+async fn resolve_sse_bearer_secret(
+    bearer_auth: &SseBearerAuth,
+    credential_resolver: &dyn CredentialResolver,
+) -> Result<String, SseBearerResolutionError> {
+    let resolve_future = credential_resolver.resolve(&bearer_auth.credential_key);
     let credential = tokio::time::timeout(Duration::from_secs(30), resolve_future)
         .await
-        .map_err(|_| McpError::ConnectionFailed {
-            server: server_name.to_string(),
-            reason: format!(
-                "timed out resolving SSE credential `{}`",
-                bearer_auth.credential_key
-            ),
-        })?
-        .map_err(|error| McpError::ConnectionFailed {
-            server: server_name.to_string(),
-            reason: format!(
-                "failed to resolve SSE credential `{}`: {error}",
-                bearer_auth.credential_key
-            ),
-        })?;
+        .map_err(|_| SseBearerResolutionError::Timeout {
+            key: bearer_auth.credential_key.clone(),
+        })??;
 
     let actual_type = resolved_credential_type(&credential);
     if actual_type != bearer_auth.credential_type {
-        return Err(McpError::ConnectionFailed {
-            server: server_name.to_string(),
-            reason: format!(
-                "SSE credential type mismatch for `{}`: expected {:?}, got {:?}",
-                bearer_auth.credential_key, bearer_auth.credential_type, actual_type
-            ),
+        return Err(SseBearerResolutionError::TypeMismatch {
+            key: bearer_auth.credential_key.clone(),
+            expected: bearer_auth.credential_type,
+            actual: actual_type,
         });
     }
 
-    Ok(Some(resolved_credential_secret(&credential).to_string()))
+    Ok(resolved_credential_secret(&credential).to_string())
+}
+
+fn sse_bearer_resolution_error(error: SseBearerResolutionError, server_name: &str) -> McpError {
+    let reason = match error {
+        SseBearerResolutionError::Timeout { key } => {
+            format!("timed out resolving SSE credential `{key}`")
+        }
+        SseBearerResolutionError::Credential(error) => {
+            format!("failed to resolve SSE credential: {error}")
+        }
+        SseBearerResolutionError::TypeMismatch {
+            key,
+            expected,
+            actual,
+        } => {
+            format!(
+                "SSE credential type mismatch for `{key}`: expected {expected:?}, got {actual:?}"
+            )
+        }
+    };
+
+    McpError::ConnectionFailed {
+        server: server_name.to_string(),
+        reason,
+    }
+}
+
+fn map_reqwest_streamable_http_error(
+    error: StreamableHttpError<reqwest::Error>,
+) -> StreamableHttpError<ResolverBackedSseHttpClientError> {
+    match error {
+        StreamableHttpError::Sse(error) => StreamableHttpError::Sse(error),
+        StreamableHttpError::Io(error) => StreamableHttpError::Io(error),
+        StreamableHttpError::Client(error) => {
+            StreamableHttpError::Client(ResolverBackedSseHttpClientError::Http(error))
+        }
+        StreamableHttpError::UnexpectedEndOfStream => StreamableHttpError::UnexpectedEndOfStream,
+        StreamableHttpError::UnexpectedServerResponse(error) => {
+            StreamableHttpError::UnexpectedServerResponse(error)
+        }
+        StreamableHttpError::UnexpectedContentType(content_type) => {
+            StreamableHttpError::UnexpectedContentType(content_type)
+        }
+        StreamableHttpError::ServerDoesNotSupportSse => {
+            StreamableHttpError::ServerDoesNotSupportSse
+        }
+        StreamableHttpError::ServerDoesNotSupportDeleteSession => {
+            StreamableHttpError::ServerDoesNotSupportDeleteSession
+        }
+        StreamableHttpError::TokioJoinError(error) => StreamableHttpError::TokioJoinError(error),
+        StreamableHttpError::Deserialize(error) => StreamableHttpError::Deserialize(error),
+        StreamableHttpError::TransportChannelClosed => StreamableHttpError::TransportChannelClosed,
+        StreamableHttpError::AuthRequired(error) => StreamableHttpError::AuthRequired(error),
+        StreamableHttpError::InsufficientScope(error) => {
+            StreamableHttpError::InsufficientScope(error)
+        }
+        StreamableHttpError::ReservedHeaderConflict(header) => {
+            StreamableHttpError::ReservedHeaderConflict(header)
+        }
+        StreamableHttpError::SessionExpired => StreamableHttpError::SessionExpired,
+        other => StreamableHttpError::UnexpectedServerResponse(
+            format!("unexpected streamable HTTP error: {other:?}").into(),
+        ),
+    }
 }
 
 const fn resolved_credential_type(credential: &ResolvedCredential) -> CredentialType {

--- a/mcp/tests/connection_test.rs
+++ b/mcp/tests/connection_test.rs
@@ -3,16 +3,26 @@
 mod common;
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, PoisonError};
 use std::time::Duration;
 
 use axum::Router;
-use axum::extract::State;
+use axum::extract::{Request, State};
 use axum::http::header::AUTHORIZATION;
 use axum::http::{HeaderMap, StatusCode};
+use axum::middleware::{Next, from_fn_with_state};
+use axum::response::{IntoResponse, Response};
 use axum::routing::post;
-use swink_agent::{CredentialFuture, CredentialResolver, CredentialType, ResolvedCredential};
+use rmcp::transport::streamable_http_server::{
+    StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
+};
+use swink_agent::{
+    ContentBlock, CredentialFuture, CredentialResolver, CredentialType, ResolvedCredential,
+};
+use tokio::sync::RwLock;
 use tokio::sync::oneshot;
+use tokio_util::sync::CancellationToken;
 
 use swink_agent_mcp::{McpConnection, McpServerConfig, McpTransport, SseBearerAuth};
 
@@ -52,6 +62,84 @@ impl CredentialResolver for StaticCredentialResolver {
             Ok(credential)
         })
     }
+}
+
+struct RotatingCredentialResolver {
+    expected_key: String,
+    current_token: Arc<RwLock<String>>,
+    calls: Arc<AtomicUsize>,
+}
+
+impl RotatingCredentialResolver {
+    fn new(expected_key: impl Into<String>, current_token: Arc<RwLock<String>>) -> Self {
+        Self {
+            expected_key: expected_key.into(),
+            current_token,
+            calls: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    fn call_count(&self) -> usize {
+        self.calls.load(Ordering::SeqCst)
+    }
+}
+
+impl CredentialResolver for RotatingCredentialResolver {
+    fn resolve(&self, key: &str) -> CredentialFuture<'_, ResolvedCredential> {
+        let expected_key = self.expected_key.clone();
+        let actual_key = key.to_string();
+        let current_token = Arc::clone(&self.current_token);
+        let calls = Arc::clone(&self.calls);
+        Box::pin(async move {
+            assert_eq!(actual_key, expected_key);
+            calls.fetch_add(1, Ordering::SeqCst);
+            Ok(ResolvedCredential::Bearer(
+                current_token.read().await.clone(),
+            ))
+        })
+    }
+}
+
+#[derive(Clone)]
+struct AuthGateState {
+    current_token: Arc<RwLock<String>>,
+    seen_authorization: Arc<Mutex<Vec<String>>>,
+}
+
+async fn require_bearer_auth(
+    State(state): State<AuthGateState>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let authorization = request
+        .headers()
+        .get(AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_owned);
+
+    if let Some(ref header) = authorization {
+        state
+            .seen_authorization
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .push(header.clone());
+    }
+
+    let expected = format!("Bearer {}", state.current_token.read().await.as_str());
+    if authorization.as_deref() != Some(expected.as_str()) {
+        return StatusCode::UNAUTHORIZED.into_response();
+    }
+
+    next.run(request).await
+}
+
+async fn current_session_id(session_manager: &Arc<LocalSessionManager>) -> String {
+    let sessions = session_manager.sessions.read().await;
+    sessions
+        .keys()
+        .next()
+        .map(std::string::ToString::to_string)
+        .expect("session should exist")
 }
 
 async fn capture_headers(
@@ -340,4 +428,121 @@ async fn connect_sse_with_resolver_auth_requires_resolver() {
         error.contains("mcp-sse-token"),
         "error should mention the missing credential key, got: {error}"
     );
+}
+
+#[tokio::test]
+#[allow(clippy::too_many_lines)]
+async fn sse_resolver_auth_refreshes_during_session_recovery() {
+    let session_manager = Arc::new(LocalSessionManager::default());
+    let shutdown = CancellationToken::new();
+    let current_token = Arc::new(RwLock::new("initial-token".to_string()));
+    let auth_gate = AuthGateState {
+        current_token: Arc::clone(&current_token),
+        seen_authorization: Arc::new(Mutex::new(Vec::new())),
+    };
+
+    let mock_cfg = common::MockServerConfig::new(vec![]);
+    let server = common::MockMcpServer::from_config(&mock_cfg);
+    let service = StreamableHttpService::new(
+        move || Ok(server.clone()),
+        Arc::clone(&session_manager),
+        StreamableHttpServerConfig::default()
+            .with_sse_keep_alive(None)
+            .with_cancellation_token(shutdown.child_token()),
+    );
+
+    let router = Router::new()
+        .nest_service("/mcp", service)
+        .layer(from_fn_with_state(auth_gate.clone(), require_bearer_auth));
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test server");
+    let address = listener.local_addr().expect("listener address");
+
+    let server_task = tokio::spawn({
+        let shutdown = shutdown.clone();
+        async move {
+            let _ = axum::serve(listener, router)
+                .with_graceful_shutdown(async move { shutdown.cancelled_owned().await })
+                .await;
+        }
+    });
+
+    let resolver = Arc::new(RotatingCredentialResolver::new(
+        "mcp-sse-token",
+        Arc::clone(&current_token),
+    ));
+    let config = McpServerConfig {
+        name: "sse-refresh-auth".into(),
+        transport: McpTransport::Sse {
+            url: format!("http://{address}/mcp"),
+            bearer_token: Some("stale-static-token".into()),
+            bearer_auth: Some(SseBearerAuth {
+                credential_key: "mcp-sse-token".into(),
+                credential_type: CredentialType::Bearer,
+            }),
+            headers: HashMap::new(),
+        },
+        tool_prefix: None,
+        tool_filter: None,
+        requires_approval: false,
+    };
+
+    let conn = McpConnection::connect_with_resolver(config, Some(resolver.clone()), None)
+        .await
+        .expect("SSE connection should succeed");
+
+    let original_session_id = current_session_id(&session_manager).await;
+    *current_token.write().await = "rotated-token".to_string();
+    session_manager.sessions.write().await.clear();
+
+    let result = conn
+        .call_tool("echo", serde_json::json!({ "text": "recovered" }))
+        .await
+        .expect("tool call should recover with the refreshed bearer token");
+    let agent_result = swink_agent_mcp::convert::call_result_to_agent_result(&result);
+    let text = ContentBlock::extract_text(&agent_result.content);
+    assert!(
+        text.contains("recovered"),
+        "recovered call should still reach the server, got: {text}"
+    );
+
+    let replacement_session_id = current_session_id(&session_manager).await;
+    assert_ne!(
+        replacement_session_id, original_session_id,
+        "session recovery should create a new server session"
+    );
+
+    let seen_authorization = auth_gate
+        .seen_authorization
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner)
+        .clone();
+    assert!(
+        seen_authorization
+            .iter()
+            .any(|header| header == "Bearer initial-token"),
+        "initial handshake should use the resolver token, got: {seen_authorization:?}"
+    );
+    assert!(
+        seen_authorization
+            .iter()
+            .any(|header| header == "Bearer rotated-token"),
+        "session recovery should use the rotated resolver token, got: {seen_authorization:?}"
+    );
+    assert!(
+        !seen_authorization
+            .iter()
+            .any(|header| header == "Bearer stale-static-token"),
+        "static bearer fallback should not override resolver auth, got: {seen_authorization:?}"
+    );
+    assert!(
+        resolver.call_count() >= 2,
+        "resolver should be consulted again for session recovery"
+    );
+
+    conn.shutdown().await;
+    shutdown.cancel();
+    let _ = server_task.await;
 }


### PR DESCRIPTION
## What changed
- wrapped rmcp's SSE reqwest transport with a resolver-backed HTTP client that resolves the configured credential on every POST/GET/DELETE request instead of freezing the bearer token at initial connect
- kept static `bearer_token` setups on the existing path while preserving fast failure for missing resolver or credential-type mismatch when `bearer_auth` is configured
- added a real SSE session-recovery regression proving a rotated resolver token is used after the server expires the session, and recorded the rmcp transport caveat in `mcp/AGENTS.md`

## Value
Resolver-backed SSE MCP auth now stays aligned with the credential resolver contract during rmcp reconnect and session re-initialization, so rotated API keys/bearer tokens do not strand long-lived SSE connections on stale auth.

## Slice completed
- completed the remaining reconnect/refresh slice for issue #669
- no non-SSE transport redesign is included

## Validation output
- `cargo fmt --all`
- `cargo test -p swink-agent-mcp`
- `cargo clippy -p swink-agent-mcp -- -D warnings`
- `git diff --check`

## Pre-existing baseline failures
- none observed in the `swink-agent-mcp` package validation for this slice

## IPC contract changes
- none

Closes #669