### PR TITLE
chore(deps): refresh claude-code-action v1 pin

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@38ec876110f9fbf8b950c79f534430740c3ac009 # v1
+        uses: anthropics/claude-code-action@b4d67413279fc18c6e5de930ae307c4f108714eb # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'


### PR DESCRIPTION
## Summary
Manual recreation of the safe github-actions bumps while the auto-close bug (fixed by #809) was in flight.

- **anthropics/claude-code-action**: \`38ec876\` → \`b4d6741\` (current \`v1\` tag, which the tag message identifies as v1.0.104). Previous pin was an untagged Apr-18 commit. This replaces the auto-closed #783 (and supersedes #688).

Other closed github-actions PRs that did **not** need bumps — the SHAs in tree already match their targets:
- #687 \`dtolnay/rust-toolchain\` → already at \`29eef336\` (head of \`stable\`)
- #689 \`EmbarkStudios/cargo-deny-action\` → already at \`91bf2b62\` (= v2.0.17)
- #690 \`cargo-bins/cargo-binstall\` → already at \`dc19f1e4\` (= v1.18.1)

Deferred (separate follow-up):
- #686 \`actions/github-script\` v7 → v9 — two-major jump with breaking API changes.

## Test plan
- [ ] CI workflows still run successfully (full suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)