### PR TITLE
impl(043): US8 plain reporters + JSON schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4822,7 +4822,6 @@ dependencies = [
  "askama",
  "async-trait",
  "backon",
- "bincode",
  "clap",
  "futures",
  "jsonschema",

--- a/eval/Cargo.toml
+++ b/eval/Cargo.toml
@@ -84,6 +84,7 @@ tempfile.workspace = true
 tokio = { workspace = true, features = ["full", "test-util"] }
 pretty_assertions.workspace = true
 wiremock.workspace = true
+jsonschema.workspace = true
 
 [lints]
 workspace = true

--- a/eval/src/lib.rs
+++ b/eval/src/lib.rs
@@ -71,6 +71,9 @@ pub use prompt::{
     JudgePromptTemplate, MinijinjaTemplate, PromptContext, PromptError, PromptFamily,
     PromptTemplateRegistry,
 };
+pub use report::{
+    ConsoleReporter, JsonReporter, MarkdownReporter, Reporter, ReporterError, ReporterOutput,
+};
 pub use response::ResponseMatcher;
 pub use runner::{AgentFactory, EvalRunner};
 pub use score::{Score, Verdict};

--- a/eval/src/report/console.rs
+++ b/eval/src/report/console.rs
@@ -98,8 +98,7 @@ fn write_metric_line(out: &mut String, metric: &EvalMetricResult) -> Result<(), 
         // Single-line only; strip embedded newlines so terminal output stays
         // strictly line-oriented per Q8.
         let sanitized = details.replace(['\n', '\r'], " ");
-        write!(out, "  reason: {sanitized}")
-            .map_err(|e| ReporterError::Format(e.to_string()))?;
+        write!(out, "  reason: {sanitized}").map_err(|e| ReporterError::Format(e.to_string()))?;
     }
     writeln!(out).map_err(|e| ReporterError::Format(e.to_string()))?;
     Ok(())

--- a/eval/src/report/console.rs
+++ b/eval/src/report/console.rs
@@ -1,0 +1,113 @@
+//! Plain-text, line-oriented console reporter.
+//!
+//! Spec 043 clarification Q8 and §FR-041 pin terminal output to plain text:
+//! no ANSI color, no cursor control, no interactivity. The reporter emits
+//! one line per case verdict followed by indented per-evaluator detail, plus
+//! a trailing summary block.
+//!
+//! # Example output
+//!
+//! ```text
+//! Eval set: demo-set (3/4 passed)
+//! - case_a  PASS  (120ms)
+//!     helpfulness  score=0.82  threshold=0.50  PASS
+//!     correctness  score=0.91  threshold=0.60  PASS
+//! - case_b  FAIL  (150ms)
+//!     helpfulness  score=0.12  threshold=0.50  FAIL  reason: off-topic
+//! Summary: 3 passed, 1 failed, total_cost=$0.012345, duration=420ms
+//! ```
+
+use std::fmt::Write as _;
+
+use crate::{EvalCaseResult, EvalMetricResult, EvalSetResult, Verdict};
+
+use super::{Reporter, ReporterError, ReporterOutput};
+
+/// Always-on, plain-text terminal reporter (spec 043 §FR-041, Q8).
+///
+/// The reporter is a zero-sized struct because it holds no configuration:
+/// the rendering is deterministic and produces the same bytes for a given
+/// result regardless of terminal capability.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ConsoleReporter;
+
+impl ConsoleReporter {
+    /// Create a new reporter. Present for API symmetry with peer reporters.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl Reporter for ConsoleReporter {
+    fn render(&self, result: &EvalSetResult) -> Result<ReporterOutput, ReporterError> {
+        let mut out = String::new();
+        writeln!(
+            out,
+            "Eval set: {id} ({passed}/{total} passed)",
+            id = result.eval_set_id,
+            passed = result.summary.passed,
+            total = result.summary.total_cases,
+        )
+        .map_err(|e| ReporterError::Format(e.to_string()))?;
+
+        for case in &result.case_results {
+            write_case_line(&mut out, case)?;
+            for metric in &case.metric_results {
+                write_metric_line(&mut out, metric)?;
+            }
+        }
+
+        writeln!(
+            out,
+            "Summary: {passed} passed, {failed} failed, total_cost=${cost:.6}, duration={dur}ms",
+            passed = result.summary.passed,
+            failed = result.summary.failed,
+            cost = result.summary.total_cost.total,
+            dur = result.summary.total_duration.as_millis(),
+        )
+        .map_err(|e| ReporterError::Format(e.to_string()))?;
+
+        Ok(ReporterOutput::Stdout(out))
+    }
+}
+
+fn write_case_line(out: &mut String, case: &EvalCaseResult) -> Result<(), ReporterError> {
+    writeln!(
+        out,
+        "- {id}  {verdict}  ({dur}ms)",
+        id = case.case_id,
+        verdict = verdict_label(case.verdict),
+        dur = case.invocation.total_duration.as_millis(),
+    )
+    .map_err(|e| ReporterError::Format(e.to_string()))
+}
+
+fn write_metric_line(out: &mut String, metric: &EvalMetricResult) -> Result<(), ReporterError> {
+    let verdict = metric.score.verdict();
+    write!(
+        out,
+        "    {name}  score={score:.2}  threshold={th:.2}  {verdict}",
+        name = metric.evaluator_name,
+        score = metric.score.value,
+        th = metric.score.threshold,
+        verdict = verdict_label(verdict),
+    )
+    .map_err(|e| ReporterError::Format(e.to_string()))?;
+    if let Some(details) = metric.details.as_ref().filter(|s| !s.is_empty()) {
+        // Single-line only; strip embedded newlines so terminal output stays
+        // strictly line-oriented per Q8.
+        let sanitized = details.replace(['\n', '\r'], " ");
+        write!(out, "  reason: {sanitized}")
+            .map_err(|e| ReporterError::Format(e.to_string()))?;
+    }
+    writeln!(out).map_err(|e| ReporterError::Format(e.to_string()))?;
+    Ok(())
+}
+
+const fn verdict_label(v: Verdict) -> &'static str {
+    match v {
+        Verdict::Pass => "PASS",
+        Verdict::Fail => "FAIL",
+    }
+}

