### PR TITLE
[codex] Fix MCP reconnect and shutdown lifecycle

### DIFF
--- a/mcp/AGENTS.md
+++ b/mcp/AGENTS.md
@@ -16,6 +16,7 @@
 ## Lessons Learned
 
 - `McpManager::shutdown()` must operate on shared connection-owned state, not `Arc::try_unwrap()`: exported `McpTool` handles keep `Arc<McpConnection>` clones alive, so deterministic disconnect has to clear the session/monitor even when callers still retain tool `Arc`s.
+- Explicit `McpServerDisconnected` events for intentional teardown come from `McpConnection::shutdown()`, not the monitor task. Tests that shut a connection down with an event channel must drain that lifecycle event before asserting later tool-call events.
 - Tool discovery happens at `connect_all()` time. Tools added to a server after connection are not auto-refreshed; call `reconnect()` to rediscover.
 - SSE recovery is delegated to rmcp's streamable HTTP transport: transient stream drops and stale-session 404s are retried/re-initialized inside rmcp, so `McpConnection` should only flip to `Disconnected` after the underlying service fully exits.
 - rmcp stores SSE `auth_header` as a static string inside the transport config and reuses it for reconnect/re-init paths. Resolver-backed SSE auth that must survive token rotation therefore needs a custom `StreamableHttpClient` wrapper that resolves credentials per HTTP request instead of only at initial connect.

