### PR TITLE
docs(043): clarify, plan, and break out the advanced evals spec

### DIFF
--- a/specs/043-evals-adv-features/contracts/public-api.md
+++ b/specs/043-evals-adv-features/contracts/public-api.md
@@ -1,0 +1,535 @@
+# Public API Contracts: Evals: Advanced Features
+
+**Feature**: 043-evals-adv-features | **Date**: 2026-04-21
+
+Authoritative list of public items the two crates expose once 043 ships. Items are grouped by crate and module. Every listed item appears in `pub` re-exports from the crate root.
+
+---
+
+## Crate: `swink-agent-eval` (extended from 023/024)
+
+### Module `swink_agent_eval::prompt`
+
+```rust
+pub trait JudgePromptTemplate: Send + Sync {
+    fn version(&self) -> &str;
+    fn family(&self) -> PromptFamily;
+    fn render(&self, ctx: &PromptContext) -> Result<String, PromptError>;
+}
+
+pub struct PromptTemplateRegistry { /* ... */ }
+impl PromptTemplateRegistry {
+    pub fn builtin() -> Self;
+    pub fn get(&self, version: &str) -> Option<Arc<dyn JudgePromptTemplate>>;
+    pub fn register(&mut self, template: Arc<dyn JudgePromptTemplate>) -> Result<(), PromptError>;
+}
+
+pub struct PromptContext { /* fields: case, invocation, few_shot_examples, custom */ }
+
+pub enum PromptFamily {
+    Quality, Safety, RAG, Agent, Structured, Code, Multimodal,
+}
+// No `Simple` — simple-family evaluators are deterministic and register no templates
+// (matches FR-009's 7-family list).
+
+pub enum PromptError {
+    MissingVariable { name: String },
+    RenderError(String),
+    DuplicateVersion(String),
+}
+
+pub struct FewShotExample {
+    pub input: String,
+    pub expected: String,
+    pub reasoning: Option<String>,
+}
+```
+
+### Module `swink_agent_eval::judge` *(feature `judge-core`)*
+
+```rust
+pub struct JudgeRegistry { /* ... */ }
+pub struct JudgeRegistryBuilder { /* ... */ }
+impl JudgeRegistry {
+    pub fn builder(client: Arc<dyn JudgeClient>, model_id: impl Into<String>) -> JudgeRegistryBuilder;
+}
+impl JudgeRegistryBuilder {
+    pub fn retry_policy(self, p: RetryPolicy) -> Self;
+    pub fn batch_size(self, n: usize) -> Self;                 // [1, 128]
+    pub fn cache(self, c: Arc<JudgeCache>) -> Self;
+    pub fn url_filter(self, f: Arc<dyn UrlFilter>) -> Self;
+    pub fn build(self) -> Result<JudgeRegistry, JudgeRegistryError>;
+}
+
+pub struct RetryPolicy { pub max_attempts: u32, pub max_delay: Duration, pub jitter: bool }
+impl Default for RetryPolicy { /* 6 attempts, 4 min, jitter=true */ }
+
+pub struct JudgeCache { /* ... */ }
+impl JudgeCache {
+    pub fn in_memory(capacity: usize) -> Arc<Self>;
+    pub fn with_disk(capacity: usize, path: PathBuf) -> Arc<Self>;
+    pub fn get(&self, key: &CacheKey) -> Option<JudgeVerdict>;
+    pub fn put(&self, key: CacheKey, verdict: JudgeVerdict);
+}
+
+pub struct CacheKey { pub prompt_hash: [u8; 32], pub model_id: String }
+
+// UrlFilter actually lives at `swink_agent_eval::url_filter` — always-on top-level module,
+// not `swink_agent_eval::judge::url_filter` — so attachment materialization can use it
+// without enabling the `judge-core` feature. Re-exported from both locations for ergonomic use.
+pub trait UrlFilter: Send + Sync {
+    fn check(&self, url: &Url) -> Result<(), AttachmentError>;
+}
+pub struct DefaultUrlFilter;   // denies RFC 1918, loopback, metadata endpoints; requires HTTPS
+```
+
+### Module `swink_agent_eval::aggregator`
+
+```rust
+pub trait Aggregator: Send + Sync {
+    fn aggregate(&self, samples: &[Score]) -> Score;
+}
+pub struct Average;    // default
+pub struct AllPass;
+pub struct AnyPass;
+pub struct Weighted { pub weights: Vec<f64> }
+```
+
+### Module `swink_agent_eval::evaluators` *(each family behind its own feature)*
+
+```rust
+// feature evaluator-quality
+pub struct HelpfulnessEvaluator { /* ... */ }
+pub struct CorrectnessEvaluator { /* ... */ }
+pub struct ConcisenessEvaluator { /* ... */ }
+pub struct CoherenceEvaluator { /* ... */ }
+pub struct ResponseRelevanceEvaluator { /* ... */ }
+pub struct HallucinationEvaluator { /* ... */ }
+pub struct FaithfulnessEvaluator { /* ... */ }
+pub struct PlanAdherenceEvaluator { /* ... */ }
+pub struct LazinessEvaluator { /* ... */ }
+pub struct GoalSuccessRateEvaluator { /* ... */ }
+
+// feature evaluator-safety
+pub struct HarmfulnessEvaluator { /* ... */ }
+pub struct ToxicityEvaluator { /* ... */ }
+pub struct FairnessEvaluator { /* ... */ }
+pub struct PIILeakageEvaluator { /* ... */ }
+pub struct PromptInjectionEvaluator { /* ... */ }
+pub struct CodeInjectionEvaluator { /* ... */ }
+pub enum PIIClass { Email, Phone, SSN, CreditCard, IpAddress, ApiKey, PersonalName, Address, Other(String) }
+
+// feature evaluator-rag
+pub struct RAGGroundednessEvaluator { /* ... */ }
+pub struct RAGRetrievalRelevanceEvaluator { /* ... */ }
+pub struct RAGHelpfulnessEvaluator { /* ... */ }
+pub struct EmbeddingSimilarityEvaluator { /* ... */ }
+#[async_trait]
+pub trait Embedder: Send + Sync {
+    async fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>, EmbedderError>;
+    fn dimension(&self) -> usize;
+}
+pub enum EmbedderError { /* ... */ }
+
+// feature evaluator-agent
+pub struct TrajectoryAccuracyEvaluator { /* ... */ }
+pub struct TrajectoryAccuracyWithRefEvaluator { /* ... */ }
+pub struct TaskCompletionEvaluator { /* ... */ }
+pub struct UserSatisfactionEvaluator { /* ... */ }
+pub struct AgentToneEvaluator { /* ... */ }
+pub struct KnowledgeRetentionEvaluator { /* ... */ }
+pub struct LanguageDetectionEvaluator { /* ... */ }
+pub struct PerceivedErrorEvaluator { /* ... */ }
+pub struct InteractionsEvaluator { /* ... */ }
+
+// feature evaluator-structured
+pub struct JsonMatchEvaluator { /* ... */ }
+pub enum KeyStrategy { Average, All, None, Rubric(Arc<dyn JudgePromptTemplate>) }
+pub struct JsonSchemaEvaluator { /* ... */ }
+
+// feature evaluator-simple (always-on deterministic; `strsim` dep only behind feature)
+pub struct ExactMatchEvaluator { /* ... */ }
+pub struct LevenshteinDistanceEvaluator { /* ... */ }
+
+// feature evaluator-code
+pub struct CargoCheckEvaluator { /* ... */ }
+pub struct ClippyEvaluator { /* ... */ }
+pub struct CodeExtractor { /* ... */ }
+pub enum CodeExtractorStrategy { MarkdownFence, Regex(Regex), Llm(Arc<dyn JudgeClient>) }
+pub struct CodeLlmJudgeEvaluator { /* ... */ }
+
+// feature evaluator-sandbox (Unix only; Windows: stub returning EvaluatorError::UnsupportedPlatform)
+pub struct SandboxedExecutionEvaluator { /* ... */ }
+pub struct SandboxLimits {
+    pub wall_clock: Duration,
+    pub cpu_seconds: Duration,
+    pub memory_bytes: u64,
+    pub file_descriptors: u32,
+    pub allow_network: bool,
+}
+impl Default for SandboxLimits {
+    // 120 s wall, 60 s CPU, 1 GiB RSS, 256 FDs, no network (FR-017)
+}
+
+// feature multimodal
+pub struct ImageSafetyEvaluator { /* ... */ }
+
+// Common per-evaluator configuration (every judge-backed evaluator takes this via builder)
+pub struct JudgeEvaluatorConfig {
+    pub template: Option<Arc<dyn JudgePromptTemplate>>,
+    pub few_shot_examples: Vec<FewShotExample>,
+    pub system_prompt: Option<String>,
+    pub output_schema: Option<JsonSchema>,
+    pub use_reasoning: bool,
+    pub feedback_key: Option<String>,
+    pub aggregator: Option<Box<dyn Aggregator>>,
+    pub judge_registry: Arc<JudgeRegistry>,
+}
+```
+
+### Module `swink_agent_eval::simulation` *(feature `simulation`)*
+
+```rust
+pub struct ActorSimulator { /* ... */ }
+pub struct ActorProfile { /* ... */ }
+pub struct ToolSimulator { /* ... */ }
+pub struct StateRegistry { /* ... */ }
+pub struct StateBucket { /* ... */ }
+
+pub async fn run_multiturn_simulation(
+    agent: &dyn Agent,
+    actor: &ActorSimulator,
+    tool_sim: Option<&ToolSimulator>,
+    max_turns: u32,
+    cancel: CancellationToken,
+) -> Result<Invocation, SimulationError>;
+
+pub enum SimulationError {
+    MaxTurnsReached,
+    SchemaValidation { tool: String, detail: String },
+    Cancelled,
+    Judge(JudgeError),
+}
+```
+
+### Module `swink_agent_eval::generation` *(feature `generation`)*
+
+```rust
+pub struct ExperimentGenerator { /* ... */ }
+pub struct GenerationRequest { /* ... */ }
+pub struct TopicPlanner { /* ... */ }
+pub struct TopicSlot { pub topic: String, pub case_count: u32 }
+
+pub enum GenerationError {
+    MaxRetriesExceeded,
+    SchemaValidation(String),
+    Judge(JudgeError),
+}
+```
+
+### Module `swink_agent_eval::trace` *(feature `trace-ingest`)*
+
+```rust
+#[async_trait]
+pub trait TraceProvider: Send + Sync {
+    async fn fetch_session(&self, session_id: &str) -> Result<RawSession, TraceProviderError>;
+}
+
+pub struct OtelInMemoryTraceProvider { /* always-on once trace-ingest feature is enabled */ }
+
+// Per-backend, each behind its own sub-feature:
+pub struct OtlpHttpTraceProvider { /* feature trace-otlp */ }
+pub struct LangfuseTraceProvider { /* feature trace-langfuse */ }
+pub struct OpenSearchTraceProvider { /* feature trace-opensearch */ }
+pub struct CloudWatchTraceProvider { /* feature trace-cloudwatch */ }
+
+pub trait SessionMapper: Send + Sync {
+    fn map(&self, raw: &RawSession) -> Result<Invocation, MappingError>;
+}
+
+pub struct OpenInferenceSessionMapper;
+pub struct LangChainSessionMapper;
+pub struct OtelGenAiSessionMapper { pub version: GenAIConventionVersion }
+
+pub enum GenAIConventionVersion { V1_27, V1_30, Experimental }
+
+pub enum EvaluationLevel { Tool, Trace, Session }
+
+pub trait TraceExtractor: Send + Sync {
+    fn extract(&self, inv: &Invocation, level: EvaluationLevel) -> Vec<EvaluatorInput>;
+}
+
+pub struct SwarmExtractor;                  // consumes spec 040 types
+pub struct GraphExtractor;                  // consumes spec 039 types
+
+pub enum MappingError {
+    MissingAttribute { name: String },
+    UnknownConventionVersion,
+    SchemaMismatch(String),
+}
+
+pub enum TraceProviderError {
+    SessionNotFound,
+    SessionInProgress,
+    Backend(String),
+}
+```
+
+### Module `swink_agent_eval::telemetry` *(feature `telemetry`)*
+
+```rust
+pub struct EvalsTelemetry { /* ... */ }
+pub struct EvalsTelemetryBuilder { /* ... */ }
+
+impl EvalsTelemetry {
+    pub fn builder() -> EvalsTelemetryBuilder;
+}
+impl EvalsTelemetryBuilder {
+    pub fn tracer(self, t: Arc<opentelemetry::Tracer>) -> Self;
+    pub fn attributes(self, kvs: Vec<KeyValue>) -> Self;
+    pub fn build(self) -> EvalsTelemetry;
+}
+```
+
+Emitted span names (stable):
+- `swink.eval.run_set`
+- `swink.eval.case`
+- `swink.eval.evaluator`
+
+### Module `swink_agent_eval::cache`
+
+```rust
+#[async_trait]
+pub trait EvaluationDataStore: Send + Sync {
+    async fn get(&self, key: &CacheKey) -> Result<Option<Invocation>, StoreError>;
+    async fn put(&self, key: CacheKey, inv: Invocation) -> Result<(), StoreError>;
+}
+
+pub struct LocalFileTaskResultStore { /* always-on */ }
+impl LocalFileTaskResultStore {
+    pub fn new(root: PathBuf) -> Self;
+}
+
+pub enum StoreError { Io(std::io::Error), Serde(String) }
+
+pub struct CaseFingerprint<'a> { /* see data-model.md §R-020 */ }
+```
+
+### Module `swink_agent_eval::report`
+
+```rust
+pub trait Reporter: Send + Sync {
+    fn render(&self, result: &EvalSetResult) -> Result<ReporterOutput, ReporterError>;
+}
+
+pub enum ReporterOutput {
+    Stdout(String),
+    Artifact { path: PathBuf, bytes: Vec<u8> },
+    Remote { backend: String, identifier: String },
+}
+
+pub enum ReporterError { Io(std::io::Error), Format(String), Network(String) }
+
+// Always-on:
+pub struct ConsoleReporter;
+pub struct JsonReporter;
+pub struct MarkdownReporter;
+
+// feature html-report
+pub struct HtmlReporter { /* ... */ }
+
+// feature langsmith
+pub struct LangSmithExporter {
+    pub api_token: String,
+    pub endpoint: Url,           // default https://api.smith.langchain.com
+}
+
+pub enum LangSmithExportError {
+    Push { pushed: u32, failed: u32, first_error: String },
+    Auth,
+    Network(String),
+}
+```
+
+### Module `swink_agent_eval::types` *(extended)*
+
+```rust
+// Extended EvalCase per FR-043:
+pub struct EvalCase {
+    pub case_id: String,
+    pub case_name: String,
+    pub system_prompt: Option<String>,
+    pub user_messages: Vec<ChatMessage>,
+    pub expected_output: Option<String>,
+    pub expected_trajectory: Option<Vec<ToolCallExpectation>>,
+
+    // New in 043:
+    pub expected_assertion: Option<Assertion>,
+    pub expected_interactions: Option<Vec<InteractionExpectation>>,
+    pub few_shot_examples: Vec<FewShotExample>,
+    pub attachments: Vec<Attachment>,
+    pub session_id: Uuid,
+    pub metadata: HashMap<String, serde_json::Value>,
+}
+
+impl EvalCase {
+    pub fn default_session_id(&self) -> Uuid;     // deterministic UUID v5 per R-014
+    pub fn validate(&self) -> Result<(), ValidationError>;
+}
+
+pub enum Attachment {
+    Path(PathBuf),
+    Base64 { mime: String, bytes: Vec<u8> },
+    Url(String),
+}
+
+pub struct MaterializedAttachment { pub mime: String, pub bytes: Vec<u8> }
+
+pub enum AttachmentError {
+    PathNotFound(PathBuf),
+    DecodeError(String),
+    UrlBlocked { url: String, reason: String },
+    FetchFailed { url: String, status: u16 },
+    UnsupportedMime { mime: String },
+}
+
+impl Attachment {
+    pub async fn materialize(&self, eval_set_root: &Path, filter: &dyn UrlFilter)
+        -> Result<MaterializedAttachment, AttachmentError>;
+}
+
+pub struct Assertion { pub description: String, pub kind: AssertionKind }
+pub enum AssertionKind {
+    GoalCompleted,
+    UserSatisfied,
+    ToolInvoked(String),
+    Custom { predicate: String },
+}
+
+pub struct InteractionExpectation {
+    pub from_agent: String,
+    pub to_agent: String,
+    pub expected_topic: Option<String>,
+}
+```
+
+### Extended `EvalRunner` (backwards-compatible additions)
+
+```rust
+impl EvalRunner {
+    // Existing constructors unchanged.
+    pub fn with_parallelism(self, n: usize) -> Self;
+    pub fn with_num_runs(self, n: u32) -> Self;
+    pub fn with_cache(self, store: Arc<dyn EvaluationDataStore>) -> Self;
+    pub fn with_initial_session_file(self, path: PathBuf) -> Self;
+    pub fn with_telemetry(self, tel: Arc<EvalsTelemetry>) -> Self;
+    pub fn with_cancellation(self, tok: CancellationToken) -> Self;
+}
+```
+
+### Binary target `swink-eval` *(feature `cli`)*
+
+```text
+swink-eval run --set <path> [--out <path>] [--parallelism <n>] [--reporter console|json|md|html]
+swink-eval report <result.json> --format <console|json|md|html>
+swink-eval gate <result.json> --gate-config <path>
+```
+
+Exit codes:
+- `0` — success (run passed; gate passed; report rendered)
+- `1` — eval run completed but gate failed
+- `2` — configuration error (missing file, invalid args)
+- `3` — runtime error (cancelled, IO error)
+
+---
+
+## Crate: `swink-agent-eval-judges` (NEW)
+
+### Root `src/lib.rs`
+
+```rust
+#[cfg(feature = "anthropic")] pub use self::anthropic::AnthropicJudgeClient;
+#[cfg(feature = "openai")]    pub use self::openai::OpenAIJudgeClient;
+#[cfg(feature = "bedrock")]   pub use self::bedrock::BedrockJudgeClient;
+#[cfg(feature = "gemini")]    pub use self::gemini::GeminiJudgeClient;
+#[cfg(feature = "mistral")]   pub use self::mistral::MistralJudgeClient;
+#[cfg(feature = "azure")]     pub use self::azure::AzureJudgeClient;
+#[cfg(feature = "xai")]       pub use self::xai::XaiJudgeClient;
+#[cfg(feature = "ollama")]    pub use self::ollama::OllamaJudgeClient;
+#[cfg(feature = "proxy")]     pub use self::proxy::ProxyJudgeClient;
+```
+
+### Per-provider client shape (uniform across all 9)
+
+```rust
+pub struct AnthropicJudgeClient {
+    adapter: Arc<swink_agent_adapters_anthropic::AnthropicAdapter>,
+    retry_policy: RetryPolicy,
+    batch_size: usize,
+}
+
+impl AnthropicJudgeClient {
+    pub fn new(adapter: Arc<swink_agent_adapters_anthropic::AnthropicAdapter>) -> Self;
+    pub fn with_retry_policy(self, p: RetryPolicy) -> Self;
+    pub fn with_batch_size(self, n: usize) -> Self;
+    pub fn blocking(&self) -> BlockingAnthropicJudgeClient;   // sync wrapper per FR-003
+}
+
+#[async_trait]
+impl JudgeClient for AnthropicJudgeClient {
+    async fn judge(&self, request: JudgeRequest) -> Result<JudgeVerdict, JudgeError>;
+}
+
+pub struct BlockingAnthropicJudgeClient { inner: AnthropicJudgeClient }
+// Synchronous wrapper that does the right thing inside or outside a Tokio runtime (FR-048).
+```
+
+Each of the 9 providers follows this exact shape: `<Provider>JudgeClient`, `Blocking<Provider>JudgeClient`, with `new`, `with_retry_policy`, `with_batch_size`, `blocking()`, and the `JudgeClient` trait impl.
+
+---
+
+## Invariants across both crates
+
+1. **FR-048 — async + blocking**: Every public `Evaluator`, `JudgeClient`, and `Reporter` exposes both `evaluate_async` (async) and `evaluate` (blocking). The blocking wrapper uses `tokio::runtime::Handle::try_current()` + `block_in_place` or `futures::executor::block_on` as appropriate so it works inside and outside a Tokio runtime.
+2. **FR-049 — no unsafe**: Both crates compile under `#![forbid(unsafe_code)]` except `eval/src/evaluators/code/sandbox.rs` which relaxes to `#![allow(unsafe_code)]` at module scope (Unix only). This is the single FFI surface; see R-006.
+3. **FR-047 / SC-009 — opt-in only**: Default build of both crates adds no new mandatory deps. Every new surface lives behind a feature flag.
+4. **FR-050 — mock-only default tests**: `cargo test -p swink-agent-eval` and `cargo test -p swink-agent-eval-judges` make zero live LLM calls. Provider canary tests gate behind `live-judges` and env-var-sourced credentials.
+5. **Stable public API**: Every item listed here is part of the 0.x → 1.0 surface. Breaking changes require a semver-major bump of the affected crate.
+
+---
+
+## JSON wire schemas
+
+### `EvalSetResult` JSON schema
+
+Path: `specs/043-evals-adv-features/contracts/eval-result.schema.json` (to be authored during implementation). `JsonReporter` output validates against it in the reporter test suite.
+
+Top-level structure:
+```json
+{
+  "schema_version": "043",
+  "eval_set": { "id": "...", "name": "...", "case_count": N },
+  "cases": [
+    {
+      "case_id": "...",
+      "session_id": "uuid-v5",
+      "verdict": "Pass|Fail|Partial",
+      "duration_ms": N,
+      "metrics": [
+        { "evaluator": "...", "prompt_version": "...", "score": 0.82,
+          "threshold": 0.7, "verdict": "Pass", "reason": "...",
+          "samples": [0.81, 0.83, 0.82], "variance": 0.00011 }
+      ]
+    }
+  ],
+  "gate": { "passed": true, "violations": [] }
+}
+```
+
+### `GateConfig` JSON schema
+
+Extends spec 024's existing `GateConfig`. No new fields in 043.
+
+### LangSmith push payload
+
+Documented in R-015; mirrors LangSmith's `/runs` and `/feedback` endpoints. Keyed by evaluator `feedback_key` where set, else evaluator `name()`.

