### PR TITLE
fix: preserve single MessageStart across overflow recovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,7 @@ gh pr comment <number> --body-file /tmp/comment.md
 - `transform_context` is **synchronous** (not async).
 - `CONTEXT_OVERFLOW_SENTINEL` triggers overflow retry — loop control signal, not an error.
 - Tool dispatch order: PreDispatch policies → Approval → Schema validation → `execute()`.
+- Overflow recovery retries and started-turn cancellation must reuse the original message lifecycle; once a turn has emitted `MessageStart`, follow-on recovery/cancellation paths must suppress any second `MessageStart`.
 
 ### Policy Slots (`src/policy.rs`)
 

--- a/src/loop_/overflow.rs
+++ b/src/loop_/overflow.rs
@@ -92,6 +92,7 @@ pub(super) async fn attempt_overflow_recovery(
         &llm_messages,
         system_prompt,
         api_key,
+        false,
         cancellation_token,
         tx,
     )

--- a/src/loop_/stream.rs
+++ b/src/loop_/stream.rs
@@ -26,12 +26,14 @@ use super::{
 /// [`ModelFallback`](crate::fallback::ModelFallback) chain is configured, each
 /// fallback model is tried in order (with its own fresh retry budget) before
 /// the error is surfaced.
+#[allow(clippy::too_many_arguments)]
 pub async fn stream_with_retry(
     config: &Arc<AgentLoopConfig>,
     agent_context: &AgentContext,
     llm_messages: &[LlmMessage],
     system_prompt: &str,
     api_key: Option<String>,
+    emit_message_start: bool,
     cancellation_token: &CancellationToken,
     tx: &mpsc::Sender<AgentEvent>,
 ) -> StreamResult {
@@ -44,6 +46,7 @@ pub async fn stream_with_retry(
         llm_messages,
         system_prompt,
         api_key.clone(),
+        emit_message_start,
         cancellation_token,
         tx,
     )
@@ -99,6 +102,7 @@ pub async fn stream_with_retry(
             llm_messages,
             system_prompt,
             api_key.clone(),
+            emit_message_start,
             cancellation_token,
             tx,
         )
@@ -147,6 +151,7 @@ async fn stream_with_retry_single(
     llm_messages: &[LlmMessage],
     system_prompt: &str,
     api_key: Option<String>,
+    emit_message_start: bool,
     cancellation_token: &CancellationToken,
     tx: &mpsc::Sender<AgentEvent>,
 ) -> StreamResult {
@@ -186,7 +191,7 @@ async fn stream_with_retry_single(
         // Emit MessageStart once for the logical turn. Attempt-local deltas are
         // buffered until the terminal attempt so retries do not leak stale
         // partials or duplicate lifecycle starts.
-        if attempt == 1 && !emit(tx, AgentEvent::MessageStart).await {
+        if emit_message_start && attempt == 1 && !emit(tx, AgentEvent::MessageStart).await {
             return StreamResult::ChannelClosed;
         }
 

--- a/src/loop_/turn.rs
+++ b/src/loop_/turn.rs
@@ -230,6 +230,7 @@ pub async fn run_single_turn(
         &llm_messages,
         system_prompt,
         api_key.clone(),
+        true,
         cancellation_token,
         tx,
     )
@@ -559,6 +560,7 @@ async fn emit_cancellation_for_turn(
     state: &mut LoopState,
     tx: &mpsc::Sender<AgentEvent>,
     emit_turn_start: bool,
+    emit_message_start: bool,
 ) -> TurnOutcome {
     let abort_msg = build_abort_message(&config.model);
     let msg_for_event = abort_msg.clone();
@@ -568,7 +570,7 @@ async fn emit_cancellation_for_turn(
     if emit_turn_start && !emit(tx, AgentEvent::TurnStart).await {
         return TurnOutcome::Return;
     }
-    if !emit(tx, AgentEvent::MessageStart).await {
+    if emit_message_start && !emit(tx, AgentEvent::MessageStart).await {
         return TurnOutcome::Return;
     }
     if !emit(
@@ -599,7 +601,7 @@ pub(super) async fn handle_cancellation(
     state: &mut LoopState,
     tx: &mpsc::Sender<AgentEvent>,
 ) -> TurnOutcome {
-    emit_cancellation_for_turn(config, state, tx, true).await
+    emit_cancellation_for_turn(config, state, tx, true, true).await
 }
 
 /// Emit cancellation events for a turn that already emitted `TurnStart`.
@@ -608,7 +610,7 @@ pub(super) async fn handle_started_turn_cancellation(
     state: &mut LoopState,
     tx: &mpsc::Sender<AgentEvent>,
 ) -> TurnOutcome {
-    emit_cancellation_for_turn(config, state, tx, false).await
+    emit_cancellation_for_turn(config, state, tx, false, false).await
 }
 
 /// Process the `StreamResult`, returning the assistant message on success,

--- a/tests/loop_overflow.rs
+++ b/tests/loop_overflow.rs
@@ -232,6 +232,11 @@ async fn emergency_overflow_recovery() {
     .await;
 
     assert!(has_event(&events, "AgentEnd"), "loop should complete");
+    assert_eq!(
+        count_events(&events, "MessageStart"),
+        1,
+        "overflow recovery must preserve a single logical MessageStart"
+    );
 
     // Verify async transformer was called with overflow=true during recovery.
     let af = async_flags.lock().unwrap().clone();
@@ -590,6 +595,11 @@ async fn cancellation_during_recovery_aborts() {
         count_events(&events, "TurnStart"),
         1,
         "cancellation during overflow recovery must not emit a duplicate TurnStart"
+    );
+    assert_eq!(
+        count_events(&events, "MessageStart"),
+        1,
+        "cancellation during overflow recovery must reuse the existing MessageStart"
     );
 
     // Should have a TurnEnd with Cancelled or Aborted reason.


### PR DESCRIPTION
## What changed
- threaded an explicit `emit_message_start` lifecycle flag through `stream_with_retry` so overflow recovery retries reuse the existing message lifecycle instead of emitting a second `MessageStart`
- updated started-turn cancellation to suppress `MessageStart` when the turn already emitted it before recovery
- added regression assertions for successful overflow recovery and cancellation during recovery
- recorded the loop lifecycle constraint in `AGENTS.md`

## Slice completed
Completed the overflow-retry and started-turn cancellation lifecycle slice for issue #708.

## Remaining work
- No remaining work identified for #708.

## Validation
- `cargo test --test loop_overflow`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
- `cargo fmt --all --check`

## Pre-existing baseline failures
- None observed in this branch.

## Notes
- IPC contract changes: none.

Closes #708