### PR TITLE
[codex] Sanitize MCP tool registration names

### DIFF
--- a/mcp/AGENTS.md
+++ b/mcp/AGENTS.md
@@ -9,7 +9,7 @@
 - `McpManager` — owns all server connections; call `connect_all()` then `tools()` to get `Vec<Arc<McpTool>>`.
 - `McpServerConfig` — name, transport, optional `tool_prefix`, optional `ToolFilter`, `requires_approval` flag.
 - `McpTransport` — `Stdio { command, args, env }`, SSE, or streamable HTTP (via `rmcp` features).
-- `McpTool` — wraps a discovered MCP tool as `AgentTool`. Prefixed as `"{prefix}.{tool_name}"` when `tool_prefix` is set.
+- `McpTool` — wraps a discovered MCP tool as `AgentTool`. Registered names use provider-safe `"{prefix}_{tool_name}"` composition when `tool_prefix` is set; dispatch still uses the original server-advertised tool name.
 - `McpConnection` tracks per-server state and exposes `status()` for health checks.
 - Uses `rmcp` SDK (v1.3) for the wire protocol.
 
@@ -20,6 +20,7 @@
 - Tool discovery happens at `connect_all()` time. Tools added to a server after connection are not auto-refreshed; call `reconnect()` to rediscover.
 - SSE recovery is delegated to rmcp's streamable HTTP transport: transient stream drops and stale-session 404s are retried/re-initialized inside rmcp, so `McpConnection` should only flip to `Disconnected` after the underlying service fully exits.
 - rmcp stores SSE `auth_header` as a static string inside the transport config and reuses it for reconnect/re-init paths. Resolver-backed SSE auth that must survive token rotation therefore needs a custom `StreamableHttpClient` wrapper that resolves credentials per HTTP request instead of only at initial connect.
+- MCP tool registration names must go through the same provider-safe sanitizer/length cap as plugin tools. `McpTool` keeps the raw `original_name` for outbound MCP calls, while `McpManager` collision detection runs on the sanitized registration name exposed to providers.
 
 ## Build & Test
 

--- a/mcp/src/tool.rs
+++ b/mcp/src/tool.rs
@@ -10,6 +10,7 @@ use tokio_util::sync::CancellationToken;
 
 use swink_agent::ResolvedCredential;
 use swink_agent::SessionState;
+use swink_agent::compose_provider_safe_tool_name;
 use swink_agent::{AgentTool, AgentToolResult, ToolFuture, ToolMetadata};
 
 use crate::connection::McpConnection;
