### PR TITLE
fix: scope tokio features per crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/SuperSwinkAI/Swink-Agent"
 [workspace.dependencies]
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
-tokio = { version = "1", features = ["full"] }
+tokio = "1"
 tokio-util = "0.7"
 tokio-stream = "0.1"
 futures = "0.3"
@@ -87,7 +87,7 @@ otel = ["dep:tracing-opentelemetry", "dep:opentelemetry", "dep:opentelemetry_sdk
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["fs", "io-util", "macros", "process", "rt", "rt-multi-thread", "sync", "time"] }
 tokio-util.workspace = true
 futures.workspace = true
 tokio-stream.workspace = true

--- a/adapters/Cargo.toml
+++ b/adapters/Cargo.toml
@@ -34,7 +34,7 @@ __no_default_features_sentinel = []
 swink-agent = { path = "..", version = "0.8.0", default-features = false }
 swink-agent-auth = { path = "../auth", version = "0.8.0", optional = true }
 reqwest.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["macros"] }
 tokio-util.workspace = true
 futures.workspace = true
 serde.workspace = true

--- a/artifacts/Cargo.toml
+++ b/artifacts/Cargo.toml
@@ -14,7 +14,7 @@ readme = "../README.md"
 swink-agent = { path = "..", version = "0.8.0", default-features = false, features = ["artifact-store"] }
 serde.workspace = true
 serde_json.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["fs", "io-util", "rt", "sync"] }
 bytes.workspace = true
 chrono.workspace = true
 tracing.workspace = true

--- a/auth/Cargo.toml
+++ b/auth/Cargo.toml
@@ -16,7 +16,7 @@ reqwest.workspace = true
 chrono.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["sync"] }
 futures.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/eval/Cargo.toml
+++ b/eval/Cargo.toml
@@ -18,7 +18,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 swink-agent = { path = "..", version = "0.8.0", default-features = false }
 serde.workspace = true
 serde_json.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["macros", "time"] }
 futures.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/local-llm/Cargo.toml
+++ b/local-llm/Cargo.toml
@@ -24,7 +24,7 @@ vulkan = ["llama-cpp-2/vulkan"]
 swink-agent = { path = "..", version = "0.8.0", default-features = false }
 llama-cpp-2 = "0.1"
 hf-hub = { version = "0.5", features = ["tokio"] }
-tokio.workspace = true
+tokio = { workspace = true, features = ["rt", "sync"] }
 tokio-util.workspace = true
 tokio-stream.workspace = true
 futures.workspace = true

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -15,7 +15,7 @@ swink-agent = { path = "..", version = "0.8.0", default-features = false }
 rmcp = { version = "1.3", features = ["client", "client-side-sse", "transport-streamable-http-client", "transport-streamable-http-client-reqwest", "transport-child-process"] }
 reqwest = { workspace = true }
 futures.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["macros", "process", "rt", "sync", "time"] }
 tokio-util.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/memory/Cargo.toml
+++ b/memory/Cargo.toml
@@ -18,7 +18,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 swink-agent = { path = "..", version = "0.8.0", default-features = false }
 serde.workspace = true
 serde_json.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["rt"] }
 dirs.workspace = true
 tracing.workspace = true
 chrono.workspace = true

--- a/patterns/Cargo.toml
+++ b/patterns/Cargo.toml
@@ -17,7 +17,7 @@ testkit = ["swink-agent/testkit"]
 
 [dependencies]
 swink-agent = { path = "..", version = "0.8.0", default-features = false }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt", "sync"] }
 tokio-util = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/plugins/web/Cargo.toml
+++ b/plugins/web/Cargo.toml
@@ -22,7 +22,7 @@ swink-agent = { path = "../..", version = "0.8.0", default-features = false, fea
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["fs", "io-util", "macros", "process", "rt", "sync", "time"] }
 tokio-util.workspace = true
 tracing.workspace = true
 thiserror.workspace = true

--- a/policies/Cargo.toml
+++ b/policies/Cargo.toml
@@ -31,7 +31,7 @@ regex = { workspace = true, optional = true }
 chrono = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
-tokio = { workspace = true, optional = true }
+tokio = { workspace = true, optional = true, features = ["rt"] }
 tracing = { workspace = true }
 unicode-truncate = { version = "2", optional = true }
 