--- a/specs/043-evals-adv-features/data-model.md
+++ b/specs/043-evals-adv-features/data-model.md
@@ -1,0 +1,748 @@
+# Data Model: Evals: Advanced Features
+
+**Feature**: 043-evals-adv-features | **Date**: 2026-04-21
+
+Entities grouped by scope item. Types use Rust-like pseudocode; trait methods show async where asyncified. All new types live in `swink-agent-eval` unless marked `[eval-judges]`.
+
+---
+
+## 1. Judge infrastructure
+
+### `JudgeRegistry`
+
+Top-level configuration binding a judge model, retry policy, batch size, and cache to an `EvaluatorRegistry`. Constructor refuses to build without an explicit `model_id` (per Q9 clarification).
+
+```rust
+pub struct JudgeRegistry {
+    client: Arc<dyn JudgeClient>,     // concrete impl from eval-judges
+    model_id: String,                  // REQUIRED — no default ships
+    retry_policy: RetryPolicy,
+    batch_size: usize,
+    cache: Arc<JudgeCache>,
+    url_filter: Arc<dyn UrlFilter>,    // for attachments
+}
+
+pub struct RetryPolicy {
+    max_attempts: u32,                 // default 6
+    max_delay: Duration,               // default 4 min
+    jitter: bool,                      // default true
+}
+
+impl JudgeRegistry {
+    pub fn builder(client: Arc<dyn JudgeClient>, model_id: impl Into<String>) -> JudgeRegistryBuilder;
+    // Builder methods return Self; build() returns Result to surface validation
+    // (e.g., batch_size == 0 is rejected).
+}
+```
+
+**Validation rules**:
+- `model_id` is non-empty.
+- `batch_size` ∈ [1, 128] (upper bound pinned per FR-005 "bounded upper limit").
+- `retry_policy.max_attempts` ≤ 16 (ceiling — anything higher is almost certainly a misconfiguration).
+
+### `JudgePromptTemplate`
+
+Versioned, variable-substituting prompt template. `render` validates variable presence at construction; missing variables surface as `PromptError::MissingVariable { name }`.
+
+```rust
+pub trait JudgePromptTemplate: Send + Sync {
+    fn version(&self) -> &str;                // e.g., "correctness_v0"
+    fn render(&self, ctx: &PromptContext) -> Result<String, PromptError>;
+    fn family(&self) -> PromptFamily;         // Quality | Safety | RAG | Agent | Structured | Code | Multimodal
+                                              // (No `Simple` — simple-family evaluators are deterministic and register no templates.)
+}
+
+pub struct PromptContext {
+    pub case: Arc<EvalCase>,
+    pub invocation: Arc<Invocation>,
+    pub few_shot_examples: Vec<FewShotExample>,
+    pub custom: HashMap<String, serde_json::Value>,
+}
+
+pub enum PromptError {
+    MissingVariable { name: String },
+    RenderError(String),
+}
+```
+
+**Built-in templates** (one per evaluator, versioned `_v0`):
+- Quality: `helpfulness_v0`, `correctness_v0`, `conciseness_v0`, `coherence_v0`, `response_relevance_v0`, `hallucination_v0`, `faithfulness_v0`, `plan_adherence_v0`, `laziness_v0`, `goal_success_rate_v0`
+- Safety: `harmfulness_v0`, `toxicity_v0`, `fairness_v0`, `pii_leakage_v0`, `prompt_injection_v0`, `code_injection_v0`
+- RAG: `rag_groundedness_v0`, `rag_retrieval_relevance_v0`, `rag_helpfulness_v0`
+- Agent: `trajectory_accuracy_v0`, `trajectory_accuracy_with_ref_v0`, `task_completion_v0`, `user_satisfaction_v0`, `agent_tone_v0`, `knowledge_retention_v0`, `language_detection_v0`, `perceived_error_v0`, `interactions_v0`
+- Code: `code_llm_judge_v0`
+- Multimodal: `image_safety_v0`
+
+### `PromptTemplateRegistry`
+
+```rust
+pub struct PromptTemplateRegistry {
+    templates: HashMap<String, Arc<dyn JudgePromptTemplate>>,   // key = version identifier
+}
+
+impl PromptTemplateRegistry {
+    pub fn builtin() -> Self;                                    // ships all _v0 templates
+    pub fn get(&self, version: &str) -> Option<Arc<dyn JudgePromptTemplate>>;
+    pub fn register(&mut self, template: Arc<dyn JudgePromptTemplate>) -> Result<(), PromptError>;
+    // Rejects duplicate version keys.
+}
+```
+
+### `JudgeCache`
+
+LRU cache of prompt + model → verdict. Default in-memory; optional disk-backed.
+
+```rust
+pub struct JudgeCache {
+    entries: Mutex<LruMap<CacheKey, CachedVerdict>>,
+    capacity: usize,                          // default 1024
+    disk_path: Option<PathBuf>,
+}
+
+pub struct CacheKey {
+    prompt_hash: [u8; 32],   // SHA-256 of rendered prompt
+    model_id: String,
+}
+
+pub struct CachedVerdict {
+    verdict: JudgeVerdict,    // from 023
+    recorded_at: SystemTime,
+}
+```
+
+**Lifecycle**:
+- Insertion updates LRU ordering.
+- Lookup updates LRU ordering.
+- Disk-backed variant flushes dirty entries on `Drop` and warm-loads on construction.
+
+---
+
+## 2. Prompt-template registry *(covered under §1)*
+
+## 3. LLM judge evaluator family
+
+### Base `Evaluator` extensions
+
+Each new evaluator implements the 023 `Evaluator` trait. The signature is unchanged; what's new is that every implementation now supports per-instance overrides via a common `JudgeEvaluatorConfig`:
+
+```rust
+pub struct JudgeEvaluatorConfig {
+    pub template: Option<Arc<dyn JudgePromptTemplate>>,   // None → use builtin _v0
+    pub few_shot_examples: Vec<FewShotExample>,
+    pub system_prompt: Option<String>,
+    pub output_schema: Option<JsonSchema>,
+    pub use_reasoning: bool,                               // default true
+    pub feedback_key: Option<String>,                      // for LangSmith export
+    pub aggregator: Option<Box<dyn Aggregator>>,           // None → Average
+    pub judge_registry: Arc<JudgeRegistry>,
+}
+```
+
+Every judge-backed evaluator holds one `JudgeEvaluatorConfig`.
+
+### Quality family (10 evaluators)
+
+```rust
+pub struct HelpfulnessEvaluator { config: JudgeEvaluatorConfig }   // 7-level scale
+pub struct CorrectnessEvaluator { config: JudgeEvaluatorConfig }   // against expected_output
+pub struct ConcisenessEvaluator { config: JudgeEvaluatorConfig }   // 3-level
+pub struct CoherenceEvaluator   { config: JudgeEvaluatorConfig }   // 5-level
+pub struct ResponseRelevanceEvaluator { config: JudgeEvaluatorConfig }
+pub struct HallucinationEvaluator { config: JudgeEvaluatorConfig } // general, against model knowledge
+pub struct FaithfulnessEvaluator  { config: JudgeEvaluatorConfig } // RAG-grounded, against retrieved context
+pub struct PlanAdherenceEvaluator { config: JudgeEvaluatorConfig }
+pub struct LazinessEvaluator { config: JudgeEvaluatorConfig }
+pub struct GoalSuccessRateEvaluator { config: JudgeEvaluatorConfig } // consumes expected_assertion
+```
+
+### Safety family (6 evaluators; default aggregator `AllPass`)
+
+```rust
+pub struct HarmfulnessEvaluator { config: JudgeEvaluatorConfig }   // binary, broad spectrum
+pub struct ToxicityEvaluator    { config: JudgeEvaluatorConfig }   // binary, narrow (hate/harassment/slurs)
+pub struct FairnessEvaluator    { config: JudgeEvaluatorConfig }
+pub struct PIILeakageEvaluator  {
+    config: JudgeEvaluatorConfig,
+    entity_classes: Vec<PIIClass>,  // default: all built-in
+}
+pub struct PromptInjectionEvaluator { config: JudgeEvaluatorConfig }
+pub struct CodeInjectionEvaluator   { config: JudgeEvaluatorConfig }
+
+pub enum PIIClass { Email, Phone, SSN, CreditCard, IpAddress, ApiKey, PersonalName, Address, Other(String) }
+```
+
+### RAG family (4 evaluators)
+
+```rust
+pub struct RAGGroundednessEvaluator      { config: JudgeEvaluatorConfig }
+pub struct RAGRetrievalRelevanceEvaluator { config: JudgeEvaluatorConfig }
+pub struct RAGHelpfulnessEvaluator        { config: JudgeEvaluatorConfig }
+pub struct EmbeddingSimilarityEvaluator {
+    embedder: Arc<dyn Embedder>,  // consumer-supplied, no default
+    threshold: f64,               // default 0.8
+    aggregator: Option<Box<dyn Aggregator>>,
+}
+```
+
+`EmbeddingSimilarityEvaluator` is the sole deterministic member of this family (no `JudgeClient` use).
+
+### Agent / trajectory family (8 evaluators)
+
+```rust
+pub struct TrajectoryAccuracyEvaluator        { config: JudgeEvaluatorConfig }  // without ref
+pub struct TrajectoryAccuracyWithRefEvaluator { config: JudgeEvaluatorConfig }  // with expected_trajectory
+pub struct TaskCompletionEvaluator            { config: JudgeEvaluatorConfig }
+pub struct UserSatisfactionEvaluator          { config: JudgeEvaluatorConfig }
+pub struct AgentToneEvaluator                 { config: JudgeEvaluatorConfig }
+pub struct KnowledgeRetentionEvaluator        { config: JudgeEvaluatorConfig }
+pub struct LanguageDetectionEvaluator         { config: JudgeEvaluatorConfig }
+pub struct PerceivedErrorEvaluator            { config: JudgeEvaluatorConfig }
+pub struct InteractionsEvaluator {
+    config: JudgeEvaluatorConfig,
+    // expected_interactions consumed from case; scores multi-agent hand-off topology
+}
+```
+
+### Structured-output family (2 evaluators)
+
+```rust
+pub struct JsonMatchEvaluator {
+    config: JudgeEvaluatorConfig,
+    per_key_strategy: HashMap<String, KeyStrategy>,
+    exclude_keys: HashSet<String>,
+}
+
+pub enum KeyStrategy {
+    Average,
+    All,
+    None,
+    Rubric(Arc<dyn JudgePromptTemplate>),
+}
+
+pub struct JsonSchemaEvaluator {
+    schema: jsonschema::JSONSchema,    // compiled ahead of time
+    // deterministic; no JudgeClient use
+}
+```
+
+### Simple family (2 evaluators, always-on deterministic)
+
+```rust
+pub struct ExactMatchEvaluator {
+    case_sensitive: bool,       // default true
+    trim: bool,                 // default false
+}
+
+pub struct LevenshteinDistanceEvaluator {
+    threshold: f64,             // default 0.8 (normalized similarity)
+}
+```
+
+### Code family (5 evaluators, behind `evaluator-code`)
+
+```rust
+pub struct CargoCheckEvaluator { ... }          // deterministic — spawns `cargo check`
+pub struct ClippyEvaluator { ... }              // deterministic — spawns `cargo clippy`
+pub struct CodeExtractor {
+    strategy: CodeExtractorStrategy,
+}
+pub enum CodeExtractorStrategy {
+    MarkdownFence,
+    Regex(Regex),
+    Llm(Arc<dyn JudgeClient>),
+}
+pub struct CodeLlmJudgeEvaluator { config: JudgeEvaluatorConfig }
+pub struct SandboxedExecutionEvaluator {
+    limits: SandboxLimits,      // defaults per FR-017: 120s wall, 60s CPU, 1GB RSS, 256 FDs, no network
+}
+
+pub struct SandboxLimits {
+    pub wall_clock: Duration,    // default 120s
+    pub cpu_seconds: Duration,   // default 60s
+    pub memory_bytes: u64,       // default 1 GiB
+    pub file_descriptors: u32,   // default 256
+    pub allow_network: bool,     // default false
+}
+```
+
+### Multimodal family (behind `multimodal`)
+
+```rust
+pub struct ImageSafetyEvaluator { config: JudgeEvaluatorConfig }
+// Audio evaluators out of scope per FR-019.
+```
+
+### Aggregators (FR-022/023)
+
+```rust
+pub trait Aggregator: Send + Sync {
+    fn aggregate(&self, samples: &[Score]) -> Score;
+}
+
+pub struct Average;   // default per Q6
+pub struct AllPass;
+pub struct AnyPass;
+pub struct Weighted { weights: Vec<f64> }
+```
+
+---
+
+## 5. Multiturn simulation *(behind `simulation` feature)*
+
+### `ActorSimulator`
+
+```rust
+pub struct ActorSimulator {
+    profile: ActorProfile,
+    judge: Arc<dyn JudgeClient>,           // drives the simulated user
+    model_id: String,
+    greeting_pool: Vec<String>,
+    max_turns: u32,                        // default 10
+    goal_completion_signal: Option<ToolDef>,
+}
+
+pub struct ActorProfile {
+    pub name: String,
+    pub traits: Vec<String>,                // e.g., ["frustrated", "terse"]
+    pub context: String,                    // paragraph describing background
+    pub goal: String,                       // natural-language goal statement
+}
+```
+
+### `ToolSimulator`
+
+```rust
+pub struct ToolSimulator {
+    tools: HashMap<String, ToolSchema>,     // tool name → schema
+    judge: Arc<dyn JudgeClient>,
+    model_id: String,
+    state_registry: Arc<StateRegistry>,
+    history_cap: usize,                     // default 32
+}
+
+pub struct StateRegistry {
+    buckets: Mutex<HashMap<String, StateBucket>>,
+}
+
+pub struct StateBucket {
+    shared_state: serde_json::Value,        // arbitrary state blob per key
+    history: VecDeque<ToolCallRecord>,      // bounded by history_cap
+}
+
+pub struct ToolCallRecord {
+    tool: String,
+    args: serde_json::Value,
+    result: serde_json::Value,
+    timestamp: SystemTime,
+}
+```
+
+### `run_multiturn_simulation`
+
+```rust
+pub async fn run_multiturn_simulation(
+    agent: &dyn Agent,
+    actor: &ActorSimulator,
+    tool_sim: Option<&ToolSimulator>,
+    max_turns: u32,
+    cancel: CancellationToken,
+) -> Result<Invocation, SimulationError>;
+```
+
+Returns a complete `Invocation` scorable by any registered evaluator. Honors cancellation cooperatively.
+
+---
+
+## 6. Experiment generation *(behind `generation` feature)*
+
+### `ExperimentGenerator`
+
+```rust
+pub struct ExperimentGenerator {
+    judge: Arc<dyn JudgeClient>,
+    model_id: String,
+    planner: Arc<TopicPlanner>,
+    retry_cap: u32,                         // bounded retries on malformed output; default 3
+    validate: bool,                         // default true — always validate before emit
+}
+
+pub struct GenerationRequest {
+    pub context: String,
+    pub task: String,
+    pub desired_count: u32,
+    pub num_topics: u32,                    // how many diverse topics to plan
+    pub include_expected_output: bool,
+    pub include_expected_trajectory: bool,
+    pub include_expected_interactions: bool,
+    pub include_metadata: bool,
+    pub agent_tools: Option<Vec<ToolDef>>,   // when provided, trajectories reference only these
+}
+
+impl ExperimentGenerator {
+    pub async fn generate(&self, req: GenerationRequest) -> Result<EvalSet, GenerationError>;
+}
+```
+
+### `TopicPlanner`
+
+```rust
+pub struct TopicPlanner { judge: Arc<dyn JudgeClient>, model_id: String }
+
+impl TopicPlanner {
+    pub async fn plan(&self, context: &str, task: &str, num_topics: u32)
+        -> Result<Vec<TopicSlot>, GenerationError>;
+}
+
+pub struct TopicSlot {
+    pub topic: String,
+    pub case_count: u32,
+}
+```
+
+**Validation**: Every emitted `EvalCase` passes `EvalCase::validate()` before being added to the `EvalSet`. Failures trigger retry up to `retry_cap`; unrecoverable slots are omitted with a warning.
+
+---
+
+## 7. Observability / trace ingestion *(behind `trace-ingest` feature)*
+
+### `TraceProvider`
+
+```rust
+#[async_trait]
+pub trait TraceProvider: Send + Sync {
+    async fn fetch_session(&self, session_id: &str)
+        -> Result<RawSession, TraceProviderError>;
+}
+
+pub struct OtelInMemoryTraceProvider {
+    exporter: Arc<InMemorySpanExporter>,
+}  // always-on
+
+// Feature-gated concrete providers:
+pub struct OtlpHttpTraceProvider { /* ... */ }        // trace-otlp
+pub struct LangfuseTraceProvider { /* ... */ }        // trace-langfuse
+pub struct OpenSearchTraceProvider { /* ... */ }      // trace-opensearch
+pub struct CloudWatchTraceProvider { /* ... */ }      // trace-cloudwatch
+```
+
+### `SessionMapper`
+
+```rust
+pub trait SessionMapper: Send + Sync {
+    fn map(&self, raw: &RawSession) -> Result<Invocation, MappingError>;
+}
+
+pub struct OpenInferenceSessionMapper;
+
+pub struct LangChainSessionMapper;
+
+pub struct OtelGenAiSessionMapper {
+    pub version: GenAIConventionVersion,
+}
+
+pub enum GenAIConventionVersion {
+    V1_27,
+    V1_30,
+    Experimental,
+}
+```
+
+**Error model**: `MappingError::MissingAttribute { name }` never panics, per spec edge case.
+
+### `EvaluationLevel` and `TraceExtractor`
+
+```rust
+pub enum EvaluationLevel { Tool, Trace, Session }
+
+pub trait TraceExtractor: Send + Sync {
+    fn extract(&self, inv: &Invocation, level: EvaluationLevel) -> Vec<EvaluatorInput>;
+}
+
+// Adapters for multi-agent frameworks (specs 040 and 039):
+pub struct SwarmExtractor;
+pub struct GraphExtractor;
+```
+
+### `EvalsTelemetry` *(behind `telemetry` feature)*
+
+```rust
+pub struct EvalsTelemetry {
+    tracer: Arc<opentelemetry::Tracer>,
+    attributes: Vec<KeyValue>,                // always-on attributes
+}
+
+impl EvalsTelemetry {
+    pub fn builder() -> EvalsTelemetryBuilder;
+    pub fn instrument_runner(self, runner: &mut EvalRunner);
+}
+```
+
+Span tree per FR-035:
+- `swink.eval.run_set` — root; attrs: `eval_set.id`, `eval_set.name`, `case_count`.
+- `swink.eval.case` — child; attrs: `case.id`, `case.name`, `verdict`, `duration_ms`, `session_id`.
+- `swink.eval.evaluator` — grandchild; attrs: `evaluator.name`, `prompt.version`, `score.value`, `score.threshold`, `verdict`.
+
+---
+
+## 8. Runner upgrades
+
+### Extended `EvalRunner`
+
+```rust
+pub struct EvalRunner {
+    // Existing fields from 023/024...
+    parallelism: usize,                     // default 1
+    num_runs: u32,                          // default 1
+    cache: Option<Arc<dyn EvaluationDataStore>>,
+    initial_session_file: Option<PathBuf>,
+    telemetry: Option<Arc<EvalsTelemetry>>,
+    cancel: Option<CancellationToken>,
+}
+
+impl EvalRunner {
+    pub fn with_parallelism(self, n: usize) -> Self;       // panics if n == 0
+    pub fn with_num_runs(self, n: u32) -> Self;             // panics if n == 0
+    pub fn with_cache(self, store: Arc<dyn EvaluationDataStore>) -> Self;
+    pub fn with_initial_session_file(self, path: PathBuf) -> Self;
+    pub fn with_telemetry(self, tel: Arc<EvalsTelemetry>) -> Self;
+    pub fn with_cancellation(self, tok: CancellationToken) -> Self;
+}
+```
+
+### `EvaluationDataStore`
+
+```rust
+#[async_trait]
+pub trait EvaluationDataStore: Send + Sync {
+    async fn get(&self, key: &CacheKey) -> Result<Option<Invocation>, StoreError>;
+    async fn put(&self, key: CacheKey, inv: Invocation) -> Result<(), StoreError>;
+}
+
+pub struct LocalFileTaskResultStore {
+    root: PathBuf,
+}
+```
+
+Cache key format per R-020:
+```rust
+pub struct CacheKey(pub [u8; 32]);  // SHA-256 of canonical CaseFingerprint bincode
+```
+
+### Runner iteration shape (pseudocode)
+
+```rust
+for case in eval_set.cases {
+    let permit = semaphore.acquire().await;
+    let fingerprint = CaseFingerprint::from(&case, &initial_session, &agent_tools, model_id);
+    let key = CacheKey::from(&fingerprint);
+
+    let invocation = match cache.as_ref().and_then(|c| c.get(&key).await?) {
+        Some(cached) => cached,
+        None => {
+            let fresh = agent.run(&case).await?;
+            if let Some(c) = cache.as_ref() { c.put(key, fresh.clone()).await?; }
+            fresh
+        }
+    };
+
+    let samples: Vec<Score> = (0..num_runs).map(|run_idx| {
+        telemetry.span("swink.eval.case", || registry.evaluate(&case, &invocation).await)
+    }).collect();
+
+    let composite = aggregator.aggregate(&samples);   // Average by default
+    let variance = samples.std_dev();
+}
+```
+
+---
+
+## 9. Reporting
+
+```rust
+pub trait Reporter: Send + Sync {
+    fn render(&self, result: &EvalSetResult) -> Result<ReporterOutput, ReporterError>;
+}
+
+pub enum ReporterOutput {
+    Stdout(String),                          // console / markdown
+    Artifact { path: PathBuf, bytes: Vec<u8> },
+    Remote { backend: String, identifier: String },   // LangSmith run URL
+}
+
+pub struct ConsoleReporter;                    // always-on, plain-text
+pub struct JsonReporter;                        // always-on, self-contained JSON + published schema
+pub struct MarkdownReporter;                    // always-on, PR-comment-ready
+pub struct HtmlReporter { /* ... */ }           // html-report feature
+pub struct LangSmithExporter { api_token: String, endpoint: Url }  // langsmith feature
+```
+
+**JSON schema**: Published at `specs/043-evals-adv-features/contracts/eval-result.schema.json` (added during implementation). `JsonReporter` output validates against it.
+
+---
+
+## 10. Case-model extensions
+
+### Extended `EvalCase`
+
+```rust
+pub struct EvalCase {
+    // Existing fields from 023...
+    pub case_id: String,
+    pub case_name: String,
+    pub system_prompt: Option<String>,
+    pub user_messages: Vec<ChatMessage>,
+    pub expected_output: Option<String>,
+    pub expected_trajectory: Option<Vec<ToolCallExpectation>>,
+
+    // New in 043:
+    pub expected_assertion: Option<Assertion>,
+    pub expected_interactions: Option<Vec<InteractionExpectation>>,
+    pub few_shot_examples: Vec<FewShotExample>,
+    pub attachments: Vec<Attachment>,
+    pub session_id: Uuid,                       // auto-default UUID v5, see below
+    pub metadata: HashMap<String, serde_json::Value>,
+}
+
+impl EvalCase {
+    pub fn default_session_id(&self) -> Uuid {
+        // CASE_NAMESPACE is a project-specific namespace UUID minted once and pinned
+        // in eval/src/types.rs. It is itself Uuid::new_v5(&NAMESPACE_OID, b"swink-agent-eval.case").
+        let canonical = bincode::serialize(&self.content_fingerprint()).unwrap();
+        let digest = Sha256::digest(&canonical);
+        Uuid::new_v5(&CASE_NAMESPACE, digest.as_slice())
+    }
+}
+```
+
+### `Attachment` (per Q10 clarification)
+
+```rust
+pub enum Attachment {
+    Path(PathBuf),
+    Base64 { mime: String, bytes: Vec<u8> },
+    Url(String),
+}
+
+pub struct MaterializedAttachment {
+    pub mime: String,
+    pub bytes: Vec<u8>,
+}
+
+pub enum AttachmentError {
+    PathNotFound(PathBuf),
+    DecodeError(String),
+    UrlBlocked { url: String, reason: String },  // SSRF filter
+    FetchFailed { url: String, status: u16 },
+    UnsupportedMime { mime: String },
+}
+
+impl Attachment {
+    pub async fn materialize(&self, eval_set_root: &Path, filter: &dyn UrlFilter)
+        -> Result<MaterializedAttachment, AttachmentError>;
+}
+```
+
+### `FewShotExample`
+
+```rust
+pub struct FewShotExample {
+    pub input: String,
+    pub expected: String,
+    pub reasoning: Option<String>,
+}
+```
+
+### `Assertion`
+
+```rust
+pub struct Assertion {
+    pub description: String,
+    pub kind: AssertionKind,
+}
+
+pub enum AssertionKind {
+    GoalCompleted,
+    UserSatisfied,
+    ToolInvoked(String),
+    Custom { predicate: String },     // free-form; judge-evaluated
+}
+```
+
+---
+
+## 11. CI and DX scaffolding
+
+Static YAML templates shipped in `eval/src/ci/templates/` (not runtime data). See R-018 for filenames and R-016 for the CLI subcommand shape.
+
+---
+
+## Relationships
+
+```text
+EvalSet ──owns*── EvalCase ──references── Attachment
+                              ──refs?──── expected_assertion: Assertion
+                              ──refs?──── expected_interactions: [InteractionExpectation]
+                              ──refs*──── few_shot_examples: [FewShotExample]
+
+EvalRunner ──uses──── EvaluatorRegistry ──owns*── Evaluator
+           ──uses──── JudgeRegistry    ──owns──── JudgeClient (from eval-judges)
+                                       ──owns──── PromptTemplateRegistry
+                                       ──owns──── JudgeCache
+           ──uses?─── EvaluationDataStore
+           ──uses?─── EvalsTelemetry
+           ──uses?─── CancellationToken
+
+ActorSimulator ──drives── Agent ──via── ToolSimulator(s)
+run_multiturn_simulation ──produces── Invocation
+
+ExperimentGenerator ──owns── TopicPlanner ──produces── [TopicSlot]
+                    ──produces── EvalSet
+
+TraceProvider ──produces── RawSession ──mapped-by── SessionMapper ──produces── Invocation
+                                      ──extracted-by── TraceExtractor ──produces── [EvaluatorInput]
+
+EvalSetResult ──rendered-by── Reporter (Console | Json | Markdown | Html | LangSmith)
+```
+
+---
+
+## Validation rules summary
+
+| Entity | Rule | Surface |
+|---|---|---|
+| `JudgeRegistry` | `model_id` non-empty | Construction-time error |
+| `JudgeRegistry` | `batch_size` ∈ [1, 128] | Construction-time error |
+| `JudgePromptTemplate::render` | All named variables populated | Construction or evaluator-construction time |
+| `EvalCase` | `case_id` unique within `EvalSet` | Validation on `EvalSet::validate()` |
+| `EvalCase` | `session_id` is valid UUID (v5 when auto) | Serde parse time |
+| `Attachment::Path` | Path exists relative to eval-set root at materialization | `AttachmentError::PathNotFound` at runtime (not parse) |
+| `Attachment::Url` | Passes `UrlFilter::check` | `AttachmentError::UrlBlocked` at materialization |
+| `SandboxedExecutionEvaluator` | Not invoked on Windows | `EvaluatorError::UnsupportedPlatform` at `evaluate_async` |
+| `ExperimentGenerator` | Every emitted case passes `EvalCase::validate` | Before adding to returned `EvalSet` |
+| `ToolSimulator` | Generated response validates against tool schema | `SimulationError::SchemaValidation` surfaced to evaluator |
+| `EvalRunner::with_parallelism` | `n > 0` | Panics on 0 (misconfiguration signal) |
+| `EvalRunner::with_num_runs` | `n > 0` | Panics on 0 |
+
+---
+
+## State transitions
+
+### `EvalRunner` execution state (per case)
+
+```text
+Queued → AcquiringPermit → RunningAgent (or CacheHit) → Evaluating[run=1..N] → Aggregating → Reporting
+                                                                      │
+                                                                      └─(cancel)→ PartialCompleted
+```
+
+### `ActorSimulator` turn loop
+
+```text
+Initialized → Greeted → Turn(i) → Turn(i+1) → ... → { GoalCompleted | MaxTurnsReached | Cancelled }
+```
+
+---
+
+## Notes on panic isolation (FR-021)
+
+Every `Evaluator`, `SessionMapper`, `TraceExtractor`, `Simulator`, and `Reporter` runs through a `tokio::spawn(...).await` wrapper at the registry/orchestrator boundary. `JoinError::is_panic()` converts to `Score::fail().with_detail(PanicDetail { location, message })` — see R-021. No panic propagates to abort the run.

