### PR TITLE
chore(ci): produce required gate checks + cargo fmt cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,13 @@ on:
   pull_request:
 
 jobs:
-  # ── Primary gate: runs on every PR and main push ────────────────────────
+  # ── Primary gate: matrix over ubuntu + macos, runs on every PR ──────────
   check:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -44,6 +48,26 @@ jobs:
         run: cargo doc --no-deps --workspace
         env:
           RUSTDOCFLAGS: "-D warnings"
+
+  # ── MSRV gate: build against the declared minimum supported Rust ────────
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Read MSRV from Cargo.toml
+        id: msrv
+        run: |
+          version=$(awk -F'"' '/^rust-version = / { print $2; exit }' Cargo.toml)
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: ${{ steps.msrv.outputs.version }}
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - run: cargo check --workspace --all-targets
 
   # ── Feature matrix: consolidated from features + feature-smoke + all-features ─
   features:
@@ -97,16 +121,10 @@ jobs:
 
       - uses: EmbarkStudios/cargo-deny-action@91bf2b620e09e18d6eb78b92e7861937469acedb # v2
 
-  # ── Platform smoke: macOS + Windows on main push only ───────────────────
-  # PRs are validated on Ubuntu; cross-platform issues are caught on the
-  # post-merge main push. Saves ~10 min of runner time per PR.
+  # ── Windows smoke: still main-push-only (Windows runners are expensive) ─
   check-platform:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [macos-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -133,12 +151,15 @@ jobs:
         env:
           RUSTDOCFLAGS: "-D warnings"
 
-  # ── Semver: only on main push (release boundary) ────────────────────────
+  # ── Semver: runs on every PR against integration or main ────────────────
+  # Baseline is the target branch so PRs against `integration` are checked
+  # against integration, not main.
   semver:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
@@ -148,7 +169,15 @@ jobs:
 
       - run: cargo binstall --no-confirm --force cargo-semver-checks
 
-      - name: Fetch main branch for baseline
-        run: git fetch origin main
+      - name: Pick baseline ref
+        id: baseline
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "ref=origin/${{ github.base_ref }}" >> "$GITHUB_OUTPUT"
+            git fetch origin "${{ github.base_ref }}"
+          else
+            echo "ref=origin/main" >> "$GITHUB_OUTPUT"
+            git fetch origin main
+          fi
 
-      - run: cargo semver-checks --workspace --exclude swink-agent-local-llm --baseline-rev origin/main
+      - run: cargo semver-checks --workspace --exclude swink-agent-local-llm --baseline-rev "${{ steps.baseline.outputs.ref }}"

--- a/eval/src/lib.rs
+++ b/eval/src/lib.rs
@@ -17,8 +17,8 @@
 
 mod audit;
 mod budget;
-mod environment_state;
 mod efficiency;
+mod environment_state;
 mod error;
 mod evaluator;
 mod gate;
@@ -38,8 +38,8 @@ mod yaml;
 
 pub use audit::AuditedInvocation;
 pub use budget::BudgetEvaluator;
-pub use environment_state::EnvironmentStateEvaluator;
 pub use efficiency::EfficiencyEvaluator;
+pub use environment_state::EnvironmentStateEvaluator;
 pub use error::EvalError;
 pub use evaluator::{Evaluator, EvaluatorRegistry};
 pub use gate::{GateConfig, GateResult, check_gate};
@@ -49,8 +49,8 @@ pub use response::ResponseMatcher;
 pub use runner::{AgentFactory, EvalRunner};
 pub use score::{Score, Verdict};
 pub use store::{EvalStore, FsEvalStore};
-pub use trajectory::TrajectoryCollector;
 pub use testing::MockJudge;
+pub use trajectory::TrajectoryCollector;
 pub use types::{
     BudgetConstraints, EnvironmentState, EvalCase, EvalCaseResult, EvalMetricResult, EvalSet,
     EvalSetResult, EvalSummary, ExpectedToolCall, Invocation, RecordedToolCall, ResponseCriteria,

--- a/eval/tests/environment_state.rs
+++ b/eval/tests/environment_state.rs
@@ -147,7 +147,10 @@ fn state_capture_panic_becomes_failure() {
 
     assert_eq!(result.score.value, Score::fail().value);
     let details = result.details.expect("details should be present");
-    assert!(details.contains("state capture panicked"), "details: {details}");
+    assert!(
+        details.contains("state capture panicked"),
+        "details: {details}"
+    );
     assert!(details.contains("capture exploded"), "details: {details}");
 }
 

--- a/local-llm/src/stream.rs
+++ b/local-llm/src/stream.rs
@@ -719,14 +719,16 @@ impl StreamState {
     fn finalize_error(mut self, message: impl Into<String>) -> Vec<AssistantMessageEvent> {
         self.flush_pending_non_gemma_thinking();
         self.events.extend(finalize_blocks(&mut self.blocks));
-        self.events.push(AssistantMessageEvent::error(message.into()));
+        self.events
+            .push(AssistantMessageEvent::error(message.into()));
         self.events
     }
 
     fn finalize_cancelled(mut self) -> Vec<AssistantMessageEvent> {
         self.flush_pending_non_gemma_thinking();
         self.events.extend(finalize_blocks(&mut self.blocks));
-        self.events.push(cancelled_event("local inference cancelled"));
+        self.events
+            .push(cancelled_event("local inference cancelled"));
         self.events
     }
 

--- a/src/agent/invoke.rs
+++ b/src/agent/invoke.rs
@@ -256,7 +256,10 @@ impl Agent {
 
         let messages_for_loop = if is_continue {
             let mut msgs = std::mem::take(&mut self.state.messages);
-            if matches!(msgs.last(), Some(AgentMessage::Llm(LlmMessage::Assistant(_)))) {
+            if matches!(
+                msgs.last(),
+                Some(AgentMessage::Llm(LlmMessage::Assistant(_)))
+            ) {
                 msgs.extend(drain_messages_from_queue(&self.steering_queue));
                 msgs.extend(drain_messages_from_queue(&self.follow_up_queue));
             }

--- a/tests/agent_continuation.rs
+++ b/tests/agent_continuation.rs
@@ -383,7 +383,8 @@ async fn agent_end_subscriber_retaining_messages_does_not_lose_history() {
         "continued steering should be recorded once without duplicating prior history"
     );
     assert_eq!(
-        agent.state()
+        agent
+            .state()
             .messages
             .iter()
             .filter(|message| matches!(

--- a/tui/src/lib.rs
+++ b/tui/src/lib.rs
@@ -277,7 +277,10 @@ mod tests {
 
         let approval_task = tokio::spawn(async move { callback(approval_request()).await });
 
-        let (_, responder) = rx.recv().await.expect("approval request should be forwarded");
+        let (_, responder) = rx
+            .recv()
+            .await
+            .expect("approval request should be forwarded");
         drop(responder);
 
         assert_eq!(approval_task.await.unwrap(), ToolApproval::Rejected);


### PR DESCRIPTION
## Summary

Branch protection on `integration` requires these check names present + SUCCESS: `check (ubuntu-latest)`, `check (macos-latest)`, `msrv`, `semver`, `features`. The current CI produces only `check` (singular), runs `semver` on main pushes only, and has no `msrv` job — so every open PR has been failing the gate on "required checks missing/non-matching" regardless of code quality.

This PR reshapes CI to match the required names and runs `cargo fmt` to fix preexisting violations that were failing the (still-present) `check` job.

## Changes

**`.github/workflows/ci.yml`**
- `check` is now a matrix over `ubuntu-latest` + `macos-latest` (produces the two required named runs).
- New `msrv` job reads `rust-version` from workspace `Cargo.toml` (currently `1.95`) and runs `cargo check --workspace --all-targets` on that toolchain.
- `semver` now runs on PRs against their target branch (not just `push` to `main`). Baseline is the PR's target ref, so PRs targeting `integration` are checked against `integration`.
- `check-platform` scoped down to Windows-only on main push. macOS is now covered by the matrixed `check` job.

**Preexisting `cargo fmt` fixups** (all mechanical, no logic changes):
- `src/agent/invoke.rs`
- `tests/agent_continuation.rs`
- `tui/src/lib.rs`
- `local-llm/src/stream.rs`
- `eval/src/lib.rs`
- `eval/tests/environment_state.rs`

## Cost tradeoff

The matrixed `check` on macOS adds ~10 min of runner time per PR (the previous design explicitly ran macOS only on post-merge main push for this reason). Running `semver` on every PR costs ~2–3 min. If the runtime cost is a concern, consider scoping `check (macos-latest)` to only changes that touch platform-sensitive code paths or gating it behind a label.

## Test plan
- [x] `cargo fmt --check` locally clean
- [ ] New CI runs complete on this PR — validating the matrix names and msrv/semver jobs work on a live run
- [ ] Once merged, open PRs (#764, #765) re-run with the new gate shape

## Context

This is infrastructure-only — does not touch any 023 spec work. Opening this to unblock #764 (Phase 9 US5) and #765 (Phase 10 US6) which are both MERGEABLE but blocked by the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)