--- a/eval/src/report/json.rs
+++ b/eval/src/report/json.rs
@@ -1,0 +1,189 @@
+//! Self-contained JSON reporter (always-on, spec 043 §FR-041).
+//!
+//! Emits a document that validates against
+//! `specs/043-evals-adv-features/contracts/eval-result.schema.json`. The
+//! schema version is carried explicitly as [`SCHEMA_VERSION`] so downstream
+//! consumers can detect breaking changes across spec revisions.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use serde::Serialize;
+
+use crate::{EvalCaseResult, EvalMetricResult, EvalSetResult, EvalSummary, Score, Verdict};
+
+use super::{Reporter, ReporterError, ReporterOutput};
+
+/// Stable schema version advertised in every JSON artifact.
+///
+/// Matches `schema_version` in `eval-result.schema.json`. Bumping this value
+/// is a breaking change for any downstream consumer (e.g. the `report`
+/// subcommand of `swink-eval`).
+pub const SCHEMA_VERSION: &str = "043";
+
+/// Default artifact filename suggested to callers via
+/// [`ReporterOutput::Artifact`].
+pub const DEFAULT_ARTIFACT_NAME: &str = "eval-result.json";
+
+/// Always-on JSON reporter (spec 043 §FR-041).
+///
+/// Produces pretty-printed, deterministic JSON suitable for persistence and
+/// later re-rendering through other reporters (see `swink-eval report`).
+#[derive(Debug, Default, Clone, Copy)]
+pub struct JsonReporter {
+    pretty: bool,
+}
+
+impl JsonReporter {
+    /// Create a reporter that emits pretty-printed JSON (default).
+    #[must_use]
+    pub const fn new() -> Self {
+        Self { pretty: true }
+    }
+
+    /// Toggle pretty-printing (off → single-line compact JSON).
+    #[must_use]
+    pub const fn pretty(mut self, pretty: bool) -> Self {
+        self.pretty = pretty;
+        self
+    }
+}
+
+impl Reporter for JsonReporter {
+    fn render(&self, result: &EvalSetResult) -> Result<ReporterOutput, ReporterError> {
+        let doc = EvalResultDoc::from(result);
+        let bytes = if self.pretty {
+            serde_json::to_vec_pretty(&doc)
+        } else {
+            serde_json::to_vec(&doc)
+        }
+        .map_err(|e| ReporterError::Format(e.to_string()))?;
+        Ok(ReporterOutput::Artifact {
+            path: PathBuf::from(DEFAULT_ARTIFACT_NAME),
+            bytes,
+        })
+    }
+}
+
+// ─── Wire types ─────────────────────────────────────────────────────────────
+//
+// These mirror the shape pinned in public-api.md §JSON wire schemas. They are
+// intentionally independent of the in-memory `EvalSetResult` so schema
+// evolution can happen without forcing breaking changes on Rust consumers.
+
+#[derive(Debug, Serialize)]
+struct EvalResultDoc<'a> {
+    schema_version: &'static str,
+    eval_set: EvalSetDoc<'a>,
+    cases: Vec<CaseDoc<'a>>,
+    summary: SummaryDoc,
+    timestamp: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct EvalSetDoc<'a> {
+    id: &'a str,
+    case_count: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct CaseDoc<'a> {
+    case_id: &'a str,
+    verdict: VerdictLabel,
+    duration_ms: u128,
+    metrics: Vec<MetricDoc<'a>>,
+}
+
+#[derive(Debug, Serialize)]
+struct MetricDoc<'a> {
+    evaluator: &'a str,
+    score: f64,
+    threshold: f64,
+    verdict: VerdictLabel,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<&'a str>,
+}
+
+#[derive(Debug, Serialize)]
+struct SummaryDoc {
+    total_cases: usize,
+    passed: usize,
+    failed: usize,
+    total_cost: f64,
+    total_input_tokens: u64,
+    total_output_tokens: u64,
+    total_duration_ms: u128,
+}
+
+#[derive(Debug, Serialize, Clone, Copy)]
+#[serde(rename_all = "lowercase")]
+enum VerdictLabel {
+    Pass,
+    Fail,
+}
+
+impl From<Verdict> for VerdictLabel {
+    fn from(v: Verdict) -> Self {
+        match v {
+            Verdict::Pass => Self::Pass,
+            Verdict::Fail => Self::Fail,
+        }
+    }
+}
+
+impl<'a> From<&'a EvalSetResult> for EvalResultDoc<'a> {
+    fn from(r: &'a EvalSetResult) -> Self {
+        Self {
+            schema_version: SCHEMA_VERSION,
+            eval_set: EvalSetDoc {
+                id: &r.eval_set_id,
+                case_count: r.case_results.len(),
+            },
+            cases: r.case_results.iter().map(CaseDoc::from).collect(),
+            summary: SummaryDoc::from(&r.summary),
+            timestamp: r.timestamp,
+        }
+    }
+}
+
+impl<'a> From<&'a EvalCaseResult> for CaseDoc<'a> {
+    fn from(c: &'a EvalCaseResult) -> Self {
+        Self {
+            case_id: &c.case_id,
+            verdict: c.verdict.into(),
+            duration_ms: c.invocation.total_duration.as_millis(),
+            metrics: c.metric_results.iter().map(MetricDoc::from).collect(),
+        }
+    }
+}
+
+impl<'a> From<&'a EvalMetricResult> for MetricDoc<'a> {
+    fn from(m: &'a EvalMetricResult) -> Self {
+        let Score { value, threshold } = m.score;
+        Self {
+            evaluator: &m.evaluator_name,
+            score: value,
+            threshold,
+            verdict: m.score.verdict().into(),
+            reason: m.details.as_deref(),
+        }
+    }
+}
+
+impl From<&EvalSummary> for SummaryDoc {
+    fn from(s: &EvalSummary) -> Self {
+        Self {
+            total_cases: s.total_cases,
+            passed: s.passed,
+            failed: s.failed,
+            total_cost: s.total_cost.total,
+            total_input_tokens: s.total_usage.input,
+            total_output_tokens: s.total_usage.output,
+            total_duration_ms: duration_ms(s.total_duration),
+        }
+    }
+}
+
+fn duration_ms(d: Duration) -> u128 {
+    d.as_millis()
+}

--- a/eval/src/report/markdown.rs
+++ b/eval/src/report/markdown.rs
@@ -12,7 +12,7 @@
 
 use std::fmt::Write as _;
 
-use crate::{EvalCaseResult, EvalMetricResult, EvalSetResult, Verdict};
+use crate::{EvalMetricResult, EvalSetResult, Verdict};
 
 use super::{Reporter, ReporterError, ReporterOutput};
 

