### PR TITLE
[codex] Wire Anthropic raw payload callbacks

### DIFF
--- a/adapters/AGENTS.md
+++ b/adapters/AGENTS.md
@@ -52,7 +52,7 @@
 - In `src/ollama.rs`, the NDJSON parser must buffer raw bytes until it has a full newline-delimited record. Decoding each transport chunk independently with `from_utf8_lossy` corrupts split multibyte UTF-8.
 - In `src/ollama.rs` and `src/proxy.rs`, deterministic parse/protocol faults (malformed NDJSON/SSE JSON, proxy terminal-frame violations, unexpected `done` EOF) must use `AssistantMessageEvent::error(...)`, not `error_network(...)`; only transport failures stay retryable.
 - In `src/openai_compat.rs`, buffer tool-call arguments and delay `ToolCallStart` until a non-empty `function.name` is known; some providers stream arguments before the name.
-- Runtime SSE adapters must thread `StreamOptions.on_raw_payload` into the callback-aware shared parser (`sse_data_lines_with_callback`). The callback-free helper silently disables payload observers.
+- Runtime SSE adapters must thread `StreamOptions.on_raw_payload` into the callback-aware shared parser (`sse_data_lines_with_callback` for data-only streams, `sse_paired_events_with_callback` for event/data streams). The callback-free helpers silently disable payload observers.
 - In `src/proxy.rs`, treat transport `data: [DONE]` as a protocol error unless the proxy has already emitted a typed `done` or `error` JSON event.
 - In `src/oai_transport.rs`, gate `OaiAdapterShell` helper methods to the provider features that actually call them. Azure-only builds reuse the request/parse pipeline but not the Bearer-auth convenience helpers, and otherwise `cargo clippy --no-default-features --features azure -D warnings` trips dead-code failures.
 

--- a/adapters/src/anthropic.rs
+++ b/adapters/src/anthropic.rs
@@ -22,7 +22,7 @@ use swink_agent::{
 use crate::base::AdapterBase;
 use crate::block_accumulator::BlockAccumulator;
 use crate::convert::extract_tool_schemas;
-use crate::sse::{SseAction, SseEvent, sse_paired_events};
+use crate::sse::{SseAction, SseEvent, sse_paired_events_with_callback};
 
 // ─── Request types ──────────────────────────────────────────────────────────
 
@@ -216,7 +216,8 @@ fn anthropic_stream<'a>(
             return stream::iter(crate::base::pre_stream_error(event)).left_stream();
         }
 
-        parse_sse_stream(response, cancellation_token).right_stream()
+        parse_sse_stream(response, cancellation_token, options.on_raw_payload.clone())
+            .right_stream()
     })
     .flatten()
 }
