### PR TITLE
[codex] Preserve dynamic prompt during overflow retry

### DIFF
--- a/src/loop_/AGENTS.md
+++ b/src/loop_/AGENTS.md
@@ -15,6 +15,7 @@
 - Cancellation has to be observed in preprocessing and before each execution group/tool dispatch, not just while collecting spawned handles. Otherwise approval waits can hang forever and later tools can still launch after the batch is already cancelled.
 - Overflow recovery cancellation must reuse a started-turn cancellation path. Calling the pre-turn helper after `TurnStart` has already been emitted duplicates `TurnStart` and breaks lifecycle ordering for the interrupted turn.
 - `handle_stream_error()` must not emit `MessageEnd` for context overflow. Overflow recovery owns the terminal message lifecycle, and unrecoverable overflow must still surface exactly one `MessageEnd`.
+- Dynamic system prompts are computed once per turn and must be carried into overflow retries. Recomputing during recovery can silently change prompt contracts within the same turn.
 - `LoopState.turn_index` must advance after every completed turn, not just tool-loop continuation. Text-only or other `BreakInner` turns still finish a turn before the outer loop polls follow-up messages.
 - First-turn `PreTurn` policies must receive the initial prompt batch in `PolicyContext::new_messages`; only `agent_loop_continue()` resumes with an empty initial batch.
 - Text-only turns cannot break the inner loop while `pending_messages` is non-empty. Post-turn or post-loop injections queued for the next turn must continue loop processing before follow-up polling or `AgentEnd`.

