### PR TITLE
fix: isolate panicking eval scorers

### DIFF
--- a/eval/AGENTS.md
+++ b/eval/AGENTS.md
@@ -19,3 +19,4 @@
 
 - `FsEvalStore` must validate eval set IDs before any path join. Reject empty IDs, `.`/`..`, NUL, and both `/` and `\` separators even on non-Windows hosts so logical identifiers cannot escape `sets/` or `results/` when tests or artifacts move across platforms.
 - `FsEvalStore` set/result persistence must go through `swink_agent::atomic_fs` helpers rather than direct `fs::write`, so interrupted rewrites never leave partial JSON or clobber the last good file.
+- `EvaluatorRegistry::evaluate()` is the panic-isolation boundary for eval scoring. Wrap each evaluator call in `catch_unwind(AssertUnwindSafe(...))`, record a failing metric for the panicking evaluator, and keep running the remaining evaluators/cases.

--- a/eval/src/evaluator.rs
+++ b/eval/src/evaluator.rs
@@ -1,7 +1,9 @@
 //! Evaluator trait and registry for composing multiple evaluation metrics.
 
+use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::Arc;
 
+use crate::score::Score;
 use crate::types::{EvalCase, EvalMetricResult, Invocation};
 
 /// Pluggable evaluator that scores an invocation against an eval case.
@@ -85,7 +87,19 @@ impl EvaluatorRegistry {
         self.evaluators
             .iter()
             .filter(|e| filter.is_empty() || filter.iter().any(|name| name == e.name()))
-            .filter_map(|e| e.evaluate(case, invocation))
+            .filter_map(
+                |e| match catch_unwind(AssertUnwindSafe(|| e.evaluate(case, invocation))) {
+                    Ok(result) => result,
+                    Err(payload) => Some(EvalMetricResult {
+                        evaluator_name: e.name().to_string(),
+                        score: Score::fail(),
+                        details: Some(format!(
+                            "evaluator panicked: {}",
+                            panic_payload_message(payload.as_ref())
+                        )),
+                    }),
+                },
+            )
             .collect()
     }
 }
@@ -94,4 +108,12 @@ impl Default for EvaluatorRegistry {
     fn default() -> Self {
         Self::new()
     }
+}
+
+fn panic_payload_message(payload: &(dyn std::any::Any + Send)) -> String {
+    payload
+        .downcast_ref::<&str>()
+        .map(|message| (*message).to_string())
+        .or_else(|| payload.downcast_ref::<String>().cloned())
+        .unwrap_or_else(|| "unknown panic".to_string())
 }

--- a/eval/tests/evaluator.rs
+++ b/eval/tests/evaluator.rs
@@ -65,6 +65,18 @@ impl Evaluator for ReturnsNone {
     }
 }
 
+struct Panics;
+
+impl Evaluator for Panics {
+    fn name(&self) -> &'static str {
+        "panics"
+    }
+
+    fn evaluate(&self, _case: &EvalCase, _invocation: &Invocation) -> Option<EvalMetricResult> {
+        panic!("deliberate evaluator panic");
+    }
+}
+
 #[test]
 fn registry_with_defaults_has_four_evaluators() {
     let registry = EvaluatorRegistry::with_defaults();
@@ -113,6 +125,39 @@ fn evaluator_returning_none_excluded() {
     assert!(names.contains(&"always_pass"));
     assert!(names.contains(&"always_fail"));
     assert!(!names.contains(&"returns_none"));
+}
+
+#[test]
+fn panicking_evaluator_becomes_failure_and_other_evaluators_continue() {
+    let mut registry = EvaluatorRegistry::new();
+    registry.register(Panics);
+    registry.register(AlwaysPass);
+
+    let invocation = common::mock_invocation(&[], None, 0.0, 0);
+    let case = minimal_case();
+    let results = registry.evaluate(&case, &invocation);
+
+    assert_eq!(results.len(), 2);
+
+    let panic_metric = results
+        .iter()
+        .find(|result| result.evaluator_name == "panics")
+        .expect("panicking evaluator should produce a failure metric");
+    assert_eq!(panic_metric.score.verdict(), Score::fail().verdict());
+    assert!(
+        panic_metric
+            .details
+            .as_deref()
+            .is_some_and(|details| details.contains("deliberate evaluator panic")),
+        "panic metric should preserve the panic message"
+    );
+
+    assert!(
+        results
+            .iter()
+            .any(|result| result.evaluator_name == "always_pass"),
+        "later evaluators should still run after a panic"
+    );
 }
 
 #[test]

--- a/eval/tests/runner.rs
+++ b/eval/tests/runner.rs
@@ -7,7 +7,10 @@ use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 
 use swink_agent::{Agent, AgentOptions, ModelSpec, testing::SimpleMockStreamFn};
-use swink_agent_eval::{AgentFactory, EvalCase, EvalError, EvalRunner, EvalSet, Verdict};
+use swink_agent_eval::{
+    AgentFactory, EvalCase, EvalError, EvalMetricResult, EvalRunner, EvalSet, Evaluator,
+    EvaluatorRegistry, Invocation, Score, Verdict,
+};
 
 /// Factory that creates agents with a deterministic mock stream returning the
 /// given tokens as a text-only response.
@@ -40,6 +43,34 @@ struct FailingFactory;
 impl AgentFactory for FailingFactory {
     fn create_agent(&self, _case: &EvalCase) -> Result<(Agent, CancellationToken), EvalError> {
         Err(EvalError::invalid_case("factory forced failure"))
+    }
+}
+
+struct PanicEvaluator;
+
+impl Evaluator for PanicEvaluator {
+    fn name(&self) -> &'static str {
+        "panic_eval"
+    }
+
+    fn evaluate(&self, _case: &EvalCase, _invocation: &Invocation) -> Option<EvalMetricResult> {
+        panic!("runner evaluator panic");
+    }
+}
+
+struct PassingEvaluator;
+
+impl Evaluator for PassingEvaluator {
+    fn name(&self) -> &'static str {
+        "pass_eval"
+    }
+
+    fn evaluate(&self, _case: &EvalCase, _invocation: &Invocation) -> Option<EvalMetricResult> {
+        Some(EvalMetricResult {
+            evaluator_name: self.name().to_string(),
+            score: Score::pass(),
+            details: None,
+        })
     }
 }
 
@@ -167,4 +198,49 @@ async fn mixed_success_and_failure() {
     // A case with no expected trajectory/response and only efficiency evaluator
     // (which returns None for zero tool calls) should pass since no metrics fail.
     assert_eq!(result.summary.passed, 1);
+}
+
+#[tokio::test]
+async fn panicking_evaluator_records_failure_and_suite_continues() {
+    let factory = MockFactory::new(vec!["Hello"]);
+    let mut registry = EvaluatorRegistry::new();
+    registry.register(PanicEvaluator);
+    registry.register(PassingEvaluator);
+    let runner = EvalRunner::new(registry);
+    let eval_set = EvalSet {
+        id: "panic-safe".to_string(),
+        name: "Panic Safe Suite".to_string(),
+        description: None,
+        cases: vec![make_case("a"), make_case("b")],
+    };
+
+    let result = runner.run_set(&eval_set, &factory).await.unwrap();
+
+    assert_eq!(result.case_results.len(), 2);
+    assert_eq!(result.summary.total_cases, 2);
+    assert_eq!(result.summary.failed, 2);
+    assert_eq!(result.summary.passed, 0);
+
+    for case_result in &result.case_results {
+        let panic_metric = case_result
+            .metric_results
+            .iter()
+            .find(|metric| metric.evaluator_name == "panic_eval")
+            .expect("panic metric should be recorded");
+        assert_eq!(panic_metric.score.verdict(), Verdict::Fail);
+        assert!(
+            panic_metric
+                .details
+                .as_deref()
+                .is_some_and(|details| details.contains("runner evaluator panic")),
+            "panic metric should preserve the panic message"
+        );
+        assert!(
+            case_result
+                .metric_results
+                .iter()
+                .any(|metric| metric.evaluator_name == "pass_eval"),
+            "non-panicking evaluators should still run"
+        );
+    }
 }


### PR DESCRIPTION
## What changed
- wrapped `EvaluatorRegistry::evaluate()` calls in `catch_unwind(AssertUnwindSafe(...))` so a panicking evaluator is recorded as a failing metric instead of aborting the eval case or suite
- preserved the panic payload in the metric details to keep evaluator failures diagnosable
- added regression coverage proving both the registry and `EvalRunner::run_set()` continue after a panicking evaluator
- recorded the eval panic-isolation rule in `eval/AGENTS.md`

## Slice completed
Completed the panic-isolation slice for evaluator scoring in issue #712.

## Remaining work
- No remaining work identified for #712.

## Validation
- `cargo test -p swink-agent-eval`
- `cargo test --workspace`
- `cargo clippy --workspace -- -D warnings`
- `cargo fmt --all --check`

## Pre-existing baseline failures
- `cargo clippy -p swink-agent-eval --tests -- -D warnings` fails on `integration` due an unrelated existing lint in `eval/src/trajectory.rs:414` (`clippy::default-trait-access` on `metadata: Default::default()`). This branch does not change that file.

## Notes
- IPC contract changes: none.

Closes #712