--- a/specs/043-evals-adv-features/plan.md
+++ b/specs/043-evals-adv-features/plan.md
@@ -1,0 +1,220 @@
+# Implementation Plan: Evals: Advanced Features
+
+**Branch**: `043-evals-adv-features` | **Date**: 2026-04-21 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/043-evals-adv-features/spec.md`
+
+## Summary
+
+Layer a production-ready LLM-as-judge and advanced evaluation surface on top of the `swink-agent-eval` crate shipped by specs 023/024. A new workspace crate `swink-agent-eval-judges` hosts per-provider `JudgeClient` implementations behind feature flags. The existing `eval` crate is extended with a versioned prompt-template registry, 24 judge-backed and deterministic evaluators across seven families (quality, safety, RAG, agent, structured, simple, code), multi-turn simulation (`ActorSimulator`/`ToolSimulator`), auto-generation (`ExperimentGenerator`/`TopicPlanner`), OTel/Langfuse/OpenSearch/CloudWatch trace ingestion, runner upgrades (parallelism, `num_runs`, cached invocations, cancellation), plain-text/JSON/Markdown/HTML reporters, a LangSmith exporter, and a `swink-eval` CLI binary. Per FR-047, the default build adds no new mandatory dependencies — every new surface is gated behind an opt-in feature.
+
+## Technical Context
+
+**Language/Version**: Rust latest stable (workspace pins `1.95` MSRV), edition 2024
+**Primary Dependencies (existing)**: `swink-agent` (core types, `CancellationToken`, `AgentEvent`), `swink-agent-eval` (023/024 — `Evaluator`, `EvalCase`, `EvalSet`, `Invocation`, `EvalRunner`, `FsEvalStore`, `GateConfig`, `Score`, `Verdict`, `JudgeClient`, `JudgeVerdict`, `JudgeError`, `MockJudge`), `serde`/`serde_json`, `tokio`/`tokio-util` (async + cancellation), `futures`, `tracing`, `uuid` (v4 + v5), `regex`, `sha2` (content-hash cache keys + UUID v5 namespaces), `thiserror`
+**Primary Dependencies (new, all feature-gated)**:
+  - `minijinja` (prompt templating with named variables and compile-time checks) — judge-core feature
+  - `backoff` (exponential-backoff retry) — judge-core feature
+  - `strsim` (Levenshtein) — `evaluator-simple` feature
+  - `jsonschema` (deterministic schema validation) — `evaluator-structured` feature
+  - `opentelemetry` + `opentelemetry-sdk` (OTel SDK for `EvalsTelemetry`) — `telemetry` feature
+  - `opentelemetry-otlp` — `trace-otlp` feature
+  - `opentelemetry-stdout` (optional dev reporter) — `telemetry` feature
+  - Provider adapters: `swink-agent-adapters-{anthropic,openai,gemini,bedrock,mistral,azure,xai,ollama,proxy}` — per-provider `judge-<name>` features in `eval-judges`
+  - `handlebars` or `askama` (HTML templating) — `html-report` feature
+  - `libc` (POSIX rlimit/setrlimit on Unix) — `evaluator-sandbox` feature (Unix-only)
+  - `reqwest` (LangSmith HTTP) — `langsmith` feature
+  - `clap` (CLI parsing) — `cli` feature / binary
+  - `dev-dependencies only`: `wiremock` (HTTP test doubles for judge clients), `opentelemetry-stdout` or in-memory exporter for trace-ingestion tests
+**Storage**: Filesystem for `LocalFileTaskResultStore` (extends `FsEvalStore` pattern from 024). No database dependency.
+**Testing**: `cargo test -p swink-agent-eval` and `cargo test -p swink-agent-eval-judges` using `MockJudge` + `wiremock`. A `live-judges` feature gates a small canary suite that hits real provider endpoints when explicit env-vars are set.
+**Target Platform**: Linux, macOS, Windows — with `SandboxedExecutionEvaluator` deliberately Unix-only (Windows fails fast with `EvaluatorError::UnsupportedPlatform`).
+**Project Type**: Library crates (`swink-agent-eval` extended; `swink-agent-eval-judges` new) + a CLI binary target (`swink-eval`) hosted in the `eval` crate behind a `cli` feature.
+**Performance Goals**: SC-002 — 20-case/parallelism-4/fast-provider suite completes in under 2× single-case wall-clock; SC-003 — prompt-only re-run reuses cached invocations and skips all agent calls.
+**Constraints**:
+  - `#![forbid(unsafe_code)]` across both crates (FR-049).
+  - Default build MUST add no new mandatory deps beyond what spec 023 pulled in (FR-047, SC-009).
+  - Both async (`evaluate_async`) and blocking (`evaluate`) entry points on every evaluator, correct inside and outside a Tokio runtime (FR-048).
+  - Panic isolation at registry boundary (FR-021) — every new evaluator/simulator/generator/reporter catches panics and converts to `Score::fail()` with diagnostic context.
+**Scale/Scope**:
+  - 50 functional requirements (FR-001 through FR-043 and FR-045 through FR-050; FR-044 was removed during clarification).
+  - 24 evaluators across 7 families (spec §Key Entities + Q1 clarification splits pairs).
+  - 9 provider `JudgeClient` implementations, each behind its own feature flag in `eval-judges`.
+  - 4+ trace providers (in-memory always-on; OTLP-HTTP, Langfuse, OpenSearch, CloudWatch feature-gated).
+  - 5 reporters (console/json/md always-on; html + langsmith feature-gated).
+  - New workspace crate raises member count from 14 → 15.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+No formal `constitution.md` exists in this repository. Prior plans (042, 023, 024) apply the following implicit workspace principles, and this plan preserves them:
+
+| Principle | Status | Notes |
+|---|---|---|
+| I. Library-First | **PASS** | `swink-agent-eval-judges` is a new independent crate depending on `swink-agent-eval` + per-provider adapter crates. `swink-agent-eval` extensions are additive and feature-gated. Neither crate takes a reverse dep from core. |
+| II. Test-Driven | **PASS** | Per FR-050, the default test suite uses `MockJudge` and HTTP test doubles — no live LLM calls. A `live-judges` feature opts into a tiny canary suite. Every new evaluator and simulator ships with contract tests before implementation. |
+| III. Efficiency & Performance | **PASS** | Runner gains structured parallelism (bounded semaphore); `EvaluationDataStore` avoids agent re-invocations; `JudgeCache` avoids duplicate prompt dispatches; `JudgeClient` supports request batching. SC-002/SC-003 measurable. |
+| IV. Leverage the Ecosystem | **PASS** | `minijinja`, `backoff`, `strsim`, `jsonschema`, `opentelemetry`, `handlebars`/`askama`, `clap`, `libc`, `wiremock` — all well-maintained crates. No hand-rolled alternatives. |
+| V. Provider Agnosticism | **PASS** | `JudgeClient` trait is the only interface evaluators depend on. Per-provider implementations live in `eval-judges` behind feature flags and wrap adapter crates without polluting them. |
+| VI. Safety & Correctness | **PASS** | `#![forbid(unsafe_code)]` on both crate roots; sandbox uses POSIX rlimit/setrlimit via `libc` (the only FFI surface), localized to `evaluators::code::sandbox::posix` and explicitly permitted by FR-049's carve-out (which pins the `cfg(target_family = "unix")` and `// SAFETY:` requirements). SSRF guards on `Attachment::Url`. Panic isolation per FR-021, which also mandates score clamping to `[0.0, 1.0]`. Cancellation propagates cooperatively per FR-040. |
+| Crate count (14 → 15) | **JUSTIFIED** | `eval-judges` has per-provider adapter deps that don't belong in the pure `eval` crate; adding them to `eval` would drag every adapter into `eval`'s default-build transitive set even behind features (Cargo feature unification bugs). A separate crate lets consumers enable only the providers they need without pulling in others' adapter crates as dev-deps. |
+| MSRV | **PASS** | Stable Rust, edition 2024. All new deps tested against 1.95. |
+
+**Gate result: ALL PASS** — no unjustified violations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/043-evals-adv-features/
+├── spec.md              # Feature specification (clarified 2026-04-21)
+├── plan.md              # This file
+├── research.md          # Phase 0: architectural decisions and dep choices
+├── data-model.md        # Phase 1: entity relationships and type signatures
+├── quickstart.md        # Phase 1: end-to-end usage walkthroughs
+├── contracts/           # Phase 1: public API contracts
+│   └── public-api.md
+├── checklists/
+│   └── requirements.md  # (already present)
+└── tasks.md             # Phase 2 output (generated by /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+eval/                                     # existing crate, extended
+├── Cargo.toml                            # adds feature flags + optional deps
+├── src/
+│   ├── lib.rs                            # new public re-exports for added surfaces
+│   ├── types.rs                          # extended: EvalCase fields per FR-043, Attachment enum
+│   ├── evaluator.rs                      # extended: EvaluatorRegistry supports panic isolation for new families
+│   ├── runner.rs                         # extended: parallelism, num_runs, cancellation, initial_session_file
+│   ├── score.rs                          # unchanged (inherited from 023/024)
+│   ├── prompt/
+│   │   ├── mod.rs                        # JudgePromptTemplate trait, registry
+│   │   ├── templates.rs                  # Built-in templates (quality/safety/RAG/agent/structured/code)
+│   │   └── version.rs                    # Version suffix helpers (_v0, _v1)
+│   ├── judge/
+│   │   ├── mod.rs                        # JudgeRegistry, JudgeCache, retry policy
+│   │   └── cache.rs                      # In-memory LRU + optional disk-backed cache
+│   ├── aggregator/
+│   │   └── mod.rs                        # Aggregator trait + Average/AllPass/AnyPass/Weighted built-ins
+│   ├── evaluators/
+│   │   ├── mod.rs                        # Family module re-exports
+│   │   ├── quality.rs                    # Helpfulness, Correctness, Conciseness, Coherence,
+│   │   │                                 #   ResponseRelevance, Hallucination, Faithfulness,
+│   │   │                                 #   PlanAdherence, Laziness, GoalSuccessRate
+│   │   ├── safety.rs                     # Harmfulness, Toxicity, Fairness, PIILeakage,
+│   │   │                                 #   PromptInjection, CodeInjection
+│   │   ├── rag.rs                        # RAGGroundedness, RAGRetrievalRelevance,
+│   │   │                                 #   RAGHelpfulness, EmbeddingSimilarity (+ Embedder trait)
+│   │   ├── agent.rs                      # TrajectoryAccuracy, TaskCompletion, UserSatisfaction,
+│   │   │                                 #   AgentTone, KnowledgeRetention, LanguageDetection,
+│   │   │                                 #   PerceivedError, Interactions
+│   │   ├── structured.rs                 # JsonMatch (per-key rubrics), JsonSchema
+│   │   ├── simple.rs                     # ExactMatch, LevenshteinDistance
+│   │   ├── code/
+│   │   │   ├── mod.rs
+│   │   │   ├── cargo_check.rs
+│   │   │   ├── clippy.rs
+│   │   │   ├── extractor.rs              # CodeExtractor (markdown-fence / LLM / regex)
+│   │   │   ├── llm_judge.rs              # CodeLlmJudgeEvaluator
+│   │   │   └── sandbox.rs                # SandboxedExecutionEvaluator (Unix only; Windows stub)
+│   │   └── multimodal.rs                 # Image-safety evaluators (behind `multimodal` feature)
+│   ├── simulation/
+│   │   ├── mod.rs                        # (behind `simulation` feature)
+│   │   ├── actor.rs                      # ActorSimulator, ActorProfile
+│   │   ├── tool.rs                       # ToolSimulator, StateRegistry, StateBucket
+│   │   └── orchestrator.rs               # run_multiturn_simulation
+│   ├── generation/
+│   │   ├── mod.rs                        # (behind `generation` feature)
+│   │   ├── experiment.rs                 # ExperimentGenerator
+│   │   └── topic.rs                      # TopicPlanner
+│   ├── trace/
+│   │   ├── mod.rs                        # (behind `trace-ingest` feature)
+│   │   ├── provider.rs                   # TraceProvider trait + OtelInMemoryTraceProvider
+│   │   ├── mapper.rs                     # SessionMapper trait,
+│   │   │                                 #   OpenInferenceSessionMapper,
+│   │   │                                 #   LangChainSessionMapper,
+│   │   │                                 #   OtelGenAiSessionMapper + GenAIConventionVersion
+│   │   ├── extractor.rs                  # TraceExtractor, EvaluationLevel,
+│   │   │                                 #   SwarmExtractor (spec 040),
+│   │   │                                 #   GraphExtractor (spec 039)
+│   │   ├── otlp.rs                       # OTLP-HTTP provider (feature `trace-otlp`)
+│   │   ├── langfuse.rs                   # (feature `trace-langfuse`)
+│   │   ├── opensearch.rs                 # (feature `trace-opensearch`)
+│   │   └── cloudwatch.rs                 # (feature `trace-cloudwatch`)
+│   ├── telemetry.rs                      # EvalsTelemetry (feature `telemetry`)
+│   ├── cache.rs                          # EvaluationDataStore + LocalFileTaskResultStore
+│   ├── url_filter.rs                     # UrlFilter trait + DefaultUrlFilter (always-on; used by attachment materialization)
+│   ├── report/
+│   │   ├── mod.rs                        # Reporter trait + Report types
+│   │   ├── console.rs                    # Plain-text ConsoleReporter (always-on)
+│   │   ├── json.rs                       # JsonReporter (always-on)
+│   │   ├── markdown.rs                   # MarkdownReporter (always-on)
+│   │   ├── html.rs                       # HtmlReporter (feature `html-report`)
+│   │   └── langsmith.rs                  # LangSmithExporter (feature `langsmith`)
+│   ├── ci/
+│   │   └── templates/                    # Shipped GitHub Actions YAML templates (static files)
+│   └── bin/
+│       └── swink_eval.rs                 # `swink-eval` CLI binary (feature `cli`)
+└── tests/
+    ├── common/mod.rs
+    ├── judge_registry_test.rs
+    ├── prompt_template_test.rs
+    ├── evaluators_quality_test.rs
+    ├── evaluators_safety_test.rs
+    ├── evaluators_rag_test.rs
+    ├── evaluators_agent_test.rs
+    ├── evaluators_structured_test.rs
+    ├── evaluators_simple_test.rs
+    ├── evaluators_code_test.rs
+    ├── simulation_test.rs
+    ├── generation_test.rs
+    ├── trace_ingest_test.rs
+    ├── runner_parallelism_test.rs
+    ├── runner_num_runs_test.rs
+    ├── cache_test.rs
+    ├── reporter_test.rs
+    ├── telemetry_test.rs
+    └── cli_test.rs
+
+eval-judges/                              # NEW workspace crate
+├── Cargo.toml                            # per-provider feature flags
+├── src/
+│   ├── lib.rs                            # Public API + feature-gated re-exports
+│   ├── client.rs                         # Shared retry + backoff wiring used by each provider
+│   ├── anthropic.rs                      # AnthropicJudgeClient (feature `anthropic`)
+│   ├── openai.rs                         # (feature `openai`)
+│   ├── bedrock.rs                        # (feature `bedrock`)
+│   ├── gemini.rs                         # (feature `gemini`)
+│   ├── mistral.rs                        # (feature `mistral`)
+│   ├── azure.rs                          # (feature `azure`)
+│   ├── xai.rs                            # (feature `xai`)
+│   ├── ollama.rs                         # (feature `ollama`)
+│   └── proxy.rs                          # (feature `proxy`)
+└── tests/
+    ├── common/mod.rs                     # Shared wiremock fixtures
+    ├── anthropic_test.rs                 # (gated by cfg(feature = "anthropic"))
+    ├── openai_test.rs
+    └── ...                               # one per provider
+```
+
+**Structure Decision**:
+
+1. **Extend `eval` rather than fragment.** Prompt registry, evaluators, simulation, generation, trace ingestion, telemetry, cache, reporters, and the CLI binary all live in `swink-agent-eval` behind feature flags. This keeps the consumer surface coherent (one crate to depend on) and matches the precedent set by `swink-agent-eval` already absorbing 023 + 024.
+2. **New `eval-judges` crate for provider judge clients only.** The spec's own Assumptions line 349 mandates this, and the rationale (adapter-dep isolation, per-provider feature flags without polluting `eval`'s default transitive set) is sound. Each provider feature enables exactly one `<Provider>JudgeClient` impl + its adapter dependency.
+3. **`swink-eval` CLI as a binary target in `eval`.** Behind a `cli` feature. Avoids a separate crate for ~500 LoC of `clap` wiring. `cargo install swink-agent-eval --features cli` gives users the binary.
+4. **Feature-flag naming convention** (pinned here; see R-010 in research.md):
+   - On `eval`: `judge-core`, `evaluator-quality`, `evaluator-safety`, `evaluator-rag`, `evaluator-agent`, `evaluator-structured`, `evaluator-simple`, `evaluator-code`, `evaluator-sandbox`, `multimodal`, `simulation`, `generation`, `trace-ingest`, `trace-otlp`, `trace-langfuse`, `trace-opensearch`, `trace-cloudwatch`, `telemetry`, `html-report`, `langsmith`, `cli`, `live-judges`.
+   - On `eval-judges`: `anthropic`, `openai`, `bedrock`, `gemini`, `mistral`, `azure`, `xai`, `ollama`, `proxy`. Each enables its own adapter dep plus `eval/judge-core`.
+   - Meta-feature `all-judges` on `eval-judges` and `all-evaluators` on `eval` for docs.rs and integration testing.
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|---|---|---|
+| Adding a 15th workspace crate (`eval-judges`) | Per-provider `JudgeClient` implementations wrap adapter crates; placing them in `eval` would make the default build's transitive-dep graph include adapter internals through Cargo feature unification in transitive dev-dep contexts | Combining with `eval` causes feature-unification pollution where enabling any eval consumer accidentally pulls adapter deps into other workspace members' builds; spec 043 Assumptions line 349 explicitly pins this decomposition |
+| `cli` binary target inside `eval` (not a separate crate) | CLI is ~500 LoC of `clap` wiring over `eval`'s public API; a separate crate would be a pure consumer with no independent logic | A standalone `eval-cli` crate would double the workspace-member count increase (14 → 16) without architectural benefit; binary target pattern is established (`xtask`) |
+| 22 new features on `eval` | Every spec scope item (11) splits into always-on core + multiple opt-in surfaces (evaluator families, trace backends, reporters, CLI); per FR-047 nothing can be mandatory | A monolithic always-on build violates FR-047 and SC-009 explicitly — the default build of `swink-agent-eval` MUST NOT add new mandatory dependencies beyond what spec 023 requires |

--- a/specs/043-evals-adv-features/quickstart.md
+++ b/specs/043-evals-adv-features/quickstart.md
@@ -1,0 +1,331 @@
+# Quickstart: Evals: Advanced Features
+
+**Feature**: 043-evals-adv-features | **Date**: 2026-04-21
+
+End-to-end walkthroughs for the advanced evals surface. Assumes the user has spec 023's baseline `swink-agent-eval` working and an `EvalSet` authored.
+
+---
+
+## 1. Score an eval set with a production judge
+
+**Goal**: Run 20 cases through `CorrectnessEvaluator` and `HelpfulnessEvaluator` backed by Anthropic.
+
+```toml
+# Cargo.toml
+[dependencies]
+swink-agent = "0.9"
+swink-agent-eval = { version = "0.9", features = ["judge-core", "evaluator-quality"] }
+swink-agent-eval-judges = { version = "0.9", features = ["anthropic"] }
+swink-agent-adapters-anthropic = "0.9"
+```
+
+```rust
+use std::sync::Arc;
+use swink_agent_eval::{
+    judge::JudgeRegistry,
+    evaluators::{CorrectnessEvaluator, HelpfulnessEvaluator, JudgeEvaluatorConfig},
+    EvaluatorRegistry, EvalRunner, EvalSet,
+};
+use swink_agent_eval_judges::AnthropicJudgeClient;
+use swink_agent_adapters_anthropic::AnthropicAdapter;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let adapter = Arc::new(AnthropicAdapter::from_env()?);
+    let judge_client = Arc::new(AnthropicJudgeClient::new(adapter));
+    let judge_registry = Arc::new(
+        JudgeRegistry::builder(judge_client, "claude-sonnet-4-6").build()?
+    );
+
+    let mut registry = EvaluatorRegistry::new();
+    registry.add(Box::new(CorrectnessEvaluator::new(
+        JudgeEvaluatorConfig::default_with(judge_registry.clone())
+    )));
+    registry.add(Box::new(HelpfulnessEvaluator::new(
+        JudgeEvaluatorConfig::default_with(judge_registry.clone())
+    )));
+
+    let eval_set = EvalSet::from_file("cases.json")?;
+    let agent = build_agent().await?;
+    let result = EvalRunner::new(agent, registry).run_set(&eval_set).await?;
+
+    println!("Verdict: {:?}", result.verdict());
+    Ok(())
+}
+```
+
+That's US1 (score runs) + the 10-line happy path promised by SC-001.
+
+---
+
+## 2. Run 200 cases fast with parallelism + caching
+
+**Goal**: Iterate on a judge prompt across 200 cases without re-calling the agent.
+
+```rust
+use swink_agent_eval::cache::LocalFileTaskResultStore;
+
+let cache = Arc::new(LocalFileTaskResultStore::new("./.swink-eval-cache".into()));
+
+let runner = EvalRunner::new(agent, registry)
+    .with_parallelism(8)
+    .with_num_runs(3)                     // judge-variance diagnostic
+    .with_cache(cache);
+
+let result = runner.run_set(&eval_set).await?;
+
+// result.cases[0].metrics[0].samples == [0.81, 0.83, 0.82]
+// result.cases[0].metrics[0].variance ≈ 0.00011
+```
+
+**First run**: every case calls the agent; invocations are cached by content-hashed key.
+**Second run** (after tweaking `HelpfulnessEvaluator`'s prompt template): cache hits, agent not invoked, only the judge loop re-executes (per Q2/R-013 clarification). This is SC-003's promise.
+
+---
+
+## 3. Override a built-in judge prompt
+
+**Goal**: Customize `CorrectnessEvaluator`'s rubric with a few-shot example.
+
+```rust
+use swink_agent_eval::prompt::{JudgePromptTemplate, FewShotExample};
+use swink_agent_eval::evaluators::JudgeEvaluatorConfig;
+
+struct MyCorrectnessTemplate;
+impl JudgePromptTemplate for MyCorrectnessTemplate {
+    fn version(&self) -> &str { "my_correctness_v0" }
+    fn family(&self) -> PromptFamily { PromptFamily::Quality }
+    fn render(&self, ctx: &PromptContext) -> Result<String, PromptError> {
+        // return rendered prompt string
+    }
+}
+
+let config = JudgeEvaluatorConfig {
+    template: Some(Arc::new(MyCorrectnessTemplate)),
+    few_shot_examples: vec![FewShotExample {
+        input: "What is 2+2?".into(),
+        expected: "4".into(),
+        reasoning: Some("Simple arithmetic".into()),
+    }],
+    use_reasoning: true,
+    ..JudgeEvaluatorConfig::default_with(judge_registry.clone())
+};
+
+let evaluator = CorrectnessEvaluator::new(config);
+```
+
+Each case's result records `prompt_version: "my_correctness_v0"`, making score drift across versions deterministic to trace (SC-005).
+
+---
+
+## 4. Multi-turn simulation with a simulated user and tools
+
+**Goal**: Test an agent's behavior across a 5-turn dialogue without wiring real tools.
+
+```toml
+[dependencies]
+swink-agent-eval = { version = "0.9", features = ["judge-core", "simulation", "evaluator-agent"] }
+```
+
+```rust
+use swink_agent_eval::simulation::{
+    ActorSimulator, ActorProfile, ToolSimulator, run_multiturn_simulation,
+};
+use swink_agent_eval::evaluators::GoalSuccessRateEvaluator;
+
+let profile = ActorProfile {
+    name: "frustrated_customer".into(),
+    traits: vec!["frustrated".into(), "terse".into()],
+    context: "Their shipment is 2 weeks late; they've already emailed twice.".into(),
+    goal: "Get a firm delivery date or a refund.".into(),
+};
+
+let actor = ActorSimulator::new(profile, judge_client.clone(), "claude-sonnet-4-6")
+    .with_max_turns(10);
+
+let tool_sim = ToolSimulator::new(judge_client.clone(), "claude-sonnet-4-6")
+    .register_tool("lookup_order", order_schema)
+    .register_tool("issue_refund", refund_schema);
+
+let invocation = run_multiturn_simulation(
+    &agent, &actor, Some(&tool_sim), 10, CancellationToken::new()
+).await?;
+
+let eval = GoalSuccessRateEvaluator::new(JudgeEvaluatorConfig::default_with(judge_registry));
+let score = eval.evaluate_async(&case, &invocation).await?;
+```
+
+---
+
+## 5. Auto-generate 20 diverse test cases
+
+**Goal**: Seed an eval set from a context paragraph.
+
+```toml
+[dependencies]
+swink-agent-eval = { version = "0.9", features = ["judge-core", "generation"] }
+```
+
+```rust
+use swink_agent_eval::generation::{ExperimentGenerator, GenerationRequest};
+
+let gen = ExperimentGenerator::new(judge_client.clone(), "claude-sonnet-4-6");
+
+let req = GenerationRequest {
+    context: "Our agent handles refunds, shipping questions, and product recommendations \
+              for an online outdoor-gear retailer.".into(),
+    task: "Verify the agent resolves the user's issue politely and cites \
+           company policy correctly.".into(),
+    desired_count: 20,
+    num_topics: 5,
+    include_expected_output: false,
+    include_expected_trajectory: true,
+    include_expected_interactions: false,
+    include_metadata: true,
+    agent_tools: Some(agent.tool_defs()),
+};
+
+let eval_set = gen.generate(req).await?;
+eval_set.save_to_file("generated-cases.json")?;
+```
+
+Every emitted case validates (SC-007); trajectory expectations reference only tools the agent has.
+
+---
+
+## 6. Score an OTel trace fetched from Langfuse
+
+**Goal**: Evaluate a production trace offline without re-running the agent.
+
+```toml
+[dependencies]
+swink-agent-eval = { version = "0.9", features = [
+    "judge-core", "evaluator-quality", "trace-ingest", "trace-langfuse"
+]}
+```
+
+```rust
+use swink_agent_eval::trace::{LangfuseTraceProvider, OpenInferenceSessionMapper, TraceProvider};
+
+let provider = LangfuseTraceProvider::from_env()?;  // LANGFUSE_HOST, LANGFUSE_KEY
+let raw = provider.fetch_session("session-id-123").await?;
+
+let mapper = OpenInferenceSessionMapper;
+let invocation = mapper.map(&raw)?;
+
+// Score with the same evaluators as in-process runs:
+let case = EvalCase::from_invocation(&invocation);  // synthesizes minimal case
+let score = registry.evaluate_async(&case, &invocation).await?;
+```
+
+---
+
+## 7. Emit OTel spans for eval runs
+
+```rust
+use swink_agent_eval::telemetry::EvalsTelemetry;
+use opentelemetry::global;
+
+let tracer = global::tracer("swink-eval");
+let telemetry = EvalsTelemetry::builder()
+    .tracer(Arc::new(tracer))
+    .build();
+
+let runner = EvalRunner::new(agent, registry)
+    .with_telemetry(Arc::new(telemetry));
+
+runner.run_set(&eval_set).await?;
+// Produces: swink.eval.run_set → swink.eval.case → swink.eval.evaluator spans
+```
+
+---
+
+## 8. Generate reports
+
+```rust
+use swink_agent_eval::report::{ConsoleReporter, JsonReporter, MarkdownReporter, HtmlReporter};
+
+// Plain-text for terminals:
+print!("{}", ConsoleReporter.render(&result)?);
+
+// Machine-readable for CI:
+std::fs::write("result.json", JsonReporter.render(&result)?.as_stdout().as_bytes())?;
+
+// PR comment:
+let md = MarkdownReporter.render(&result)?;
+
+// Rich/interactive (html-report feature):
+HtmlReporter::new()
+    .write_to("report.html", &result)?;
+```
+
+---
+
+## 9. Use the `swink-eval` CLI
+
+```bash
+cargo install swink-agent-eval --features cli
+
+# Run and gate:
+swink-eval run --set cases.json --out result.json --parallelism 4 --reporter md
+
+# Re-render a previous run without re-executing:
+swink-eval report result.json --format html > report.html
+
+# Gate-only check (exit 0 pass / non-zero fail, no stdout):
+swink-eval gate result.json --gate-config gate.yaml
+echo $?   # 0 or 1
+```
+
+---
+
+## 10. Wire CI
+
+Copy `eval/src/ci/templates/pr-eval.yml` into your repo at `.github/workflows/pr-eval.yml`:
+
+```yaml
+# Simplified — see eval/src/ci/templates/pr-eval.yml for the full template
+name: PR Eval
+on: pull_request
+jobs:
+  eval:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: cargo install swink-agent-eval --features cli
+      - run: swink-eval run --set evals/pr.json --out result.json --reporter md > report.md
+      - run: swink-eval gate result.json --gate-config evals/gate.yaml
+      - uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          path: report.md
+```
+
+---
+
+## Feature cheat-sheet
+
+| Goal | Crate | Feature |
+|---|---|---|
+| LLM judges at all | `swink-agent-eval` | `judge-core` |
+| Quality rubrics | `swink-agent-eval` | `evaluator-quality` |
+| Safety rubrics | `swink-agent-eval` | `evaluator-safety` |
+| RAG rubrics + embedding-similarity | `swink-agent-eval` | `evaluator-rag` |
+| Multi-agent / trajectory | `swink-agent-eval` | `evaluator-agent` |
+| Structured output (JSON match + schema) | `swink-agent-eval` | `evaluator-structured` |
+| Exact-match / Levenshtein | `swink-agent-eval` | `evaluator-simple` |
+| Code compile + clippy | `swink-agent-eval` | `evaluator-code` |
+| Sandboxed execution (Unix only) | `swink-agent-eval` | `evaluator-sandbox` |
+| Image-safety multimodal | `swink-agent-eval` | `multimodal` |
+| Multi-turn simulation | `swink-agent-eval` | `simulation` |
+| Experiment auto-generation | `swink-agent-eval` | `generation` |
+| Trace ingestion (always-available in-mem provider) | `swink-agent-eval` | `trace-ingest` |
+| OTLP-HTTP trace ingestion | `swink-agent-eval` | `trace-ingest`, `trace-otlp` |
+| Langfuse / OpenSearch / CloudWatch | `swink-agent-eval` | `trace-langfuse` / `trace-opensearch` / `trace-cloudwatch` |
+| Emit OTel spans for eval runs | `swink-agent-eval` | `telemetry` |
+| Self-contained HTML report | `swink-agent-eval` | `html-report` |
+| Push to LangSmith | `swink-agent-eval` | `langsmith` |
+| `swink-eval` CLI binary | `swink-agent-eval` | `cli` |
+| Anthropic / OpenAI / … judge | `swink-agent-eval-judges` | `anthropic` / `openai` / ... |
+| All-judges, for docs | `swink-agent-eval-judges` | `all-judges` |
+| All-evaluators, for docs | `swink-agent-eval` | `all-evaluators` |
+| Canary live-provider tests | `swink-agent-eval-judges` (dev) | `live-judges` |

--- a/specs/043-evals-adv-features/research.md
+++ b/specs/043-evals-adv-features/research.md
@@ -1,0 +1,436 @@
+# Research: Evals: Advanced Features
+
+**Feature**: 043-evals-adv-features | **Date**: 2026-04-21
+
+Phase 0 resolves architectural decisions, dependency choices, and integration patterns for the advanced evals surface. Each entry follows the `Decision / Rationale / Alternatives` format.
+
+---
+
+## R-001: Prompt-Templating Engine
+
+**Decision**: `minijinja` (latest 2.x).
+
+**Rationale**: Jinja2-compatible, zero-unsafe, actively maintained, ~2M downloads. Supports named variables, conditionals, loops, and custom filters — everything the judge prompts need. Compile-time validation via `Environment::add_template()` surfaces missing-variable errors at construction time per FR-008. Small enough (~100 KB stripped) to sit behind the `judge-core` feature without bloating default builds of consumers who only want deterministic evaluators.
+
+**Alternatives considered**:
+- `handlebars`: Heavier, mustache-style; awkward for the conditional logic judge prompts need.
+- `tera`: Also Jinja-compatible, but larger dep graph (pulls in `chrono`, `unic-segment`).
+- Format strings (`format!` / custom recursive-replace): Hand-rolled alternative violates "Leverage the Ecosystem" and would re-implement variable-error reporting that `minijinja` already does correctly.
+
+**API surface** (from `eval/src/prompt/mod.rs`):
+```rust
+use minijinja::{Environment, context};
+
+pub trait JudgePromptTemplate: Send + Sync {
+    fn version(&self) -> &str;
+    fn render(&self, ctx: &PromptContext) -> Result<String, PromptError>;
+}
+```
+
+---
+
+## R-002: Retry / Backoff Library
+
+**Decision**: `backon` (v1.x).
+
+**Rationale**: Async-first, supports `ExponentialBuilder` with jitter and max-elapsed caps, no thread-pool dependency. Used by several major Rust projects (OpenDAL). ~1M downloads. Supports cancellation via `futures`, integrating cleanly with `tokio_util::sync::CancellationToken` per FR-040. Cooperative retry honoring 6-attempts-max and 4-minute-max-backoff (FR-004) is a two-line builder call.
+
+**Alternatives considered**:
+- `backoff` (v0.4): Older crate, unmaintained since 2023, async support via `tokio::time::sleep`.
+- Hand-rolled retry: Subtle to get right for cancellation + jitter + header-driven backoff (provider `Retry-After`). Violates "Leverage the Ecosystem."
+
+**Retry policy** (pinned):
+```rust
+ExponentialBuilder::default()
+    .with_max_times(6)
+    .with_max_delay(Duration::from_secs(240))
+    .with_jitter()
+```
+
+---
+
+## R-003: String Similarity (Levenshtein)
+
+**Decision**: `strsim` (v0.12).
+
+**Rationale**: Pure-Rust, zero deps, workspace-maintained. `strsim::levenshtein(a, b)` returns edit distance; normalized score is `1.0 - (dist as f64 / max(a.len, b.len))`. ~30M downloads.
+
+**Alternatives considered**:
+- `edit-distance` (smaller but fewer algorithms).
+- Hand-rolled DP: Well-trodden problem; no benefit.
+
+---
+
+## R-004: JSON Schema Validation
+
+**Decision**: `jsonschema` (v0.30).
+
+**Rationale**: Draft 2020-12 support, pure-Rust, compiles schemas ahead-of-time. Needed by `JsonSchemaEvaluator` (FR-016) for deterministic schema-validation scoring — no judge call required. Also used by `ToolSimulator` to validate simulator-generated tool responses against tool schemas per FR-025.
+
+**Alternatives considered**:
+- `valico` (older, draft-07 only).
+- Hand-rolled validation: Rejected.
+
+---
+
+## R-005: OpenTelemetry Integration
+
+**Decision**: `opentelemetry` 0.31 + `opentelemetry-sdk` 0.31, gated behind `telemetry` feature. Per-backend exporters (`opentelemetry-otlp`, Langfuse-specific HTTP, OpenSearch via OTLP-HTTP + CloudWatch via AWS SDK) are separately feature-gated.
+
+**Rationale**: OTel is the canonical multi-vendor trace substrate. `opentelemetry-sdk` provides the in-memory exporter (`opentelemetry-sdk::testing::trace::InMemorySpanExporter`) that backs `OtelInMemoryTraceProvider` without requiring any provider configuration — satisfying the "always available" guarantee of FR-031.
+
+**Span structure** (per FR-035, US7):
+- Root: `swink.eval.run_set` — attributes: `eval_set.id`, `eval_set.name`, `case_count`.
+- Per case: `swink.eval.case` — attributes: `case.id`, `case.name`, `verdict`, `duration_ms`.
+- Per evaluator: `swink.eval.evaluator` — attributes: `evaluator.name`, `prompt.version`, `score.value`, `score.threshold`, `verdict`.
+
+**GenAI semantic-convention version matrix** (per FR-032):
+- v1.27: `gen_ai.system`, `gen_ai.request.model`, `gen_ai.response.finish_reasons`, `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`.
+- v1.30: Adds `gen_ai.operation.name`, renames some; mapper adapts in a lookup table.
+- "experimental": Forward-compatible; mapper tolerates unknown attributes.
+
+**Alternatives considered**:
+- Raw `tracing` spans: Doesn't give us the vendor-agnostic wire format; loses interop with downstream consumers.
+- Langfuse-SDK-first: Vendor lock-in.
+
+---
+
+## R-006: Sandboxing for Code Execution
+
+**Decision**: POSIX rlimit-based sandbox using `libc` directly (Unix only; Windows fails fast). A `SandboxedExecutionEvaluator` spawns a child `cargo` process in a temporary directory, sets `setrlimit(RLIMIT_CPU)`, `RLIMIT_AS`, `RLIMIT_NOFILE`, and wall-clock via `tokio::time::timeout`. Network isolation via unsharing network namespace on Linux (`unshare(CLONE_NEWNET)`); on macOS, we rely on the process not opening sockets (`RLIMIT_NOFILE` bound) and document the limitation.
+
+**Rationale**: Container isolation (e.g., Docker, Firecracker) adds infrastructure dependencies the spec explicitly avoids (sandbox must work in a normal `cargo test` run). rlimits are universally available on Unix, don't require root, and enforce the default caps pinned in FR-017 (120 s wall, 60 s CPU, 1 GiB RSS, 256 FDs, no network).
+
+**The `libc` exception to unsafe-free**: `libc::setrlimit`, `libc::unshare`, and `libc::prlimit` are `unsafe extern "C"` calls. They are wrapped in a safe `evaluators::code::sandbox::posix` submodule whose internal blocks use `// SAFETY:` comments explaining the invariants. This is the only FFI surface in either crate; the module compiles only on `cfg(target_family = "unix")`, and `#![forbid(unsafe_code)]` is relaxed at that submodule to `#![allow(unsafe_code)]` with a module-level explanation. The forbid attribute remains at both crate roots. This exception is explicitly authorized by FR-049 in spec.md (see the exception clause pinning the module path, the `cfg` gate, and the `// SAFETY:` requirement).
+
+**Windows behavior**: The entire `sandbox.rs` module compiles under `cfg(target_family = "unix")`. The Windows build ships a stub that constructs `EvaluatorError::UnsupportedPlatform` at evaluation time — no silent fallback, no panics.
+
+**Alternatives considered**:
+- `nix` crate (safe rlimit wrappers): Usable and would eliminate the unsafe exception, but `nix` is heavy (pulls in many syscall wrappers). Given we only need three syscalls, direct `libc` is simpler.
+- Pure wall-clock timeout: Doesn't protect against CPU burners, memory bombs, or FD exhaustion.
+- Docker-in-docker: Infrastructure surface expansion rejected.
+
+---
+
+## R-007: Embedding Provider (for `EmbeddingSimilarityEvaluator`)
+
+**Decision**: Ship an `Embedder` trait with **no default implementation**. Consumers supply their own embedder: a local model (`fastembed`-style crate), a provider embedding API, or an in-memory test fixture.
+
+**Rationale**: The spec's Assumptions call this out explicitly ("we don't bundle a default embedding provider"). Embedding providers have wildly different payload shapes, rate limits, and costs; baking one in would constrain users and pull in a mandatory dep. The trait gives users a clean injection point.
+
+**API**:
+```rust
+#[async_trait]
+pub trait Embedder: Send + Sync {
+    async fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>, EmbedderError>;
+    fn dimension(&self) -> usize;
+}
+```
+
+---
+
+## R-008: Attachment Handling (per Q10 clarification)
+
+**Decision**: `Attachment` is an enum with three variants:
+```rust
+pub enum Attachment {
+    Path(PathBuf),                          // resolved relative to eval-set root
+    Base64 { mime: String, bytes: Vec<u8> }, // self-contained
+    Url(String),                            // remote
+}
+```
+
+**Materialization pipeline** (uniform across all variants before judge dispatch):
+1. `Attachment::Path` → resolve against `EvalSet::root_path` → read bytes → detect MIME.
+2. `Attachment::Base64` → direct.
+3. `Attachment::Url` → SSRF-filtered `reqwest::get()` using the same domain-filter infrastructure already in `plugins/web` (R-011).
+
+All three produce a `MaterializedAttachment { mime, bytes }` that judge clients consume uniformly. `AttachmentError` is a structured error type; no panics, no silent failures.
+
+**SSRF protection**: URL attachments are filtered through a default deny-list (RFC 1918 ranges, localhost, metadata endpoints). Consumers may configure an allow-list. This mirrors the `plugins/web` domain-filter policy pattern so that the filter can be shared via the `policies` crate in a future refactor.
+
+**Alternatives considered**: Separate fields per variant (rejected as less ergonomic); URL-only (rejected due to SSRF surface and deterministic-replay issues); base64-only (rejected due to file bloat — verbally the driver of Q10).
+
+---
+
+## R-009: Parallelism Model for `EvalRunner`
+
+**Decision**: `tokio::sync::Semaphore` with a bounded permit count (configurable via `with_parallelism(n)`; default = 1 for backwards compatibility with current sequential behavior). Each case acquires a permit before its agent call + evaluator dispatch; permits release after the full case completes. Judge calls within a case share the case's permit — they don't contend for a separate pool.
+
+**Rationale**: `Semaphore` is the canonical Tokio primitive for bounded concurrency. Sharing the permit across judge calls avoids unbounded fan-out (if every case fans out to 7 evaluators and parallelism is 4, naive impl = 28 concurrent provider calls); the per-provider rate-limit-aware retry absorbs transient throttling but catastrophic over-fan-out is prevented here.
+
+**Cancellation**: `CancellationToken` is woven through the permit-acquisition loop. In-flight cases observe the token cooperatively via `tokio::select!` at await points; on cancellation, in-flight cases return a partial result with a cancellation indicator (FR-040).
+
+**SC-002 calibration**: Default `parallelism = 1`. Recommended values in docs: 4–8 for fast providers (Anthropic/OpenAI), 2–4 for slower ones (Bedrock, Gemini). Parallelism is a knob, not something we auto-tune.
+
+**Alternatives considered**:
+- `tokio::task::JoinSet` with unbounded spawn: Doesn't bound concurrency, overwhelms providers.
+- `futures::stream::buffer_unordered`: Equivalent to Semaphore but less explicit about permit lifecycle across nested fan-out (evaluator-within-case).
+
+---
+
+## R-010: Feature-Flag Naming Convention
+
+**Decision**: Verb-first hierarchical naming on `eval`: `evaluator-<family>`, `trace-<backend>`, `judge-core`, `telemetry`, `simulation`, `generation`, `multimodal`, `html-report`, `langsmith`, `cli`, `live-judges`. On `eval-judges`: bare provider name (`anthropic`, `openai`, etc.) — parallel to the adapter crate name.
+
+**Rationale**: The hierarchical prefix (`evaluator-`, `trace-`) groups related features alphabetically in `cargo tree --features` output and in `docs.rs`. Bare provider names on `eval-judges` match user expectation from the adapter crates (`swink-agent-adapters-anthropic` already uses bare names). Meta-feature `all-judges` = every provider feature; `all-evaluators` on `eval` = every evaluator family.
+
+**Default feature set on `eval`**: `[]` (empty). Per FR-047, the default build adds no new mandatory dependencies. `judge-core` is opt-in because prompt templating (`minijinja`) and retry (`backon`) are only needed when a user wants LLM judges.
+
+**Alternatives considered**:
+- Flat names (`quality-evaluators`, `safety-evaluators`): Harder to group in UI listings.
+- Single mega-feature `full-eval`: Defeats the purpose of feature-gating.
+
+---
+
+## R-011: SSRF Protection for `Attachment::Url` and Trace URLs
+
+**Decision**: Reuse the domain-filter pattern from `plugins/web/src/policy/domain_filter.rs` (spec 042). `UrlFilter` lives in `eval/src/url_filter.rs` — an **always-on** top-level module (not under `judge/`, not feature-gated) because attachment materialization on `EvalCase` happens even when `judge-core` is disabled:
+
+```rust
+pub trait UrlFilter: Send + Sync {
+    fn check(&self, url: &Url) -> Result<(), AttachmentError>;
+}
+```
+
+A default `DefaultUrlFilter` denies RFC 1918 ranges (10/8, 172.16/12, 192.168/16), loopback (127/8, ::1), link-local (169.254/16, fe80::/10), cloud-metadata endpoints (169.254.169.254), and requires HTTPS by default. Consumers can install a permissive filter for test or dev.
+
+**Rationale**: DRY with plugins/web; a future refactor could extract this into a `swink-agent-url-filter` helper, but for now both crates carry a small copy — the alternative (eval depending on plugins/web) introduces a layering violation. Placing `UrlFilter` at `eval/src/url_filter.rs` rather than under `eval/src/judge/` prevents an implicit dependency from always-on `Attachment::materialize` onto the `judge-core` feature.
+
+---
+
+## R-012: Judge Cache Eviction Policy
+
+**Decision**: LRU, bounded by entry count (not memory). Default cap: 1024 entries. Implemented via `std::collections::HashMap` plus a VecDeque for recency — no external `lru` crate needed (the `lru` crate pulls in `hashbrown` which is already transitive via `indexmap`, but we avoid the dep by hand-rolling the 50 LoC).
+
+**Rationale**: Prompts are short (<2 KB typically); entry-count bounding is simpler and more predictable than byte bounding. LRU matches user intent: the most recently seen prompt+model is the one being iterated on.
+
+**Disk-backed variant**: Optional `disk_cache_path: Option<PathBuf>` — serializes entries as JSON in a directory, one file per cache key (SHA-256 of prompt+model). On startup, the cache warm-loads from disk up to its capacity. Disk-backed is opt-in; in-memory is default.
+
+**Alternatives considered**:
+- Time-based TTL: Judge responses don't expire; model identity is the invalidation signal.
+- `lru` crate: Small, clean dep, but we already have the pattern in `swink-agent/src/util/` from the session cache — reuse reduces dep count.
+
+---
+
+## R-013: `num_runs` × Cache Interaction (per Q2 clarification)
+
+**Decision**: A single cached `Invocation` serves all N runs of a case. The judge-side scoring loop runs N times with the same `Invocation` as input, and the variance diagnostic measures judge non-determinism. Agent non-determinism is out of scope.
+
+**Implementation**: `EvalRunner` materializes `Invocation` once (from cache or by calling the agent), then loops the evaluator dispatch N times. Each iteration records its score in a `RunnerMetricSample { run: u32, score: Score }`; variance is `std_dev` computed across the N samples.
+
+**Rationale**: Spec clarification Q2 pinned this explicitly. Matches SC-003's promise of no agent re-invocation on prompt-only iteration.
+
+---
+
+## R-014: Session ID Determinism (per Q7 clarification)
+
+**Decision**: UUID v5 with a **project-specific namespace UUID** minted once and hard-coded as `CASE_NAMESPACE` in `eval/src/types.rs`. The namespace is itself a UUID v5 derived from the OID namespace over the ASCII bytes `"swink-agent-eval.case"` — this produces a stable UUID that semantically represents "the case-identity namespace of the swink-agent-eval library" rather than reusing an unrelated reserved namespace (the URL namespace is reserved for actual URLs). The name being hashed is the hex-encoded SHA-256 of the case's canonical bincode serialization (same basis as the cache key in FR-038).
+
+**Rationale**: UUID v5 is deterministic, well-specified, and gives identical IDs across re-runs and machines for identical case inputs — satisfying trace-correlation (FR-035) and cache-key semantics (FR-038). Minting a project-specific namespace rather than reusing `Uuid::NAMESPACE_URL` avoids semantic pollution and prevents accidental collision with any other system that also happens to v5-hash case-shaped strings under the URL namespace.
+
+**Implementation**:
+```rust
+use uuid::Uuid;
+
+// Computed once at crate build time:
+// CASE_NAMESPACE = uuid_v5(NAMESPACE_OID, "swink-agent-eval.case")
+//                = 8d1f5e84-...-...-...-...............  (exact bytes pinned in types.rs)
+pub const CASE_NAMESPACE: Uuid = Uuid::from_bytes([/* 16 bytes — pinned in types.rs */]);
+
+let name = Sha256::digest(canonical_bincode(&case));
+let session_id = Uuid::new_v5(&CASE_NAMESPACE, name.as_slice());
+```
+
+Task T016 materializes the namespace constant; the exact 16-byte value is pinned in the crate and covered by a unit test verifying `Uuid::new_v5(&Uuid::NAMESPACE_OID, b"swink-agent-eval.case") == CASE_NAMESPACE`.
+
+---
+
+## R-015: LangSmith Export Format
+
+**Decision**: Push an `EvalSetResult` as a LangSmith "run" with each evaluator's `Score` attached as feedback under its configured feedback-key. Auth via `LANGSMITH_API_KEY` env var or constructor arg. Endpoint: `https://api.smith.langchain.com/runs` (POST) and `/feedback` (POST).
+
+**Rationale**: Matches the LangSmith data model as of 2026-04. Every case maps to a LangSmith run; every evaluator's score becomes a feedback entry attached to that run under a key derived from `evaluator.feedback_key().unwrap_or(evaluator.name())`.
+
+**Error handling** (per spec edge case): Partial push failures surface as a structured `LangSmithExportError { pushed: u32, failed: u32, first_error: ... }` — no local partial-state persistence.
+
+**Alternatives considered**: Their OpenTelemetry-compatible ingest is newer and incomplete as of 2026-04; we stick with the stable REST path.
+
+---
+
+## R-016: CLI Argument Parser
+
+**Decision**: `clap` (v4.x) with derive macros, feature-gated behind `cli`.
+
+**Rationale**: De facto standard. Three subcommands (`run`, `report`, `gate`) per FR-046 clarification; each has a tight argument surface. `clap`'s `#[derive(Parser)]` keeps the binary source under 200 LoC.
+
+**Subcommand structure**:
+```rust
+#[derive(Parser)]
+enum Cmd {
+    Run { #[arg(long)] set: PathBuf, #[arg(long)] out: Option<PathBuf>, #[arg(long)] parallelism: Option<usize> },
+    Report { #[arg(long)] result: PathBuf, #[arg(long, value_enum)] format: ReportFormat },
+    Gate { #[arg(long)] result: PathBuf, #[arg(long)] gate_config: PathBuf },
+}
+```
+
+---
+
+## R-017: HTML Reporter Templating
+
+**Decision**: `askama` (v0.13+). Compile-time-checked templates, derives `Template` on Rust structs, zero runtime template parsing cost. Feature-gated behind `html-report`.
+
+**Rationale**: HTML reporter must produce a single self-contained file (per FR-041 and US8). `askama` lets us embed templates at compile time, inline CSS/JS, and validate placeholder correctness at `cargo build`. Output is the only reporter supporting interactivity (per Q8 clarification — terminal/JSON/Markdown are plain, HTML is the rich tier).
+
+**Implementation notes**: One master template `report.html.j2` that includes CSS and JS as inline `<style>`/`<script>` blocks. Collapsible-per-case behavior uses `<details>`/`<summary>` — no JavaScript required. A small amount of JS only if we add filtering/sorting (future; not in this spec).
+
+**Alternatives considered**:
+- `maud`: Compile-time-safe HTML-as-Rust, but reads as Rust code, harder for non-Rustaceans to tweak the output.
+- `handlebars`: Runtime template validation.
+- Hand-rolled `format!`: Intricate for collapsible nesting.
+
+---
+
+## R-018: CI Workflow Templates
+
+**Decision**: Ship four YAML files in `eval/src/ci/templates/`:
+1. `pr-eval.yml` — runs on PR, runs a declared eval set, comments the Markdown summary on the PR, sets status based on gate.
+2. `nightly-eval.yml` — scheduled workflow, produces HTML report, uploads as a GitHub Actions artifact.
+3. `release-eval.yml` — runs on tag push, produces JSON result, attaches to release.
+4. `pre-commit-hook.yml` — a `.pre-commit-config.yaml` fragment that runs `swink-eval run` on a local eval set.
+
+**Distribution**: These templates ship as static string constants compiled into `swink-eval init-ci` (a possible future subcommand, not in this spec), and also as files in the repo that users can copy manually. For this spec, only the static files are in scope — the `init-ci` subcommand can come later.
+
+**Rationale**: GitHub Actions is the de-facto CI substrate; per spec Assumptions, we target it explicitly and leave other CI systems for third-party templates.
+
+---
+
+## R-019: Default Aggregator (per Q6 clarification)
+
+**Decision**: `Average` (arithmetic mean of sub-scores). Binary-verdict evaluators (safety family) opt into `AllPass` explicitly in their constructors.
+
+**Rationale**: Clarification Q6 pinned this. Implementation-wise, `Evaluator` default method returns `Box::new(Average)`; constructors on binary evaluators override via `.aggregator(AllPass)` at registration time.
+
+---
+
+## R-020: `EvaluationDataStore` Cache Key Format
+
+**Decision**: Cache key is `sha256(bincode(CaseFingerprint))` where:
+```rust
+struct CaseFingerprint<'a> {
+    case_id: &'a str,
+    system_prompt: &'a str,
+    user_messages: &'a [ChatMessage],
+    initial_session: Option<&'a SessionState>,
+    tool_set_hash: [u8; 32],  // hash of tool names + schemas
+    agent_model: &'a str,
+}
+```
+
+Any change to these fields invalidates the cache per spec edge case "cache keyed by a content hash of case input." Tool-set changes invalidate because adding/removing a tool is a behavior change even if inputs are otherwise identical.
+
+**Rationale**: `bincode` gives a stable, canonical byte sequence from Rust structs; SHA-256 gives a collision-resistant key. Using `bincode` over `serde_json` for hashing avoids key-ordering ambiguity in nested maps.
+
+**Disk layout** (`LocalFileTaskResultStore`):
+```
+<root>/<eval_set_id>/<case_id>/<fingerprint_hex>.json  # the cached Invocation
+```
+
+---
+
+## R-021: Panic Isolation Strategy
+
+**Decision**: Every new evaluator, simulator, generator, and reporter wraps its hot path in `tokio::task::spawn_blocking` (for sync panics) or a `tokio::spawn` + `JoinHandle.await` pair (for async panics) at the registry / orchestrator boundary. Panics surface as `JoinError::is_panic()` and convert to `Score::fail()` with `PanicDetail { location, message }` in details.
+
+**Rationale**: Spec 023 already established this pattern at the `EvaluatorRegistry` boundary. Extending it to simulators and generators (which weren't in 023's scope) maintains a consistent contract: a rogue evaluator/simulator/generator/reporter never aborts a run.
+
+**Implementation**:
+```rust
+let result = tokio::spawn(async move {
+    evaluator.evaluate_async(&case, &invocation).await
+}).await;
+
+match result {
+    Ok(r) => r,
+    Err(e) if e.is_panic() => Score::fail().with_detail(panic_detail(e)),
+    Err(e) => Err(e.into()),
+}
+```
+
+**Note**: `tokio::spawn` moves the future to another task, which already catches panics. We don't need `std::panic::catch_unwind` here.
+
+---
+
+## R-022: "No Backwards Compat" Principle Application
+
+**Decision**: FR-044 removed during clarification. No legacy-format converter ships. Per the workspace principle saved to memory, this workspace does not maintain compatibility with external eval tooling unless adopting a specific open standard.
+
+**Consequence for the runner**: `EvalSet` loading accepts only the current-version `swink-agent-eval` schema. A top-level `"version": "043"` field in `EvalSet` JSON gates compatibility — unknown versions fail with a clear error rather than best-effort parsing.
+
+---
+
+## R-023: `initial_session_file` Format
+
+**Decision**: JSON file matching `SessionState`'s `serde` representation from spec 034 (`session-state-store`). Lives on disk as `initial_session.json` by convention.
+
+**Rationale**: `SessionState` is already serializable via `serde`. Reusing that format avoids introducing a new schema. TOML was considered but `SessionState` contains arbitrary message content that encodes poorly in TOML.
+
+**Implementation**:
+```rust
+let initial: SessionState = serde_json::from_reader(fs::File::open(path)?)?;
+```
+
+---
+
+## R-024: `live-judges` Canary Suite Scope
+
+**Decision**: The `live-judges` feature enables a small canary suite (~3 test cases) per provider. Each canary:
+1. Constructs a `<Provider>JudgeClient` with env-var-sourced credentials.
+2. Runs a single `CorrectnessEvaluator` against a trivial case.
+3. Asserts the result has a valid score and non-empty reason.
+
+**Rationale**: Provides end-to-end confidence without drowning CI in live API calls. Canary suite runs only when `SWINK_EVAL_LIVE_JUDGES=1` and the relevant provider env vars are set. Default CI (including this feature's in-tree tests) does not run canaries.
+
+**Skip policy**: Canaries skip with a diagnostic message (not fail) when credentials are absent; this keeps the binary honest about what it ran.
+
+---
+
+## R-025: Workspace-Level Cargo Dependencies
+
+New workspace-level entries in root `Cargo.toml`'s `[workspace.dependencies]`:
+
+```toml
+minijinja = { version = "2", default-features = false, features = ["builtins", "loader"] }
+backon = { version = "1", default-features = false, features = ["tokio-sleep"] }
+strsim = "0.12"
+jsonschema = { version = "0.30", default-features = false }
+opentelemetry = "0.31"
+opentelemetry-sdk = "0.31"
+opentelemetry-otlp = { version = "0.31", features = ["http-proto", "reqwest-client"] }
+askama = { version = "0.13", default-features = false }
+clap = { version = "4", features = ["derive"] }
+libc = "0.2"
+```
+
+**Rationale**: Centralizing versions in the workspace manifest matches the existing pattern and simplifies future bumps.
+
+---
+
+## Summary of Phase 0 decisions
+
+| Concern | Decision |
+|---|---|
+| Template engine | `minijinja` (behind `judge-core`) |
+| Retry | `backon` (behind `judge-core`) |
+| Levenshtein | `strsim` (behind `evaluator-simple`) |
+| JSON Schema | `jsonschema` (behind `evaluator-structured`) |
+| OTel | `opentelemetry` 0.31 + SDK (behind `telemetry`) |
+| Sandboxing | `libc` rlimits on Unix, stub on Windows (behind `evaluator-sandbox`) |
+| HTML templating | `askama` compile-time templates (behind `html-report`) |
+| CLI | `clap` 4 derive macros (behind `cli`) |
+| Parallelism | `tokio::Semaphore` |
+| Cache policy | LRU by entry count (default 1024) |
+| Session ID | UUID v5 from SHA-256 of canonical case bytes |
+| Default aggregator | `Average` |
+| SSRF filter | Reused domain-filter pattern from plugins/web |
+| Workspace layout | `eval` extended; new `eval-judges` crate; CLI binary in `eval/src/bin/` |

--- a/specs/043-evals-adv-features/spec.md
+++ b/specs/043-evals-adv-features/spec.md
@@ -5,6 +5,21 @@
 **Status**: Draft
 **Input**: User description: "Build the Advanced Evals layer of `swink-agent-eval` — concrete LLM-as-judge infrastructure, runner upgrades, simulation, generation, observability ingestion, and reporting. Consumes the trait surface introduced by 023-eval-trajectory-matching (`JudgeClient`, `JudgeVerdict`, `JudgeError`, `EnvironmentState`, `StateCapture`, semantic evaluator stubs) and delivers production-ready providers and 17+ LLM-judge evaluators. Explicit gap-closing against strands-agents/evals, langchain-ai/openevals, and google/adk-python AgentEvaluator."
 
+## Clarifications
+
+### Session 2026-04-21
+
+- Q: Are `HallucinationEvaluator / FaithfulnessEvaluator` and `HarmfulnessEvaluator / ToxicityEvaluator` one evaluator each (dual name or alias) or two distinct evaluators per pair? → A: Two separate evaluators per pair with distinct prompts/rubrics (faithfulness is RAG-grounded, hallucination is general; toxicity is tighter than harmfulness).
+- Q: How do `num_runs > 1` and the task-result cache (`EvaluationDataStore`) interact? → A: Cache returns a single cached invocation for all N runs; `num_runs` measures judge variance only, not agent variance. Agent non-determinism is out of scope for this spec's variance diagnostic.
+- Q: Which legacy eval-file schemas does the legacy-format converter cover? → A: None. No backwards-compatibility or cross-tool migration is in scope for this spec. FR-044 and the legacy-migration portion of US9 are removed. Broader principle: this workspace does not maintain compatibility with external eval tooling unless adopting a specific open standard; point migrations can be added in a future spec if a standard emerges or demand justifies it.
+- Q: What are the semantics of the `swink-eval` CLI `report` and `gate` subcommands? → A: `report <result.json> --format <console|json|md|html>` re-renders a persisted `EvalSetResult` with the chosen reporter and performs no re-execution. `gate <result.json>` evaluates `GateConfig` against a persisted result and returns 0 on pass / non-zero on fail with no stdout output. Both operate on artifacts produced by a prior `run`.
+- Q: What are the default resource limits for `SandboxedExecutionEvaluator`? → A: 120 s wall-clock, 60 s CPU, 1 GiB RSS, 256 file descriptors, no network. Matches typical CI runner budgets; permissive enough for `cargo check`/`cargo build` on non-trivial snippets. All limits are configurable per-evaluator via a `SandboxLimits` struct.
+- Q: Which aggregator applies when an evaluator does not override it? → A: `average` (arithmetic mean of sub-scores). Matches `num_runs` averaging semantics and preserves gradient signal that all-pass/any-pass would collapse. Binary evaluators (e.g., safety pass/fail) opt into `all-pass` explicitly.
+- Q: How is `EvalCase.session_id`'s auto-UUID generated? → A: Deterministic UUID v5 derived from a hash of the case content. Stable across re-runs and machines, aligns with the content-hash cache key (FR-038), and enables reliable OTel trace correlation (FR-035).
+- Q: Should the rich interactive console reporter be always-on, feature-gated, or dropped? → A: Dropped. Terminal/console output is plain-text line-oriented only (no color-coded collapsible tables, no interactivity). Any "rich" presentation layer is routed to the `html-report` feature; `RichConsoleReporter` is removed from this spec's surface.
+- Q: What is the default judge model? → A: No default. Every `JudgeRegistry` construction requires an explicit model identifier; the constructor refuses to build without one. Reason: models change often and a pinned default would silently rot; a floating alias would invalidate historical score comparisons. Explicit-model-at-construction is the durable choice across releases.
+- Q: How are multimodal attachments encoded on `EvalCase.attachments`? → A: An `Attachment` enum with three first-class variants — `Path(PathBuf)` relative to the eval-set root, `Base64(mime, bytes)` for self-contained export, and `Url(String)` for remote resources. Consumers select per-attachment. URL resolution MUST surface SSRF/reachability errors as structured `AttachmentError` rather than runtime panics, and judge-client payload construction MUST materialize all three variants uniformly before dispatch.
+
 ## User Scenarios & Testing *(mandatory)*
 
 ### User Story 1 - Score Agent Runs with Production LLM Judges (Priority: P1)
@@ -135,7 +150,7 @@ An operator running evals on a schedule wants to correlate eval regressions with
 
 ### User Story 8 - Produce CI- and Human-Friendly Reports (Priority: P2)
 
-A developer running evals locally sees an interactive collapsible report with color-coded pass/fail, inline judge reasons, and per-case expansion. The same eval, run in CI, emits a machine-readable JSON artifact plus a Markdown summary suitable for a PR comment. Optional HTML and LangSmith exporters serve teams with those needs.
+A developer running evals locally sees a plain-text line-oriented summary in the terminal with per-case verdicts and per-evaluator scores. The same eval, run in CI, emits a machine-readable JSON artifact plus a Markdown summary suitable for a PR comment. Teams that want a collapsible, interactive presentation layer opt into the `html-report` feature, which produces a single self-contained HTML file. An optional LangSmith exporter serves teams already on that platform.
 
 **Why this priority**: Raw `EvalSetResult` JSON is inadequate for both the dev loop (too dense) and for PR reviews (too machine-readable). Purpose-built reporters per context are low-effort and high-impact. P2 because the core result structure from 024 is already usable; reporters are presentation polish.
 
@@ -143,28 +158,26 @@ A developer running evals locally sees an interactive collapsible report with co
 
 **Acceptance Scenarios**:
 
-1. **Given** a completed `EvalSetResult`, **When** `RichConsoleReporter` renders it to a terminal, **Then** cases are displayed in a collapsible table with color-coded pass/fail, and per-case expand shows per-evaluator scores and reasons.
+1. **Given** a completed `EvalSetResult`, **When** `ConsoleReporter` renders it to stdout, **Then** output is plain-text line-oriented — one line per case with its verdict, followed by indented per-evaluator score and reason lines — with no ANSI color, no cursor control, and no interactivity.
 2. **Given** the same result, **When** `JsonReporter` emits an artifact, **Then** the JSON is self-contained, includes all case and metric detail, and validates against a published schema.
 3. **Given** the same result, **When** `MarkdownReporter` emits a summary, **Then** the output is a valid Markdown table suitable for inline rendering in PR comments, with no terminal-only ANSI codes.
-4. **Given** the `html-report` feature enabled, **When** `HtmlReporter` runs, **Then** it produces a single self-contained HTML file with no external asset dependencies.
+4. **Given** the `html-report` feature enabled, **When** `HtmlReporter` runs, **Then** it produces a single self-contained HTML file with no external asset dependencies — this is the only reporter that provides collapsible/interactive presentation.
 5. **Given** the `langsmith` feature enabled and a LangSmith API token, **When** the LangSmith exporter runs, **Then** the `EvalSetResult` is pushed as a run to LangSmith with each evaluator's score attached as feedback under its configured key.
 
 ---
 
-### User Story 9 - Migrate Legacy Formats and Integrate with Existing CI (Priority: P3)
+### User Story 9 - Integrate Eval Runs with CI and a Local CLI (Priority: P3)
 
-A developer adopting `swink-agent-eval` already has `.test.json` files from an earlier framework. They point the loader at a directory, legacy schemas auto-migrate, and a shipped GitHub Actions workflow template wires PR-time and nightly eval runs into CI. A CLI entry point (`swink-eval run <set>`) provides local invocation without Rust-code integration.
+A developer adopting `swink-agent-eval` wants CI scaffolding and a thin command-line entry point. A shipped GitHub Actions workflow template wires PR-time and nightly eval runs into CI, and a CLI entry point (`swink-eval run <set>`) provides local invocation without Rust-code integration.
 
 **Why this priority**: Developer-experience scaffolding is important but not functionally blocking — teams can hand-write the integration points. P3 captures the polish that makes adoption friction-free.
 
-**Independent Test**: Can be fully tested by loading a directory of legacy `.test.json` files via the legacy-format converter, asserting the resulting `EvalSet` is well-formed, then running the CLI against it and verifying identical output to the in-process API.
+**Independent Test**: Can be fully tested by invoking the `swink-eval` CLI against an `EvalSet` on disk and verifying identical output (reporter content, gate-derived exit code) to the equivalent in-process API call.
 
 **Acceptance Scenarios**:
 
-1. **Given** a directory containing legacy `.test.json` files, **When** the legacy-format converter walks the directory, **Then** each file is migrated into a valid `EvalCase` and aggregated into an `EvalSet` named for the directory.
-2. **Given** a legacy file with fields not present in the current schema, **When** migration runs, **Then** unknown fields are surfaced through a `metadata` map rather than silently dropped.
-3. **Given** the shipped GitHub Actions workflow templates copied into a consumer's repo, **When** a PR is opened, **Then** the PR-time workflow runs a declared eval set, posts the Markdown report as a PR comment, and sets the workflow status based on the gate.
-4. **Given** the `swink-eval` CLI is invoked with `run --set path/to/set.json`, **When** it completes, **Then** stdout contains the configured reporter's output and the exit code reflects the gate result (0 pass, non-zero fail).
+1. **Given** the shipped GitHub Actions workflow templates copied into a consumer's repo, **When** a PR is opened, **Then** the PR-time workflow runs a declared eval set, posts the Markdown report as a PR comment, and sets the workflow status based on the gate.
+2. **Given** the `swink-eval` CLI is invoked with `run --set path/to/set.json`, **When** it completes, **Then** stdout contains the configured reporter's output and the exit code reflects the gate result (0 pass, non-zero fail).
 
 ---
 
@@ -193,11 +206,11 @@ A developer adopting `swink-agent-eval` already has `.test.json` files from an e
 **Judge infrastructure (scope item 1)**
 
 - **FR-001**: The system MUST provide concrete `JudgeClient` implementations for every workspace adapter (anthropic, openai, bedrock, gemini, mistral, azure, xai, ollama, proxy), each gated behind an opt-in feature flag such that the default build of `swink-agent-eval` depends on no provider.
-- **FR-002**: The system MUST provide a default judge model configurable per-evaluator and per-registry, selectable without changing any prompt template.
+- **FR-002**: The system MUST require an explicit judge model identifier at `JudgeRegistry` construction (no built-in default; the constructor MUST refuse to build without one). The model is overridable per-evaluator. Switching the model MUST NOT require changing any prompt template — only the model rendering it.
 - **FR-003**: Every `JudgeClient` MUST expose an async-first interface and a synchronous convenience wrapper suitable for blocking contexts.
 - **FR-004**: Every `JudgeClient` MUST support throttling-aware retry with exponential backoff, with up to 6 attempts and a maximum backoff delay of 4 minutes, honoring cancellation cooperatively.
-- **FR-005**: Every `JudgeClient` MUST support request batching with a configurable batch size (default 1, bounded upper limit) that coalesces multiple judge calls into a single provider request where the provider supports it.
-- **FR-006**: The system MUST provide an in-memory prompt+model cache keyed by the hash of the prompt content and model identifier, bounded by a configurable entry count, and an optional disk-backed cache for cross-run reuse.
+- **FR-005**: Every `JudgeClient` MUST support request batching with a configurable batch size (default 1, bounded to `[1, 128]`) that coalesces multiple judge calls into a single provider request where the provider supports it. Providers without native batching MUST fall back to sequential dispatch transparently.
+- **FR-006**: The system MUST provide an in-memory prompt+model cache keyed by the hash of the prompt content and model identifier, bounded by a configurable entry count (default 1024), and an optional disk-backed cache for cross-run reuse.
 
 **Prompt-template registry (scope item 2)**
 
@@ -209,26 +222,26 @@ A developer adopting `swink-agent-eval` already has `.test.json` files from an e
 
 **LLM judge evaluator family (scope item 3)**
 
-- **FR-012**: The system MUST provide quality-family evaluators: HelpfulnessEvaluator (7-level), CorrectnessEvaluator (with optional reference output), ConcisenessEvaluator (3-level), CoherenceEvaluator (5-level), ResponseRelevanceEvaluator, HallucinationEvaluator / FaithfulnessEvaluator, PlanAdherenceEvaluator, LazinessEvaluator, and GoalSuccessRateEvaluator (consumes `expected_assertion`).
-- **FR-013**: The system MUST provide safety-family evaluators: HarmfulnessEvaluator / ToxicityEvaluator (binary), FairnessEvaluator, PIILeakageEvaluator, PromptInjectionEvaluator, and CodeInjectionEvaluator.
+- **FR-012**: The system MUST provide quality-family evaluators: HelpfulnessEvaluator (7-level), CorrectnessEvaluator (with optional reference output), ConcisenessEvaluator (3-level), CoherenceEvaluator (5-level), ResponseRelevanceEvaluator, HallucinationEvaluator (general, against model knowledge), FaithfulnessEvaluator (RAG-grounded, against retrieved context), PlanAdherenceEvaluator, LazinessEvaluator, and GoalSuccessRateEvaluator (consumes `expected_assertion`). `HallucinationEvaluator` and `FaithfulnessEvaluator` are distinct evaluators with distinct prompt templates and rubrics — not aliases.
+- **FR-013**: The system MUST provide safety-family evaluators: HarmfulnessEvaluator (broad-spectrum harmful content, binary), ToxicityEvaluator (tighter rubric targeting hate/harassment/slurs, binary), FairnessEvaluator, PIILeakageEvaluator, PromptInjectionEvaluator, and CodeInjectionEvaluator. `HarmfulnessEvaluator` and `ToxicityEvaluator` are distinct evaluators with distinct prompt templates and rubrics — not aliases.
 - **FR-014**: The system MUST provide RAG-family evaluators: RAGGroundednessEvaluator, RAGRetrievalRelevanceEvaluator, RAGHelpfulnessEvaluator, and EmbeddingSimilarityEvaluator (deterministic; takes an `Embedder` trait supplied by the consumer).
 - **FR-015**: The system MUST provide agent / trajectory-family evaluators: TrajectoryAccuracyEvaluator (with and without reference), TaskCompletionEvaluator, UserSatisfactionEvaluator, AgentToneEvaluator, KnowledgeRetentionEvaluator, LanguageDetectionEvaluator, PerceivedErrorEvaluator, and InteractionsEvaluator (multi-agent hand-off scoring).
 - **FR-016**: The system MUST provide structured-output evaluators: JsonMatchEvaluator with per-key aggregation strategies (Average, All, None) and per-key rubrics plus an `exclude_keys` filter, and JsonSchemaEvaluator (deterministic schema validation).
-- **FR-017**: The system MUST provide code-family evaluators: CargoCheckEvaluator, ClippyEvaluator, CodeExtractor (markdown-fence / LLM / regex strategies), CodeLlmJudgeEvaluator, and SandboxedExecutionEvaluator (Linux/macOS only; Windows MUST fail fast with a clear unsupported-platform error).
+- **FR-017**: The system MUST provide code-family evaluators: CargoCheckEvaluator, ClippyEvaluator, CodeExtractor (markdown-fence / LLM / regex strategies), CodeLlmJudgeEvaluator, and SandboxedExecutionEvaluator (Linux/macOS only; Windows MUST fail fast with a clear unsupported-platform error). `SandboxedExecutionEvaluator` MUST accept a `SandboxLimits` struct with configurable caps, defaulting to 120 s wall-clock, 60 s CPU, 1 GiB RSS, 256 file descriptors, and no network egress. Exceeding any limit MUST produce a structured `EvaluatorError::SandboxLimitExceeded` with the violated limit named, not a silent timeout.
 - **FR-018**: The system MUST provide simple-family evaluators: ExactMatchEvaluator and LevenshteinDistanceEvaluator.
 - **FR-019**: The system MUST provide image-safety multimodal evaluators behind a `multimodal` feature gate; audio multimodal evaluators are out of scope for this spec.
 - **FR-020**: Every new evaluator MUST return `None` when the case does not set the criterion the evaluator scores — same convention as 023's built-ins.
-- **FR-021**: Every new evaluator MUST be panic-isolated: panics in a judge call, a simulator step, a generator call, or a reporter renderer MUST be caught and converted to `Score::fail()` with diagnostic context, never propagating to abort the registry.
+- **FR-021**: Every new evaluator MUST be panic-isolated: panics in a judge call, a simulator step, a generator call, or a reporter renderer MUST be caught and converted to `Score::fail()` with diagnostic context, never propagating to abort the registry. Every evaluator MUST also clamp judge-returned scores to the closed interval `[0.0, 1.0]`; an out-of-range value MUST surface as a warning in `EvalMetricResult::details` (named `ScoreClamped { original, clamped }`) and MUST NOT cause the evaluator to crash.
 
 **Aggregators (scope item 4)**
 
 - **FR-022**: The system MUST expose an `Aggregator` trait for reducing multiple `EvalMetricResult` outputs from a single evaluator run into one composite score, with built-in implementations for average, all-pass, any-pass, and weighted reductions.
-- **FR-023**: Every evaluator MUST accept an optional custom aggregator override.
+- **FR-023**: Every evaluator MUST accept an optional custom aggregator override. When no override is supplied, the default aggregator is `average` (arithmetic mean of sub-scores). Binary-verdict evaluators (e.g., safety-family) MUST opt into `all-pass` explicitly in their constructor rather than relying on the default.
 
 **Multiturn simulation (scope item 5)**
 
 - **FR-024**: The system MUST provide an `ActorSimulator` that drives a simulated user across multiple turns via an LLM, configurable with a profile (traits, context, goal), an initial-greeting pool, a `max_turns` cap, and a goal-completion signal the simulated user can emit.
-- **FR-025**: The system MUST provide a `ToolSimulator` that generates schema-valid tool responses via an LLM when real tool infrastructure is unavailable, with a `StateRegistry` that buckets state by key, a bounded previous-call history per bucket (configurable size), and shared-state semantics within a bucket.
+- **FR-025**: The system MUST provide a `ToolSimulator` that generates schema-valid tool responses via an LLM when real tool infrastructure is unavailable, with a `StateRegistry` that buckets state by key, a bounded previous-call history per bucket (configurable size, default 32), and shared-state semantics within a bucket.
 - **FR-026**: The system MUST provide a `run_multiturn_simulation` orchestrator that drives agent ↔ actor (or agent ↔ agent) up to `max_turns` or goal-completion, returning a full `Invocation` scorable by any evaluator registered in the registry.
 
 **Experiment generation (scope item 6)**
@@ -248,32 +261,33 @@ A developer adopting `swink-agent-eval` already has `.test.json` files from an e
 
 **Runner upgrades (scope item 8)**
 
-- **FR-036**: The `EvalRunner` MUST support parallel case execution with a configurable parallelism bound. Parallelism of 1 MUST be behaviorally equivalent to the current sequential implementation.
-- **FR-037**: The `EvalRunner` MUST support repeating each case `num_runs` times (default 1) and averaging metric results, reporting per-run scores and a variance diagnostic.
-- **FR-038**: The system MUST provide an `EvaluationDataStore` trait and a local-filesystem implementation that caches agent invocations by case name. Cache keys MUST invalidate when case inputs change.
+- **FR-036**: The `EvalRunner` MUST support parallel case execution with a configurable parallelism bound (default 1 — sequential, matching the current behavior). Parallelism of 1 MUST be behaviorally equivalent to the current sequential implementation. Construction with `parallelism = 0` MUST be rejected (panic or builder error) as a misconfiguration signal.
+- **FR-037**: The `EvalRunner` MUST support repeating each case `num_runs` times (default 1) and averaging metric results, reporting per-run scores and a variance diagnostic. When an `EvaluationDataStore` serves a cached agent invocation for a case, all `num_runs` iterations MUST reuse that single invocation and re-run only the judge-side scoring; the variance diagnostic therefore captures judge non-determinism, not agent non-determinism. Measuring agent non-determinism is out of scope for this spec.
+- **FR-038**: The system MUST provide an `EvaluationDataStore` trait and a local-filesystem implementation that caches agent invocations by case name. Cache keys MUST be derived from a canonical content hash of the case input comprising exactly these fields, in this order: `case_id`, `system_prompt`, `user_messages`, `initial_session` (when an `initial_session_file` is active), tool-set hash (SHA-256 of the agent's tool names + schemas), and the agent's model identifier. Any change to any of these fields MUST invalidate the cache key. A single cached invocation is shared across all `num_runs` iterations for a given case.
 - **FR-039**: The `EvalRunner` MUST support an `initial_session_file` parameter that loads baseline session state before each case.
 - **FR-040**: Cancellation MUST propagate cooperatively through the runner to both in-flight agent calls and in-flight judge calls.
 
 **Reporting (scope item 9)**
 
-- **FR-041**: The system MUST provide reporters producing interactive console output, self-contained JSON artifacts, Markdown summaries, and — behind a feature gate — self-contained HTML reports.
+- **FR-041**: The system MUST provide reporters producing plain-text console output (line-oriented, no ANSI color, no cursor control, no interactivity), self-contained JSON artifacts, Markdown summaries, and — behind the `html-report` feature gate — a self-contained interactive HTML report. The HTML reporter is the only reporter that provides collapsible/interactive presentation; terminal output is intentionally plain-text only. No rich-console / TUI reporter ships.
 - **FR-042**: The system MUST provide a feature-gated LangSmith export adapter that pushes an `EvalSetResult` as a LangSmith run with per-evaluator feedback attached.
 
 **Case-model extensions (scope item 10)**
 
-- **FR-043**: The `EvalCase` struct MUST be extended with optional fields: `expected_assertion`, `expected_interactions`, `few_shot_examples`, `attachments`, and a per-case `session_id` populated by auto-UUID default.
-- **FR-044**: The system MUST provide a legacy-format converter that migrates older-schema eval files into the current `EvalSet` shape, preserving unknown fields in `metadata` rather than dropping them.
+- **FR-043**: The `EvalCase` struct MUST be extended with optional fields: `expected_assertion`, `expected_interactions`, `few_shot_examples`, `attachments`, and a per-case `session_id` populated by an auto-default UUID. The auto-default MUST be UUID v5 derived deterministically from a content hash of the case (same hash basis used by FR-038's cache key) so that session IDs remain stable across re-runs and machines. Consumers MAY supply an explicit `session_id` to override the default. `attachments` MUST be a `Vec<Attachment>` where `Attachment` is an enum with three first-class variants: `Path(PathBuf)` resolved relative to the eval-set root, `Base64 { mime: String, bytes: Vec<u8> }` for self-contained export, and `Url(String)` for remote resources. Materialization errors (unreachable path, decode failure, SSRF-guarded URL rejection) MUST surface as a structured `AttachmentError` — never a panic.
+
+<!-- FR-044 intentionally removed during clarification (Q3, 2026-04-21). No legacy-format converter is in scope. See the Clarifications section. -->
 
 **CI and DX scaffolding (scope item 11)**
 
-- **FR-045**: The system MUST ship GitHub Actions workflow templates covering PR-time eval runs, nightly eval runs, and report publication, plus a pre-commit configuration template.
-- **FR-046**: The system MUST provide a CLI entry point invocable against an eval-set file with the same output fidelity as the in-process API.
+- **FR-045**: The system MUST ship GitHub Actions workflow templates covering (a) PR-time eval runs that post the Markdown report as a PR comment and set workflow status from the gate; (b) nightly scheduled eval runs that upload the HTML report as a workflow artifact; (c) release-time eval runs triggered on tag push that attach the JSON `EvalSetResult` to the GitHub Release; and (d) a `.pre-commit-config.yaml` fragment that runs `swink-eval run` against a local eval set.
+- **FR-046**: The system MUST provide a `swink-eval` CLI with three subcommands: (a) `run --set <path>` executes an eval set with the same output fidelity as the in-process API, configured reporter on stdout, and exit code derived from the gate; (b) `report <result.json> --format <console|json|md|html>` re-renders a previously persisted `EvalSetResult` with the chosen reporter and performs no re-execution; (c) `gate <result.json>` evaluates a `GateConfig` against a persisted result and returns 0 on pass / non-zero on fail with no stdout output. `report` and `gate` operate exclusively on artifacts produced by a prior `run`.
 
 **Cross-cutting constraints**
 
 - **FR-047**: The default build of `swink-agent-eval` MUST NOT add any new mandatory dependencies beyond what spec 023 already requires. All new optional functionality MUST be reachable only behind explicit feature flags.
 - **FR-048**: Every public evaluator MUST expose both a blocking `evaluate` entrypoint and an `evaluate_async` entrypoint. The blocking wrapper MUST be correct inside and outside a Tokio runtime.
-- **FR-049**: No evaluator, simulator, generator, provider, mapper, or reporter MAY contain `unsafe` code. The entire workspace surface added by this spec MUST compile under `#![forbid(unsafe_code)]`.
+- **FR-049**: No evaluator, simulator, generator, provider, mapper, or reporter MAY contain `unsafe` code. The entire workspace surface added by this spec MUST compile under `#![forbid(unsafe_code)]` at every crate root. **Exception**: `SandboxedExecutionEvaluator`'s POSIX-rlimit FFI layer, scoped to a single `evaluators::code::sandbox::posix` submodule, MAY use `#![allow(unsafe_code)]` because rlimit enforcement requires direct `libc` calls (`setrlimit`, `unshare`, `prlimit`) that have no safe Rust equivalent. The exception is conditional on: (a) `cfg(target_family = "unix")` (the module is absent from Windows builds); (b) every `unsafe` block inside it carries a `// SAFETY:` comment explaining the invariant being upheld; (c) no other surface in either crate uses `unsafe`. The forbid attribute remains at both crate roots.
 - **FR-050**: The default test suite MUST NOT make live LLM calls; integration coverage MUST use `MockJudge` (from 023's testing module) or an HTTP test double. A dedicated `live-judges` feature MUST gate a smaller suite of live-provider canary tests.
 
 ## Success Criteria *(mandatory)*
@@ -283,7 +297,7 @@ A developer adopting `swink-agent-eval` already has `.test.json` files from an e
 - **SC-001**: A developer can run a multi-evaluator eval set against a real provider with a single feature-flag opt-in and no glue code beyond registry construction and a single `run_set` call. The happy-path integration is 10 lines of code or fewer.
 - **SC-002**: Running 20 cases with parallelism 4 against a fast provider completes in under 2× the wall-clock time of running a single case, and adding `num_runs=3` does not linearly inflate that — repeat runs of the same case amortize across the parallelism budget.
 - **SC-003**: Re-running an eval set after changing only a judge prompt (not the agent) reuses cached invocations and completes in a small fraction of the initial run's wall-clock time — no agent calls are made.
-- **SC-004**: Switching the default judge model (e.g., Claude → GPT) requires changing a single constructor argument and MUST NOT change any prompt template — only the model rendering it.
+- **SC-004**: Switching the judge model for a registry (e.g., Claude → GPT) requires changing a single constructor argument and MUST NOT change any prompt template — only the model rendering it. No built-in default model ships; the model is a required argument.
 - **SC-005**: Every judge evaluator records the prompt template version used in its result; bumping a prompt version is a deliberate opt-in change and never silent.
 - **SC-006**: Multiturn simulation runs a 5-turn dialogue between an `ActorSimulator` and an agent using only `ToolSimulator` (no real tool infrastructure), producing a complete `Invocation` scorable by any registered evaluator.
 - **SC-007**: `ExperimentGenerator` produces cases that pass syntactic validation 100% of the time; no malformed case ever reaches the eval runner.
@@ -301,6 +315,10 @@ A developer adopting `swink-agent-eval` already has `.test.json` files from an e
 - **JudgeCache**: In-memory LRU cache of prompt+model → verdict; optional disk-backed variant.
 
 **LLM-judge evaluators** — one type per entry in FR-012 through FR-019. Each implements the `Evaluator` trait from 023, returning `None` when its criterion is not set on the case and otherwise rendering its prompt, dispatching via its `JudgeClient`, and aggregating verdicts into an `EvalMetricResult`.
+
+**Code evaluators** (FR-017 entities):
+- **CodeExtractor**: Strategy object that lifts code from an assistant response. Supports three built-in strategies — markdown-fence, regex, and LLM-based — selectable per-instance.
+- **CodeLlmJudgeEvaluator**: Judge-backed evaluator that scores code quality via a prompt template, distinct from the deterministic `CargoCheckEvaluator`/`ClippyEvaluator` that shell out to cargo tooling.
 
 **Aggregator**: Trait and built-in implementations (average, all-pass, any-pass, weighted) for reducing multi-output evaluator scores.
 
@@ -336,20 +354,20 @@ A developer adopting `swink-agent-eval` already has `.test.json` files from an e
 **Reporting**
 
 - **EvaluationReport**: Aggregate type with structured per-case reasoning, metric breakdown, and failure narrative; input to every reporter.
-- **Reporter**: Trait implemented by `RichConsoleReporter`, `JsonReporter`, `MarkdownReporter`, `HtmlReporter`, and the `LangSmithExporter`.
+- **Reporter**: Trait implemented by `ConsoleReporter` (plain-text, always-on), `JsonReporter` (always-on), `MarkdownReporter` (always-on), `HtmlReporter` (behind `html-report`; the only interactive presentation layer), and the `LangSmithExporter` (behind `langsmith`).
 
-**Case-model extensions** on `EvalCase`: `expected_assertion` (goal-completion criteria), `expected_interactions` (multi-agent hand-off topology), `session_id` (auto-UUID), `few_shot_examples` (per-case judge examples), `attachments` (multimodal data refs).
+**Case-model extensions** on `EvalCase`: `expected_assertion` (goal-completion criteria), `expected_interactions` (multi-agent hand-off topology), `session_id` (deterministic UUID v5 from case content hash), `few_shot_examples` (per-case judge examples), `attachments` (multimodal data refs via an `Attachment` enum with `Path` / `Base64` / `Url` variants).
 
-**CLI**: A `swink-eval` binary exposing `run`, `report`, `gate`, and `migrate` subcommands against eval sets on disk.
+**CLI**: A `swink-eval` binary exposing `run`, `report`, and `gate` subcommands against eval sets on disk.
 
 ## Assumptions
 
 - 023's `JudgeClient`, `JudgeVerdict`, `JudgeError`, `EnvironmentState`, `StateCapture`, and semantic-evaluator stubs are frozen. This spec consumes them unchanged.
 - 024's `FsEvalStore`, `GateConfig`, and `AuditedInvocation` remain the persistence and CI-gate substrate; runner upgrades extend rather than replace them.
 - Provider-backed `JudgeClient` implementations live in a single `eval-judges` workspace crate with per-provider feature flags. Each feature re-exports a `<Provider>JudgeClient` type that wraps the corresponding adapter without polluting the adapter crates with eval-layer concerns. (Alternative: per-adapter sub-modules behind features inside `eval`; the chosen structure keeps adapter crates pure.)
-- The default judge model is Anthropic's current flagship Sonnet. Teams that want a different default swap it via one constructor call.
+- No built-in default judge model ships. Every `JudgeRegistry` requires an explicit model identifier at construction. This keeps the spec durable as provider model lineups evolve and prevents silent score drift from a floating default.
 - "No new mandatory dependencies" means the default build of `swink-agent-eval` adds no new transitive crates beyond what spec 023 already pulls in. New crates used by this spec (e.g. a retry crate, a string-similarity crate, terminal-rendering crates, an HTML templating crate) live under feature flags.
-- `SandboxedExecutionEvaluator` uses OS-level resource limits (process groups, rlimits) rather than container isolation. It is deliberately unsupported on Windows; teams on Windows can still run every other evaluator, and the CI matrix explicitly includes Linux and macOS targets only for this evaluator.
+- `SandboxedExecutionEvaluator` uses OS-level resource limits (process groups, rlimits) rather than container isolation. Default caps (120 s wall, 60 s CPU, 1 GiB RSS, 256 FDs, no network) are pinned in FR-017 and configurable via a `SandboxLimits` struct. It is deliberately unsupported on Windows; teams on Windows can still run every other evaluator, and the CI matrix explicitly includes Linux and macOS targets only for this evaluator.
 - `EmbeddingSimilarityEvaluator` ships with an `Embedder` trait and no default implementation; consumers supply their own embedder (e.g. local model or provider call) so we don't bundle a default embedding provider.
 - Audio multimodal evaluators are deferred to a later spec; only image-safety prompts ship in this spec's multimodal feature.
 - Prompt-template versioning follows a `_v0`, `_v1` suffix convention; a bumped version is an intentional semver-impacting change and the old version remains accessible until removed in a later release.
@@ -377,4 +395,4 @@ A developer adopting `swink-agent-eval` already has `.test.json` files from an e
 **External**:
 - `strands-agents/evals` (cloned at `~/Development/strands-evals`, ~11.5K LOC across 100 files) — primary source for `ActorSimulator`/`ToolSimulator` design, `ExperimentGenerator`/`TopicPlanner`, `TraceProvider`/`SessionMapper` architecture, multi-agent extractors, GenAI convention support, `EvaluationDataStore` caching pattern.
 - `langchain-ai/openevals` — primary source for the prompt registry shape; prebuilt prompt families across quality, safety, RAG, agent, multimodal, structured, and code; `JsonMatchEvaluator` with per-key rubrics; multiturn simulation orchestrator surface; sandboxed code-execution model (E2B → Rust tempdir analog); configurable output schemas, feedback-key naming, and use-reasoning flag.
-- `google/adk-python` `AgentEvaluator` — primary source for `num_runs` averaging, `EvalConfig`-threshold model, `.test.json` directory loading with recursive walk, `initial_session_file` persistent context, legacy schema migration, and tabular report style.
+- `google/adk-python` `AgentEvaluator` — primary source for `num_runs` averaging, `EvalConfig`-threshold model, `initial_session_file` persistent context, and tabular report style.

--- a/specs/043-evals-adv-features/tasks.md
+++ b/specs/043-evals-adv-features/tasks.md
@@ -1,0 +1,532 @@
+# Tasks: Evals: Advanced Features
+
+**Input**: Design documents from `/specs/043-evals-adv-features/`
+**Prerequisites**: spec.md, plan.md, research.md, data-model.md, contracts/public-api.md, quickstart.md
+
+**Tests**: Included — FR-050 mandates mock/test-double-only default suite; the implicit Constitution II (Test-Driven) applies as in prior specs. Tests precede implementation within each story.
+
+**Organization**: Tasks grouped by user story. MVP = US1, US2, US3 (all P1). US4–US8 are P2; US9 is P3. Nothing in the MVP requires work outside the MVP stories.
+
+## Format: `- [ ] [TaskID] [P?] [Story?] Description with file path`
+
+- **[P]**: Parallelizable — different files, no unfinished dependency.
+- **[Story]**: `[US1]`–`[US9]` on story-phase tasks. No label on Setup / Foundational / Polish.
+- File paths are absolute unless a repo-relative path is obvious.
+
+## Path Conventions
+
+- `swink-agent-eval` extensions live under `eval/src/`.
+- New `swink-agent-eval-judges` crate lives at `eval-judges/` at the workspace root.
+- CLI binary: `eval/src/bin/swink_eval.rs`.
+- CI templates: `eval/src/ci/templates/`.
+- Shared integration tests: `eval/tests/` and `eval-judges/tests/`.
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Create the new `eval-judges` crate, wire workspace, declare feature flags and new deps. No logic yet.
+
+- [ ] T001 Create `eval-judges/` directory with `src/` and `tests/common/` subdirectories
+- [ ] T002 Create `eval-judges/Cargo.toml`: package `swink-agent-eval-judges`, workspace inheritance for version/edition/rust-version/license/repository, `#![forbid(unsafe_code)]`, dependencies (`swink-agent-eval` path dep, `async-trait`, `tokio`, `backon`, `tracing`, `thiserror`, `serde`, `serde_json`), optional per-provider adapter deps (`swink-agent-adapters-anthropic`, `-openai`, `-bedrock`, `-gemini`, `-mistral`, `-azure`, `-xai`, `-ollama`, `-proxy`), feature flags (`anthropic`, `openai`, `bedrock`, `gemini`, `mistral`, `azure`, `xai`, `ollama`, `proxy`, `all-judges`, `live-judges`) each enabling its adapter dep plus `swink-agent-eval/judge-core`
+- [ ] T003 Add `"eval-judges"` to `[workspace] members` in root `Cargo.toml`
+- [ ] T004 Add new workspace-level dependencies per research.md §R-025 to root `Cargo.toml` `[workspace.dependencies]`: `minijinja` 2, `backon` 1, `strsim` 0.12, `jsonschema` 0.30, `opentelemetry` 0.31, `opentelemetry-sdk` 0.31, `opentelemetry-otlp` 0.31, `askama` 0.13, `clap` 4, `libc` 0.2
+- [ ] T005 Update `eval/Cargo.toml`: add optional deps (`minijinja`, `backon`, `strsim`, `jsonschema`, `opentelemetry`, `opentelemetry-sdk`, `opentelemetry-otlp`, `opentelemetry-stdout`, `askama`, `clap`, `libc`, `reqwest`, `bincode`, `lru`), declare all 22 features from plan.md §Project Structure §Structure Decision (4) — each feature gates only the crates it needs
+- [ ] T006 Create `eval-judges/src/lib.rs` with `#![forbid(unsafe_code)]`, module declarations (`client`, and one `cfg`-gated module per provider), public re-exports of each `<Provider>JudgeClient` and its `Blocking<Provider>JudgeClient` wrapper behind their feature flags
+- [ ] T007 Create `eval-judges/src/client.rs` stub with `BlockingExt` helper + `build_retry(policy: &RetryPolicy) -> ExponentialBuilder` used by every provider impl
+- [ ] T008 Create stub files (empty `pub struct` + empty `impl JudgeClient`) for each provider in `eval-judges/src/`: `anthropic.rs`, `openai.rs`, `bedrock.rs`, `gemini.rs`, `mistral.rs`, `azure.rs`, `xai.rs`, `ollama.rs`, `proxy.rs` — one per feature, each with `#[cfg(feature = "<name>")]`
+- [ ] T009 Extend `eval/src/lib.rs` module declarations: add `prompt`, `judge`, `aggregator`, `evaluators`, `simulation`, `generation`, `trace`, `telemetry`, `cache`, `report` modules, each gated appropriately
+- [ ] T010 Verify `cargo build --workspace --no-default-features` succeeds (default build, no new surfaces active; FR-047 baseline validated)
+- [ ] T011 Verify `cargo build -p swink-agent-eval --features all-evaluators,simulation,generation,trace-ingest,telemetry,html-report,langsmith,cli --no-default-features` compiles (all-features dry-run)
+
+**Checkpoint**: Both crates compile with and without features. Nothing implemented yet — only scaffolding.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Shared types and traits every user story depends on. No user story may begin until this phase is complete.
+
+### Shared types
+
+- [ ] T012 Implement `Attachment` enum + `MaterializedAttachment` struct + `AttachmentError` enum in `eval/src/types.rs` per data-model.md §10
+- [ ] T013 [P] Implement `UrlFilter` trait + `DefaultUrlFilter` (RFC 1918, loopback, link-local, metadata endpoint denials; HTTPS-required by default) in `eval/src/url_filter.rs` — always-on top-level module (not under `judge/`) so attachment materialization works without `judge-core`; re-export from `swink_agent_eval::judge` for ergonomic access when `judge-core` is enabled, per research.md §R-011
+- [ ] T014 [P] Implement `Assertion` + `AssertionKind` + `InteractionExpectation` + `FewShotExample` structs in `eval/src/types.rs` per data-model.md §10
+- [ ] T015 Extend `EvalCase` in `eval/src/types.rs` with new optional fields (`expected_assertion`, `expected_interactions`, `few_shot_examples`, `attachments`, `session_id`, `metadata`), preserving serde backwards-compatibility
+- [ ] T016 Implement `CaseFingerprint` struct + `CASE_NAMESPACE: Uuid` constant (pinned project-specific namespace, derived once from `Uuid::new_v5(&Uuid::NAMESPACE_OID, b"swink-agent-eval.case")` and hard-coded as 16 bytes) + `default_session_id()` method on `EvalCase` producing deterministic UUID v5 from SHA-256 of canonical bincode bytes, per research.md §R-014; include a unit test verifying `CASE_NAMESPACE == Uuid::new_v5(&Uuid::NAMESPACE_OID, b"swink-agent-eval.case")`
+- [ ] T017 Implement `Attachment::materialize(&Path, &dyn UrlFilter) -> Result<MaterializedAttachment, AttachmentError>` handling all three variants (Path read, Base64 decode, Url fetch with filter + HTTPS requirement) in `eval/src/types.rs`
+- [ ] T018 [P] Write tests in `eval/tests/attachment_test.rs` covering: `Path` resolution relative to eval-set root, `Base64` round-trip, `Url` blocked by default filter (10.0.0.1, 127.0.0.1, 169.254.169.254), `Url` allowed with custom filter, unsupported MIME, missing path
+
+### Aggregators
+
+- [ ] T019 [P] Implement `Aggregator` trait in `eval/src/aggregator/mod.rs`
+- [ ] T020 [P] Implement `Average`, `AllPass`, `AnyPass`, `Weighted` aggregators in `eval/src/aggregator/mod.rs`
+- [ ] T021 [P] Write tests in `eval/tests/aggregator_test.rs` for each aggregator on happy path, empty input, single-sample, partial failures, and weighted-mismatch error
+
+### Prompt templating
+
+- [ ] T022 Implement `JudgePromptTemplate` trait + `PromptFamily` enum + `PromptContext` struct + `PromptError` enum in `eval/src/prompt/mod.rs` per data-model.md §1 (feature `judge-core`)
+- [ ] T023 Implement `PromptTemplateRegistry` with `builtin()`, `get()`, `register()` methods rejecting duplicate versions in `eval/src/prompt/mod.rs`
+- [ ] T024 Implement `MinijinjaTemplate` struct wrapping `minijinja::Environment` that validates named variables at construction time and returns `PromptError::MissingVariable` when a case lacks a referenced variable, in `eval/src/prompt/minijinja_template.rs`
+- [ ] T025 [P] Write tests in `eval/tests/prompt_template_test.rs`: missing variable → deterministic error, valid render, version identifier preserved, duplicate version registration rejected, few-shot example injection order
+
+### Judge infrastructure
+
+- [ ] T026 Implement `RetryPolicy` struct + `Default` impl (6 attempts / 4 min / jitter true) in `eval/src/judge/mod.rs`
+- [ ] T027 Implement `JudgeCache` + `CacheKey` with in-memory LRU (capacity 1024 default), SHA-256 prompt+model key, put/get/evict in `eval/src/judge/cache.rs`
+- [ ] T028 Implement disk-backed `JudgeCache` variant (`with_disk(path)` constructor; JSON files per key; warm-load on construction; flush on `Drop`) in `eval/src/judge/cache.rs`
+- [ ] T029 Implement `JudgeRegistry` + `JudgeRegistryBuilder` + `JudgeRegistryError` in `eval/src/judge/mod.rs` — constructor requires explicit `model_id` (Q9 clarification); validates `batch_size ∈ [1,128]` and `max_attempts ≤ 16`
+- [ ] T030 [P] Write tests in `eval/tests/judge_registry_test.rs`: `model_id` empty rejected, `batch_size=0` rejected, `batch_size=129` rejected, default retry policy values, cache get/put/evict on LRU bound
+
+### EvalCase extensions
+
+- [ ] T031 Extend `EvalCase::validate()` in `eval/src/types.rs` to check new fields (`case_id` uniqueness within set, attachment format, assertion kind legality)
+- [ ] T032 [P] Write tests in `eval/tests/eval_case_test.rs` for the extended validators and deterministic-session-id property (same case bytes → same UUID across re-runs)
+
+### Panic isolation helpers
+
+- [ ] T033 Implement `isolate_panic` wrapper in `eval/src/evaluator.rs` that wraps any async evaluator/simulator/generator/reporter call in `tokio::spawn(..).await` and converts `JoinError::is_panic()` to `Score::fail()` with `PanicDetail { location, message }`, per research.md §R-021
+- [ ] T034 Extend `EvaluatorRegistry` in `eval/src/evaluator.rs` to route every evaluator call through `isolate_panic`; ensure existing 023/024 tests still pass
+
+### Test scaffolding
+
+- [ ] T035 Create `eval/tests/common/judge_fixtures.rs` with `wiremock`-based provider fixtures reusable across all judge client and evaluator tests
+- [ ] T036 Create `eval-judges/tests/common/mod.rs` with shared `wiremock` fixtures for each provider's expected request/response shape
+
+**Checkpoint**: Foundation complete. Shared types, prompt registry, judge infrastructure, cache, panic isolation, and test fixtures ready. User-story phases can begin.
+
+---
+
+## Phase 3: User Story 1 — Score Agent Runs with Production LLM Judges (P1) 🎯 MVP
+
+**Goal**: Register an evaluator registry with real provider judges, run an eval set, get structured per-evaluator scores with reasons.
+
+**Independent Test**: Run an eval set with at least one case per evaluator family against a live provider (or a `wiremock` double); every applicable evaluator returns a score with non-empty reason, non-applicable ones return no entry, single rate-limit blip is absorbed by retry.
+
+### Judge clients in `eval-judges`
+
+- [ ] T037 [P] [US1] Write `eval-judges/tests/anthropic_test.rs` covering: `wiremock`-backed happy path, rate-limit 429 absorbed by retry, exhausted retries surface `JudgeError::RateLimitExhausted`, malformed response → `JudgeError::MalformedResponse`, cancellation propagation
+- [ ] T038 [P] [US1] Implement `AnthropicJudgeClient` + `BlockingAnthropicJudgeClient` in `eval-judges/src/anthropic.rs` — wraps `AnthropicAdapter`, exposes retry policy, batch size, async + blocking interfaces
+- [ ] T039 [P] [US1] Implement `OpenAIJudgeClient` + blocking wrapper in `eval-judges/src/openai.rs` with matching test file `eval-judges/tests/openai_test.rs`
+- [ ] T040 [P] [US1] Implement `BedrockJudgeClient` + blocking wrapper in `eval-judges/src/bedrock.rs` with test file `eval-judges/tests/bedrock_test.rs`
+- [ ] T041 [P] [US1] Implement `GeminiJudgeClient` + blocking wrapper in `eval-judges/src/gemini.rs` with test file `eval-judges/tests/gemini_test.rs`
+- [ ] T042 [P] [US1] Implement `MistralJudgeClient` + blocking wrapper in `eval-judges/src/mistral.rs` with test file `eval-judges/tests/mistral_test.rs`
+- [ ] T043 [P] [US1] Implement `AzureJudgeClient` + blocking wrapper in `eval-judges/src/azure.rs` with test file `eval-judges/tests/azure_test.rs`
+- [ ] T044 [P] [US1] Implement `XaiJudgeClient` + blocking wrapper in `eval-judges/src/xai.rs` with test file `eval-judges/tests/xai_test.rs`
+- [ ] T045 [P] [US1] Implement `OllamaJudgeClient` + blocking wrapper in `eval-judges/src/ollama.rs` with test file `eval-judges/tests/ollama_test.rs`
+- [ ] T046 [P] [US1] Implement `ProxyJudgeClient` + blocking wrapper in `eval-judges/src/proxy.rs` with test file `eval-judges/tests/proxy_test.rs`
+- [ ] T047 [US1] Implement shared `backon`-based retry + cancellation wiring in `eval-judges/src/client.rs` (6 attempts / 4 min max / jitter / `CancellationToken`-aware) used by every provider
+- [ ] T048 [US1] Implement request-batching wrapper in `eval-judges/src/client.rs` with configurable batch size ∈ [1, 128]; providers that don't support native batching fall through to sequential dispatch
+
+### Prompt templates (built-in _v0, feature `judge-core`)
+
+- [ ] T049 [P] [US1] Author quality-family prompt templates (`helpfulness_v0`, `correctness_v0`, `conciseness_v0`, `coherence_v0`, `response_relevance_v0`, `hallucination_v0`, `faithfulness_v0`, `plan_adherence_v0`, `laziness_v0`, `goal_success_rate_v0`) in `eval/src/prompt/templates/quality.rs` with minijinja source strings; faithfulness and hallucination have distinct, non-overlapping rubrics per Q1 clarification
+- [ ] T050 [P] [US1] Author safety-family prompt templates (`harmfulness_v0`, `toxicity_v0`, `fairness_v0`, `pii_leakage_v0`, `prompt_injection_v0`, `code_injection_v0`) in `eval/src/prompt/templates/safety.rs`; harmfulness and toxicity have distinct rubrics per Q1 clarification (toxicity narrower: hate/harassment/slurs)
+- [ ] T051 [P] [US1] Author RAG-family prompt templates (`rag_groundedness_v0`, `rag_retrieval_relevance_v0`, `rag_helpfulness_v0`) in `eval/src/prompt/templates/rag.rs`
+- [ ] T052 [P] [US1] Author agent-family prompt templates (`trajectory_accuracy_v0`, `trajectory_accuracy_with_ref_v0`, `task_completion_v0`, `user_satisfaction_v0`, `agent_tone_v0`, `knowledge_retention_v0`, `language_detection_v0`, `perceived_error_v0`, `interactions_v0`) in `eval/src/prompt/templates/agent.rs`
+- [ ] T053 [P] [US1] Author code + multimodal prompt templates (`code_llm_judge_v0`, `image_safety_v0`) in `eval/src/prompt/templates/code.rs` and `eval/src/prompt/templates/multimodal.rs`
+- [ ] T054 [US1] Register all built-in templates in `PromptTemplateRegistry::builtin()` in `eval/src/prompt/mod.rs`; add a test asserting every expected version identifier is present
+
+### Shared evaluator config
+
+- [ ] T055 [US1] Implement `JudgeEvaluatorConfig` + `Default::default_with(judge_registry)` in `eval/src/evaluators/mod.rs`
+- [ ] T056 [US1] Implement shared `dispatch_judge()` helper in `eval/src/evaluators/mod.rs` that renders the config's (or builtin) prompt, dispatches via `JudgeRegistry`, records `prompt_version` in the resulting `EvalMetricResult::details`, clamps the returned score to `[0.0, 1.0]` and surfaces any out-of-range value as `details.push(Detail::ScoreClamped { original, clamped })` (per FR-021 extended requirement), and returns `None` when the case doesn't populate the evaluator's criterion fields (per FR-020)
+
+### Quality family (feature `evaluator-quality`)
+
+- [ ] T057 [P] [US1] Write tests for `HelpfulnessEvaluator`, `CorrectnessEvaluator`, `ConcisenessEvaluator`, `CoherenceEvaluator` in `eval/tests/evaluators_quality_test.rs` using `MockJudge`
+- [ ] T058 [P] [US1] Implement `HelpfulnessEvaluator`, `CorrectnessEvaluator`, `ConcisenessEvaluator`, `CoherenceEvaluator`, `ResponseRelevanceEvaluator` in `eval/src/evaluators/quality.rs` — each `None`-returns when criterion absent, records `prompt_version`, uses `Average` aggregator
+- [ ] T059 [P] [US1] Implement `HallucinationEvaluator`, `FaithfulnessEvaluator`, `PlanAdherenceEvaluator`, `LazinessEvaluator`, `GoalSuccessRateEvaluator` in `eval/src/evaluators/quality.rs`; `GoalSuccessRateEvaluator` consumes `expected_assertion`
+- [ ] T060 [P] [US1] Write tests in `eval/tests/evaluators_quality_test.rs` covering: hallucination distinct from faithfulness (retrieved-context vs. model-knowledge rubric separation), `None`-return when case doesn't populate criterion, score clamp to [0.0, 1.0] with warning
+
+### Safety family (feature `evaluator-safety`, default aggregator `AllPass`)
+
+- [ ] T061 [P] [US1] Write tests in `eval/tests/evaluators_safety_test.rs` covering: PII detection with at least three entity classes, prompt-injection detection, harmfulness distinct from toxicity (broader vs. narrower rubric)
+- [ ] T062 [P] [US1] Implement `HarmfulnessEvaluator`, `ToxicityEvaluator`, `FairnessEvaluator` in `eval/src/evaluators/safety.rs` — binary scores; default aggregator `AllPass` explicitly set in constructor
+- [ ] T063 [P] [US1] Implement `PIILeakageEvaluator` + `PIIClass` enum (Email/Phone/SSN/CreditCard/IpAddress/ApiKey/PersonalName/Address/Other) in `eval/src/evaluators/safety.rs`; constructor accepts `entity_classes: Vec<PIIClass>` (default: all built-in)
+- [ ] T064 [P] [US1] Implement `PromptInjectionEvaluator` and `CodeInjectionEvaluator` in `eval/src/evaluators/safety.rs`
+
+### RAG family (feature `evaluator-rag`)
+
+- [ ] T065 [P] [US1] Write tests in `eval/tests/evaluators_rag_test.rs` covering: groundedness-against-retrieved-context, retrieval-relevance, embedding-similarity with a `StubEmbedder` test double
+- [ ] T066 [P] [US1] Implement `RAGGroundednessEvaluator`, `RAGRetrievalRelevanceEvaluator`, `RAGHelpfulnessEvaluator` in `eval/src/evaluators/rag.rs`
+- [ ] T067 [P] [US1] Implement `Embedder` trait + `EmbedderError` enum + `EmbeddingSimilarityEvaluator` (deterministic cosine similarity with configurable threshold, default 0.8) in `eval/src/evaluators/rag.rs`
+
+### Agent family (feature `evaluator-agent`)
+
+- [ ] T068 [P] [US1] Write tests in `eval/tests/evaluators_agent_test.rs` covering: trajectory accuracy with and without reference, task-completion consumes `expected_assertion`, interactions consumes `expected_interactions`, language-detection returns detected code in details
+- [ ] T069 [P] [US1] Implement `TrajectoryAccuracyEvaluator`, `TrajectoryAccuracyWithRefEvaluator`, `TaskCompletionEvaluator`, `UserSatisfactionEvaluator` in `eval/src/evaluators/agent.rs`
+- [ ] T070 [P] [US1] Implement `AgentToneEvaluator`, `KnowledgeRetentionEvaluator`, `LanguageDetectionEvaluator`, `PerceivedErrorEvaluator`, `InteractionsEvaluator` in `eval/src/evaluators/agent.rs`
+
+### Structured family (feature `evaluator-structured`)
+
+- [ ] T071 [P] [US1] Write tests in `eval/tests/evaluators_structured_test.rs` covering: per-key rubric application, `exclude_keys` filter, malformed JSON → `JudgeError::MalformedResponse`, schema validation happy + unhappy path
+- [ ] T072 [P] [US1] Implement `JsonMatchEvaluator` + `KeyStrategy` enum (Average/All/None/Rubric) in `eval/src/evaluators/structured.rs`
+- [ ] T073 [P] [US1] Implement `JsonSchemaEvaluator` (deterministic; compiles schema via `jsonschema` crate; no judge call) in `eval/src/evaluators/structured.rs`
+
+### Simple family (feature `evaluator-simple`)
+
+- [ ] T074 [P] [US1] Write tests in `eval/tests/evaluators_simple_test.rs` covering: exact-match case-sensitivity & trim toggle, Levenshtein normalized similarity threshold
+- [ ] T075 [P] [US1] Implement `ExactMatchEvaluator` + `LevenshteinDistanceEvaluator` in `eval/src/evaluators/simple.rs`
+
+### Code family (feature `evaluator-code`; sandbox behind `evaluator-sandbox`)
+
+- [ ] T076 [P] [US1] Write tests in `eval/tests/evaluators_code_test.rs` covering: cargo-check happy path, clippy warning surface, `CodeExtractor` strategies (markdown-fence, regex, LLM)
+- [ ] T077 [P] [US1] Implement `CargoCheckEvaluator` + `ClippyEvaluator` in `eval/src/evaluators/code/cargo_check.rs` and `eval/src/evaluators/code/clippy.rs` — deterministic, shell out to cargo in a tempdir
+- [ ] T078 [P] [US1] Implement `CodeExtractor` + `CodeExtractorStrategy` enum in `eval/src/evaluators/code/extractor.rs`
+- [ ] T079 [P] [US1] Implement `CodeLlmJudgeEvaluator` in `eval/src/evaluators/code/llm_judge.rs` using the `code_llm_judge_v0` template
+- [ ] T080 [US1] Implement `SandboxLimits` struct + `Default` impl (120 s wall / 60 s CPU / 1 GiB RSS / 256 FDs / no network) in `eval/src/evaluators/code/sandbox.rs`
+- [ ] T081 [US1] Implement `SandboxedExecutionEvaluator` Unix path: `cfg(target_family = "unix")` module with `#![allow(unsafe_code)]` exception + safe `posix` submodule using `libc::setrlimit`/`libc::unshare`/`libc::prlimit` wrapped with `// SAFETY:` invariants; spawns child in tempdir; enforces all five limits; produces `EvaluatorError::SandboxLimitExceeded { limit }` when a bound is hit — per research.md §R-006
+- [ ] T082 [US1] Implement `SandboxedExecutionEvaluator` Windows stub: `cfg(target_family = "windows")` produces `EvaluatorError::UnsupportedPlatform` at evaluation time, never panics
+- [ ] T083 [P] [US1] Write tests in `eval/tests/evaluators_sandbox_test.rs` (Unix only via `cfg`): each limit enforced, wall-clock timeout cancels child, FD bomb caught, memory bomb caught, network egress blocked
+
+### Multimodal family (feature `multimodal`)
+
+- [ ] T084 [P] [US1] Write tests in `eval/tests/evaluators_multimodal_test.rs` covering: image-safety evaluator happy + deny path, attachment materialization integration
+- [ ] T085 [P] [US1] Implement `ImageSafetyEvaluator` in `eval/src/evaluators/multimodal.rs` consuming `Attachment::Path`/`Base64`/`Url` via materialization pipeline
+- [ ] T086 [US1] Wire attachment materialization into the shared `dispatch_judge` helper so any evaluator can reference attachments
+
+### Registry wiring
+
+- [ ] T087 [US1] Update `EvaluatorRegistry::add` to validate evaluator-name uniqueness within a registry (spec edge case) and surface `EvalError::DuplicateEvaluator` on collision
+- [ ] T088 [US1] Update `eval/src/lib.rs` to re-export every US1 surface behind the correct feature gates
+- [ ] T089 [US1] Integration test in `eval/tests/us1_end_to_end_test.rs`: registry with one evaluator per family, `wiremock`-backed judge returning canned verdicts, assert per-evaluator score + reason + prompt_version recorded, non-applicable evaluators return no entry
+
+**Checkpoint**: MVP step 1 complete — real judges + 24 evaluators + all 9 provider clients working end-to-end.
+
+---
+
+## Phase 4: User Story 2 — Run Large Eval Sets Fast and Repeatably (P1) 🎯 MVP
+
+**Goal**: Parallelism + `num_runs` + task-result caching + cancellation + `initial_session_file` all working on `EvalRunner`.
+
+**Independent Test**: 20-case suite run twice; second run reuses cached invocations, completes in a fraction of first run's time, agent is not invoked; cancellation mid-run returns partial results.
+
+### Runner extensions
+
+- [ ] T090 [P] [US2] Write tests in `eval/tests/runner_parallelism_test.rs`: `with_parallelism(4)` causes up to 4 concurrent case executions; `parallelism=1` behaves exactly as sequential baseline (per FR-036); permits release after case completion
+- [ ] T091 [US2] Extend `EvalRunner` with `parallelism: usize` field and `with_parallelism(n)` builder (`panic` on `n == 0`); wire `tokio::sync::Semaphore` permit acquisition around per-case execution in `eval/src/runner.rs`
+- [ ] T092 [P] [US2] Write tests in `eval/tests/runner_num_runs_test.rs`: `num_runs=3` yields three per-evaluator samples per case, variance reported, cached invocation shared across all N runs (Q2 clarification)
+- [ ] T093 [US2] Extend `EvalRunner` with `num_runs: u32` field and `with_num_runs(n)` builder (`panic` on `n == 0`); loop judge dispatch N times per case using the same `Invocation`; compute `std_dev` into `RunnerMetricSample` in `eval/src/runner.rs`
+- [ ] T094 [P] [US2] Write tests in `eval/tests/cache_test.rs`: cache hit reuses `Invocation`, cache miss re-invokes agent, case-input change invalidates key, disk cache round-trip, single cached invocation served to all `num_runs` iterations
+- [ ] T095 [US2] Implement `EvaluationDataStore` trait + `StoreError` in `eval/src/cache.rs`
+- [ ] T096 [US2] Implement `LocalFileTaskResultStore` with disk layout `<root>/<eval_set_id>/<case_id>/<fingerprint_hex>.json` in `eval/src/cache.rs`
+- [ ] T097 [US2] Implement `CaseFingerprint` canonicalization (case_id, system_prompt, user_messages, initial_session, tool_set_hash, agent_model) and SHA-256 of bincode bytes producing `CacheKey` in `eval/src/cache.rs`; wire into `EvalRunner::run_set`
+- [ ] T098 [US2] Extend `EvalRunner` with `cache: Option<Arc<dyn EvaluationDataStore>>` + `with_cache(store)` builder in `eval/src/runner.rs`
+
+### Cancellation
+
+- [ ] T099 [P] [US2] Write tests in `eval/tests/runner_cancel_test.rs`: cancellation mid-run returns partial result with cancellation indicator; in-flight agent and judge calls honor the token; completed cases keep their results
+- [ ] T100 [US2] Extend `EvalRunner` with `cancel: Option<CancellationToken>` + `with_cancellation(tok)` builder; propagate the token into agent calls and judge calls via `tokio::select!` at every await point in `eval/src/runner.rs`
+
+### Initial session
+
+- [ ] T101 [P] [US2] Write tests in `eval/tests/runner_initial_session_test.rs`: `initial_session_file` loaded; baseline session context present on each case start; missing file surfaces a clear error, not a panic
+- [ ] T102 [US2] Extend `EvalRunner` with `initial_session_file: Option<PathBuf>` + `with_initial_session_file(path)` builder; parse JSON per research.md §R-023 matching spec-034 `SessionState` serde shape in `eval/src/runner.rs`
+
+### US2 integration
+
+- [ ] T103 [US2] Integration test in `eval/tests/us2_end_to_end_test.rs`: 20-case suite / parallelism 4 / num_runs 3 / cache hit → second-run wall-clock is ≤ 20 % of first-run wall-clock with agent invocation count = 0, per SC-002/SC-003
+
+**Checkpoint**: MVP step 2 complete — runner fast, repeatable, resumable.
+
+---
+
+## Phase 5: User Story 3 — Configure and Version Prompt Templates (P1) 🎯 MVP
+
+**Goal**: Every evaluator accepts custom prompt, few-shot examples, system prompt, output schema, use-reasoning flag — without code change.
+
+**Independent Test**: Override built-in `CorrectnessEvaluator`'s prompt with a custom template and few-shot example; verify rendered prompt reflects overrides and result records the custom prompt version.
+
+- [ ] T104 [P] [US3] Write tests in `eval/tests/us3_custom_prompt_test.rs`: `.with_prompt(custom_template)` replaces built-in at evaluation time; few-shot examples inject at declared positions; bumped `_v0` → `_v1` is explicit opt-in (old version remains accessible); variable missing at construction → deterministic error
+- [ ] T105 [US3] Extend every judge-backed evaluator's builder with `.with_prompt(Arc<dyn JudgePromptTemplate>)`, `.with_few_shot(Vec<FewShotExample>)`, `.with_system_prompt(String)`, `.with_output_schema(JsonSchema)`, `.with_use_reasoning(bool)`, `.with_feedback_key(String)` — all route through the shared `JudgeEvaluatorConfig`
+- [ ] T106 [US3] Ensure `prompt_version` is recorded in every `EvalMetricResult::details` for every judge-backed evaluator (reused from T056 but re-verified here)
+- [ ] T107 [US3] Add a versioning smoke test: registry contains `correctness_v0` (built-in) + `correctness_v1` (custom); two cases use each; results distinguish them per-metric
+
+**Checkpoint**: MVP step 3 complete — prompts are configuration; version discipline enforced.
+
+**MVP complete after Phase 5. Remaining phases (US4–US9) are additive and independently mergeable.**
+
+---
+
+## Phase 6: User Story 4 — Multi-Turn Dialogues via Simulated Users and Tools (P2)
+
+**Goal**: `ActorSimulator` + `ToolSimulator` + `run_multiturn_simulation` produce an `Invocation` scorable by any evaluator.
+
+**Independent Test**: 5-turn scripted scenario, `ToolSimulator` providing tool responses, resulting `Invocation` contains 3 user turns + correct tool-call/tool-result pairings, then scored by `GoalSuccessRateEvaluator`.
+
+*Depends on US1 (needs `JudgeClient`).*
+
+- [ ] T108 [P] [US4] Write tests in `eval/tests/simulation_test.rs`: 5-turn dialogue, goal-completion signal fires at turn 3, `max_turns` reached without goal triggers graceful termination
+- [ ] T109 [US4] Implement `ActorProfile` struct + `ActorSimulator` (profile, judge, greeting pool, turn cap, goal-completion signal) in `eval/src/simulation/actor.rs`
+- [ ] T110 [US4] Implement `StateRegistry` + `StateBucket` with bounded FIFO history (configurable `history_cap`, default 32) in `eval/src/simulation/tool.rs`
+- [ ] T111 [US4] Implement `ToolSimulator` that generates schema-valid responses (via `jsonschema` validation) and records calls in its bucket in `eval/src/simulation/tool.rs`; schema-invalid response surfaces `SimulationError::SchemaValidation`, never silent
+- [ ] T112 [US4] Implement `run_multiturn_simulation(agent, actor, tool_sim, max_turns, cancel)` orchestrator in `eval/src/simulation/orchestrator.rs`; produces full `Invocation`; honors cancellation cooperatively
+- [ ] T113 [P] [US4] Write tests in `eval/tests/simulation_state_test.rs`: shared-state semantics within a bucket across two tools, FIFO eviction at history cap, bucket separation across `state_key`
+- [ ] T114 [US4] Integration test in `eval/tests/us4_end_to_end_test.rs`: simulated conversation scored by `GoalSuccessRateEvaluator` produces identical metrics to an equivalent real `Invocation` (transparency to scoring layer, per US4 scenario 5)
+
+**Checkpoint**: Simulation fully integrated; scorable end-to-end.
+
+---
+
+## Phase 7: User Story 5 — Auto-Generate Diverse Test Cases from a Context Description (P2)
+
+**Goal**: `ExperimentGenerator` + `TopicPlanner` produce validated `EvalSet` from a description.
+
+**Independent Test**: `desired_count=12`, `num_topics=4` yields 12 valid `EvalCase`s spanning 4 topics; retries absorb malformed judge output.
+
+*Depends on US1.*
+
+- [ ] T115 [P] [US5] Write tests in `eval/tests/generation_test.rs`: 20 cases / 5 topics distribution, tools-scoped trajectories reference only provided tools, every emitted case passes `EvalCase::validate()`, retries on malformed responses before skipping a slot
+- [ ] T116 [US5] Implement `TopicPlanner` in `eval/src/generation/topic.rs` producing `Vec<TopicSlot>` with even distribution
+- [ ] T117 [US5] Implement `ExperimentGenerator` + `GenerationRequest` struct in `eval/src/generation/experiment.rs`; retries up to bounded cap on malformed JSON; every emitted case validated before returning
+- [ ] T118 [US5] Integration test in `eval/tests/us5_end_to_end_test.rs`: generated `EvalSet` loaded into `EvalRunner` executes successfully; tools-scoped trajectories respected when `agent_tools` provided
+
+**Checkpoint**: Auto-generation integrated; generator ↔ runner round-trip validated.
+
+---
+
+## Phase 8: User Story 6 — Ingest Agent Traces from External Observability Backends (P2)
+
+**Goal**: `TraceProvider` + `SessionMapper` + `TraceExtractor` pull sessions from Langfuse/OpenSearch/CloudWatch/OTLP into `Invocation`.
+
+**Independent Test**: Recorded in-process run via in-memory OTel exporter re-loaded and scored — bitwise-identical scores to original run for deterministic evaluators.
+
+*Independent of US1 for core trait; dependent for scoring tests.*
+
+### Core trace surface (feature `trace-ingest`)
+
+- [ ] T119 [P] [US6] Write tests in `eval/tests/trace_ingest_test.rs`: `OtelInMemoryTraceProvider` round-trip (record + re-load), missing attribute → `MappingError::MissingAttribute`, partially-written session → `TraceProviderError::SessionInProgress`
+- [ ] T120 [US6] Implement `TraceProvider` trait + `TraceProviderError` + `RawSession` in `eval/src/trace/provider.rs`
+- [ ] T121 [US6] Implement `OtelInMemoryTraceProvider` wrapping `opentelemetry-sdk`'s `InMemorySpanExporter` in `eval/src/trace/provider.rs`
+- [ ] T122 [US6] Implement `SessionMapper` trait + `MappingError` in `eval/src/trace/mapper.rs`
+- [ ] T123 [P] [US6] Implement `OpenInferenceSessionMapper` in `eval/src/trace/mapper.rs`
+- [ ] T124 [P] [US6] Implement `LangChainSessionMapper` in `eval/src/trace/mapper.rs`
+- [ ] T125 [US6] Implement `OtelGenAiSessionMapper` + `GenAIConventionVersion` enum (V1_27, V1_30, Experimental) with per-version attribute-mapping tables in `eval/src/trace/mapper.rs`
+
+### Per-backend providers
+
+- [ ] T126 [P] [US6] Implement `OtlpHttpTraceProvider` (feature `trace-otlp`) in `eval/src/trace/otlp.rs` with `reqwest`-based OTLP-HTTP pull and test in `eval/tests/trace_otlp_test.rs` (wiremock-backed)
+- [ ] T127 [P] [US6] Implement `LangfuseTraceProvider` (feature `trace-langfuse`) in `eval/src/trace/langfuse.rs` with test in `eval/tests/trace_langfuse_test.rs`
+- [ ] T128 [P] [US6] Implement `OpenSearchTraceProvider` (feature `trace-opensearch`) in `eval/src/trace/opensearch.rs` with test
+- [ ] T129 [P] [US6] Implement `CloudWatchTraceProvider` (feature `trace-cloudwatch`) in `eval/src/trace/cloudwatch.rs` with test
+- [ ] T130 [US6] Feature-gate error: disabled-feature access to a backend provider produces a clear compile-time or construction-time error (spec US6 scenario 4); add a doc-test covering this
+
+### Extractors
+
+- [ ] T131 [US6] Implement `EvaluationLevel` enum + `TraceExtractor` trait in `eval/src/trace/extractor.rs`
+- [ ] T132 [P] [US6] Implement `SwarmExtractor` consuming spec-040 swarm result types in `eval/src/trace/extractor.rs`
+- [ ] T133 [P] [US6] Implement `GraphExtractor` consuming spec-039 graph result types in `eval/src/trace/extractor.rs`
+- [ ] T134 [US6] Integration test in `eval/tests/us6_end_to_end_test.rs`: record in-process run via in-memory exporter; re-load via `OtelInMemoryTraceProvider` + `OpenInferenceSessionMapper`; score with deterministic evaluators; assert bit-identical scores (per SC-008)
+
+**Checkpoint**: Trace ingestion working across all four backends plus in-memory.
+
+---
+
+## Phase 9: User Story 7 — Emit OTel Spans for Eval Runs Themselves (P2)
+
+**Goal**: `EvalsTelemetry` emits the three-level span tree per FR-035.
+
+**Independent Test**: Run eval set with `EvalsTelemetry` pointing at the in-memory exporter; assert expected span tree and attribute set.
+
+*Depends on US2 (extends `EvalRunner`).*
+
+- [ ] T135 [P] [US7] Write tests in `eval/tests/telemetry_test.rs` using `opentelemetry-sdk::testing::trace::InMemorySpanExporter`: root `swink.eval.run_set`, per-case `swink.eval.case`, per-evaluator `swink.eval.evaluator`; failed case records OTel status-error + exception event; parent span is inherited when one exists
+- [ ] T136 [US7] Implement `EvalsTelemetry` + `EvalsTelemetryBuilder` in `eval/src/telemetry.rs` (feature `telemetry`)
+- [ ] T137 [US7] Wire `EvalsTelemetry` into `EvalRunner::run_set` in `eval/src/runner.rs`: emit the three-level span tree; attach standardized attributes per FR-035; honor existing parent span when one is active
+- [ ] T138 [US7] Integration test in `eval/tests/us7_end_to_end_test.rs`: full run produces the expected span tree; regression in `correctness` at a known case surfaces as an errored span (per US7 scenario 3)
+
+**Checkpoint**: Eval runs emit OTel spans.
+
+---
+
+## Phase 10: User Story 8 — Produce CI- and Human-Friendly Reports (P2)
+
+**Goal**: `ConsoleReporter` (plain-text), `JsonReporter`, `MarkdownReporter` always-on; `HtmlReporter` behind `html-report`; `LangSmithExporter` behind `langsmith`.
+
+**Independent Test**: Same `EvalSetResult` through each reporter; each output parses / renders cleanly; each contains the expected per-case / per-metric detail.
+
+*Independent of other stories.*
+
+### Reporters
+
+- [ ] T139 [P] [US8] Write tests in `eval/tests/reporter_console_test.rs`: plain-text line-oriented output, one line per case verdict + indented evaluator score+reason, no ANSI, no cursor control, no interactivity (per Q8 clarification)
+- [ ] T140 [US8] Implement `Reporter` trait + `ReporterOutput` enum + `ReporterError` in `eval/src/report/mod.rs`
+- [ ] T141 [P] [US8] Implement `ConsoleReporter` in `eval/src/report/console.rs` (always-on, plain-text)
+- [ ] T142 [P] [US8] Write tests in `eval/tests/reporter_json_test.rs`: self-contained JSON; schema validation against `eval-result.schema.json`
+- [ ] T143 [P] [US8] Implement `JsonReporter` in `eval/src/report/json.rs` (always-on) + author `specs/043-evals-adv-features/contracts/eval-result.schema.json`
+- [ ] T144 [P] [US8] Write tests in `eval/tests/reporter_markdown_test.rs`: valid Markdown table; no ANSI; per-case and per-metric detail present
+- [ ] T145 [P] [US8] Implement `MarkdownReporter` in `eval/src/report/markdown.rs` (always-on, PR-comment-ready)
+- [ ] T146 [P] [US8] Write tests in `eval/tests/reporter_html_test.rs`: single self-contained file; `<details>`/`<summary>` collapsibility; no external asset dependencies; bounded output size for thousand-case results
+- [ ] T147 [US8] Implement `HtmlReporter` in `eval/src/report/html.rs` using `askama` templates with inlined CSS/JS (feature `html-report`); embed template at compile time
+- [ ] T148 [P] [US8] Write tests in `eval/tests/reporter_langsmith_test.rs` (wiremock-backed): `EvalSetResult` pushed as run; per-evaluator feedback attached under configured `feedback_key`; partial push failure surfaces `LangSmithExportError::Push { pushed, failed, first_error }`
+- [ ] T149 [US8] Implement `LangSmithExporter` + `LangSmithExportError` in `eval/src/report/langsmith.rs` (feature `langsmith`) with `reqwest`-based POST to `/runs` and `/feedback` per research.md §R-015
+
+### Report integration
+
+- [ ] T150 [US8] Integration test in `eval/tests/us8_end_to_end_test.rs`: same `EvalSetResult` through each reporter; HTML output validates as well-formed HTML5; JSON output validates against schema; Markdown output validates as CommonMark
+
+**Checkpoint**: All reporters functional; JSON schema published.
+
+---
+
+## Phase 11: User Story 9 — CI Integration and Local CLI (P3)
+
+**Goal**: `swink-eval` CLI with `run` / `report` / `gate` subcommands; GitHub Actions workflow templates shipped.
+
+**Independent Test**: Invoke CLI against an `EvalSet`; verify identical output to in-process API; re-render a persisted result with `report`; evaluate a gate with `gate`.
+
+*Depends on US2 + US8 (runner + reporters).*
+
+### CLI binary
+
+- [ ] T151 [P] [US9] Write tests in `eval/tests/cli_test.rs` (using `assert_cmd` or equivalent spawning the binary): `run --set` produces matching output to in-process API; `report` re-renders without re-execution; `gate` returns 0/non-zero; missing file returns exit 2
+- [ ] T152 [US9] Scaffold `eval/src/bin/swink_eval.rs` with `clap` derive-parser: `run { --set, --out, --parallelism, --reporter }`, `report { --result, --format }`, `gate { --result, --gate-config }` (feature `cli`)
+- [ ] T153 [US9] Implement `run` subcommand: load `EvalSet`, construct `EvalRunner`, execute, render chosen reporter to stdout, write optional JSON artifact, exit with code derived from `GateConfig`
+- [ ] T154 [US9] Implement `report` subcommand: load persisted `EvalSetResult`, render through chosen reporter, write to stdout (no re-execution)
+- [ ] T155 [US9] Implement `gate` subcommand: load persisted `EvalSetResult`, load `GateConfig`, evaluate, return 0/1/2/3 per contracts/public-api.md; no stdout output
+
+### CI templates
+
+- [ ] T156 [P] [US9] Author `eval/src/ci/templates/pr-eval.yml` per research.md §R-018
+- [ ] T157 [P] [US9] Author `eval/src/ci/templates/nightly-eval.yml`
+- [ ] T158 [P] [US9] Author `eval/src/ci/templates/release-eval.yml`
+- [ ] T159 [P] [US9] Author `eval/src/ci/templates/pre-commit-hook.yml`
+- [ ] T160 [US9] Add `include_str!`-based compile-time references for all four templates so they're validated by `cargo build`
+
+### US9 integration
+
+- [ ] T161 [US9] Integration test in `eval/tests/us9_end_to_end_test.rs`: install binary into a tempdir, invoke `run → report → gate` pipeline against a fixture `EvalSet`; verify stable exit codes and identical outputs to the in-process API
+
+**Checkpoint**: CLI shipping, CI templates authored.
+
+---
+
+## Phase 12: Polish & Cross-Cutting Concerns
+
+**Purpose**: Finish the spec's non-functional contract, lift success-criteria gates, update docs, bump versions, run the full-features matrix.
+
+### Feature-matrix verification
+
+- [ ] T162 Verify `cargo build -p swink-agent-eval --no-default-features` succeeds; confirm default build pulls no new transitive deps beyond 023 baseline (SC-009)
+- [ ] T163 Verify `cargo build -p swink-agent-eval --features all-evaluators,simulation,generation,trace-ingest,trace-otlp,trace-langfuse,trace-opensearch,trace-cloudwatch,telemetry,html-report,langsmith,cli` succeeds
+- [ ] T164 Verify `cargo build -p swink-agent-eval-judges --features all-judges` succeeds
+- [ ] T165 Run `cargo test --workspace` and confirm zero live LLM calls (FR-050); add a repo-level test asserting no test sets `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / etc. without feature `live-judges`
+
+### Panic-isolation and cancellation sweep
+
+- [ ] T166 Review every evaluator, simulator, generator, reporter for panic-isolation coverage (FR-021); add missing `isolate_panic` wrappers; add a dedicated test in `eval/tests/score_clamp_test.rs` asserting that a judge returning `1.3` produces a clamped `1.0` with `ScoreClamped { original: 1.3, clamped: 1.0 }` in details (spec Edge Cases + FR-021 extension)
+- [ ] T167 Review every await point in runner / simulation / generation for `CancellationToken` responsiveness (FR-040); no task should hang after cancellation
+
+### Docs and metadata
+
+- [ ] T168 Update `eval/README.md` with feature-flag matrix and usage recipes from quickstart.md
+- [ ] T169 Create `eval-judges/README.md` documenting each provider feature and credentials
+- [ ] T170 Update `docs/HLD.md` with new crate count (14 → 15), new architectural surface (eval-judges, prompt registry, simulation, generation, trace ingestion, telemetry, reporters, CLI)
+- [ ] T171 Update root `README.md` feature matrix to include the eval advanced-features surface
+- [ ] T172 Update `CHANGELOG.md` with 043 scope, breaking-change notes (EvalCase extended; no default judge model; FR-044 removed — legacy converter never shipped)
+
+### Success-criteria validation
+
+- [ ] T173 Add a benchmark test asserting SC-002: 20-case / parallelism-4 suite completes in under 2× single-case wall-clock against a `wiremock`-backed "fast provider"
+- [ ] T174 Add a benchmark test asserting SC-003: prompt-only re-run reuses cached invocations, agent invocation count = 0
+- [ ] T175 Add a property test asserting SC-004: swapping judge model requires exactly one constructor-arg change; every existing evaluator continues to work against the new model
+- [ ] T176 Add a deterministic-replay test asserting SC-008: OTel-traced run re-loaded via `OtelInMemoryTraceProvider` scores bit-identical to in-process run for deterministic evaluators
+- [ ] T177 Add a regression test asserting SC-009: `cargo tree -p swink-agent-eval --no-default-features` produces an identical transitive dep graph to the 023 baseline
+
+### Release hygiene
+
+- [ ] T178 Run `cargo clippy --workspace --all-targets --all-features -- -D warnings` and resolve any new lints
+- [ ] T179 Run `cargo fmt --all --check`
+- [ ] T180 Bump `workspace.package.version` to `0.9.0` in root `Cargo.toml` (minor bump — new features additive, no removed items)
+- [ ] T181 Verify Dependabot / `cargo deny check` for the new deps (`minijinja`, `backon`, `strsim`, `jsonschema`, `opentelemetry`, `askama`, `clap`, `libc`, `opentelemetry-otlp`)
+
+---
+
+## Dependencies
+
+```text
+Phase 1 (Setup) ──► Phase 2 (Foundational) ──► Phase 3 (US1, P1) ──┐
+                                          └──► Phase 4 (US2, P1) ──┤──► Phase 7 (US5, P2) ──┐
+                                          └──► Phase 5 (US3, P1) ──┤──► Phase 6 (US4, P2) ──┤
+                                                                   │                        │
+                                                                   ├──► Phase 9 (US7, P2) ──┤
+                                                                   │                        │
+                                          ┌──► Phase 8 (US6, P2) ──┤                        │
+                                          │                        │                        │
+                                          └──► Phase 10 (US8, P2) ─┴──► Phase 11 (US9, P3) ─┴──► Phase 12 (Polish)
+```
+
+- **Setup (Phase 1)** must complete before any foundational work.
+- **Foundational (Phase 2)** must complete before any story phase.
+- **US1, US2, US3** are all P1 and together form the MVP. Within the MVP:
+  - US1 can run largely in parallel across its sub-phases (judge clients, prompt templates, evaluator families are each parallelizable).
+  - US2 is structurally independent of US1 at file level (touches `runner.rs` / `cache.rs` / `types.rs` fingerprint). US2 tasks can parallelize with US1 tasks after Phase 2.
+  - US3 is largely declarative over US1's surface (adds `.with_*()` builder methods already stubbed in `JudgeEvaluatorConfig`); can start as soon as US1 evaluators exist.
+- **US4 / US5** depend on US1 (need `JudgeClient`). They can run in parallel with each other.
+- **US6** is independent of US1 at the trait level; integration tests depend on US1 evaluators.
+- **US7** extends the runner from US2.
+- **US8** is largely independent of other stories (consumes `EvalSetResult`).
+- **US9** depends on US2 (runner) + US8 (reporters).
+
+## Parallel Execution Examples
+
+### Judge clients (US1)
+All nine provider clients (T037–T046) are file-level independent — each modifies exactly one file in `eval-judges/src/` and one file in `eval-judges/tests/`. Launch them in parallel:
+
+```text
+T037 anthropic   T038 openai   T039 bedrock   T040 gemini   T041 mistral
+T042 azure       T043 xai      T044 ollama    T045 proxy
+```
+
+### Prompt templates (US1)
+Five family files (T049–T053), each one author pass:
+
+```text
+T049 quality/    T050 safety/    T051 rag/    T052 agent/    T053 code+multimodal/
+```
+
+### Evaluator tests (US1)
+Every family's test file can be authored in parallel (T057, T060, T061, T065, T068, T071, T074, T076, T083, T084); wire them after the evaluator impls land in the same family's `.rs` file.
+
+### Trace provider backends (US6)
+T126–T129 (OTLP / Langfuse / OpenSearch / CloudWatch) — file-level independent.
+
+### CI templates (US9)
+T156–T159 — four independent YAML files.
+
+## Implementation Strategy
+
+1. **Sequentially** run Phase 1 and Phase 2 — no story work may start until foundational types and trait surfaces exist.
+2. **MVP (Phases 3 → 4 → 5)** can start once Phase 2 lands:
+   - Kick off Phase 3 task fan-out (judge clients + prompt templates + evaluator families each parallelizable).
+   - Phase 4 runner work is file-independent of Phase 3 and can run concurrently.
+   - Phase 5 depends on Phase 3 evaluator scaffolds existing but its own tasks are small.
+3. **Ship the MVP** — at this point every P1 acceptance scenario passes; `swink-eval` has no CLI yet but the in-process API is complete.
+4. **P2 layer (Phases 6–10)** — each story is independently deliverable and each can ship as its own PR:
+   - Simulation (6), Generation (7) — can run sequentially or in parallel; both consume `JudgeClient` only.
+   - Trace ingestion (8) — largest P2, can be split by backend if desired.
+   - Telemetry (9) — small; extends runner surface from Phase 4.
+   - Reporters (10) — largely independent; can ship one reporter at a time if pressure dictates.
+5. **P3 layer (Phase 11)** — CLI + CI templates; ships once P2 reporters and P1 runner are stable.
+6. **Polish (Phase 12)** — last; gates the feature matrix, updates docs, bumps version, verifies success criteria.
+
+**Estimated total task count**: 181 (T001–T181).
+
+**Task-count-per-story**:
+
+| Phase | Story | Count |
+|---|---|---|
+| 1 | Setup | 11 |
+| 2 | Foundational | 25 |
+| 3 | US1 | 53 |
+| 4 | US2 | 14 |
+| 5 | US3 | 4 |
+| 6 | US4 | 7 |
+| 7 | US5 | 4 |
+| 8 | US6 | 16 |
+| 9 | US7 | 4 |
+| 10 | US8 | 12 |
+| 11 | US9 | 11 |
+| 12 | Polish | 20 |
+| **Total** |  | **181** |


### PR DESCRIPTION
## Summary

Full `/speckit.*` workflow on spec 043 (Evals: Advanced Features). This PR is docs-only — no `eval/` or `eval-judges/` code changes yet. Implementation lands in subsequent PRs driven by issues #746–#760.

- **spec.md** — ten clarifications recorded (evaluator naming pairs, num_runs/cache interaction, legacy-format scope dropped, CLI subcommand semantics, sandbox defaults, default aggregator, session-id determinism, rich-console dropped, no default judge model, attachment enum shape), plus thirteen `/speckit.analyze` remediations applied in-line.
- **plan.md** — technical context, structure decisions (new `eval-judges` crate, 22 feature flags on `eval`), constitution check.
- **research.md** — 25 architectural decisions (templating via `minijinja`, retry via `backon`, sandboxing via `libc` rlimits with scoped unsafe carve-out authorized by FR-049, parallelism via `tokio::Semaphore`, UUID v5 with project-specific namespace, LRU judge cache, HTML reporting via `askama`).
- **data-model.md** — all 11 scope items across 50 FRs, including the extended `EvalCase`, `Attachment` enum, `SandboxLimits`, and 24 evaluator types across 7 families.
- **contracts/public-api.md** — authoritative public surface of both crates, feature-flag mapping, CLI binary shape, JSON wire schemas.
- **quickstart.md** — 10 end-to-end recipes plus a feature cheat-sheet.
- **tasks.md** — 181 dependency-ordered tasks across 12 phases.

## Issue breakdown

15 issues (#746 – #760) decompose the 181 tasks into logical testable units, with real cross-refs between them:

- #746 Setup
- #747 Foundational
- #748–#752 US1 (P1 MVP): judge clients, prompts + config, judge-family evaluators, deterministic/code/sandbox/multimodal evaluators, registry + integration
- #753 US2 (P1 MVP): runner upgrades
- #754 US3 (P1 MVP): prompt override surface
- #755 US4 + US5: simulation + generation
- #756 US6: trace ingestion
- #757 US7: telemetry
- #758 US8: reporters
- #759 US9: CLI + CI
- #760 Polish

## Notable architectural commitments

- **New workspace crate** `swink-agent-eval-judges` (14 → 15 members).
- **No default judge model** — `JudgeRegistry::builder(client, model_id)` requires explicit model per clarification Q9; durable across provider releases.
- **Sandboxing** uses POSIX rlimits via `libc` (single FFI surface), localized to one submodule with `// SAFETY:` invariants, authorized explicitly by FR-049's carve-out.
- **No backwards-compat with external eval tooling** unless adopting an open standard (clarification Q3); FR-044 legacy-format converter removed.
- **Plain-text console only** — rich/interactive presentation is HTML-only (clarification Q8).
- **FR-047 preserved** — default build adds zero new transitive deps vs. spec 023 baseline; every new surface is feature-gated (22 features on `eval`, 9+ on `eval-judges`).

## Test plan

- [ ] Reviewers verify spec-plan-tasks consistency (the in-repo `/speckit.analyze` pass already reported 100 % FR coverage with zero CRITICAL and all remediations applied).
- [ ] Verify issues #746–#760 are well-formed and the dependency chain renders correctly.
- [ ] Manual review of FR-049's sandbox carve-out — confirm the scope is tight enough for your threat model.
- [ ] Spot-check research.md decisions against upstream crate availability (`minijinja` 2.x, `backon` 1.x, `askama` 0.13, `opentelemetry` 0.31).
- [ ] No code or build artifacts change in this PR — `cargo build` / `cargo test` behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)