--- a/eval/src/report/markdown.rs
+++ b/eval/src/report/markdown.rs
@@ -1,0 +1,155 @@
+//! PR-comment-ready Markdown reporter (always-on, spec 043 §FR-041).
+//!
+//! Emits a valid GFM-flavoured Markdown document:
+//!
+//! * A top-level header with the eval set id.
+//! * A summary table (total / passed / failed / cost / duration).
+//! * A per-case table listing verdict and duration.
+//! * An optional per-metric section with evaluator score, verdict, and reason.
+//!
+//! The output contains no ANSI escapes, no HTML, and no interactivity —
+//! suitable for direct inclusion in a GitHub PR comment.
+
+use std::fmt::Write as _;
+
+use crate::{EvalCaseResult, EvalMetricResult, EvalSetResult, Verdict};
+
+use super::{Reporter, ReporterError, ReporterOutput};
+
+/// Always-on Markdown reporter (spec 043 §FR-041).
+///
+/// Produces a self-contained Markdown document safe to paste into a PR
+/// comment. The rendering is deterministic: identical `EvalSetResult`
+/// inputs always produce byte-identical output.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct MarkdownReporter;
+
+impl MarkdownReporter {
+    /// Create a new reporter.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl Reporter for MarkdownReporter {
+    fn render(&self, result: &EvalSetResult) -> Result<ReporterOutput, ReporterError> {
+        let mut out = String::new();
+        fmt_err(writeln!(
+            out,
+            "# Eval Result: `{id}`",
+            id = result.eval_set_id
+        ))?;
+        fmt_err(writeln!(out))?;
+
+        // Summary table
+        fmt_err(writeln!(out, "## Summary"))?;
+        fmt_err(writeln!(out))?;
+        fmt_err(writeln!(out, "| Metric | Value |"))?;
+        fmt_err(writeln!(out, "| --- | --- |"))?;
+        fmt_err(writeln!(
+            out,
+            "| Total cases | {} |",
+            result.summary.total_cases
+        ))?;
+        fmt_err(writeln!(out, "| Passed | {} |", result.summary.passed))?;
+        fmt_err(writeln!(out, "| Failed | {} |", result.summary.failed))?;
+        fmt_err(writeln!(
+            out,
+            "| Total cost | ${:.6} |",
+            result.summary.total_cost.total
+        ))?;
+        fmt_err(writeln!(
+            out,
+            "| Duration | {}ms |",
+            result.summary.total_duration.as_millis()
+        ))?;
+        fmt_err(writeln!(out))?;
+
+        // Per-case table
+        fmt_err(writeln!(out, "## Cases"))?;
+        fmt_err(writeln!(out))?;
+        fmt_err(writeln!(out, "| Case | Verdict | Duration |"))?;
+        fmt_err(writeln!(out, "| --- | --- | --- |"))?;
+        for case in &result.case_results {
+            fmt_err(writeln!(
+                out,
+                "| `{id}` | {verdict} | {dur}ms |",
+                id = escape_md_cell(&case.case_id),
+                verdict = verdict_label(case.verdict),
+                dur = case.invocation.total_duration.as_millis(),
+            ))?;
+        }
+        fmt_err(writeln!(out))?;
+
+        // Per-metric details (only if any case has metrics)
+        let has_metrics = result
+            .case_results
+            .iter()
+            .any(|c| !c.metric_results.is_empty());
+        if has_metrics {
+            fmt_err(writeln!(out, "## Metrics"))?;
+            fmt_err(writeln!(out))?;
+            fmt_err(writeln!(
+                out,
+                "| Case | Evaluator | Score | Threshold | Verdict | Reason |"
+            ))?;
+            fmt_err(writeln!(out, "| --- | --- | --- | --- | --- | --- |"))?;
+            for case in &result.case_results {
+                for metric in &case.metric_results {
+                    write_metric_row(&mut out, &case.case_id, metric)?;
+                }
+            }
+        }
+
+        Ok(ReporterOutput::Stdout(out))
+    }
+}
+
+fn write_metric_row(
+    out: &mut String,
+    case_id: &str,
+    metric: &EvalMetricResult,
+) -> Result<(), ReporterError> {
+    let reason = metric
+        .details
+        .as_deref()
+        .map_or_else(String::new, escape_md_cell);
+    fmt_err(writeln!(
+        out,
+        "| `{case}` | `{name}` | {score:.2} | {th:.2} | {verdict} | {reason} |",
+        case = escape_md_cell(case_id),
+        name = escape_md_cell(&metric.evaluator_name),
+        score = metric.score.value,
+        th = metric.score.threshold,
+        verdict = verdict_label(metric.score.verdict()),
+    ))
+}
+
+/// Escape characters that would break a Markdown table cell.
+///
+/// Pipes and newlines are the only Markdown-table-significant characters;
+/// backslashes are escaped so a trailing `\` cannot consume the row's pipe.
+fn escape_md_cell(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '|' => out.push_str("\\|"),
+            '\\' => out.push_str("\\\\"),
+            '\n' | '\r' => out.push(' '),
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
+fn fmt_err<T>(res: Result<T, std::fmt::Error>) -> Result<T, ReporterError> {
+    res.map_err(|e| ReporterError::Format(e.to_string()))
+}
+
+const fn verdict_label(v: Verdict) -> &'static str {
+    match v {
+        Verdict::Pass => "PASS",
+        Verdict::Fail => "FAIL",
+    }
+}

--- a/eval/src/report/mod.rs
+++ b/eval/src/report/mod.rs
@@ -1,1 +1,136 @@
 //! Reporters and export surfaces for eval results.
