### PR TITLE
[QA][Artifacts] Make delete exact-name-safe for nested artifact IDs

### DIFF
--- a/artifacts/AGENTS.md
+++ b/artifacts/AGENTS.md
@@ -11,6 +11,8 @@
 - `validate_artifact_name` enforces name constraints shared by both backends.
 - `FileArtifactStore` layout: versioned files + JSON metadata sidecar per artifact.
 - Streaming reads available via the `streaming` module.
+- `FileArtifactStore::delete` must remove only the exact artifact's direct files, then prune empty parent directories. Recursive directory deletion breaks exact-name semantics for slash-containing artifact IDs like `foo` and `foo/bar`.
+- `FileArtifactStore::discover_artifacts` must normalize filesystem separators back to `/` before returning artifact names; Windows paths otherwise fail `validate_artifact_name` for nested IDs.
 - All filesystem mutations for one artifact key must share `artifact_lock(session_id, name)`. `delete` needs the same lock path as `save` and `save_stream` or concurrent writers can race directory removal.
 
 ## Build & Test

--- a/artifacts/src/fs_store.rs
+++ b/artifacts/src/fs_store.rs
@@ -231,7 +231,7 @@ impl FileArtifactStore {
                         if let Ok(relative) = path.strip_prefix(&session_dir)
                             && let Some(name) = relative.to_str()
                         {
-                            names.push(name.to_string());
+                            names.push(name.replace('\\', "/"));
                         }
                     }
                     // Also recurse into it (for nested artifact names like "tool/output")
@@ -241,6 +241,60 @@ impl FileArtifactStore {
         }
 
         Ok(names)
+    }
+
+    /// Remove only the direct files for one logical artifact directory.
+    ///
+    /// Child artifact names such as `foo/bar` live in nested directories under
+    /// `foo/`, so deleting `foo` must not recurse and wipe those children.
+    async fn delete_artifact_files(&self, dir: &Path) -> Result<(), ArtifactError> {
+        let mut entries = match tokio::fs::read_dir(dir).await {
+            Ok(entries) => entries,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(e) => return Err(storage_err(e)),
+        };
+
+        while let Some(entry) = entries.next_entry().await.map_err(storage_err)? {
+            let file_type = entry.file_type().await.map_err(storage_err)?;
+            if file_type.is_dir() {
+                continue;
+            }
+
+            match tokio::fs::remove_file(entry.path()).await {
+                Ok(()) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => return Err(storage_err(e)),
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Remove now-empty artifact directories up to, but not including, the
+    /// session root. Stops once a parent still contains sibling artifacts.
+    async fn prune_empty_artifact_dirs(
+        &self,
+        session_id: &str,
+        name: &str,
+    ) -> Result<(), ArtifactError> {
+        let session_dir = self.resolve_session_dir(session_id)?;
+        let mut current = self.resolve_artifact_dir(session_id, name)?;
+
+        while current != session_dir {
+            match tokio::fs::remove_dir(&current).await {
+                Ok(()) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) if e.kind() == std::io::ErrorKind::DirectoryNotEmpty => break,
+                Err(e) => return Err(storage_err(e)),
+            }
+
+            let Some(parent) = current.parent() else {
+                break;
+            };
+            current = parent.to_path_buf();
+        }
+
+        Ok(())
     }
 }
 
@@ -422,15 +476,10 @@ impl ArtifactStore for FileArtifactStore {
         let lock = self.artifact_lock(session_id, name).await;
         let _guard = lock.lock().await;
 
-        match tokio::fs::remove_dir_all(&dir).await {
-            Ok(()) => {
-                tracing::debug!(session_id, name, "artifact deleted");
-            }
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                tracing::debug!(session_id, name, "artifact already absent");
-            }
-            Err(e) => return Err(storage_err(e)),
-        }
+        self.delete_artifact_files(&dir).await?;
+        self.prune_empty_artifact_dirs(session_id, name).await?;
+
+        tracing::debug!(session_id, name, "artifact deleted");
         Ok(())
     }
 }

--- a/artifacts/tests/fs_store_delete.rs
+++ b/artifacts/tests/fs_store_delete.rs
@@ -74,3 +74,41 @@ async fn fs_delete_nonexistent_succeeds() {
     let (data, _) = store.load("s1", "keep.txt").await.unwrap().unwrap();
     assert_eq!(data.content, b"hello");
 }
+
+// T073: fs_delete_exact_name_preserves_nested_children
+#[tokio::test]
+async fn fs_delete_exact_name_preserves_nested_children() {
+    let tmpdir = tempfile::TempDir::new().unwrap();
+    let store = FileArtifactStore::new(tmpdir.path());
+
+    store.save("s1", "foo", text_data("parent")).await.unwrap();
+    store
+        .save("s1", "foo/bar", text_data("child"))
+        .await
+        .unwrap();
+
+    store.delete("s1", "foo").await.unwrap();
+
+    assert!(
+        store.load("s1", "foo").await.unwrap().is_none(),
+        "deleting the exact parent artifact should remove that logical name"
+    );
+
+    let (child, version) = store.load("s1", "foo/bar").await.unwrap().unwrap();
+    assert_eq!(version.name, "foo/bar");
+    assert_eq!(child.content, b"child");
+
+    let names = store
+        .list("s1")
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|meta| meta.name)
+        .collect::<Vec<_>>();
+    assert_eq!(names, vec!["foo/bar".to_string()]);
+
+    assert!(
+        tmpdir.path().join("s1").join("foo").join("bar").exists(),
+        "child artifact directory must survive parent-name deletion"
+    );
+}


### PR DESCRIPTION
## What changed
- changed `FileArtifactStore::delete` to remove only the exact artifact's direct files instead of recursively deleting the whole directory tree
- prune now-empty parent directories after exact-name deletion so nested artifact paths still clean up when safe
- normalized discovered artifact names back to `/` separators so nested IDs list correctly on Windows
- added regression coverage for deleting `foo` while preserving `foo/bar`
- recorded the delete/discovery invariants in `artifacts/AGENTS.md`

## Why / value
Deleting a parent artifact name like `foo` could previously erase nested logical artifacts such as `foo/bar`. This slice restores exact-name delete semantics so filesystem behavior matches the in-memory store and avoids accidental data loss.

## Slice completed
This PR completes the exact-name delete semantics fix for filesystem-backed artifact IDs with `/` in the name.

## Validation
- `cargo fmt --all`
- `cargo test -p swink-agent-artifacts`
- `cargo clippy -p swink-agent-artifacts -- -D warnings`
- `cargo clippy --workspace -- -D warnings`

## Pre-existing / local validation failures
- `cargo test --workspace` failed in this Windows worktree for unrelated environment/build-system reasons:
  - multiple dep-info writes under `target/debug/.fingerprint/...` failed with `The system cannot find the path specified. (os error 3)`
  - `llama-cpp-sys-2` failed its CMake/MSBuild install step while building `swink-agent-local-llm`, ending with missing `build_info.vcxproj`
- these failures occurred outside the changed artifact crate; the focused artifact crate suite passed cleanly

## Notes
- No IPC contract changes in this slice.
- Closes #696