### PR TITLE
[codex] fix(memory): require explicit atomic save_full

### DIFF
--- a/memory/AGENTS.md
+++ b/memory/AGENTS.md
@@ -3,4 +3,5 @@
 ## Lessons Learned
 
 - Session transcript saves and session-state saves must share one store-level write path when callers need a consistent snapshot. `SessionStore::save_full()` is the atomic seam for that contract; `JsonlSessionStore` must rewrite messages plus the `_state` line under one lock and one sequence bump so TUI autosave cannot persist mixed transcript/state snapshots.
+- `SessionStore::save_full()` must not silently fall back to `save()` + `save_state()`. Backends without an explicit atomic implementation now return `io::ErrorKind::Unsupported` so callers cannot assume mixed transcript/state writes are safe.
 - File-backed checkpoint persistence must validate checkpoint IDs before turning them into filenames. Reject path separators, `..`, and null bytes so consumer-provided checkpoint IDs cannot escape the configured checkpoint root.

--- a/memory/src/store.rs
+++ b/memory/src/store.rs
@@ -30,8 +30,10 @@ pub trait SessionStore: Send + Sync {
     ///
     /// Stores with optimistic-concurrency metadata should return the metadata
     /// as persisted on disk so callers can keep their local sequence in sync.
-    /// The default implementation composes [`SessionStore::save`] and
-    /// [`SessionStore::save_state`], then reloads metadata from the store.
+    /// Backends must implement this explicitly if they support atomic
+    /// transcript+state persistence; the default returns
+    /// [`io::ErrorKind::Unsupported`] so callers do not accidentally rely on a
+    /// non-atomic fallback.
     fn save_full(
         &self,
         id: &str,
@@ -39,10 +41,11 @@ pub trait SessionStore: Send + Sync {
         messages: &[AgentMessage],
         state: &serde_json::Value,
     ) -> io::Result<SessionMeta> {
-        self.save(id, meta, messages)?;
-        self.save_state(id, state)?;
-        let (persisted_meta, _) = self.load(id, None)?;
-        Ok(persisted_meta)
+        let _ = (id, meta, messages, state);
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "SessionStore::save_full requires an explicit atomic backend implementation",
+        ))
     }
 
     /// Append messages to an existing session without rewriting the entire file.
@@ -112,4 +115,94 @@ pub trait SessionStore: Send + Sync {
         id: &str,
         options: &LoadOptions,
     ) -> io::Result<(SessionMeta, Vec<SessionEntry>)>;
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use chrono::Utc;
+    use serde_json::json;
+
+    use super::*;
+
+    struct CountingStore {
+        save_calls: Arc<AtomicUsize>,
+        save_state_calls: Arc<AtomicUsize>,
+    }
+
+    impl SessionStore for CountingStore {
+        fn save(
+            &self,
+            _id: &str,
+            _meta: &SessionMeta,
+            _messages: &[AgentMessage],
+        ) -> io::Result<()> {
+            self.save_calls.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        }
+
+        fn append(&self, _id: &str, _messages: &[AgentMessage]) -> io::Result<()> {
+            Ok(())
+        }
+
+        fn load(
+            &self,
+            _id: &str,
+            _registry: Option<&CustomMessageRegistry>,
+        ) -> io::Result<(SessionMeta, Vec<AgentMessage>)> {
+            Ok((sample_meta(), Vec::new()))
+        }
+
+        fn list(&self) -> io::Result<Vec<SessionMeta>> {
+            Ok(Vec::new())
+        }
+
+        fn delete(&self, _id: &str) -> io::Result<()> {
+            Ok(())
+        }
+
+        fn save_state(&self, _id: &str, _state: &serde_json::Value) -> io::Result<()> {
+            self.save_state_calls.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        }
+
+        fn load_with_options(
+            &self,
+            _id: &str,
+            _options: &LoadOptions,
+        ) -> io::Result<(SessionMeta, Vec<SessionEntry>)> {
+            Ok((sample_meta(), Vec::new()))
+        }
+    }
+
+    fn sample_meta() -> SessionMeta {
+        SessionMeta {
+            id: "session-1".to_string(),
+            title: "Session 1".to_string(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            version: 1,
+            sequence: 0,
+        }
+    }
+
+    #[test]
+    fn default_save_full_rejects_non_atomic_fallback_without_writing() {
+        let save_calls = Arc::new(AtomicUsize::new(0));
+        let save_state_calls = Arc::new(AtomicUsize::new(0));
+        let store = CountingStore {
+            save_calls: Arc::clone(&save_calls),
+            save_state_calls: Arc::clone(&save_state_calls),
+        };
+
+        let error = store
+            .save_full("session-1", &sample_meta(), &[], &json!({"draft": true}))
+            .unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::Unsupported);
+        assert_eq!(save_calls.load(Ordering::Relaxed), 0);
+        assert_eq!(save_state_calls.load(Ordering::Relaxed), 0);
+    }
 }


### PR DESCRIPTION
## What changed
- changed `SessionStore::save_full()` so the trait default no longer composes `save()` + `save_state()` + reload
- made the default return `io::ErrorKind::Unsupported` unless a backend provides an explicit atomic implementation
- added a regression proving the default path rejects the non-atomic fallback without writing either transcript or state
- recorded the contract rule in `memory/AGENTS.md`

## Value
Callers can no longer accidentally assume atomic transcript+state persistence from a backend that only supports separate writes. The atomicity contract now matches the memory crate documentation instead of silently violating it.

## Slice completed
- completed the `SessionStore::save_full` contract-tightening slice from #672
- no follow-up remains in this slice; `JsonlSessionStore` already provides the explicit atomic implementation

## Validation output
- `cargo fmt --all --check`
- `cargo clippy -p swink-agent-memory --tests -- -D warnings`
- `cargo test -p swink-agent-memory`

## Pre-existing baseline failures
- workspace-wide `cargo clippy --workspace -- -D warnings` / `cargo test --workspace` were not rerun in this Windows automation runner because `swink-agent-local-llm` still depends on the existing LLVM/libclang environment prerequisite for `llama-cpp-sys-2`; the touched `swink-agent-memory` crate validated cleanly

## IPC contract changes
- none

Closes #672