### PR TITLE
[QA][Tests] Make external editor cancellation test cross-platform

### DIFF
--- a/tui/AGENTS.md
+++ b/tui/AGENTS.md
@@ -23,6 +23,7 @@
 
 ## Lessons Learned
 
+- External editor tests must not hardcode Unix-only helpers like `true`. Use a temporary no-op script/batch file so `tui/src/editor.rs` passes on Windows and Unix while still exercising the empty-file cancellation path.
 - **Mouse capture vs. native selection** — `EnableMouseCapture` is required for the scroll wheel but blocks the terminal's own click-drag text selection. The TUI works around this with in-app selection: drag anchors/extends a `Selection` in conversation-inner cell coords, rendering applies `Modifier::REVERSED` after the `Paragraph` draws, and mouse-up / Ctrl+C copies via `arboard`. Terminal-native bypasses (Shift/Option/Fn drag) continue to work on terminals that support them (kitty, Alacritty, WezTerm, Ghostty, iTerm2 Option-drag, Terminal.app Fn-drag).
 - **Resume after agent construction** — `App::load_session()` syncs both transcript messages and `SessionState` into the live `Agent`, so `launch_with_session()` must call `set_agent()` before `resume_into()`. Loading earlier only updates TUI display state and leaves the agent's internal conversation/state unsynchronized.
 - **Approval mode is owned by `Agent`** — `App::approval_mode()` reads through to `agent.approval_mode()` and returns `Smart` before `set_agent` is called. Do not add an `App.approval_mode` field; doing so reintroduces the dual-write drift bug (#565). Configure the startup mode via `AgentOptions::with_approval_mode` before building the agent.

--- a/tui/src/editor.rs
+++ b/tui/src/editor.rs
@@ -69,6 +69,58 @@ pub fn open_editor(editor_command: &str) -> io::Result<Option<String>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::{Path, PathBuf};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    struct TempNoopEditor {
+        path: PathBuf,
+    }
+
+    impl TempNoopEditor {
+        fn create() -> Self {
+            let unique = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system clock should be after unix epoch")
+                .as_nanos();
+            let mut path = std::env::temp_dir()
+                .join(format!("swink-editor-test-{unique}-{}", std::process::id()));
+
+            #[cfg(windows)]
+            {
+                path.set_extension("cmd");
+                std::fs::write(&path, "@echo off\r\nexit /b 0\r\n")
+                    .expect("should write noop cmd script");
+            }
+
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+
+                path.set_extension("sh");
+                std::fs::write(&path, "#!/bin/sh\nexit 0\n")
+                    .expect("should write noop shell script");
+
+                let mut permissions = std::fs::metadata(&path)
+                    .expect("noop script metadata")
+                    .permissions();
+                permissions.set_mode(0o755);
+                std::fs::set_permissions(&path, permissions)
+                    .expect("should mark noop script executable");
+            }
+
+            Self { path }
+        }
+
+        fn path(&self) -> &Path {
+            &self.path
+        }
+    }
+
+    impl Drop for TempNoopEditor {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
 
     #[test]
     fn resolve_editor_with_config_override() {
@@ -90,9 +142,14 @@ mod tests {
     }
 
     #[test]
-    fn open_editor_with_true_command_returns_none() {
-        // `true` exits successfully but writes nothing to the file
-        let result = open_editor("true");
+    fn open_editor_with_noop_command_returns_none() {
+        let noop_editor = TempNoopEditor::create();
+        let result = open_editor(
+            noop_editor
+                .path()
+                .to_str()
+                .expect("temp script path should be valid unicode"),
+        );
         assert!(result.is_ok());
         assert!(result.unwrap().is_none()); // empty file = cancellation
     }


### PR DESCRIPTION
## What changed
- replaced the Unix-only `true` dependency in `tui/src/editor.rs` tests with a temporary no-op script helper that works on Windows and Unix
- kept the assertion on the existing empty-file cancellation behavior, so the test still exercises the same `open_editor(...) -> Ok(None)` contract
- recorded the portability lesson in `tui/AGENTS.md`

## Slice completed
This slice completes issue #698 by making the external editor cancellation unit test portable across platforms without changing runtime editor behavior.
Nothing remains for this issue.

## Validation
- `cargo clippy -p swink-agent-tui -- -D warnings`
- `cargo test -p swink-agent-tui`

## Pre-existing baseline failures
- None observed in the scoped `swink-agent-tui` validation for this slice.
- Full workspace validation was not rerun in this PR.

## Notes
- No IPC contract changes in this slice.
- Closes #698