### PR TITLE
fix(tui): wizard keychain fallback + editor temp safety (#715)

### DIFF
--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -40,6 +40,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-appender = "0.2"
 dotenvy.workspace = true
 thiserror.workspace = true
+tempfile.workspace = true
 
 [features]
 default = ["cli"]

--- a/tui/src/editor.rs
+++ b/tui/src/editor.rs
@@ -5,7 +5,8 @@
 //! file contents as a user prompt when the editor closes.
 
 use std::io;
-use std::process::Command;
+use std::path::Path;
+use std::process::{Command, ExitStatus};
 
 /// Resolve the editor command from environment or fallback.
 ///
@@ -26,37 +27,57 @@ pub fn resolve_editor(config_override: Option<&str>) -> String {
 
 /// Open the editor with a temporary file and return the file contents on close.
 ///
+/// Uses `tempfile::Builder` to create an exclusive, randomized temp path so
+/// the file cannot collide with another user's file in a shared temp
+/// directory. The temp file is removed when the returned `NamedTempFile`
+/// goes out of scope, which happens before this function returns regardless
+/// of success or failure.
+///
 /// Returns `Ok(Some(content))` if the editor exited successfully and the file is non-empty.
 /// Returns `Ok(None)` if the editor exited successfully but the file is empty (cancellation).
 /// Returns `Err` if the editor could not be launched or exited with a non-zero status.
 pub fn open_editor(editor_command: &str) -> io::Result<Option<String>> {
-    let temp_dir = std::env::temp_dir();
-    let temp_path = temp_dir.join(format!("swink-prompt-{}.md", std::process::id()));
+    open_editor_with(editor_command, default_spawn)
+}
 
-    // Create empty temp file
-    std::fs::write(&temp_path, "")?;
+/// Default spawn strategy: actually launch the editor and wait for it.
+fn default_spawn(editor_command: &str, path: &Path) -> io::Result<ExitStatus> {
+    Command::new(editor_command).arg(path).status()
+}
 
-    // Launch the editor
-    let status = Command::new(editor_command).arg(&temp_path).status();
+/// Core editor helper with an injectable spawn function so tests can
+/// observe the temp path (and verify it is randomized) without launching
+/// a real editor.
+pub(crate) fn open_editor_with<F>(editor_command: &str, spawn: F) -> io::Result<Option<String>>
+where
+    F: FnOnce(&str, &Path) -> io::Result<ExitStatus>,
+{
+    // `tempfile::Builder` creates a file with a randomized, exclusive path
+    // (O_CREAT | O_EXCL on Unix, equivalent on Windows) so there is no
+    // predictable filename to race against.
+    let temp = tempfile::Builder::new()
+        .prefix("swink-prompt-")
+        .suffix(".md")
+        .rand_bytes(16)
+        .tempfile()?;
 
-    let status = match status {
-        Ok(s) => s,
-        Err(e) => {
-            let _ = std::fs::remove_file(&temp_path);
-            return Err(e);
-        }
-    };
+    let temp_path = temp.path().to_path_buf();
+
+    // Launch the editor. If it fails to spawn, `temp` is dropped here and
+    // the file is cleaned up automatically.
+    let status = spawn(editor_command, &temp_path)?;
 
     if !status.success() {
-        let _ = std::fs::remove_file(&temp_path);
         return Err(io::Error::other(format!(
             "Editor exited with status: {status}"
         )));
     }
 
-    // Read and clean up
+    // Read the edited content. Reading via the path keeps this compatible
+    // with editors that replace the file (write-to-temp-then-rename) rather
+    // than editing in-place.
     let content = std::fs::read_to_string(&temp_path).unwrap_or_default();
-    let _ = std::fs::remove_file(&temp_path);
+    // `temp` is dropped at end of scope, deleting the file.
 
     let trimmed = content.trim();
     if trimmed.is_empty() {
@@ -68,6 +89,9 @@ pub fn open_editor(editor_command: &str) -> io::Result<Option<String>> {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(unix)]
+    use std::sync::{Arc, Mutex};
+
     use super::*;
     use std::path::{Path, PathBuf};
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -158,5 +182,104 @@ mod tests {
         );
         assert!(result.is_ok());
         assert!(result.unwrap().is_none()); // empty file = cancellation
+    }
+
+    /// Produce a real success `ExitStatus` without relying on platform-specific
+    /// `ExitStatusExt`. Using `Command::new("true")` gives us a cross-platform
+    /// success status on any host that has a `true` binary (all CI targets
+    /// for this crate: Linux, macOS; Windows is skipped via `cfg(unix)` below).
+    #[cfg(unix)]
+    fn success_status() -> ExitStatus {
+        Command::new("true")
+            .status()
+            .expect("`true` command should succeed")
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn temp_path_is_randomized_and_cleaned_up() {
+        // Run the helper twice with a stub spawner that captures the temp
+        // path used. The paths must differ (random suffix) and the files
+        // must be removed after `open_editor_with` returns.
+        let captured: Arc<Mutex<Vec<std::path::PathBuf>>> = Arc::new(Mutex::new(Vec::new()));
+
+        for _ in 0..2 {
+            let captured = Arc::clone(&captured);
+            let result = open_editor_with("unused", move |_cmd, path| {
+                // Stub editor: the temp file must exist when the editor
+                // would be launched.
+                assert!(
+                    path.exists(),
+                    "temp file must exist for spawned editor, path={}",
+                    path.display()
+                );
+                captured.lock().unwrap().push(path.to_path_buf());
+                Ok(success_status())
+            })
+            .expect("open_editor_with should succeed");
+            // Empty file -> Ok(None)
+            assert!(result.is_none());
+        }
+
+        let paths = captured.lock().unwrap().clone();
+        assert_eq!(paths.len(), 2);
+
+        // Neither path is the old predictable `swink-prompt-<pid>.md` form.
+        let predictable = format!("swink-prompt-{}.md", std::process::id());
+        for p in &paths {
+            let name = p
+                .file_name()
+                .expect("temp path has a filename")
+                .to_string_lossy()
+                .to_string();
+            assert_ne!(
+                name, predictable,
+                "temp filename must not be the old predictable form"
+            );
+            // It should still start with our prefix and end with the suffix.
+            assert!(
+                name.starts_with("swink-prompt-") && name.ends_with(".md"),
+                "unexpected temp filename: {name}"
+            );
+            // And the random middle must be non-trivial (>= a few chars).
+            let middle = &name["swink-prompt-".len()..name.len() - ".md".len()];
+            assert!(
+                middle.len() >= 8,
+                "random segment too short to be exclusive: {middle:?}"
+            );
+        }
+
+        // Two successive calls must produce distinct paths (random suffix).
+        assert_ne!(
+            paths[0], paths[1],
+            "two temp files must have distinct randomized paths"
+        );
+
+        // Both files must have been cleaned up when open_editor_with returned.
+        for p in &paths {
+            assert!(
+                !p.exists(),
+                "temp file should be deleted after open_editor_with returns: {}",
+                p.display()
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn non_zero_exit_status_is_error_and_cleans_up() {
+        let captured: Arc<Mutex<Option<std::path::PathBuf>>> = Arc::new(Mutex::new(None));
+        let captured_clone = Arc::clone(&captured);
+        let result = open_editor_with("unused", move |_cmd, path| {
+            captured_clone.lock().unwrap().replace(path.to_path_buf());
+            // `false` is a tiny portable binary that exits non-zero on Unix.
+            Command::new("false").status()
+        });
+        assert!(result.is_err());
+        let path = captured.lock().unwrap().clone().expect("path captured");
+        assert!(
+            !path.exists(),
+            "temp file should be cleaned up after non-zero exit"
+        );
     }
 }

--- a/tui/src/editor.rs
+++ b/tui/src/editor.rs
@@ -48,7 +48,7 @@ fn default_spawn(editor_command: &str, path: &Path) -> io::Result<ExitStatus> {
 /// Core editor helper with an injectable spawn function so tests can
 /// observe the temp path (and verify it is randomized) without launching
 /// a real editor.
-pub(crate) fn open_editor_with<F>(editor_command: &str, spawn: F) -> io::Result<Option<String>>
+fn open_editor_with<F>(editor_command: &str, spawn: F) -> io::Result<Option<String>>
 where
     F: FnOnce(&str, &Path) -> io::Result<ExitStatus>,
 {

--- a/tui/src/wizard.rs
+++ b/tui/src/wizard.rs
@@ -255,9 +255,7 @@ impl SetupWizard {
                     "⚠ Could not save {} credential to keychain: {}",
                     err.provider_name, err.message
                 ),
-                Style::default()
-                    .fg(Color::Red)
-                    .add_modifier(Modifier::BOLD),
+                Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
             )));
             lines.push(Line::from(Span::styled(
                 format!(

--- a/tui/src/wizard.rs
+++ b/tui/src/wizard.rs
@@ -35,6 +35,21 @@ pub struct SetupWizard {
     selected: usize,
     should_quit: bool,
     should_continue: bool,
+    /// Most recent keychain write failure, shown inline with env-var fallback
+    /// guidance. Cleared when the user starts a new key entry or successfully
+    /// stores a credential.
+    last_error: Option<WizardError>,
+}
+
+/// Inline error surfaced in the wizard UI after a keychain write failure.
+#[derive(Debug, Clone)]
+struct WizardError {
+    /// Provider name (e.g. "Anthropic").
+    provider_name: &'static str,
+    /// Environment variable the user can set as a fallback.
+    env_var: &'static str,
+    /// Underlying keychain error message.
+    message: String,
 }
 
 impl Default for SetupWizard {
@@ -64,6 +79,7 @@ impl SetupWizard {
             selected: 0,
             should_quit: false,
             should_continue: false,
+            last_error: None,
         }
     }
 
@@ -230,6 +246,28 @@ impl SetupWizard {
             Style::default().add_modifier(Modifier::DIM),
         )));
 
+        // Surface any keychain write failure from the last KeyEntry submission,
+        // along with provider-specific ENV_VAR fallback guidance.
+        if let Some(err) = &self.last_error {
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled(
+                format!(
+                    "⚠ Could not save {} credential to keychain: {}",
+                    err.provider_name, err.message
+                ),
+                Style::default()
+                    .fg(Color::Red)
+                    .add_modifier(Modifier::BOLD),
+            )));
+            lines.push(Line::from(Span::styled(
+                format!(
+                    "  Fallback: set `{}=<your-key>` in your shell profile and restart.",
+                    err.env_var
+                ),
+                Style::default().fg(Color::Yellow),
+            )));
+        }
+
         let paragraph = Paragraph::new(lines).wrap(Wrap { trim: false });
         frame.render_widget(paragraph, inner);
     }
@@ -377,6 +415,8 @@ impl SetupWizard {
                     // "Continue" selected
                     self.step = WizardStep::Done;
                 } else if self.providers[self.selected].requires_key {
+                    // Clear any stale error when the user starts a new entry.
+                    self.last_error = None;
                     self.step = WizardStep::KeyEntry {
                         provider_index: self.selected,
                         input: String::new(),
@@ -396,6 +436,18 @@ impl SetupWizard {
     }
 
     fn handle_key_entry_key(&mut self, key: crossterm::event::KeyEvent) {
+        self.handle_key_entry_key_with(key, credentials::store_credential);
+    }
+
+    /// Core key-entry handler with an injectable credential-store function.
+    ///
+    /// The production path uses `credentials::store_credential`; tests can
+    /// substitute a stub that simulates a keychain write failure to verify
+    /// the inline error + env-var fallback guidance is surfaced.
+    fn handle_key_entry_key_with<F>(&mut self, key: crossterm::event::KeyEvent, store: F)
+    where
+        F: FnOnce(&str, &str) -> Result<(), String>,
+    {
         // Extract current key-entry state to work with
         let (provider_index, input, cursor) = match &mut self.step {
             WizardStep::KeyEntry {
@@ -412,15 +464,23 @@ impl SetupWizard {
             }
             (_, KeyCode::Enter) => {
                 if !input.is_empty() {
-                    let provider_key = self.providers[provider_index].key_name;
+                    let provider = &self.providers[provider_index];
+                    let provider_key = provider.key_name;
                     // Attempt to store the credential
-                    match credentials::store_credential(provider_key, input) {
+                    match store(provider_key, input) {
                         Ok(()) => {
                             self.configured[provider_index] = true;
+                            self.last_error = None;
                         }
-                        Err(_e) => {
-                            // On failure, still go back to the list; the checkbox
-                            // won't be checked so the user can retry.
+                        Err(e) => {
+                            // Surface the failure inline with env-var fallback
+                            // guidance. The checkbox stays unchecked so the
+                            // user can retry or fall back to the env var.
+                            self.last_error = Some(WizardError {
+                                provider_name: provider.name,
+                                env_var: provider.env_var,
+                                message: e,
+                            });
                         }
                     }
                 }
@@ -459,6 +519,7 @@ impl SetupWizard {
             selected: 0,
             should_quit: false,
             should_continue: false,
+            last_error: None,
         }
     }
 }
@@ -707,6 +768,107 @@ mod tests {
         let mut wizard = SetupWizard::new_for_test();
         wizard.handle_key(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE));
         assert!(wizard.should_quit);
+    }
+
+    #[test]
+    fn keychain_failure_surfaces_inline_error_with_env_var_fallback() {
+        let mut wizard = SetupWizard::new_for_test();
+        // Pick the first provider that requires a key (OpenAI / Anthropic /
+        // proxy) so we have a deterministic env var to assert on.
+        let provider_index = wizard
+            .providers
+            .iter()
+            .position(|p| p.requires_key)
+            .expect("expected at least one provider requiring a key");
+        let expected_env_var = wizard.providers[provider_index].env_var;
+        let expected_name = wizard.providers[provider_index].name;
+
+        wizard.step = WizardStep::KeyEntry {
+            provider_index,
+            input: "secret-key".to_string(),
+            cursor: 10,
+        };
+
+        // Simulate a keychain write failure via the injectable store.
+        wizard.handle_key_entry_key_with(key(KeyCode::Enter), |_provider_key, _secret| {
+            Err("keyring store error: keychain unavailable".to_string())
+        });
+
+        // After the failure we return to the provider list…
+        assert!(matches!(wizard.step, WizardStep::ProviderList));
+        // …the provider is NOT marked configured…
+        assert!(!wizard.configured[provider_index]);
+        // …and the error is recorded with the provider-specific env-var fallback.
+        let err = wizard
+            .last_error
+            .as_ref()
+            .expect("keychain failure should populate last_error");
+        assert_eq!(err.provider_name, expected_name);
+        assert_eq!(err.env_var, expected_env_var);
+        assert!(
+            err.message.contains("keychain unavailable"),
+            "underlying keychain error should be preserved, got: {}",
+            err.message
+        );
+
+        // Render the provider list and assert the error + env-var guidance
+        // make it into the rendered text (the actual UI surface).
+        let backend = ratatui::backend::TestBackend::new(100, 30);
+        let mut terminal = ratatui::Terminal::new(backend).expect("test terminal");
+        terminal
+            .draw(|f| wizard.render_provider_list(f, f.area()))
+            .expect("render");
+        let buf = terminal.backend().buffer().clone();
+        let rendered: String = (0..buf.area.height)
+            .map(|y| {
+                let mut line = String::new();
+                for x in 0..buf.area.width {
+                    line.push_str(buf[(x, y)].symbol());
+                }
+                line.push('\n');
+                line
+            })
+            .collect();
+        assert!(
+            rendered.contains(expected_env_var),
+            "rendered wizard should include env-var fallback `{expected_env_var}`, got:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("Fallback"),
+            "rendered wizard should include `Fallback:` guidance, got:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("keychain"),
+            "rendered wizard should mention keychain failure, got:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn keychain_success_clears_last_error() {
+        let mut wizard = SetupWizard::new_for_test();
+        let provider_index = wizard
+            .providers
+            .iter()
+            .position(|p| p.requires_key)
+            .expect("expected provider requiring a key");
+
+        // Pre-populate an error from a prior failed attempt.
+        wizard.last_error = Some(WizardError {
+            provider_name: wizard.providers[provider_index].name,
+            env_var: wizard.providers[provider_index].env_var,
+            message: "stale".to_string(),
+        });
+
+        wizard.step = WizardStep::KeyEntry {
+            provider_index,
+            input: "new-secret".to_string(),
+            cursor: 10,
+        };
+
+        wizard.handle_key_entry_key_with(key(KeyCode::Enter), |_k, _v| Ok(()));
+
+        assert!(wizard.last_error.is_none());
+        assert!(wizard.configured[provider_index]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Surface keychain write failures in the setup wizard with provider-specific `ENV_VAR` fallback guidance so credential setup failures are no longer opaque.
- Replace the predictable `swink-prompt-<pid>.md` temp path with `tempfile::Builder` (randomized, exclusive, auto-cleanup) to remove the collision / tampering risk in shared temp directories.
- Adds regression tests for both fixes; wizard flow structure is unchanged.

## Approach
- **Wizard**: `SetupWizard` gains a `last_error: Option<WizardError>` field. On a keychain write failure in the `KeyEntry` Enter path, we populate it with the provider name, the provider's `env_var` (sourced from the existing `credentials::ProviderInfo.env_var` mapping — no local hardcoding), and the underlying keyring error. `render_provider_list` appends a red "⚠ Could not save … to keychain" line plus a yellow `Fallback: set \`<ENV_VAR>=<your-key>\` …` hint. The error is cleared when the user starts a new key entry or a subsequent write succeeds. A `handle_key_entry_key_with` seam makes this testable by injecting a stub credential store.
- **Editor**: `open_editor` now builds a `tempfile::NamedTempFile` via `tempfile::Builder` with a `swink-prompt-` prefix, `.md` suffix, and 16 random bytes. The randomized path is passed to the editor command; `NamedTempFile` drop handles cleanup on every exit path (success, non-zero exit, spawn failure). `tempfile` moved from dev-dep to regular dep in `tui/Cargo.toml`. An `open_editor_with` seam lets the regression test stub the spawn step so it can observe the temp path is randomized (two successive calls yield distinct paths, neither matches the old predictable form) and cleaned up after return.

## Test plan
- [ ] CI `cargo test --workspace` passes
- [ ] CI `cargo clippy --workspace -- -D warnings` clean
- [ ] Regression tests added for both fixes (`keychain_failure_surfaces_inline_error_with_env_var_fallback`, `keychain_success_clears_last_error`, `temp_path_is_randomized_and_cleaned_up`, `non_zero_exit_status_is_error_and_cleans_up`)

Closes #715
🤖 Generated with [Claude Code](https://claude.com/claude-code)