--- a/src/loop_/overflow.rs
+++ b/src/loop_/overflow.rs
@@ -15,8 +15,8 @@ use crate::types::{AgentMessage, LlmMessage, StopReason};
 
 use super::stream::stream_with_retry;
 use super::turn::{
-    build_snapshot, emit_turn_end_and_agent_end, handle_started_turn_cancellation,
-    run_context_transformers,
+    build_llm_messages, build_snapshot, emit_turn_end_and_agent_end,
+    handle_started_turn_cancellation, run_context_transformers,
 };
 use super::{
     AgentEvent, AgentLoopConfig, LoopState, StreamResult, TurnEndReason, TurnOutcome,
@@ -43,6 +43,7 @@ pub(super) async fn attempt_overflow_recovery(
     state: &mut LoopState,
     system_prompt: &str,
     agent_context: &crate::types::AgentContext,
+    dynamic_prompt_injected: Option<&LlmMessage>,
     api_key: Option<String>,
     cancellation_token: &CancellationToken,
     tx: &mpsc::Sender<AgentEvent>,
@@ -82,11 +83,7 @@ pub(super) async fn attempt_overflow_recovery(
     }
 
     // Re-run convert-to-LLM pipeline with compacted context.
-    let llm_messages: Vec<LlmMessage> = state
-        .context_messages
-        .iter()
-        .filter_map(|m| (config.convert_to_llm)(m))
-        .collect();
+    let llm_messages = build_llm_messages(config, &state.context_messages, dynamic_prompt_injected);
 
     // Retry the stream call with compacted context.
     let retry_result = stream_with_retry(

--- a/src/loop_/turn.rs
+++ b/src/loop_/turn.rs
@@ -182,33 +182,14 @@ pub async fn run_single_turn(
     }
 
     // ii-d. Inject dynamic system prompt as a user-role message (non-cacheable)
-    let dynamic_prompt_injected = config
-        .dynamic_system_prompt
-        .as_ref()
-        .and_then(|dynamic_fn| {
-            let dynamic_text = dynamic_fn();
-            if dynamic_text.is_empty() {
-                None
-            } else {
-                Some(LlmMessage::User(crate::types::UserMessage {
-                    content: vec![ContentBlock::Text { text: dynamic_text }],
-                    timestamp: crate::util::now_timestamp(),
-                    cache_hint: None,
-                }))
-            }
-        });
+    let dynamic_prompt_injected = build_dynamic_system_prompt_message(config);
 
     // iii. Apply convert_to_llm to filter messages for the provider
-    let mut llm_messages: Vec<LlmMessage> = state
-        .context_messages
-        .iter()
-        .filter_map(|m| (config.convert_to_llm)(m))
-        .collect();
-
-    // Insert dynamic prompt as the first message (after system prompt, before history)
-    if let Some(dynamic_msg) = dynamic_prompt_injected {
-        llm_messages.insert(0, dynamic_msg);
-    }
+    let llm_messages = build_llm_messages(
+        config,
+        &state.context_messages,
+        dynamic_prompt_injected.as_ref(),
+    );
 
     // iv. Resolve a per-call API key if configured
     let api_key = if let Some(ref get_key) = config.get_api_key {
@@ -262,6 +243,7 @@ pub async fn run_single_turn(
             state,
             system_prompt,
             &agent_context,
+            dynamic_prompt_injected.as_ref(),
             api_key,
             cancellation_token,
             tx,
@@ -339,6 +321,43 @@ pub async fn run_single_turn(
         tx,
     )
     .await
+}
+
+pub(super) fn build_dynamic_system_prompt_message(
+    config: &Arc<AgentLoopConfig>,
+) -> Option<LlmMessage> {
+    config
+        .dynamic_system_prompt
+        .as_ref()
+        .and_then(|dynamic_fn| {
+            let dynamic_text = dynamic_fn();
+            if dynamic_text.is_empty() {
+                None
+            } else {
+                Some(LlmMessage::User(crate::types::UserMessage {
+                    content: vec![ContentBlock::Text { text: dynamic_text }],
+                    timestamp: now_timestamp(),
+                    cache_hint: None,
+                }))
+            }
+        })
+}
+
+pub(super) fn build_llm_messages(
+    config: &AgentLoopConfig,
+    context_messages: &[AgentMessage],
+    dynamic_prompt_injected: Option<&LlmMessage>,
+) -> Vec<LlmMessage> {
+    let mut llm_messages: Vec<LlmMessage> = context_messages
+        .iter()
+        .filter_map(|message| (config.convert_to_llm)(message))
+        .collect();
+
+    if let Some(dynamic_prompt) = dynamic_prompt_injected {
+        llm_messages.insert(0, dynamic_prompt.clone());
+    }
+
+    llm_messages
 }
 
 // ─── Context transformer runner ─────────────────────────────────────────

--- a/tests/loop_overflow.rs
+++ b/tests/loop_overflow.rs
@@ -12,16 +12,16 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use common::{
-    MockContextCapturingStreamFn, MockStreamFn, MockTool, default_model, text_only_events,
-    tool_call_events, user_msg,
+    MockContextCapturingStreamFn, MockStreamFn, MockTool, default_exhausted_fallback,
+    default_model, next_response, text_only_events, tool_call_events, user_msg,
 };
 use futures::Stream;
 use futures::stream::StreamExt;
 use tokio_util::sync::CancellationToken;
 
 use swink_agent::{
-    AgentEvent, AgentLoopConfig, AgentMessage, AssistantMessageEvent, ContentBlock,
-    DefaultRetryStrategy, LlmMessage, StreamFn, StreamOptions, UserMessage, agent_loop,
+    AgentContext, AgentEvent, AgentLoopConfig, AgentMessage, AssistantMessageEvent, ContentBlock,
+    DefaultRetryStrategy, LlmMessage, ModelSpec, StreamFn, StreamOptions, UserMessage, agent_loop,
 };
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
@@ -101,6 +101,54 @@ fn count_events(events: &[AgentEvent], name: &str) -> usize {
         .iter()
         .filter(|e| common::event_variant_name(e) == name)
         .count()
+}
+
+struct MockMessageCapturingStreamFn {
+    responses: Mutex<Vec<Vec<AssistantMessageEvent>>>,
+    captured_first_user_texts: Mutex<Vec<Option<String>>>,
+}
+
+impl MockMessageCapturingStreamFn {
+    const fn new(responses: Vec<Vec<AssistantMessageEvent>>) -> Self {
+        Self {
+            responses: Mutex::new(responses),
+            captured_first_user_texts: Mutex::new(Vec::new()),
+        }
+    }
+}
+
+impl StreamFn for MockMessageCapturingStreamFn {
+    fn stream<'a>(
+        &'a self,
+        _model: &'a ModelSpec,
+        context: &'a AgentContext,
+        _options: &'a StreamOptions,
+        _cancellation_token: CancellationToken,
+    ) -> Pin<Box<dyn Stream<Item = AssistantMessageEvent> + Send + 'a>> {
+        self.captured_first_user_texts
+            .lock()
+            .unwrap()
+            .push(context.messages.first().and_then(agent_user_text));
+        let events = next_response(&self.responses, default_exhausted_fallback());
+        Box::pin(futures::stream::iter(events))
+    }
+}
+
+fn user_text(message: &LlmMessage) -> Option<&str> {
+    match message {
+        LlmMessage::User(user) => match user.content.first() {
+            Some(ContentBlock::Text { text }) => Some(text.as_str()),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn agent_user_text(message: &AgentMessage) -> Option<String> {
+    match message {
+        AgentMessage::Llm(llm_message) => user_text(llm_message).map(ToString::to_string),
+        AgentMessage::Custom(_) => None,
+    }
 }
 
 // ─── Mock async context transformer ─────────────────────────────────────────
@@ -211,6 +259,64 @@ async fn emergency_overflow_recovery() {
         "retry should see fewer messages: first={}, second={}",
         counts[0],
         counts[1]
+    );
+}
+
+#[tokio::test]
+async fn overflow_recovery_preserves_dynamic_system_prompt() {
+    let capturing_fn = Arc::new(MockMessageCapturingStreamFn::new(vec![
+        overflow_error_events(),
+        text_only_events("recovered after compaction"),
+    ]));
+    let stream_fn: Arc<dyn StreamFn> = Arc::clone(&capturing_fn) as Arc<dyn StreamFn>;
+
+    let dynamic_prompt_calls = Arc::new(Mutex::new(0usize));
+    let dynamic_prompt_calls_clone = Arc::clone(&dynamic_prompt_calls);
+
+    let mut config = default_config(stream_fn);
+    config.dynamic_system_prompt = Some(Arc::new(move || {
+        let mut calls = dynamic_prompt_calls_clone.lock().unwrap();
+        *calls += 1;
+        format!("dynamic prompt invocation {}", *calls)
+    }));
+    config.transform_context = Some(Arc::new(
+        |messages: &mut Vec<AgentMessage>, overflow: bool| {
+            if overflow && messages.len() > 1 {
+                messages.truncate(1);
+            }
+        },
+    ));
+
+    let events = collect_events(agent_loop(
+        vec![user_msg("msg1"), user_msg("msg2"), user_msg("msg3")],
+        "system".to_string(),
+        config,
+        CancellationToken::new(),
+    ))
+    .await;
+
+    assert!(has_event(&events, "AgentEnd"), "loop should complete");
+    assert_eq!(
+        *dynamic_prompt_calls.lock().unwrap(),
+        1,
+        "dynamic system prompt should be computed once per turn"
+    );
+
+    let captured_first_user_texts = capturing_fn
+        .captured_first_user_texts
+        .lock()
+        .unwrap()
+        .clone();
+    assert_eq!(captured_first_user_texts.len(), 2, "exactly 2 stream calls");
+    assert_eq!(
+        captured_first_user_texts[0].as_deref(),
+        Some("dynamic prompt invocation 1"),
+        "initial call should start with the injected dynamic prompt"
+    );
+    assert_eq!(
+        captured_first_user_texts[1].as_deref(),
+        Some("dynamic prompt invocation 1"),
+        "overflow retry should preserve the same injected dynamic prompt"
     );
 }
 


### PR DESCRIPTION
## What changed
- preserve the per-turn `dynamic_system_prompt` message when emergency overflow recovery rebuilds retry LLM messages
- factor dynamic prompt / LLM message assembly into shared helpers so the initial call and overflow retry use the same message construction path
- add a regression test proving the overflow retry keeps the same injected prompt and does not recompute the dynamic prompt closure mid-turn
- record the loop-specific lesson in `src/loop_/AGENTS.md`

## Why / value
Overflow recovery previously rebuilt retry messages from `state.context_messages` only, which dropped the injected dynamic prompt and could change model steering within the same turn. This keeps retry behavior aligned with the original turn contract.

## Slice completed
Completed the `#692` slice end to end. No additional work is expected for this issue if review agrees with the fix.

## Validation
- `cargo test -p swink-agent --test loop_overflow --features testkit overflow_recovery_preserves_dynamic_system_prompt -- --nocapture`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace --features testkit`

## Pre-existing baseline failures
- `cargo test --workspace --features testkit` still fails in `swink-agent-tui` on Windows at `editor::tests::open_editor_with_true_command_returns_none`
- This is a pre-existing baseline failure already tracked by `#698`; it is not introduced by this PR

Closes #692