### PR TITLE
fix(clippy): clear integration-branch workspace lints

### DIFF
--- a/eval/src/evaluator.rs
+++ b/eval/src/evaluator.rs
@@ -220,7 +220,7 @@ where
 {
     match tokio::spawn(action).await {
         Ok(result) => result,
-        Err(join_error) => Some(panic_metric(location, join_error_message(join_error))),
+        Err(join_error) => Some(panic_metric(location, &join_error_message(join_error))),
     }
 }
 
@@ -232,7 +232,7 @@ where
         Ok(result) => result,
         Err(payload) => Some(panic_metric(
             location,
-            panic_payload_message(payload.as_ref()),
+            &panic_payload_message(payload.as_ref()),
         )),
     }
 }
@@ -248,7 +248,7 @@ fn join_error_message(join_error: tokio::task::JoinError) -> String {
     }
 }
 
-fn panic_metric(location: &str, message: String) -> EvalMetricResult {
+fn panic_metric(location: &str, message: &str) -> EvalMetricResult {
     EvalMetricResult {
         evaluator_name: location.to_string(),
         score: Score::fail(),

--- a/src/tool_name.rs
+++ b/src/tool_name.rs
@@ -44,6 +44,7 @@ pub fn compose_provider_safe_tool_name(namespace: Option<&str>, tool_name: &str)
 /// name preserves that grammar while appending a stable hash derived from the
 /// raw pre-sanitized identity so distinct inputs that collapse onto the same
 /// sanitized wire name can still coexist.
+#[cfg(feature = "plugins")]
 #[must_use]
 pub fn disambiguate_provider_safe_tool_name(base_name: &str, raw_identity: &str) -> String {
     let hash_suffix = stable_name_hash_hex(raw_identity);
@@ -141,6 +142,7 @@ mod tests {
         assert_eq!(second.len(), MAX_TOOL_NAME_LEN);
     }
 
+    #[cfg(feature = "plugins")]
     #[test]
     fn disambiguated_provider_safe_name_preserves_grammar_and_length() {
         let base = compose_provider_safe_tool_name(Some("my-web"), "search");

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -29,6 +29,7 @@ pub const fn meets_minimum_size(width: u16, height: u16) -> bool {
 }
 
 /// Render the complete UI into the given frame.
+#[allow(clippy::too_many_lines)]
 pub fn render(frame: &mut Frame, app: &mut App) {
     let area = frame.area();
     if !meets_minimum_size(area.width, area.height) {


### PR DESCRIPTION
## Summary
Three pre-existing clippy failures on \`integration\` were causing every PR rebased onto HEAD to fail CI (observed on #795, #796, #797, #798, and a dozen recreated dependabot PRs):

1. **\`tui/src/ui/mod.rs\`** — \`render\` is 101/100 lines and cohesive. Added \`#[allow(clippy::too_many_lines)]\` rather than split for the single-line overage.
2. **\`src/tool_name.rs\`** — \`disambiguate_provider_safe_tool_name\` and its test are only reachable from a \`#[cfg(feature = \"plugins\")]\` code path in \`src/agent.rs\`, so gate the helper and its test the same way. Otherwise \`-D dead-code\` fires with default features.
3. **\`eval/src/evaluator.rs\`** — \`panic_metric(..., message: String)\` does nothing with ownership; take \`&str\`.

## Test plan
- [x] \`cargo clippy --workspace --exclude swink-agent-local-llm -- -D warnings\` clean locally.
- [ ] Full CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)