@@ -456,8 +457,9 @@ fn convert_messages(
 fn parse_sse_stream(
     response: reqwest::Response,
     cancellation_token: CancellationToken,
+    on_raw_payload: Option<swink_agent::OnRawPayload>,
 ) -> impl Stream<Item = AssistantMessageEvent> + Send {
-    let line_stream = sse_paired_events(response.bytes_stream());
+    let line_stream = sse_paired_events_with_callback(response.bytes_stream(), on_raw_payload);
 
     let state = SseStreamState {
         blocks: BlockAccumulator::default(),

--- a/adapters/src/sse.rs
+++ b/adapters/src/sse.rs
@@ -362,9 +362,21 @@ pub struct SseEvent {
 pub fn sse_paired_events(
     byte_stream: impl Stream<Item = Result<bytes::Bytes, reqwest::Error>> + Send + 'static,
 ) -> Pin<Box<dyn Stream<Item = SseEvent> + Send + 'static>> {
+    sse_paired_events_with_callback(byte_stream, None)
+}
+
+/// Like [`sse_paired_events`] but with an optional raw-payload callback.
+pub fn sse_paired_events_with_callback(
+    byte_stream: impl Stream<Item = Result<bytes::Bytes, reqwest::Error>> + Send + 'static,
+    on_raw_payload: Option<swink_agent::OnRawPayload>,
+) -> Pin<Box<dyn Stream<Item = SseEvent> + Send + 'static>> {
     Box::pin(stream::unfold(
-        (Box::pin(sse_lines(byte_stream)), Option::<String>::None),
-        |(mut stream, mut current_event)| async move {
+        (
+            Box::pin(sse_lines(byte_stream)),
+            Option::<String>::None,
+            on_raw_payload,
+        ),
+        |(mut stream, mut current_event, callback)| async move {
             loop {
                 match stream.next().await {
                     Some(SseLine::Empty | SseLine::Done) => {
@@ -376,7 +388,7 @@ pub fn sse_paired_events(
                                 event_type: SSE_TRANSPORT_ERROR_EVENT.to_string(),
                                 data: message,
                             },
-                            (stream, current_event),
+                            (stream, current_event, callback),
                         ));
                     }
                     Some(SseLine::Event(event_type)) => {
@@ -384,10 +396,18 @@ pub fn sse_paired_events(
                     }
                     Some(SseLine::Data(data)) => {
                         if !data.is_empty() {
+                            if let Some(cb) = &callback {
+                                let cb = AssertUnwindSafe(cb);
+                                let data = AssertUnwindSafe(&data);
+                                let _ = catch_unwind(|| (cb)(&data));
+                            }
                             let event_type = current_event
                                 .take()
                                 .unwrap_or_else(|| "unknown".to_string());
-                            return Some((SseEvent { event_type, data }, (stream, current_event)));
+                            return Some((
+                                SseEvent { event_type, data },
+                                (stream, current_event, callback),
+                            ));
                         }
                     }
                     None => return None,
@@ -838,6 +858,52 @@ mod tests {
 
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].event_type, "unknown");
+    }
+
+    #[tokio::test]
+    async fn paired_events_on_raw_payload_fires_for_each_line() {
+        use std::sync::{Arc, Mutex};
+
+        let captured = Arc::new(Mutex::new(Vec::<String>::new()));
+        let captured_clone = Arc::clone(&captured);
+        let callback: Arc<dyn Fn(&str) + Send + Sync> = Arc::new(move |data: &str| {
+            captured_clone.lock().unwrap().push(data.to_owned());
+        });
+
+        let chunks = vec![Ok(bytes::Bytes::from(
+            "event: one\ndata: first\n\nevent: two\ndata: second\n\n",
+        ))];
+        let byte_stream = futures::stream::iter(chunks);
+        let events: Vec<_> = super::sse_paired_events_with_callback(byte_stream, Some(callback))
+            .collect()
+            .await;
+
+        assert_eq!(events.len(), 2);
+        assert_eq!(
+            captured.lock().unwrap().clone(),
+            vec!["first".to_string(), "second".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn paired_events_on_raw_payload_panic_caught() {
+        use std::sync::Arc;
+
+        let callback: Arc<dyn Fn(&str) + Send + Sync> = Arc::new(|_data: &str| {
+            panic!("callback panic!");
+        });
+
+        let chunks = vec![Ok(bytes::Bytes::from(
+            "event: one\ndata: safe\n\nevent: two\ndata: still_safe\n\n",
+        ))];
+        let byte_stream = futures::stream::iter(chunks);
+        let events: Vec<_> = super::sse_paired_events_with_callback(byte_stream, Some(callback))
+            .collect()
+            .await;
+
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].data, "safe");
+        assert_eq!(events[1].data, "still_safe");
     }
 
     // ─── sse_adapter_stream tests ─────────────────────────────────────────

--- a/adapters/tests/anthropic.rs
+++ b/adapters/tests/anthropic.rs
@@ -4,6 +4,7 @@
 mod common;
 
 use futures::StreamExt;
+use std::sync::{Arc, Mutex};
 use tokio_util::sync::CancellationToken;
 use wiremock::matchers::{header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -20,9 +21,15 @@ fn test_model() -> ModelSpec {
 }
 
 async fn collect_events(stream_fn: &AnthropicStreamFn) -> Vec<AssistantMessageEvent> {
+    collect_events_with_options(stream_fn, StreamOptions::default()).await
+}
+
+async fn collect_events_with_options(
+    stream_fn: &AnthropicStreamFn,
+    options: StreamOptions,
+) -> Vec<AssistantMessageEvent> {
     let model = test_model();
     let context = test_context();
-    let options = StreamOptions::default();
     let token = CancellationToken::new();
     let stream = stream_fn.stream(&model, &context, &options, token);
     stream.collect::<Vec<_>>().await
@@ -900,5 +907,52 @@ async fn anthropic_empty_response_body() {
     assert!(
         err.contains("stream ended unexpectedly"),
         "expected 'stream ended unexpectedly', got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn anthropic_on_raw_payload_observes_runtime_sse_lines() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(sse_response(&basic_text_sse()))
+        .mount(&server)
+        .await;
+
+    let observed = Arc::new(Mutex::new(Vec::<String>::new()));
+    let callback_lines = Arc::clone(&observed);
+    let options = StreamOptions {
+        on_raw_payload: Some(Arc::new(move |line| {
+            callback_lines
+                .lock()
+                .expect("callback buffer poisoned")
+                .push(line.to_owned());
+        })),
+        ..StreamOptions::default()
+    };
+
+    let sf = AnthropicStreamFn::new(server.uri(), "test-key");
+    let events = collect_events_with_options(&sf, options).await;
+    let observed = observed.lock().expect("callback buffer poisoned").clone();
+
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, AssistantMessageEvent::Done { .. })),
+        "expected runtime stream to complete successfully"
+    );
+    assert_eq!(
+        observed,
+        vec![
+            r#"{"type":"message_start","message":{"usage":{"input_tokens":25}}}"#.to_string(),
+            r#"{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}"#
+                .to_string(),
+            r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}"#
+                .to_string(),
+            r#"{"type":"content_block_stop","index":0}"#.to_string(),
+            r#"{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":10}}"#
+                .to_string(),
+            r#"{"type":"message_stop"}"#.to_string(),
+        ]
     );
 }


### PR DESCRIPTION
## What changed
- added a callback-aware paired SSE parser in `adapters/src/sse.rs` so event/data-style streams can emit raw payload observations without losing event pairing
- threaded `StreamOptions.on_raw_payload` through the Anthropic runtime path in `adapters/src/anthropic.rs`
- added regression coverage for the shared paired-event callback helper and a runtime Anthropic integration test proving raw payload lines are observed end to end
- updated `adapters/AGENTS.md` with the paired-event callback requirement

## Value
This completes the remaining runtime observability gap for Anthropic SSE streams: `on_raw_payload` now fires for each raw data line before event parsing, matching spec 011 and the other SSE-backed adapters.

## Slice completed
Completed the remaining `on_raw_payload` plumbing slice for #709. Strict malformed-known-event handling already landed on `integration` in #720, so nothing remains for this issue after this PR.

## Validation output
- `cargo test -p swink-agent-adapters --test anthropic`
- `cargo test -p swink-agent-adapters --lib`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
- `cargo fmt --all --check`

## Pre-existing baseline failures
- None observed.

## Notes
- IPC contract changes: none.

Closes #709