--- a/tests/workspace_tokio_manifest.rs
+++ b/tests/workspace_tokio_manifest.rs
@@ -1,0 +1,82 @@
+use std::fs;
+use std::path::PathBuf;
+
+use toml::Value;
+
+const MANIFESTS: &[&str] = &[
+    "Cargo.toml",
+    "adapters/Cargo.toml",
+    "artifacts/Cargo.toml",
+    "auth/Cargo.toml",
+    "eval/Cargo.toml",
+    "local-llm/Cargo.toml",
+    "mcp/Cargo.toml",
+    "memory/Cargo.toml",
+    "patterns/Cargo.toml",
+    "plugins/web/Cargo.toml",
+    "policies/Cargo.toml",
+    "tui/Cargo.toml",
+    "xtask/Cargo.toml",
+];
+
+fn manifest_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn load_manifest(relative_path: &str) -> Value {
+    let manifest_path = manifest_root().join(relative_path);
+    let raw = fs::read_to_string(&manifest_path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", manifest_path.display()));
+    toml::from_str::<Value>(&raw)
+        .unwrap_or_else(|error| panic!("failed to parse {}: {error}", manifest_path.display()))
+}
+
+fn tokio_features(section: Option<&Value>) -> Vec<String> {
+    section
+        .and_then(Value::as_table)
+        .and_then(|table| table.get("tokio"))
+        .and_then(Value::as_table)
+        .and_then(|tokio| tokio.get("features"))
+        .and_then(Value::as_array)
+        .map(|features| {
+            features
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::to_owned)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+#[test]
+fn workspace_tokio_baseline_avoids_full_profile() {
+    let manifest = load_manifest("Cargo.toml");
+    let tokio_features = manifest
+        .get("workspace")
+        .and_then(Value::as_table)
+        .and_then(|workspace| workspace.get("dependencies"))
+        .and_then(Value::as_table)
+        .and_then(|dependencies| dependencies.get("tokio"))
+        .and_then(Value::as_table)
+        .and_then(|tokio| tokio.get("features"));
+
+    assert!(
+        tokio_features.is_none(),
+        "workspace tokio should stay feature-minimal; crate-specific features belong in member manifests"
+    );
+}
+
+#[test]
+fn production_tokio_dependencies_do_not_use_full_or_test_util() {
+    for manifest_path in MANIFESTS {
+        let manifest = load_manifest(manifest_path);
+        let features = tokio_features(manifest.get("dependencies"));
+
+        assert!(
+            !features
+                .iter()
+                .any(|feature| feature == "full" || feature == "test-util"),
+            "{manifest_path} should not enable broad tokio production features: {features:?}"
+        );
+    }
+}

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -26,7 +26,7 @@ swink-agent-memory = { path = "../memory", version = "0.8.0" }
 swink-agent-local-llm = { path = "../local-llm", version = "0.8.0", optional = true }
 ratatui = "0.30"
 crossterm = { version = "0.29", features = ["event-stream"] }
-tokio.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }
 syntect = { version = "5", default-features = false, features = ["default-syntaxes", "default-themes", "parsing", "html", "regex-onig"] }
 futures.workspace = true
 arboard = "3"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -12,7 +12,7 @@ clap = { version = "4", features = ["derive"] }
 futures.workspace = true
 reqwest = { workspace = true, features = ["json", "query"] }
 serde_json.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [lints.rust]
 unsafe_code = "forbid"


### PR DESCRIPTION
## What changed
- removed the workspace-wide `tokio` `full` baseline from the root manifest
- added explicit Tokio feature sets to each production crate that depends on `tokio`
- added a manifest regression test that prevents production manifests from drifting back to `full`/`test-util`

## Value
This reduces unnecessary Tokio feature activation for library consumers while preserving the existing dev/test experience.

## Slice completed
Completed the workspace Tokio feature-scoping manifest slice for the production crates listed in issue #673.

## Remaining work
None for this issue's stated scope.

## Validation
- `cargo check --workspace`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace` *(fails on a pre-existing TUI baseline: `editor::tests::open_editor_with_true_command_returns_none` at `tui/src/editor.rs:96`)*
- `cargo test --test workspace_tokio_manifest`
- `cargo fmt --all --check`
- `git diff --check`

## Baseline failures
- `cargo test --workspace` still fails in `swink-agent-tui` at `editor::tests::open_editor_with_true_command_returns_none` (`tui/src/editor.rs:96`); this predates this manifest-only slice.

Closes #673
