### PR TITLE
fix: honor cooperative cancellation in web tools

### DIFF
--- a/plugins/web/AGENTS.md
+++ b/plugins/web/AGENTS.md
@@ -5,3 +5,4 @@
 - `src/playwright.rs` must write a unique temp bridge script per `PlaywrightBridge::start()` call. Reusing one fixed temp filename is race-prone when multiple bridge instances start concurrently.
 - `src/playwright_bridge.js` must lazy-load the `playwright` package inside browser startup instead of at module load time. That keeps the bridge's pure extraction helpers testable from plain Node without requiring Playwright to be installed for unit tests.
 - `src/policy/rate_limiter.rs` must treat `Instant::checked_sub()` underflow as a no-prune tick instead of unwrapping. Short-uptime hosts can otherwise panic in the live rate-limit path.
+- `src/tools/screenshot.rs` must drop the shared `PlaywrightBridge` after a screenshot request is cancelled or times out. Once the JSON request is written, abandoning the response read can leave a stale line on stdout that corrupts the next bridge exchange.

--- a/plugins/web/src/tools/screenshot.rs
+++ b/plugins/web/src/tools/screenshot.rs
@@ -10,6 +10,29 @@ use swink_agent::{AgentTool, AgentToolResult, ContentBlock, ImageSource, ToolFut
 
 use crate::playwright::{PlaywrightBridge, PlaywrightError, Viewport};
 
+enum OperationOutcome<T> {
+    Completed(T),
+    Cancelled,
+    TimedOut,
+}
+
+async fn await_with_cancellation<F, T>(
+    cancellation_token: &CancellationToken,
+    timeout: Duration,
+    future: F,
+) -> OperationOutcome<T>
+where
+    F: std::future::Future<Output = T>,
+{
+    tokio::select! {
+        result = tokio::time::timeout(timeout, future) => match result {
+            Ok(value) => OperationOutcome::Completed(value),
+            Err(_) => OperationOutcome::TimedOut,
+        },
+        () = cancellation_token.cancelled() => OperationOutcome::Cancelled,
+    }
+}
+
 /// Tool for taking screenshots of web pages.
 ///
 /// Lazily starts a Playwright bridge subprocess on first use and reuses it for
@@ -72,7 +95,7 @@ impl AgentTool for ScreenshotTool {
     ) -> ToolFuture<'_> {
         Box::pin(async move {
             if cancellation_token.is_cancelled() {
-                return AgentToolResult::error("cancelled");
+                return AgentToolResult::error("Request cancelled");
             }
 
             // Parse parameters.
@@ -93,9 +116,21 @@ impl AgentTool for ScreenshotTool {
             let viewport = Some(Viewport { width, height });
 
             // Acquire bridge lock and lazily start if needed.
-            let mut guard = self.bridge.lock().await;
+            let mut guard = tokio::select! {
+                guard = self.bridge.lock() => guard,
+                () = cancellation_token.cancelled() => {
+                    return AgentToolResult::error("Request cancelled");
+                }
+            };
             if guard.is_none() {
-                match PlaywrightBridge::start(self.playwright_path.as_deref()).await {
+                let bridge_start = tokio::select! {
+                    result = PlaywrightBridge::start(self.playwright_path.as_deref()) => result,
+                    () = cancellation_token.cancelled() => {
+                        return AgentToolResult::error("Request cancelled");
+                    }
+                };
+
+                match bridge_start {
                     Ok(b) => *guard = Some(b),
                     Err(PlaywrightError::NotInstalled) => {
                         return AgentToolResult::error(
@@ -109,14 +144,18 @@ impl AgentTool for ScreenshotTool {
                 }
             }
 
-            let bridge = guard.as_mut().expect("bridge initialized above");
+            let operation = {
+                let bridge = guard.as_mut().expect("bridge initialized above");
+                await_with_cancellation(
+                    &cancellation_token,
+                    self.timeout,
+                    bridge.screenshot(&url, viewport),
+                )
+                .await
+            };
 
-            // Apply tool-level timeout.
-            let result =
-                tokio::time::timeout(self.timeout, bridge.screenshot(&url, viewport)).await;
-
-            match result {
-                Ok(Ok(base64_data)) => AgentToolResult {
+            match operation {
+                OperationOutcome::Completed(Ok(base64_data)) => AgentToolResult {
                     content: vec![ContentBlock::Image {
                         source: ImageSource::Base64 {
                             media_type: "image/png".into(),
@@ -131,12 +170,23 @@ impl AgentTool for ScreenshotTool {
                     is_error: false,
                     transfer_signal: None,
                 },
-                Ok(Err(PlaywrightError::NotInstalled)) => AgentToolResult::error(
-                    "Playwright/Node.js not found. Install with:\n\
+                OperationOutcome::Completed(Err(PlaywrightError::NotInstalled)) => {
+                    AgentToolResult::error(
+                        "Playwright/Node.js not found. Install with:\n\
                      npm install -g playwright && npx playwright install chromium",
-                ),
-                Ok(Err(e)) => AgentToolResult::error(format!("Screenshot failed: {e}")),
-                Err(_) => {
+                    )
+                }
+                OperationOutcome::Completed(Err(e)) => {
+                    AgentToolResult::error(format!("Screenshot failed: {e}"))
+                }
+                OperationOutcome::Cancelled => {
+                    // Dropping the bridge avoids leaving an unread response on stdout after the
+                    // request was already written to the subprocess.
+                    *guard = None;
+                    AgentToolResult::error("Request cancelled")
+                }
+                OperationOutcome::TimedOut => {
+                    *guard = None;
                     AgentToolResult::error(format!("Screenshot timed out after {:?}", self.timeout))
                 }
             }
@@ -168,4 +218,38 @@ fn build_schema() -> Value {
         "required": ["url"],
         "additionalProperties": false
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future::pending;
+    use std::time::Duration;
+
+    use tokio_util::sync::CancellationToken;
+
+    use super::{OperationOutcome, await_with_cancellation};
+
+    #[tokio::test]
+    async fn await_with_cancellation_returns_cancelled_before_completion() {
+        let cancellation_token = CancellationToken::new();
+        cancellation_token.cancel();
+
+        let outcome =
+            await_with_cancellation(&cancellation_token, Duration::from_secs(1), pending::<()>())
+                .await;
+
+        assert!(matches!(outcome, OperationOutcome::Cancelled));
+    }
+
+    #[tokio::test]
+    async fn await_with_cancellation_returns_timed_out_for_slow_operations() {
+        let outcome = await_with_cancellation(
+            &CancellationToken::new(),
+            Duration::from_millis(10),
+            tokio::time::sleep(Duration::from_millis(50)),
+        )
+        .await;
+
+        assert!(matches!(outcome, OperationOutcome::TimedOut));
+    }
 }

--- a/plugins/web/src/tools/search.rs
+++ b/plugins/web/src/tools/search.rs
@@ -78,7 +78,7 @@ impl AgentTool for SearchTool {
         &self,
         _tool_call_id: &str,
         params: Value,
-        _cancellation_token: CancellationToken,
+        cancellation_token: CancellationToken,
         _on_update: Option<Box<dyn Fn(AgentToolResult) + Send + Sync>>,
         _state: Arc<std::sync::RwLock<swink_agent::SessionState>>,
         _credential: Option<swink_agent::ResolvedCredential>,
@@ -101,7 +101,14 @@ impl AgentTool for SearchTool {
                 return AgentToolResult::error("Missing required parameter: query");
             }
 
-            match provider.search(&query, max_results).await {
+            let search_result = tokio::select! {
+                result = provider.search(&query, max_results) => result,
+                () = cancellation_token.cancelled() => {
+                    return AgentToolResult::error("Request cancelled");
+                }
+            };
+
+            match search_result {
                 Ok(results) if results.is_empty() => {
                     AgentToolResult::text(format!("No results found for '{query}'."))
                 }
@@ -115,9 +122,11 @@ impl AgentTool for SearchTool {
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
+    use std::time::Duration;
 
     use serde_json::json;
     use swink_agent::{AgentTool, SessionState};
+    use tokio::time::timeout;
     use tokio_util::sync::CancellationToken;
 
     use super::SearchTool;
@@ -166,6 +175,28 @@ mod tests {
             >,
         > {
             Box::pin(async move { Err(SearchError::NetworkError("connection refused".into())) })
+        }
+    }
+
+    struct PendingProvider;
+
+    impl SearchProvider for PendingProvider {
+        fn name(&self) -> &str {
+            "pending"
+        }
+
+        fn search(
+            &self,
+            _query: &str,
+            _max_results: usize,
+        ) -> std::pin::Pin<
+            Box<
+                dyn std::future::Future<Output = Result<Vec<SearchResult>, SearchError>>
+                    + Send
+                    + '_,
+            >,
+        > {
+            Box::pin(std::future::pending())
         }
     }
 
@@ -245,5 +276,31 @@ mod tests {
             )
             .await;
         assert!(provider_failure.is_error);
+    }
+
+    #[tokio::test]
+    async fn execute_returns_cancelled_when_provider_request_is_interrupted() {
+        let tool = SearchTool::new(Arc::new(PendingProvider), 10);
+        let state = Arc::new(std::sync::RwLock::new(SessionState::default()));
+        let cancellation_token = CancellationToken::new();
+        cancellation_token.cancel();
+
+        let result = timeout(
+            Duration::from_millis(100),
+            tool.execute(
+                "call-4",
+                json!({"query": "cancel me"}),
+                cancellation_token,
+                None,
+                state,
+                None,
+            ),
+        )
+        .await
+        .expect("cancelled search should not hang");
+
+        assert!(result.is_error);
+        let text = format!("{:?}", result.content);
+        assert!(text.contains("Request cancelled"));
     }
 }


### PR DESCRIPTION
## What changed
This completes issue #714 by making the web plugin's long-running `search` and `screenshot` tool awaits cooperate with `CancellationToken` instead of running to completion after cancellation.

For `search`, provider requests now race against cancellation and return a clean cancellation error. For `screenshot`, bridge lock acquisition, bridge startup, and the screenshot capture itself now all honor cancellation. When a screenshot is cancelled or times out after the Playwright request has already been written, the shared bridge is dropped so a stale unread response cannot desynchronize the next bridge exchange.

## Slice completed
Completed the cancellation slice called out in issue #714 for:
- `plugins/web/src/tools/search.rs`
- `plugins/web/src/tools/screenshot.rs`

Nothing remains for this issue in the scope described there.

## Validation
- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`

## Baseline failures
None.

Closes #714