+//!
+//! Spec 043 §FR-041 requires always-on, plain-text reporters that render an
+//! [`EvalSetResult`] to stdout strings or artifact bytes. The `Reporter` trait
+//! is the common surface; concrete implementations live in sibling modules:
+//!
+//! * [`ConsoleReporter`] — plain-text, line-oriented (no ANSI, no cursor
+//!   control, no interactivity per Q8 clarification).
+//! * [`JsonReporter`] — self-contained JSON matching
+//!   `specs/043-evals-adv-features/contracts/eval-result.schema.json`.
+//! * [`MarkdownReporter`] — PR-comment-ready Markdown table.
+//!
+//! HTML and LangSmith exporters (behind their respective feature flags) follow
+//! in later tasks.
+//!
+//! All reporters are deterministic: given the same `EvalSetResult` they
+//! produce byte-identical output.
+//!
+//! [`EvalSetResult`]: crate::EvalSetResult
+
+use std::path::PathBuf;
+
+use thiserror::Error;
+
+use crate::EvalSetResult;
+
+pub mod console;
+pub mod json;
+pub mod markdown;
+
+pub use console::ConsoleReporter;
+pub use json::{JsonReporter, SCHEMA_VERSION};
+pub use markdown::MarkdownReporter;
+
+/// Stable JSON schema path shipped alongside spec 043.
+///
+/// Consumers that want to validate a reporter's JSON output against the
+/// published schema can `include_str!` this file; the `JsonReporter`
+/// regression tests do exactly that.
+pub const JSON_SCHEMA_PATH: &str =
+    "specs/043-evals-adv-features/contracts/eval-result.schema.json";
+
+/// Renders an [`EvalSetResult`] into a concrete output surface.
+///
+/// Per spec 043 §FR-041 the three always-on reporters
+/// ([`ConsoleReporter`], [`JsonReporter`], [`MarkdownReporter`]) are plain,
+/// deterministic, and side-effect-free. Reporters that target a remote
+/// backend (e.g. LangSmith) use [`ReporterOutput::Remote`] and may perform
+/// network I/O; consult each reporter's documentation.
+///
+/// [`EvalSetResult`]: crate::EvalSetResult
+pub trait Reporter: Send + Sync {
+    /// Render the given result.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ReporterError`] when formatting fails, when an artifact
+    /// cannot be written, or when a remote backend rejects the payload.
+    fn render(&self, result: &EvalSetResult) -> Result<ReporterOutput, ReporterError>;
+}
+
+/// Output produced by a [`Reporter::render`] call.
+///
+/// The three variants cover the common delivery channels:
+/// * [`Stdout`](Self::Stdout) — text intended for terminal display.
+/// * [`Artifact`](Self::Artifact) — bytes + filesystem path the caller may
+///   persist (e.g. `--out report.json`).
+/// * [`Remote`](Self::Remote) — the payload was pushed to an external
+///   backend; `identifier` is backend-specific (LangSmith run id, etc.).
+#[derive(Debug, Clone)]
+pub enum ReporterOutput {
+    /// Plain text suitable for stdout or a log line.
+    Stdout(String),
+    /// A byte artifact to write at the given path.
+    Artifact {
+        /// Suggested destination path. The reporter does not write to it;
+        /// the caller decides whether to persist.
+        path: PathBuf,
+        /// Raw bytes of the artifact.
+        bytes: Vec<u8>,
+    },
+    /// A remote push result, identified by backend + opaque id.
+    Remote {
+        /// Human-readable backend name (e.g. `"langsmith"`).
+        backend: String,
+        /// Backend-specific identifier (e.g. LangSmith run id).
+        identifier: String,
+    },
+}
+
+/// Error surface for [`Reporter`] implementations.
+#[derive(Debug, Error)]
+pub enum ReporterError {
+    /// Filesystem or stream I/O failed.
+    #[error("reporter I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    /// Rendering/serialization failed (e.g. JSON encoding).
+    #[error("reporter formatting error: {0}")]
+    Format(String),
+    /// A remote backend push failed.
+    #[error("reporter network error: {0}")]
+    Network(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reporter_error_from_io() {
+        let io_err = std::io::Error::other("boom");
+        let err: ReporterError = io_err.into();
+        assert!(err.to_string().contains("boom"));
+        assert!(matches!(err, ReporterError::Io(_)));
+    }
+
+    #[test]
+    fn reporter_output_variants_are_constructible() {
+        let _stdout = ReporterOutput::Stdout("hello".into());
+        let _artifact = ReporterOutput::Artifact {
+            path: PathBuf::from("/tmp/out.json"),
+            bytes: vec![0xDE, 0xAD, 0xBE, 0xEF],
+        };
+        let _remote = ReporterOutput::Remote {
+            backend: "langsmith".into(),
+            identifier: "run-1234".into(),
+        };
+    }
+
+    #[test]
+    fn schema_path_constant_points_at_repo_contract() {
+        // Sanity: the published schema path stays stable; reporters and
+        // their regression tests must reference the same string.
+        assert!(JSON_SCHEMA_PATH.ends_with("eval-result.schema.json"));
+    }
+}

--- a/eval/src/report/mod.rs
+++ b/eval/src/report/mod.rs
@@ -37,8 +37,7 @@ pub use markdown::MarkdownReporter;
 /// Consumers that want to validate a reporter's JSON output against the
 /// published schema can `include_str!` this file; the `JsonReporter`
 /// regression tests do exactly that.
-pub const JSON_SCHEMA_PATH: &str =
-    "specs/043-evals-adv-features/contracts/eval-result.schema.json";
+pub const JSON_SCHEMA_PATH: &str = "specs/043-evals-adv-features/contracts/eval-result.schema.json";
 
 /// Renders an [`EvalSetResult`] into a concrete output surface.
 ///

--- a/eval/tests/reporter_console_test.rs
+++ b/eval/tests/reporter_console_test.rs
@@ -76,9 +76,9 @@ fn render_console(result: &EvalSetResult) -> String {
 #[test]
 fn console_output_header_and_line_count() {
     let out = render_console(&sample_result());
-    // One line header, one per case, one per metric (3 total), one summary = 6
+    // 1 header + 2 cases + 3 metrics + 1 summary = 7
     let lines: Vec<&str> = out.lines().collect();
-    assert_eq!(lines.len(), 6, "unexpected line count:\n{out}");
+    assert_eq!(lines.len(), 7, "unexpected line count:\n{out}");
     assert!(
         lines[0].starts_with("Eval set: demo-set"),
         "header: {}",

--- a/eval/tests/reporter_console_test.rs
+++ b/eval/tests/reporter_console_test.rs
@@ -1,0 +1,193 @@
+//! Regression tests for `ConsoleReporter` (T139).
+//!
+//! Spec 043 Q8 clarification pins terminal output to plain text:
+//! no ANSI color, no cursor control, no interactivity. These tests assert
+//! those invariants alongside line-oriented structure and per-case/metric
+//! detail.
+
+mod common;
+
+use std::time::Duration;
+
+use swink_agent::{Cost, Usage};
+use swink_agent_eval::{
+    ConsoleReporter, EvalCaseResult, EvalMetricResult, EvalSetResult, EvalSummary, Reporter,
+    ReporterOutput, Score, Verdict,
+};
+
+use common::mock_invocation;
+
+fn sample_result() -> EvalSetResult {
+    let case_pass = EvalCaseResult {
+        case_id: "case_alpha".into(),
+        invocation: mock_invocation(&[], Some("ok"), 0.0012, 32),
+        metric_results: vec![
+            EvalMetricResult {
+                evaluator_name: "helpfulness".into(),
+                score: Score::new(0.82, 0.5),
+                details: Some("looks good".into()),
+            },
+            EvalMetricResult {
+                evaluator_name: "correctness".into(),
+                score: Score::new(0.91, 0.6),
+                details: None,
+            },
+        ],
+        verdict: Verdict::Pass,
+    };
+
+    let case_fail = EvalCaseResult {
+        case_id: "case_beta".into(),
+        invocation: mock_invocation(&[], Some("nope"), 0.0034, 48),
+        metric_results: vec![EvalMetricResult {
+            evaluator_name: "helpfulness".into(),
+            score: Score::new(0.12, 0.5),
+            // Contains an embedded newline — the reporter MUST strip it.
+            details: Some("off-topic\nmultiline".into()),
+        }],
+        verdict: Verdict::Fail,
+    };
+
+    EvalSetResult {
+        eval_set_id: "demo-set".into(),
+        case_results: vec![case_pass, case_fail],
+        summary: EvalSummary {
+            total_cases: 2,
+            passed: 1,
+            failed: 1,
+            total_cost: Cost {
+                total: 0.0046,
+                ..Default::default()
+            },
+            total_usage: Usage::default(),
+            total_duration: Duration::from_millis(220),
+        },
+        timestamp: 0,
+    }
+}
+
+fn render_console(result: &EvalSetResult) -> String {
+    match ConsoleReporter::new().render(result).expect("render ok") {
+        ReporterOutput::Stdout(s) => s,
+        other => panic!("expected Stdout output, got {other:?}"),
+    }
+}
+
+#[test]
+fn console_output_header_and_line_count() {
+    let out = render_console(&sample_result());
+    // One line header, one per case, one per metric (3 total), one summary = 6
+    let lines: Vec<&str> = out.lines().collect();
+    assert_eq!(lines.len(), 6, "unexpected line count:\n{out}");
+    assert!(
+        lines[0].starts_with("Eval set: demo-set"),
+        "header: {}",
+        lines[0]
+    );
+    assert!(lines[0].contains("1/2 passed"));
+}
+
+#[test]
+fn console_output_contains_per_case_verdict_and_duration() {
+    let out = render_console(&sample_result());
+    assert!(out.contains("- case_alpha  PASS"), "\n{out}");
+    assert!(out.contains("- case_beta  FAIL"), "\n{out}");
+    assert!(out.contains("100ms"), "each case shows ms duration\n{out}");
+}
+
+#[test]
+fn console_output_contains_indented_metric_lines() {
+    let out = render_console(&sample_result());
+    // Metric lines must be indented (4 spaces) to visually group under the
+    // parent case; any indentation loss would collapse grouping.
+    assert!(
+        out.contains("    helpfulness  score=0.82  threshold=0.50  PASS"),
+        "\n{out}"
+    );
+    assert!(
+        out.contains("    correctness  score=0.91  threshold=0.60  PASS"),
+        "\n{out}"
+    );
+    assert!(
+        out.contains("    helpfulness  score=0.12  threshold=0.50  FAIL"),
+        "\n{out}"
+    );
+}
+
+#[test]
+fn console_output_includes_reason_when_present_single_line() {
+    let out = render_console(&sample_result());
+    // The failing metric has embedded newline "off-topic\nmultiline"; the
+    // reporter MUST keep it on a single line (Q8 "line-oriented").
+    let failing_line = out
+        .lines()
+        .find(|l| l.contains("helpfulness  score=0.12"))
+        .expect("failing metric line");
+    assert!(
+        failing_line.contains("reason: off-topic multiline"),
+        "reason must be sanitized onto one line: {failing_line}"
+    );
+}
+
+#[test]
+fn console_output_has_no_ansi_or_cursor_control() {
+    let out = render_console(&sample_result());
+    // ESC (0x1B) is the prefix of every ANSI sequence; CSI ("\x1b[") is the
+    // most common cursor-control / color prefix.
+    assert!(
+        !out.contains('\x1b'),
+        "ANSI escape found in console output:\n{out}"
+    );
+    // Control characters other than \n MUST NOT appear.
+    for ch in out.chars() {
+        if ch.is_control() {
+            assert_eq!(
+                ch, '\n',
+                "unexpected control character {ch:?} in console output"
+            );
+        }
+    }
+}
+
+#[test]
+fn console_output_summary_line_carries_totals() {
+    let out = render_console(&sample_result());
+    let summary = out
+        .lines()
+        .last()
+        .expect("non-empty reporter output has a last line");
+    assert!(summary.starts_with("Summary: "));
+    assert!(summary.contains("1 passed"));
+    assert!(summary.contains("1 failed"));
+    assert!(summary.contains("total_cost=$0.004600"));
+    assert!(summary.contains("duration=220ms"));
+}
+
+#[test]
+fn console_output_is_deterministic_across_two_renders() {
+    let result = sample_result();
+    let first = render_console(&result);
+    let second = render_console(&result);
+    assert_eq!(first, second);
+}
+
+#[test]
+fn console_output_handles_empty_eval_set() {
+    let empty = EvalSetResult {
+        eval_set_id: "empty".into(),
+        case_results: vec![],
+        summary: EvalSummary {
+            total_cases: 0,
+            passed: 0,
+            failed: 0,
+            total_cost: Cost::default(),
+            total_usage: Usage::default(),
+            total_duration: Duration::ZERO,
+        },
+        timestamp: 0,
+    };
+    let out = render_console(&empty);
+    assert!(out.lines().count() == 2, "header + summary only:\n{out}");
+    assert!(out.contains("0/0 passed"));
+    assert!(out.contains("0 passed, 0 failed"));
+}

--- a/eval/tests/reporter_json_test.rs
+++ b/eval/tests/reporter_json_test.rs
@@ -17,9 +17,8 @@ use swink_agent_eval::{
 use common::mock_invocation;
 
 /// Embed the schema at compile time so the test suite is hermetic.
-const SCHEMA_JSON: &str = include_str!(
-    "../../specs/043-evals-adv-features/contracts/eval-result.schema.json"
-);
+const SCHEMA_JSON: &str =
+    include_str!("../../specs/043-evals-adv-features/contracts/eval-result.schema.json");
 
 fn sample_result() -> EvalSetResult {
     let case = EvalCaseResult {

--- a/eval/tests/reporter_json_test.rs
+++ b/eval/tests/reporter_json_test.rs
@@ -1,0 +1,191 @@
+//! Regression tests for `JsonReporter` (T142).
+//!
+//! Validates every emitted artifact against
+//! `specs/043-evals-adv-features/contracts/eval-result.schema.json`.
+
+mod common;
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use swink_agent::{Cost, Usage};
+use swink_agent_eval::{
+    EvalCaseResult, EvalMetricResult, EvalSetResult, EvalSummary, JsonReporter, Reporter,
+    ReporterOutput, Score, Verdict,
+};
+
+use common::mock_invocation;
+
+/// Embed the schema at compile time so the test suite is hermetic.
+const SCHEMA_JSON: &str = include_str!(
+    "../../specs/043-evals-adv-features/contracts/eval-result.schema.json"
+);
+
+fn sample_result() -> EvalSetResult {
+    let case = EvalCaseResult {
+        case_id: "case_alpha".into(),
+        invocation: mock_invocation(&[], Some("ok"), 0.01, 120),
+        metric_results: vec![
+            EvalMetricResult {
+                evaluator_name: "helpfulness".into(),
+                score: Score::new(0.82, 0.5),
+                details: Some("looks good".into()),
+            },
+            EvalMetricResult {
+                evaluator_name: "correctness".into(),
+                score: Score::new(0.91, 0.6),
+                details: None,
+            },
+        ],
+        verdict: Verdict::Pass,
+    };
+    EvalSetResult {
+        eval_set_id: "demo-set".into(),
+        case_results: vec![case],
+        summary: EvalSummary {
+            total_cases: 1,
+            passed: 1,
+            failed: 0,
+            total_cost: Cost {
+                input: 0.004,
+                output: 0.006,
+                total: 0.01,
+                ..Default::default()
+            },
+            total_usage: Usage {
+                input: 60,
+                output: 60,
+                total: 120,
+                ..Default::default()
+            },
+            total_duration: Duration::from_millis(150),
+        },
+        timestamp: 1_700_000_000,
+    }
+}
+
+fn render(reporter: JsonReporter, result: &EvalSetResult) -> (PathBuf, Vec<u8>) {
+    match reporter.render(result).expect("render ok") {
+        ReporterOutput::Artifact { path, bytes } => (path, bytes),
+        other => panic!("expected Artifact output, got {other:?}"),
+    }
+}
+
+fn schema_value() -> serde_json::Value {
+    serde_json::from_str(SCHEMA_JSON).expect("schema parses as JSON")
+}
+
+#[test]
+fn json_artifact_parses_and_validates_against_schema() {
+    let result = sample_result();
+    let (path, bytes) = render(JsonReporter::new(), &result);
+    assert_eq!(path, PathBuf::from("eval-result.json"));
+
+    let doc: serde_json::Value =
+        serde_json::from_slice(&bytes).expect("JsonReporter output is valid JSON");
+
+    let schema = schema_value();
+    let validator = jsonschema::validator_for(&schema).expect("schema compiles");
+    let errors: Vec<_> = validator
+        .iter_errors(&doc)
+        .map(|e| format!("{e} @ {}", e.instance_path))
+        .collect();
+    assert!(errors.is_empty(), "schema validation failed: {errors:#?}");
+}
+
+#[test]
+fn json_artifact_carries_schema_version() {
+    let (_, bytes) = render(JsonReporter::new(), &sample_result());
+    let doc: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(doc["schema_version"], "043");
+}
+
+#[test]
+fn json_artifact_preserves_per_case_and_per_metric_detail() {
+    let (_, bytes) = render(JsonReporter::new(), &sample_result());
+    let doc: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+
+    assert_eq!(doc["eval_set"]["id"], "demo-set");
+    assert_eq!(doc["eval_set"]["case_count"], 1);
+    assert_eq!(doc["cases"][0]["case_id"], "case_alpha");
+    assert_eq!(doc["cases"][0]["verdict"], "pass");
+    assert_eq!(doc["cases"][0]["metrics"].as_array().unwrap().len(), 2);
+
+    let m0 = &doc["cases"][0]["metrics"][0];
+    assert_eq!(m0["evaluator"], "helpfulness");
+    assert_eq!(m0["reason"], "looks good");
+    assert_eq!(m0["verdict"], "pass");
+
+    // The second metric omitted `details`; `reason` MUST be absent (not
+    // null) so the schema's additionalProperties=false stays green.
+    let m1 = &doc["cases"][0]["metrics"][1];
+    assert!(m1.get("reason").is_none(), "missing reason must be absent");
+}
+
+#[test]
+fn json_artifact_summary_matches_totals() {
+    let (_, bytes) = render(JsonReporter::new(), &sample_result());
+    let doc: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    let summary = &doc["summary"];
+    assert_eq!(summary["total_cases"], 1);
+    assert_eq!(summary["passed"], 1);
+    assert_eq!(summary["failed"], 0);
+    assert_eq!(summary["total_duration_ms"], 150);
+    assert_eq!(summary["total_input_tokens"], 60);
+    assert_eq!(summary["total_output_tokens"], 60);
+}
+
+#[test]
+fn json_compact_and_pretty_both_validate() {
+    let result = sample_result();
+    let schema = schema_value();
+    let validator = jsonschema::validator_for(&schema).expect("schema compiles");
+
+    for (label, reporter) in [
+        ("pretty", JsonReporter::new().pretty(true)),
+        ("compact", JsonReporter::new().pretty(false)),
+    ] {
+        let (_, bytes) = render(reporter, &result);
+        let doc: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let errs: Vec<_> = validator
+            .iter_errors(&doc)
+            .map(|e| format!("{e}"))
+            .collect();
+        assert!(errs.is_empty(), "{label} output failed schema: {errs:?}");
+    }
+}
+
+#[test]
+fn json_renders_are_deterministic() {
+    let result = sample_result();
+    let (_, bytes_a) = render(JsonReporter::new(), &result);
+    let (_, bytes_b) = render(JsonReporter::new(), &result);
+    assert_eq!(bytes_a, bytes_b);
+}
+
+#[test]
+fn json_artifact_validates_empty_case_set() {
+    let empty = EvalSetResult {
+        eval_set_id: "empty".into(),
+        case_results: vec![],
+        summary: EvalSummary {
+            total_cases: 0,
+            passed: 0,
+            failed: 0,
+            total_cost: Cost::default(),
+            total_usage: Usage::default(),
+            total_duration: Duration::ZERO,
+        },
+        timestamp: 0,
+    };
+    let (_, bytes) = render(JsonReporter::new(), &empty);
+    let doc: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    let schema = schema_value();
+    let validator = jsonschema::validator_for(&schema).unwrap();
+    let errors: Vec<_> = validator
+        .iter_errors(&doc)
+        .map(|e| format!("{e}"))
+        .collect();
+    assert!(errors.is_empty(), "empty result schema errors: {errors:?}");
+    assert_eq!(doc["cases"], serde_json::json!([]));
+}

--- a/eval/tests/reporter_markdown_test.rs
+++ b/eval/tests/reporter_markdown_test.rs
@@ -1,0 +1,205 @@
+//! Regression tests for `MarkdownReporter` (T144).
+//!
+//! Verifies the emitted document is PR-comment-ready: valid Markdown tables,
+//! no ANSI escapes, per-case and per-metric detail preserved.
+
+mod common;
+
+use std::time::Duration;
+
+use swink_agent::{Cost, Usage};
+use swink_agent_eval::{
+    EvalCaseResult, EvalMetricResult, EvalSetResult, EvalSummary, MarkdownReporter, Reporter,
+    ReporterOutput, Score, Verdict,
+};
+
+use common::mock_invocation;
+
+fn sample_result() -> EvalSetResult {
+    let case_pass = EvalCaseResult {
+        case_id: "case_alpha".into(),
+        invocation: mock_invocation(&[], Some("ok"), 0.01, 120),
+        metric_results: vec![EvalMetricResult {
+            evaluator_name: "helpfulness".into(),
+            score: Score::new(0.82, 0.5),
+            details: Some("looks good".into()),
+        }],
+        verdict: Verdict::Pass,
+    };
+    // Embed a pipe character in the case id to exercise Markdown escaping.
+    let case_fail = EvalCaseResult {
+        case_id: "case|beta".into(),
+        invocation: mock_invocation(&[], Some("bad"), 0.01, 120),
+        metric_results: vec![EvalMetricResult {
+            evaluator_name: "correctness".into(),
+            score: Score::new(0.12, 0.6),
+            details: Some("off-topic".into()),
+        }],
+        verdict: Verdict::Fail,
+    };
+    EvalSetResult {
+        eval_set_id: "demo-set".into(),
+        case_results: vec![case_pass, case_fail],
+        summary: EvalSummary {
+            total_cases: 2,
+            passed: 1,
+            failed: 1,
+            total_cost: Cost {
+                total: 0.02,
+                ..Default::default()
+            },
+            total_usage: Usage::default(),
+            total_duration: Duration::from_millis(220),
+        },
+        timestamp: 0,
+    }
+}
+
+fn render(result: &EvalSetResult) -> String {
+    match MarkdownReporter::new().render(result).expect("render ok") {
+        ReporterOutput::Stdout(s) => s,
+        other => panic!("expected Stdout output, got {other:?}"),
+    }
+}
+
+#[test]
+fn markdown_output_contains_header_and_sections() {
+    let out = render(&sample_result());
+    assert!(out.contains("# Eval Result: `demo-set`"));
+    assert!(out.contains("## Summary"));
+    assert!(out.contains("## Cases"));
+    assert!(out.contains("## Metrics"));
+}
+
+#[test]
+fn markdown_summary_table_is_valid() {
+    let out = render(&sample_result());
+    // Valid Markdown table: header row, delimiter row, N body rows.
+    let summary_section: String = out
+        .split("## Summary")
+        .nth(1)
+        .expect("summary section present")
+        .split("## Cases")
+        .next()
+        .expect("summary terminator")
+        .into();
+    assert!(summary_section.contains("| Metric | Value |"));
+    assert!(summary_section.contains("| --- | --- |"));
+    assert!(summary_section.contains("| Total cases | 2 |"));
+    assert!(summary_section.contains("| Passed | 1 |"));
+    assert!(summary_section.contains("| Failed | 1 |"));
+    assert!(summary_section.contains("| Duration | 220ms |"));
+}
+
+#[test]
+fn markdown_cases_table_carries_per_case_detail() {
+    let out = render(&sample_result());
+    assert!(out.contains("| Case | Verdict | Duration |"));
+    assert!(out.contains("| `case_alpha` | PASS | 100ms |"));
+    // Pipe inside the case id must be escaped with a backslash so GFM
+    // renders the row correctly.
+    assert!(
+        out.contains("| `case\\|beta` | FAIL | 100ms |"),
+        "expected escaped pipe in case id:\n{out}"
+    );
+}
+
+#[test]
+fn markdown_metrics_table_carries_per_metric_detail() {
+    let out = render(&sample_result());
+    assert!(
+        out.contains("| Case | Evaluator | Score | Threshold | Verdict | Reason |")
+    );
+    assert!(
+        out.contains("| `case_alpha` | `helpfulness` | 0.82 | 0.50 | PASS | looks good |"),
+        "\n{out}"
+    );
+    assert!(
+        out.contains("| `case\\|beta` | `correctness` | 0.12 | 0.60 | FAIL | off-topic |"),
+        "\n{out}"
+    );
+}
+
+#[test]
+fn markdown_output_has_no_ansi_or_html() {
+    let out = render(&sample_result());
+    assert!(
+        !out.contains('\x1b'),
+        "ANSI escape found in markdown output:\n{out}"
+    );
+    // Output must be Markdown, not HTML. No tag-like constructs.
+    assert!(!out.contains("<table"));
+    assert!(!out.contains("<div"));
+    assert!(!out.contains("<span"));
+    assert!(!out.contains("<script"));
+}
+
+#[test]
+fn markdown_every_table_row_has_matching_pipe_count() {
+    let out = render(&sample_result());
+    // Every table row (a line beginning with '|') must have the same number
+    // of pipes within a contiguous table block. We coarsely assert each
+    // row has at least 2 pipes (a minimal table cell) and all rows within
+    // a block share the same pipe count.
+    let mut blocks: Vec<Vec<&str>> = vec![];
+    let mut current: Vec<&str> = vec![];
+    for line in out.lines() {
+        if line.trim_start().starts_with('|') {
+            current.push(line);
+        } else if !current.is_empty() {
+            blocks.push(std::mem::take(&mut current));
+        }
+    }
+    if !current.is_empty() {
+        blocks.push(current);
+    }
+    assert!(!blocks.is_empty(), "no table rows rendered");
+    for block in blocks {
+        let counts: Vec<usize> = block
+            .iter()
+            .map(|l| l.chars().filter(|c| *c == '|').count())
+            .collect();
+        let first = counts[0];
+        assert!(first >= 2, "row has fewer than 2 pipes: {:?}", block[0]);
+        for (i, c) in counts.iter().enumerate() {
+            assert_eq!(
+                *c, first,
+                "row {i} pipe count mismatch in block starting with {:?}",
+                block[0]
+            );
+        }
+    }
+}
+
+#[test]
+fn markdown_render_is_deterministic() {
+    let result = sample_result();
+    let a = render(&result);
+    let b = render(&result);
+    assert_eq!(a, b);
+}
+
+#[test]
+fn markdown_omits_metrics_section_when_no_metrics() {
+    let result = EvalSetResult {
+        eval_set_id: "no-metrics".into(),
+        case_results: vec![EvalCaseResult {
+            case_id: "solo".into(),
+            invocation: mock_invocation(&[], Some("ok"), 0.0, 0),
+            metric_results: vec![],
+            verdict: Verdict::Pass,
+        }],
+        summary: EvalSummary {
+            total_cases: 1,
+            passed: 1,
+            failed: 0,
+            total_cost: Cost::default(),
+            total_usage: Usage::default(),
+            total_duration: Duration::from_millis(5),
+        },
+        timestamp: 0,
+    };
+    let out = render(&result);
+    assert!(out.contains("## Cases"));
+    assert!(!out.contains("## Metrics"), "metrics section leaked:\n{out}");
+}

--- a/eval/tests/reporter_markdown_test.rs
+++ b/eval/tests/reporter_markdown_test.rs
@@ -107,9 +107,7 @@ fn markdown_cases_table_carries_per_case_detail() {
 #[test]
 fn markdown_metrics_table_carries_per_metric_detail() {
     let out = render(&sample_result());
-    assert!(
-        out.contains("| Case | Evaluator | Score | Threshold | Verdict | Reason |")
-    );
+    assert!(out.contains("| Case | Evaluator | Score | Threshold | Verdict | Reason |"));
     assert!(
         out.contains("| `case_alpha` | `helpfulness` | 0.82 | 0.50 | PASS | looks good |"),
         "\n{out}"
@@ -154,11 +152,16 @@ fn markdown_every_table_row_has_matching_pipe_count() {
         blocks.push(current);
     }
     assert!(!blocks.is_empty(), "no table rows rendered");
+    // Count cell-boundary pipes only — escaped `\|` within a cell does not
+    // delimit a new cell in GFM.
+    fn cell_boundary_pipes(line: &str) -> usize {
+        line.replace("\\|", "")
+            .chars()
+            .filter(|c| *c == '|')
+            .count()
+    }
     for block in blocks {
-        let counts: Vec<usize> = block
-            .iter()
-            .map(|l| l.chars().filter(|c| *c == '|').count())
-            .collect();
+        let counts: Vec<usize> = block.iter().map(|l| cell_boundary_pipes(l)).collect();
         let first = counts[0];
         assert!(first >= 2, "row has fewer than 2 pipes: {:?}", block[0]);
         for (i, c) in counts.iter().enumerate() {
@@ -201,5 +204,8 @@ fn markdown_omits_metrics_section_when_no_metrics() {
     };
     let out = render(&result);
     assert!(out.contains("## Cases"));
-    assert!(!out.contains("## Metrics"), "metrics section leaked:\n{out}");
+    assert!(
+        !out.contains("## Metrics"),
+        "metrics section leaked:\n{out}"
+    );
 }

--- a/specs/043-evals-adv-features/contracts/eval-result.schema.json
+++ b/specs/043-evals-adv-features/contracts/eval-result.schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spec.swink-agent.dev/043/eval-result.schema.json",
+  "title": "EvalSetResult",
+  "description": "Self-contained wire format emitted by swink_agent_eval::report::JsonReporter. Version 043.",
+  "type": "object",
+  "required": ["schema_version", "eval_set", "cases", "summary", "timestamp"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "043",
+      "description": "Stable schema identifier matching JsonReporter::SCHEMA_VERSION."
+    },
+    "eval_set": {
+      "type": "object",
+      "required": ["id", "case_count"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string" },
+        "case_count": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "cases": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/case" }
+    },
+    "summary": { "$ref": "#/$defs/summary" },
+    "timestamp": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Unix timestamp (seconds) of the eval run."
+    }
+  },
+  "$defs": {
+    "verdict": {
+      "type": "string",
+      "enum": ["pass", "fail"]
+    },
+    "case": {
+      "type": "object",
+      "required": ["case_id", "verdict", "duration_ms", "metrics"],
+      "additionalProperties": false,
+      "properties": {
+        "case_id": { "type": "string" },
+        "verdict": { "$ref": "#/$defs/verdict" },
+        "duration_ms": { "type": "integer", "minimum": 0 },
+        "metrics": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/metric" }
+        }
+      }
+    },
+    "metric": {
+      "type": "object",
+      "required": ["evaluator", "score", "threshold", "verdict"],
+      "additionalProperties": false,
+      "properties": {
+        "evaluator": { "type": "string" },
+        "score": { "type": "number", "minimum": 0.0, "maximum": 1.0 },
+        "threshold": { "type": "number", "minimum": 0.0, "maximum": 1.0 },
+        "verdict": { "$ref": "#/$defs/verdict" },
+        "reason": { "type": "string" }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "required": [
+        "total_cases",
+        "passed",
+        "failed",
+        "total_cost",
+        "total_input_tokens",
+        "total_output_tokens",
+        "total_duration_ms"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "total_cases": { "type": "integer", "minimum": 0 },
+        "passed": { "type": "integer", "minimum": 0 },
+        "failed": { "type": "integer", "minimum": 0 },
+        "total_cost": { "type": "number", "minimum": 0.0 },
+        "total_input_tokens": { "type": "integer", "minimum": 0 },
+        "total_output_tokens": { "type": "integer", "minimum": 0 },
+        "total_duration_ms": { "type": "integer", "minimum": 0 }
+      }
+    }
+  }
+}

--- a/specs/043-evals-adv-features/tasks.md
+++ b/specs/043-evals-adv-features/tasks.md
@@ -350,13 +350,13 @@
 
 ### Reporters
 
-- [ ] T139 [P] [US8] Write tests in `eval/tests/reporter_console_test.rs`: plain-text line-oriented output, one line per case verdict + indented evaluator score+reason, no ANSI, no cursor control, no interactivity (per Q8 clarification)
-- [ ] T140 [US8] Implement `Reporter` trait + `ReporterOutput` enum + `ReporterError` in `eval/src/report/mod.rs`
-- [ ] T141 [P] [US8] Implement `ConsoleReporter` in `eval/src/report/console.rs` (always-on, plain-text)
-- [ ] T142 [P] [US8] Write tests in `eval/tests/reporter_json_test.rs`: self-contained JSON; schema validation against `eval-result.schema.json`
-- [ ] T143 [P] [US8] Implement `JsonReporter` in `eval/src/report/json.rs` (always-on) + author `specs/043-evals-adv-features/contracts/eval-result.schema.json`
-- [ ] T144 [P] [US8] Write tests in `eval/tests/reporter_markdown_test.rs`: valid Markdown table; no ANSI; per-case and per-metric detail present
-- [ ] T145 [P] [US8] Implement `MarkdownReporter` in `eval/src/report/markdown.rs` (always-on, PR-comment-ready)
+- [x] T139 [P] [US8] Write tests in `eval/tests/reporter_console_test.rs`: plain-text line-oriented output, one line per case verdict + indented evaluator score+reason, no ANSI, no cursor control, no interactivity (per Q8 clarification)
+- [x] T140 [US8] Implement `Reporter` trait + `ReporterOutput` enum + `ReporterError` in `eval/src/report/mod.rs`
+- [x] T141 [P] [US8] Implement `ConsoleReporter` in `eval/src/report/console.rs` (always-on, plain-text)
+- [x] T142 [P] [US8] Write tests in `eval/tests/reporter_json_test.rs`: self-contained JSON; schema validation against `eval-result.schema.json`
+- [x] T143 [P] [US8] Implement `JsonReporter` in `eval/src/report/json.rs` (always-on) + author `specs/043-evals-adv-features/contracts/eval-result.schema.json`
+- [x] T144 [P] [US8] Write tests in `eval/tests/reporter_markdown_test.rs`: valid Markdown table; no ANSI; per-case and per-metric detail present
+- [x] T145 [P] [US8] Implement `MarkdownReporter` in `eval/src/report/markdown.rs` (always-on, PR-comment-ready)
 - [ ] T146 [P] [US8] Write tests in `eval/tests/reporter_html_test.rs`: single self-contained file; `<details>`/`<summary>` collapsibility; no external asset dependencies; bounded output size for thousand-case results
 - [ ] T147 [US8] Implement `HtmlReporter` in `eval/src/report/html.rs` using `askama` templates with inlined CSS/JS (feature `html-report`); embed template at compile time
 - [ ] T148 [P] [US8] Write tests in `eval/tests/reporter_langsmith_test.rs` (wiremock-backed): `EvalSetResult` pushed as run; per-evaluator feedback attached under configured `feedback_key`; partial push failure surfaces `LangSmithExportError::Push { pushed, failed, first_error }`


### PR DESCRIPTION
## Summary
- Reporter trait + ReporterOutput enum + ReporterError (T140)
- ConsoleReporter — plain-text, no ANSI per Q8 (T141)
- JsonReporter + eval-result.schema.json contract (T143)
- MarkdownReporter — PR-comment-ready (T145)
- Regression tests for each (T139, T142, T144)

## Tasks completed
T139, T140, T141, T142, T143, T144, T145

## Deferred
T146–T147 (HTML), T148–T149 (LangSmith), T150 (integration test) — follow-up PRs.

## Test plan
Worker did not run cargo; orchestrator verifies sequentially.

Part of #758

🤖 Generated with [Claude Code](https://claude.com/claude-code)