### PR TITLE
[codex] fix(artifacts): serialize delete mutations

### DIFF
--- a/artifacts/AGENTS.md
+++ b/artifacts/AGENTS.md
@@ -11,6 +11,7 @@
 - `validate_artifact_name` enforces name constraints shared by both backends.
 - `FileArtifactStore` layout: versioned files + JSON metadata sidecar per artifact.
 - Streaming reads available via the `streaming` module.
+- All filesystem mutations for one artifact key must share `artifact_lock(session_id, name)`. `delete` needs the same lock path as `save` and `save_stream` or concurrent writers can race directory removal.
 
 ## Build & Test
 

--- a/artifacts/src/fs_store.rs
+++ b/artifacts/src/fs_store.rs
@@ -419,6 +419,9 @@ impl ArtifactStore for FileArtifactStore {
 
     async fn delete(&self, session_id: &str, name: &str) -> Result<(), ArtifactError> {
         let dir = self.resolve_artifact_dir(session_id, name)?;
+        let lock = self.artifact_lock(session_id, name).await;
+        let _guard = lock.lock().await;
+
         match tokio::fs::remove_dir_all(&dir).await {
             Ok(()) => {
                 tracing::debug!(session_id, name, "artifact deleted");
@@ -429,5 +432,70 @@ impl ArtifactStore for FileArtifactStore {
             Err(e) => return Err(storage_err(e)),
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use tokio::sync::oneshot;
+    use tokio::time::sleep;
+
+    use super::FileArtifactStore;
+    use swink_agent::{ArtifactData, ArtifactStore};
+
+    fn text_data(content: &str) -> ArtifactData {
+        ArtifactData {
+            content: content.as_bytes().to_vec(),
+            content_type: "text/plain".to_string(),
+            metadata: HashMap::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn delete_waits_for_in_flight_artifact_lock() {
+        let tmpdir = tempfile::TempDir::new().expect("tempdir");
+        let store = Arc::new(FileArtifactStore::new(tmpdir.path()));
+        store
+            .save("s1", "report.md", text_data("v1"))
+            .await
+            .expect("initial save");
+
+        let lock = store.artifact_lock("s1", "report.md").await;
+        let guard = lock.lock().await;
+
+        let (started_tx, started_rx) = oneshot::channel();
+        let delete_store = Arc::clone(&store);
+        let delete_task = tokio::spawn(async move {
+            started_tx.send(()).expect("notify delete start");
+            delete_store.delete("s1", "report.md").await
+        });
+
+        started_rx.await.expect("delete task started");
+        sleep(Duration::from_millis(50)).await;
+        let delete_finished = delete_task.is_finished();
+        assert!(
+            !delete_finished,
+            "delete should wait for the per-artifact lock before removing files"
+        );
+
+        drop(guard);
+
+        delete_task
+            .await
+            .expect("delete task join")
+            .expect("delete should succeed after lock release");
+
+        assert!(
+            store
+                .load("s1", "report.md")
+                .await
+                .expect("load after delete")
+                .is_none(),
+            "artifact should be deleted once the lock is released"
+        );
     }
 }


### PR DESCRIPTION
## What changed
- routed `FileArtifactStore::delete` through the same per-artifact `artifact_lock(session_id, name)` used by `save` and `save_stream`
- added a focused regression test that holds the mutation lock and verifies `delete` waits instead of removing files concurrently
- recorded the delete-locking invariant in `artifacts/AGENTS.md`

## Why / value
This closes a race where `delete` could remove an artifact directory while another write on the same `(session_id, name)` was still mutating it, which could otherwise produce lost writes or transient filesystem errors.

## Slice completed
- completed the issue fix for serializing `delete` with other filesystem mutations for one artifact key
- remaining work: none for issue scope

## Validation output
- `cargo fmt --package swink-agent-artifacts`
- `cargo clippy -p swink-agent-artifacts -- -D warnings`
- `cargo test -p swink-agent-artifacts`
- `cargo test --workspace` -> fails on pre-existing baseline `swink-agent-tui` test `editor::tests::open_editor_with_true_command_returns_none`

## Pre-existing baseline failures
- `cargo test --workspace` currently fails in `swink-agent-tui` at `editor::tests::open_editor_with_true_command_returns_none` (`tui/src/editor.rs:96`)

## IPC contract changes
- none

Closes #671