--- a/mcp/src/connection.rs
+++ b/mcp/src/connection.rs
@@ -539,18 +539,29 @@ impl McpConnection {
     ///
     /// Aborts the monitor task (which drops the underlying `RunningService`).
     /// For stdio servers, rmcp's `ChildWithCleanup` terminates the subprocess
-    /// on drop. For SSE servers, the HTTP connection is closed.
+    /// on drop. For SSE servers, the HTTP connection is closed. Explicit
+    /// shutdown also emits `McpServerDisconnected` because the monitor only
+    /// reports transport-driven exits.
     pub async fn shutdown(&self) {
-        let monitor = {
+        let (monitor, should_emit_disconnect) = {
             let mut state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+            let was_live = state.status == McpConnectionStatus::Connected
+                || state.peer.is_some()
+                || state.monitor.is_some();
             state.status = McpConnectionStatus::Disconnected;
             state.peer = None;
-            state.monitor.take()
+            (state.monitor.take(), was_live)
         };
 
         if let Some(monitor) = monitor {
             monitor.abort();
             let _ = monitor.await;
+        }
+
+        if should_emit_disconnect {
+            emit_event(self.event_tx.as_ref(), || {
+                crate::event::server_disconnected(&self.config.name, "shutdown")
+            });
         }
     }
 }

--- a/mcp/src/manager.rs
+++ b/mcp/src/manager.rs
@@ -120,9 +120,14 @@ impl McpManager {
     /// Connect to all configured servers, discover tools.
     ///
     /// Servers that fail to connect are logged and skipped; the remaining
-    /// servers' tools are still available. Returns an error only if a tool
-    /// name collision is detected across servers.
+    /// servers' tools are still available. Repeated calls replace the prior
+    /// connection set instead of appending to it. Returns an error only if a
+    /// tool name collision is detected across servers.
     pub async fn connect_all(&mut self) -> Result<(), McpError> {
+        if !self.connections.is_empty() || !self.tools.is_empty() {
+            self.shutdown().await;
+        }
+
         let mut all_tools: Vec<(String, String, Arc<dyn AgentTool>)> = Vec::new();
 
         for config in self.configs.clone() {

--- a/mcp/tests/lifecycle_test.rs
+++ b/mcp/tests/lifecycle_test.rs
@@ -110,6 +110,146 @@ async fn shutdown_disconnects_cloned_tool_handles() {
     );
 }
 
+/// Explicit shutdown should emit `McpServerDisconnected` with a shutdown reason.
+#[tokio::test]
+async fn explicit_shutdown_emits_disconnect_event() {
+    let (event_tx, mut event_rx) = unbounded_channel::<AgentEvent>();
+
+    let service =
+        common::spawn_mock_server_with_client(&common::MockServerConfig::new(vec![])).await;
+
+    let config = McpServerConfig {
+        name: "explicit-shutdown-server".into(),
+        transport: McpTransport::Stdio {
+            command: "mock".into(),
+            args: vec![],
+            env: HashMap::default(),
+        },
+        tool_prefix: None,
+        tool_filter: None,
+        requires_approval: false,
+    };
+
+    let conn = McpConnection::from_service(config, service, Some(event_tx))
+        .await
+        .expect("connection should succeed");
+
+    let _connect = event_rx.try_recv().expect("connect event");
+    let _discovery = event_rx.try_recv().expect("discovery event");
+
+    conn.shutdown().await;
+
+    let event = event_rx.try_recv().expect("disconnect event");
+    match event {
+        AgentEvent::McpServerDisconnected {
+            server_name,
+            reason,
+        } => {
+            assert_eq!(server_name, "explicit-shutdown-server");
+            assert_eq!(reason, "shutdown");
+        }
+        other => panic!("expected McpServerDisconnected, got: {other:?}"),
+    }
+}
+
+/// Repeated `connect_all()` calls should replace prior live connections rather
+/// than leaving the previous ones usable through retained tool handles.
+#[tokio::test]
+async fn repeated_connect_all_replaces_prior_live_connections() {
+    let session_manager = Arc::new(LocalSessionManager::default());
+    let shutdown = tokio_util::sync::CancellationToken::new();
+
+    let mock_cfg = common::MockServerConfig::new(vec![]);
+    let server = common::MockMcpServer::from_config(&mock_cfg);
+    let service = StreamableHttpService::new(
+        move || Ok(server.clone()),
+        Arc::clone(&session_manager),
+        StreamableHttpServerConfig::default()
+            .with_sse_keep_alive(None)
+            .with_cancellation_token(shutdown.child_token()),
+    );
+
+    let router = axum::Router::new().nest_service("/mcp", service);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("listener should bind");
+    let addr = listener
+        .local_addr()
+        .expect("listener should expose an addr");
+    let server_task = tokio::spawn({
+        let shutdown = shutdown.clone();
+        async move {
+            let _ = axum::serve(listener, router)
+                .with_graceful_shutdown(async move { shutdown.cancelled_owned().await })
+                .await;
+        }
+    });
+
+    let config = McpServerConfig {
+        name: "connect-all-reset-server".into(),
+        transport: McpTransport::Sse {
+            url: format!("http://{addr}/mcp"),
+            bearer_token: None,
+            bearer_auth: None,
+            headers: HashMap::new(),
+        },
+        tool_prefix: None,
+        tool_filter: None,
+        requires_approval: false,
+    };
+
+    let mut manager = McpManager::new(vec![config]);
+    manager
+        .connect_all()
+        .await
+        .expect("initial connect_all should succeed");
+
+    let stale_tool = manager
+        .tools()
+        .into_iter()
+        .next()
+        .expect("manager should expose a tool after first connect");
+
+    manager
+        .connect_all()
+        .await
+        .expect("repeated connect_all should succeed");
+
+    assert_eq!(
+        manager.tools().len(),
+        1,
+        "repeated connect_all should not duplicate discovered tools"
+    );
+
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let state = Arc::new(std::sync::RwLock::new(SessionState::default()));
+    let result = stale_tool
+        .execute(
+            "call-after-reconnect",
+            serde_json::json!({"text": "hello"}),
+            cancel,
+            None,
+            state,
+            None,
+        )
+        .await;
+
+    assert!(
+        result.is_error,
+        "retained tool handles from the previous connect_all should be disconnected"
+    );
+
+    let text = ContentBlock::extract_text(&result.content);
+    assert!(
+        text.contains("disconnected") || text.contains("active session"),
+        "stale tool handle should fail with a disconnect-style error, got: {text}"
+    );
+
+    manager.shutdown().await;
+    shutdown.cancel();
+    let _ = server_task.await;
+}
+
 /// T042: Background monitor detects transport closure, updates status to
 /// Disconnected, and emits McpServerDisconnected on the event channel.
 ///
@@ -552,6 +692,11 @@ async fn tool_call_completed_event_reports_error_on_failure() {
 
     // Force the call to fail by shutting down the connection before invoking.
     conn.shutdown().await;
+    let shutdown_event = event_rx.try_recv().expect("shutdown disconnect event");
+    assert!(
+        matches!(shutdown_event, AgentEvent::McpServerDisconnected { .. }),
+        "shutdown should emit McpServerDisconnected, got: {shutdown_event:?}"
+    );
 
     let conn = Arc::new(conn);
     let tool = McpTool::new(


### PR DESCRIPTION
## What changed
- made `McpConnection::shutdown()` emit `McpServerDisconnected` with a `shutdown` reason for explicit teardown paths
- made `McpManager::connect_all()` reset existing live connections before reconnecting so repeated calls replace the active connection set instead of accumulating stale live handles
- added MCP lifecycle regressions covering explicit shutdown events and repeated `connect_all()` behavior, and updated the MCP crate notes with the new lifecycle expectation

## Why this change matters
This closes the MCP lifecycle contract gaps called out in #693: consumers now receive the disconnect lifecycle event for intentional shutdown, and reconnect flows no longer leave prior live connections reachable through retained tool handles.

## Slice completed
This PR completes the lifecycle correctness slice for explicit shutdown and reconnect behavior in the MCP manager/connection layer.

## What remains
No follow-up is required for issue #693 from this slice.

## Validation
- `cargo clippy -p swink-agent-mcp -- -D warnings`
- `cargo test -p swink-agent-mcp`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace` *(fails on a pre-existing Windows TUI test: `editor::tests::open_editor_with_true_command_returns_none`, matching open issue #698)*

## Baseline failures
- `cargo test --workspace` currently fails in `swink-agent-tui` on Windows at `tui/src/editor.rs:96` because `editor::tests::open_editor_with_true_command_returns_none` assumes the Unix `true` executable exists. This is unrelated to the MCP lifecycle changes here and matches issue #698.

Closes #693