### PR TITLE
test(adapters): edge-case coverage for build_remote_connection_with_credential (#791)

### DIFF
--- a/adapters/src/remote_presets.rs
+++ b/adapters/src/remote_presets.rs
@@ -578,6 +578,60 @@ mod tests {
         );
     }
 
+    // Explicit-but-empty credential must be rejected the same way `None` is.
+    // `Some("")` and `Some("   ")` can sneak past a naive `is_some()` check,
+    // so pin the contract: trimmed-empty explicit keys error as MissingCredential.
+    #[cfg(feature = "anthropic")]
+    #[test]
+    fn build_with_credential_rejects_explicit_empty_string() {
+        let key = RemotePresetKey::new("anthropic", "sonnet_46");
+        for candidate in [String::new(), "   ".to_string(), "\t\n".to_string()] {
+            let err = match build_remote_connection_with_credential(key, Some(candidate), None) {
+                Ok(_) => panic!("empty/whitespace explicit credential must error"),
+                Err(err) => err,
+            };
+            assert!(
+                matches!(err, RemoteModelConnectionError::MissingCredential { .. }),
+                "expected MissingCredential, got {err:?}"
+            );
+        }
+    }
+
+    // Unknown preset must short-circuit with UnknownPreset before any credential
+    // or env-var work happens — protects callers from misleading MissingCredential
+    // errors when the real problem is a bad preset key.
+    #[test]
+    fn build_with_credential_rejects_unknown_preset() {
+        let key = RemotePresetKey::new("anthropic", "nonexistent_preset_xyz");
+        let err =
+            match build_remote_connection_with_credential(key, Some("irrelevant".into()), None) {
+                Ok(_) => panic!("unknown preset must error"),
+                Err(err) => err,
+            };
+        assert_eq!(
+            err,
+            RemoteModelConnectionError::UnknownPreset {
+                provider_key: "anthropic",
+                preset_id: "nonexistent_preset_xyz",
+            }
+        );
+    }
+
+    // Bedrock uses SigV4, not a bearer token — `Some("")` must still route
+    // through the bedrock branch (which reads AWS env) and never return
+    // MissingCredential. Complements the `None` test above.
+    #[cfg(feature = "bedrock")]
+    #[test]
+    fn bedrock_ignores_explicit_empty_api_key() {
+        let key = RemotePresetKey::new("bedrock", "anthropic_claude_sonnet_45");
+        if let Err(err) = build_remote_connection_with_credential(key, Some(String::new()), None) {
+            assert!(
+                !matches!(err, RemoteModelConnectionError::MissingCredential { .. }),
+                "bedrock must not surface MissingCredential when api_key is Some(\"\"); got {err:?}"
+            );
+        }
+    }
+
     #[test]
     fn build_remote_connection_for_model_rejects_unknown() {
         let result = build_remote_connection_for_model("nonexistent-xyz");


### PR DESCRIPTION
## Summary

#791 was landed upstream as commit [984eb8f](https://github.com/SuperSwinkAI/Swink-Agent/commit/984eb8f) (by \`unseriousAI\`) about a minute before I could open this PR. This branch has now been rebased onto that commit and retains only additional test coverage that their implementation did not include. No functional change — the public API shipped in 984eb8f is unchanged.

## Why keep this PR

The three added tests pin down behavior that downstream consumers (SuperSwink-Core et al.) are likely to rely on:

1. **Explicit-but-empty credentials are rejected.** \`Some(\"\")\`, \`Some(\"   \")\`, and \`Some(\"\\t\\n\")\` all yield \`MissingCredential\`. Without this test, an \`is_some()\` gate could let whitespace creep through.
2. **Unknown preset short-circuits with \`UnknownPreset\`.** Callers don't get a misleading \`MissingCredential\` when the real problem is a bad preset key.
3. **Bedrock ignores \`Some(\"\")\` too.** Complements the existing \`None\` test so the SigV4 branch is covered regardless of how the caller signals \"no bearer token.\"

## Collision details

- Claimed at 23:05:33Z via \`in-progress\` label + comment.
- \`unseriousAI\` pushed \`984eb8f\` directly to \`integration\` at 23:10:02Z (no PR).
- Issue comment posted at 23:10:25Z.
- My PR opened at 23:10:47Z, originally with an env-fallback variant.
- Reset onto \`984eb8f\` and layered tests on top.

## Test plan
- [x] \`cargo test -p swink-agent-adapters --all-features --lib\` — 183 pass (3 new)
- [x] \`cargo clippy -p swink-agent-adapters --all-features --lib -- -D warnings\` — clean
- [x] \`cargo fmt --check -p swink-agent-adapters\` — clean

Part of #791

🤖 Generated with [Claude Code](https://claude.com/claude-code)