### PR TITLE
ci: disable Claude Code Review PR trigger

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,14 +1,13 @@
 name: Claude Code Review
 
+# Disabled for now — the workflow's app-token exchange requires the workflow
+# file on the PR branch to exactly match the default branch, which is brittle
+# and produces a required-check failure on every PR. Re-enable by restoring
+# the `pull_request:` trigger below.
 on:
-  pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+  workflow_dispatch:
+  # pull_request:
+  #   types: [opened, synchronize, ready_for_review, reopened]
 
 jobs:
   claude-review:


### PR DESCRIPTION
## Summary
Disable the PR trigger for the Claude Code Review workflow. It has been failing on every PR with a 401 during app-token exchange (\`Workflow validation failed. The workflow file must exist and have identical content to the version on the repository's default branch\`), adding noise to the status checks without providing any value.

\`workflow_dispatch\` is preserved so the job can still be invoked manually when needed.

## Why it was failing
The \`anthropics/claude-code-action\` requires the workflow file on the PR branch to be byte-identical to the one on the default branch. Any PR created from an older branch (e.g. branched from \`main\` while \`integration\` is ahead) triggers the mismatch check even when the PR doesn't modify the workflow file itself.

## Re-enabling later
Uncomment the \`pull_request:\` trigger block in \`.github/workflows/claude-code-review.yml\` once the underlying app-token exchange flow is worked around or the action behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)