@@ -39,7 +40,9 @@ pub struct McpTool {
 impl McpTool {
     /// Create a new MCP tool wrapper.
     ///
-    /// If `prefix` is provided, the tool name becomes `{prefix}_{original_name}`.
+    /// If `prefix` is provided, the tool name becomes a provider-safe
+    /// `{prefix}_{original_name}`. Otherwise the original name is sanitized and
+    /// bounded without adding a namespace.
     pub fn new(
         tool: &rmcp::model::Tool,
         prefix: Option<&str>,
@@ -48,7 +51,7 @@ impl McpTool {
         connection: Arc<McpConnection>,
     ) -> Self {
         let (original_name, description, input_schema) = convert::tool_definition(tool);
-        let name = prefix.map_or_else(|| original_name.clone(), |p| format!("{p}_{original_name}"));
+        let name = compose_provider_safe_tool_name(prefix, &original_name);
 
         Self {
             name,

--- a/mcp/tests/manager_test.rs
+++ b/mcp/tests/manager_test.rs
@@ -2,6 +2,8 @@
 
 mod common;
 
+use rmcp::model::Tool;
+use serde_json::json;
 use swink_agent_mcp::{McpManager, McpServerConfig, McpTransport};
 
 /// T019: Connect to two mock servers with prefixes, verify tools are prefixed
@@ -106,4 +108,46 @@ async fn same_tool_name_without_prefix_causes_collision() {
         err_msg.contains("server-a") || err_msg.contains("server-b"),
         "error should mention at least one server name, got: {err_msg}"
     );
+}
+
+#[test]
+fn sanitized_tool_name_collision_is_detected() {
+    let mut conn_a = swink_agent_mcp::McpConnection::disconnected(mock_config("server-a"));
+    conn_a.discovered_tools = vec![mock_tool("read.file")];
+
+    let mut conn_b = swink_agent_mcp::McpConnection::disconnected(mock_config("server-b"));
+    conn_b.discovered_tools = vec![mock_tool("read-file")];
+
+    let err = McpManager::from_connections(vec![conn_a, conn_b]).expect_err("collision expected");
+    let err_msg = err.to_string();
+    assert!(
+        err_msg.contains("read_file"),
+        "sanitized colliding name should be reported, got: {err_msg}"
+    );
+}
+
+fn mock_config(server_name: &str) -> McpServerConfig {
+    McpServerConfig {
+        name: server_name.to_string(),
+        transport: McpTransport::Stdio {
+            command: "mock".into(),
+            args: vec![],
+            env: Default::default(),
+        },
+        tool_prefix: None,
+        tool_filter: None,
+        requires_approval: false,
+    }
+}
+
+fn mock_tool(name: &str) -> Tool {
+    let schema = json!({
+        "type": "object",
+        "properties": {},
+    });
+    Tool::new(
+        name.to_owned(),
+        format!("Mock tool: {name}"),
+        schema.as_object().expect("object schema").clone(),
+    )
 }

--- a/mcp/tests/tool_test.rs
+++ b/mcp/tests/tool_test.rs
@@ -5,7 +5,10 @@ mod common;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use rmcp::model::Tool;
+use serde_json::json;
 use swink_agent::AgentTool;
+use swink_agent::{MAX_TOOL_NAME_LEN, TOOL_NAME_HASH_HEX_LEN};
 use swink_agent_mcp::McpTool;
 use swink_agent_mcp::convert;
 
@@ -65,6 +68,43 @@ async fn mcp_tool_applies_prefix() {
     assert_eq!(mcp_tool.name(), "fs_echo");
     assert!(mcp_tool.requires_approval());
     assert_eq!(mcp_tool.original_name(), "echo");
+}
+
+#[tokio::test]
+async fn mcp_tool_sanitizes_unsafe_name_without_prefix() {
+    let mock_connection = create_mock_connection();
+    let tool = mock_tool("read.file");
+
+    let mcp_tool = McpTool::new(&tool, None, "test-server", false, mock_connection);
+
+    assert_eq!(mcp_tool.name(), "read_file");
+    assert_eq!(mcp_tool.original_name(), "read.file");
+}
+
+#[tokio::test]
+async fn mcp_tool_truncates_long_prefixed_name_with_hash_suffix() {
+    let mock_connection = create_mock_connection();
+    let tool = mock_tool(&"b".repeat(80));
+
+    let mcp_tool = McpTool::new(
+        &tool,
+        Some(&"a".repeat(40)),
+        "test-server",
+        false,
+        mock_connection,
+    );
+
+    assert_eq!(mcp_tool.name().len(), MAX_TOOL_NAME_LEN);
+    assert_eq!(
+        mcp_tool
+            .name()
+            .rsplit_once('_')
+            .expect("hash suffix")
+            .1
+            .len(),
+        TOOL_NAME_HASH_HEX_LEN
+    );
+    assert_eq!(mcp_tool.original_name(), "b".repeat(80));
 }
 
 /// T012: Execute `McpTool`, verify call is forwarded to MCP server and result
@@ -134,4 +174,16 @@ fn create_mock_connection() -> Arc<swink_agent_mcp::McpConnection> {
     };
 
     Arc::new(swink_agent_mcp::McpConnection::disconnected(config))
+}
+
+fn mock_tool(name: &str) -> Tool {
+    let schema = json!({
+        "type": "object",
+        "properties": {},
+    });
+    Tool::new(
+        name.to_owned(),
+        format!("Mock tool: {name}"),
+        schema.as_object().expect("object schema").clone(),
+    )
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,7 @@ pub(crate) mod tool;
 mod tool_execution_policy;
 pub(crate) mod tool_filter;
 mod tool_middleware;
+mod tool_name;
 pub(crate) mod tools;
 pub(crate) mod transfer;
 pub(crate) mod types;
@@ -153,6 +154,7 @@ pub use tool_execution_policy::{
 };
 pub use tool_filter::{ToolFilter, ToolPattern};
 pub use tool_middleware::ToolMiddleware;
+pub use tool_name::{MAX_TOOL_NAME_LEN, TOOL_NAME_HASH_HEX_LEN, compose_provider_safe_tool_name};
 #[cfg(feature = "builtin-tools")]
 pub use tools::{BashTool, EditFileTool, ReadFileTool, WriteFileTool, builtin_tools};
 #[cfg(feature = "artifact-tools")]

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -8,7 +8,7 @@
 //! [`PluginRegistry`] manages a collection of plugins with deduplication and priority
 //! ordering. [`NamespacedTool`] wraps a plugin-contributed tool, prefixing the plugin
 //! name so the composed identifier is unique and safe for every provider's tool-name
-//! grammar (see `sanitize_tool_name_component`).
+//! grammar (see `compose_provider_safe_tool_name`).
 
 use std::sync::Arc;
 
@@ -19,6 +19,9 @@ use tracing::warn;
 use crate::loop_::AgentEvent;
 use crate::policy::{PostLoopPolicy, PostTurnPolicy, PreDispatchPolicy, PreTurnPolicy};
 use crate::tool::{AgentTool, AgentToolResult, ToolFuture, ToolMetadata};
+use crate::tool_name::compose_provider_safe_tool_name;
+#[cfg(test)]
+use crate::tool_name::{MAX_TOOL_NAME_LEN, TOOL_NAME_HASH_HEX_LEN};
 
 // ─── Plugin Trait ──────────────────────────────────────────────────────────
 
@@ -152,42 +155,6 @@ impl Default for PluginRegistry {
 
 // ─── Tool name sanitization ────────────────────────────────────────────────
 
-/// Maximum length for a composed tool name (the tightest cap across providers:
-/// `OpenAI`, Bedrock, and Gemini all cap at 64; Anthropic allows 128).
-const MAX_TOOL_NAME_LEN: usize = 64;
-/// Hex characters preserved from the stable hash when truncation is required.
-const TOOL_NAME_HASH_HEX_LEN: usize = 16;
-
-/// Sanitize a single component (plugin name or inner tool name) to the common
-/// subset of characters accepted by every provider's tool-name grammar.
-///
-/// The strictest grammar is Bedrock's `^[a-zA-Z][a-zA-Z0-9_]*` (max 64). This
-/// is also a subset of what Anthropic (`^[a-zA-Z0-9_-]{1,128}$`), OpenAI-style
-/// providers (same pattern, cap 64), and Gemini accept, so names produced here
-/// round-trip safely across providers.
-///
-/// Rules:
-/// - Every character outside `[a-zA-Z0-9_]` is replaced with `_`.
-/// - The result is not truncated here; truncation happens on the composed name
-///   in [`NamespacedTool::new`] so both components survive when possible.
-/// - An empty input becomes `"_"` — callers should still prepend a letter
-///   prefix if the composed result needs to start with a letter.
-fn sanitize_tool_name_component(input: &str) -> String {
-    if input.is_empty() {
-        return "_".to_owned();
-    }
-    input
-        .chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || c == '_' {
-                c
-            } else {
-                '_'
-            }
-        })
-        .collect()
-}
-
 /// Compose a plugin-namespaced tool name that is safe across every provider.
 ///
 /// Joins `plugin_name` and `tool_name` with `_`, sanitizes each half, prepends
@@ -197,30 +164,7 @@ fn sanitize_tool_name_component(input: &str) -> String {
 /// hash suffix is appended so long names do not silently collapse onto the same
 /// dispatch key.
 fn compose_namespaced_name(plugin_name: &str, tool_name: &str) -> String {
-    let plugin = sanitize_tool_name_component(plugin_name);
-    let tool = sanitize_tool_name_component(tool_name);
-    let joined = format!("{plugin}_{tool}");
-    let with_leading_letter = match joined.chars().next() {
-        Some(c) if c.is_ascii_alphabetic() => joined,
-        _ => format!("t_{joined}"),
-    };
-    if with_leading_letter.len() <= MAX_TOOL_NAME_LEN {
-        with_leading_letter
-    } else {
-        let hash_suffix = stable_name_hash_hex(&with_leading_letter);
-        let prefix_len = MAX_TOOL_NAME_LEN - TOOL_NAME_HASH_HEX_LEN - 1;
-        let prefix: String = with_leading_letter.chars().take(prefix_len).collect();
-        format!("{prefix}_{hash_suffix}")
-    }
-}
-
-fn stable_name_hash_hex(input: &str) -> String {
-    let mut hash = 0xcbf2_9ce4_8422_2325_u64;
-    for byte in input.bytes() {
-        hash ^= u64::from(byte);
-        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
-    }
-    format!("{hash:0TOOL_NAME_HASH_HEX_LEN$x}")
+    compose_provider_safe_tool_name(Some(plugin_name), tool_name)
 }
 
 // ─── NamespacedTool ────────────────────────────────────────────────────────
@@ -231,7 +175,7 @@ fn stable_name_hash_hex(input: &str) -> String {
 /// the same name. The composed name format is `"{plugin_name}_{tool_name}"`,
 /// with each component sanitized so the result matches the strictest tool-name
 /// grammar across supported providers (Anthropic, `OpenAI`, Bedrock, Mistral,
-/// Gemini, Ollama, Azure). See `sanitize_tool_name_component`.
+/// Gemini, Ollama, Azure). See `compose_provider_safe_tool_name`.
 ///
 /// The original (unsanitized) plugin name is preserved in
 /// [`ToolMetadata::namespace`] for introspection.

--- a/src/tool_name.rs
+++ b/src/tool_name.rs
@@ -1,0 +1,155 @@
+//! Helpers for composing provider-safe tool names.
+
+/// Maximum length for a composed tool name (the tightest cap across providers:
+/// `OpenAI`, Bedrock, and Gemini all cap at 64; Anthropic allows 128).
+pub const MAX_TOOL_NAME_LEN: usize = 64;
+/// Hex characters preserved from the stable hash when truncation is required.
+pub const TOOL_NAME_HASH_HEX_LEN: usize = 16;
+
+/// Compose a tool name that is safe across every supported provider.
+///
+/// `namespace` is optional. When present, the namespace and tool name are
+/// joined with `_` after sanitization. When absent, the sanitized tool name is
+/// used directly. The final name always starts with an ASCII letter, contains
+/// only ASCII alphanumerics / `_`, and is bounded to the strictest provider
+/// length limit.
+#[must_use]
+pub fn compose_provider_safe_tool_name(namespace: Option<&str>, tool_name: &str) -> String {
+    let sanitized_tool = sanitize_tool_name_component(tool_name);
+    let joined = match namespace {
+        Some(namespace) => {
+            let sanitized_namespace = sanitize_tool_name_component(namespace);
+            format!("{sanitized_namespace}_{sanitized_tool}")
+        }
+        None => sanitized_tool,
+    };
+    let with_leading_letter = match joined.chars().next() {
+        Some(c) if c.is_ascii_alphabetic() => joined,
+        _ => format!("t_{joined}"),
+    };
+
+    if with_leading_letter.len() <= MAX_TOOL_NAME_LEN {
+        with_leading_letter
+    } else {
+        let hash_suffix = stable_name_hash_hex(&with_leading_letter);
+        let prefix_len = MAX_TOOL_NAME_LEN - TOOL_NAME_HASH_HEX_LEN - 1;
+        let prefix: String = with_leading_letter.chars().take(prefix_len).collect();
+        format!("{prefix}_{hash_suffix}")
+    }
+}
+
+fn sanitize_tool_name_component(input: &str) -> String {
+    if input.is_empty() {
+        return "_".to_owned();
+    }
+
+    input
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+fn stable_name_hash_hex(input: &str) -> String {
+    let mut hash = 0xcbf2_9ce4_8422_2325_u64;
+    for byte in input.bytes() {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    format!("{hash:0TOOL_NAME_HASH_HEX_LEN$x}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn namespaced_name_replaces_dashes_and_dots() {
+        assert_eq!(
+            compose_provider_safe_tool_name(Some("my-web"), "read.file"),
+            "my_web_read_file"
+        );
+        assert_eq!(
+            compose_provider_safe_tool_name(Some("my.ns"), "x.y.z"),
+            "my_ns_x_y_z"
+        );
+    }
+
+    #[test]
+    fn namespaced_name_prepends_letter_when_leading_non_alpha() {
+        assert_eq!(
+            compose_provider_safe_tool_name(Some("1plugin"), "foo"),
+            "t_1plugin_foo"
+        );
+        assert_eq!(
+            compose_provider_safe_tool_name(Some("_plugin"), "foo"),
+            "t__plugin_foo"
+        );
+    }
+
+    #[test]
+    fn bare_tool_name_is_sanitized_without_namespace_separators() {
+        assert_eq!(compose_provider_safe_tool_name(None, "echo"), "echo");
+        assert_eq!(
+            compose_provider_safe_tool_name(None, "read.file"),
+            "read_file"
+        );
+        assert_eq!(
+            compose_provider_safe_tool_name(None, "1invalid"),
+            "t_1invalid"
+        );
+    }
+
+    #[test]
+    fn provider_safe_name_truncates_to_max_length() {
+        let result = compose_provider_safe_tool_name(Some(&"a".repeat(40)), &"b".repeat(40));
+        assert_eq!(result.len(), MAX_TOOL_NAME_LEN);
+        assert_eq!(
+            result.rsplit_once('_').expect("hash suffix").1.len(),
+            TOOL_NAME_HASH_HEX_LEN
+        );
+    }
+
+    #[test]
+    fn provider_safe_name_long_collisions_get_distinct_hash_suffixes() {
+        let prefix = "a".repeat(40);
+        let first = compose_provider_safe_tool_name(Some(&prefix), &format!("{}x", "b".repeat(40)));
+        let second =
+            compose_provider_safe_tool_name(Some(&prefix), &format!("{}y", "b".repeat(40)));
+
+        assert_ne!(first, second);
+        assert_eq!(first.len(), MAX_TOOL_NAME_LEN);
+        assert_eq!(second.len(), MAX_TOOL_NAME_LEN);
+    }
+
+    #[test]
+    fn provider_safe_name_satisfies_strictest_grammar() {
+        let is_valid = |s: &str| {
+            s.len() <= MAX_TOOL_NAME_LEN
+                && s.chars().next().is_some_and(|c| c.is_ascii_alphabetic())
+                && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+        };
+
+        for (namespace, tool) in [
+            (Some("web"), "search"),
+            (Some("my-web"), "search"),
+            (Some("web"), "read.file"),
+            (Some("1plugin"), "foo"),
+            (None, "1invalid"),
+            (None, "naïve"),
+            (None, ""),
+            (Some(&"a".repeat(100)), &"b".repeat(100)),
+        ] {
+            let name = compose_provider_safe_tool_name(namespace, tool);
+            assert!(
+                is_valid(&name),
+                "composed name {name:?} (from {namespace:?} + {tool:?}) violates the strictest grammar"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## What changed
- added a shared provider-safe tool-name composer in `swink-agent` so plugin and MCP registrations use the same sanitization, leading-letter, length-cap, and hash-suffix rules
- updated `McpTool` to sanitize and bound registered names while still dispatching with the MCP server's original tool name
- added MCP regressions covering unsafe-name sanitization, truncation with a stable hash suffix, and collision detection after sanitization
- documented the MCP naming invariant in `mcp/AGENTS.md`

## Why / value
This closes the MCP registration hygiene gap from issue #694. Server-advertised tool names can now be exposed to providers without violating strict tool-name grammars, and collisions introduced by sanitization are detected deterministically at registration time.

## Slice completed
Completed the MCP tool-registration naming slice for provider-safe registration and regression coverage. Nothing remains for this issue beyond review.

## Validation
- `cargo fmt --all`
- `cargo test -p swink-agent-mcp`
- `cargo clippy -p swink-agent-mcp -- -D warnings`
- `cargo clippy -p swink-agent --features plugins -- -D warnings`
- `cargo test -p swink-agent --features plugins,testkit`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`

## Pre-existing baseline failure
- `cargo test --workspace` still fails on `swink-agent-tui` test `editor::tests::open_editor_with_true_command_returns_none` at `tui/src/editor.rs:96` (tracked by #698)

Closes #694