### PR TITLE
impl(043): US6 core trace surface + mappers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4822,7 +4822,6 @@ dependencies = [
  "askama",
  "async-trait",
  "backon",
- "bincode",
  "clap",
  "futures",
  "jsonschema",

--- a/eval/Cargo.toml
+++ b/eval/Cargo.toml
@@ -68,7 +68,7 @@ all-evaluators = [
 ]
 simulation = ["judge-core"]
 generation = ["judge-core"]
-trace-ingest = ["dep:opentelemetry_sdk"]
+trace-ingest = ["dep:opentelemetry", "dep:opentelemetry_sdk", "opentelemetry_sdk/testing"]
 trace-otlp = ["trace-ingest", "dep:opentelemetry-otlp"]
 trace-langfuse = ["trace-ingest", "dep:reqwest"]
 trace-opensearch = ["trace-ingest", "dep:reqwest"]

--- a/eval/src/trace/extractor.rs
+++ b/eval/src/trace/extractor.rs
@@ -102,7 +102,11 @@ mod tests {
             arguments: serde_json::Value::Null,
         };
         assert_eq!(
-            ExtractedInput::Tool { turn_index: 0, call }.level(),
+            ExtractedInput::Tool {
+                turn_index: 0,
+                call
+            }
+            .level(),
             EvaluationLevel::Tool
         );
         assert_eq!(

--- a/eval/src/trace/extractor.rs
+++ b/eval/src/trace/extractor.rs
@@ -1,0 +1,113 @@
+//! `EvaluationLevel` and the `TraceExtractor` trait (spec 043 FR-033).
+//!
+//! Evaluators work at one of three granularities:
+//!
+//! * [`EvaluationLevel::Tool`] — per tool-call judgement (one input per
+//!   recorded tool invocation).
+//! * [`EvaluationLevel::Trace`] — per trajectory (a single input covering
+//!   the full recorded run).
+//! * [`EvaluationLevel::Session`] — per aggregated session, potentially
+//!   spanning multiple invocations (multi-agent swarms, graph runs).
+//!
+//! A [`TraceExtractor`] yields a vector of [`ExtractedInput`]s shaped for
+//! the consuming evaluator family. Concrete extractors
+//! (`SwarmExtractor`, `GraphExtractor`, tool-level extractors) follow in
+//! tasks T132–T134; this module only defines the trait and the minimal
+//! input payload so downstream code has a stable compile target.
+
+use crate::types::{Invocation, RecordedToolCall, TurnRecord};
+
+/// Granularity at which an evaluator operates (FR-033).
+///
+/// Serde-ready so evaluation configs can name a level in YAML.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvaluationLevel {
+    /// One unit of input per individual tool call.
+    Tool,
+    /// One unit of input covering the full trajectory of a single
+    /// invocation.
+    Trace,
+    /// One unit of input covering an entire multi-invocation session
+    /// (e.g. swarm / graph runs).
+    Session,
+}
+
+/// Unit of input produced by a [`TraceExtractor`] for an evaluator.
+///
+/// The variant selected MUST match the requested `EvaluationLevel`.
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub enum ExtractedInput {
+    /// A single tool call belonging to `turn_index` within the source
+    /// invocation.
+    Tool {
+        /// Zero-based index of the turn the tool call was executed in.
+        turn_index: usize,
+        /// The recorded tool call payload.
+        call: RecordedToolCall,
+    },
+    /// The entire invocation, passed through as-is.
+    Trace(Box<Invocation>),
+    /// A session-level payload carrying every turn of an invocation.
+    Session {
+        /// All turns that make up the session, in chronological order.
+        turns: Vec<TurnRecord>,
+    },
+}
+
+impl ExtractedInput {
+    /// Level of granularity this input represents.
+    #[must_use]
+    pub fn level(&self) -> EvaluationLevel {
+        match self {
+            Self::Tool { .. } => EvaluationLevel::Tool,
+            Self::Trace(_) => EvaluationLevel::Trace,
+            Self::Session { .. } => EvaluationLevel::Session,
+        }
+    }
+}
+
+/// Extract one or more `ExtractedInput`s from an `Invocation` at a given
+/// `EvaluationLevel` (FR-033).
+///
+/// Implementations MUST be deterministic: equal `Invocation` + `level`
+/// inputs MUST produce equal output vectors (required for cache-key stability
+/// and SC-008 replay-equality).
+pub trait TraceExtractor: Send + Sync {
+    /// Produce inputs of the requested granularity from `inv`.
+    fn extract(&self, inv: &Invocation, level: EvaluationLevel) -> Vec<ExtractedInput>;
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn evaluation_level_serde_round_trip() {
+        let yaml_like = serde_json::to_string(&EvaluationLevel::Trace).unwrap();
+        assert_eq!(yaml_like, "\"trace\"");
+        let back: EvaluationLevel = serde_json::from_str(&yaml_like).unwrap();
+        assert_eq!(back, EvaluationLevel::Trace);
+    }
+
+    #[test]
+    fn extracted_input_level_matches_variant() {
+        let call = RecordedToolCall {
+            id: "id".into(),
+            name: "n".into(),
+            arguments: serde_json::Value::Null,
+        };
+        assert_eq!(
+            ExtractedInput::Tool { turn_index: 0, call }.level(),
+            EvaluationLevel::Tool
+        );
+        assert_eq!(
+            ExtractedInput::Session { turns: vec![] }.level(),
+            EvaluationLevel::Session
+        );
+    }
+}

--- a/eval/src/trace/mapper.rs
+++ b/eval/src/trace/mapper.rs
@@ -1,0 +1,742 @@
+//! `SessionMapper` trait and built-in implementations.
+//!
+//! Session mappers translate a backend-neutral [`RawSession`] (produced by a
+//! [`TraceProvider`](crate::trace::provider::TraceProvider)) into an internal
+//! [`Invocation`]. Each mapper encodes one semantic convention:
+//!
+//! * [`OpenInferenceSessionMapper`] — OpenInference / Arize attribute vocabulary.
+//! * [`LangChainSessionMapper`] — LangChain-OTel attribute vocabulary.
+//! * [`OtelGenAiSessionMapper`] — OpenTelemetry GenAI semantic conventions,
+//!   with per-version attribute tables (v1.27, v1.30, experimental) per
+//!   research R-005 and FR-032.
+//!
+//! Missing-but-required attributes surface as
+//! [`MappingError::MissingAttribute`] — mappers never panic on bad input
+//! (spec 043 edge case under FR-031/FR-032).
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use opentelemetry::Value;
+use opentelemetry_sdk::trace::SpanData;
+use swink_agent::{
+    AssistantMessage, ContentBlock, Cost, ModelSpec, StopReason, Usage,
+};
+use thiserror::Error;
+
+use crate::trace::provider::RawSession;
+use crate::types::{Invocation, RecordedToolCall, TurnRecord};
+
+// ─── Error model ────────────────────────────────────────────────────────────
+
+/// Errors a [`SessionMapper`] can surface. No mapper variant panics on
+/// missing data (spec 043 FR-031 edge case).
+#[non_exhaustive]
+#[derive(Debug, Error)]
+pub enum MappingError {
+    /// A required attribute was absent on every span in the session.
+    #[error("required attribute `{name}` not found on any span in session")]
+    MissingAttribute {
+        /// Fully-qualified attribute key per the backend's convention.
+        name: String,
+    },
+
+    /// The raw session shape is not one this mapper knows how to handle.
+    #[error("raw session shape is unsupported by this mapper: {reason}")]
+    UnsupportedShape {
+        /// Human-readable diagnostic.
+        reason: String,
+    },
+
+    /// An attribute value was present but could not be parsed into the
+    /// expected Rust type (e.g. a token count that wasn't an integer).
+    #[error("attribute `{name}` has unexpected value: {reason}")]
+    InvalidAttribute {
+        /// Fully-qualified attribute key.
+        name: String,
+        /// Why the value failed to parse.
+        reason: String,
+    },
+}
+
+// ─── Trait ──────────────────────────────────────────────────────────────────
+
+/// Translate an external-convention [`RawSession`] into an [`Invocation`].
+///
+/// Mappers SHOULD be stateless and cheap to clone; the runner instantiates
+/// them once per backend configuration and shares them across cases.
+pub trait SessionMapper: Send + Sync {
+    /// Produce an `Invocation` from the raw payload. MUST return
+    /// [`MappingError::MissingAttribute`] rather than panic when required
+    /// attributes are absent.
+    fn map(&self, raw: &RawSession) -> Result<Invocation, MappingError>;
+}
+
+// ─── Shared helpers ─────────────────────────────────────────────────────────
+
+fn spans_of<'a>(raw: &'a RawSession) -> Result<&'a [SpanData], MappingError> {
+    match raw {
+        RawSession::OtelSpans { spans, .. } => Ok(spans),
+    }
+}
+
+/// Find the first span carrying attribute `key` and return the attribute
+/// value as a borrowed string slice.
+fn first_string_attr<'a>(spans: &'a [SpanData], key: &str) -> Option<String> {
+    for span in spans {
+        for kv in &span.attributes {
+            if kv.key.as_str() == key {
+                return Some(kv.value.as_str().into_owned());
+            }
+        }
+    }
+    None
+}
+
+/// Sum a numeric attribute across every span that carries it.
+fn sum_u64_attr(spans: &[SpanData], key: &str) -> Result<u64, MappingError> {
+    let mut sum: u64 = 0;
+    for span in spans {
+        for kv in &span.attributes {
+            if kv.key.as_str() == key {
+                let parsed = match &kv.value {
+                    Value::I64(v) => {
+                        u64::try_from(*v).map_err(|_| MappingError::InvalidAttribute {
+                            name: key.to_string(),
+                            reason: format!("negative token count: {v}"),
+                        })?
+                    }
+                    Value::String(s) => s.as_str().parse::<u64>().map_err(|e| {
+                        MappingError::InvalidAttribute {
+                            name: key.to_string(),
+                            reason: format!("not u64: {e}"),
+                        }
+                    })?,
+                    other => {
+                        return Err(MappingError::InvalidAttribute {
+                            name: key.to_string(),
+                            reason: format!("expected integer, got {other:?}"),
+                        });
+                    }
+                };
+                sum = sum.saturating_add(parsed);
+            }
+        }
+    }
+    Ok(sum)
+}
+
+fn total_duration(spans: &[SpanData]) -> Duration {
+    spans
+        .iter()
+        .filter_map(|s| s.end_time.duration_since(s.start_time).ok())
+        .sum()
+}
+
+fn current_ts() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
+        .unwrap_or(0)
+}
+
+/// Build a minimal `AssistantMessage` from a provider/model pair and optional
+/// final response text. Used by every mapper to produce a single terminal
+/// turn that carries the model-identifying attributes.
+fn assistant_message(
+    provider: &str,
+    model: &str,
+    response_text: Option<String>,
+    usage: Usage,
+) -> AssistantMessage {
+    let mut content: Vec<ContentBlock> = Vec::new();
+    if let Some(text) = response_text
+        && !text.is_empty()
+    {
+        content.push(ContentBlock::Text { text });
+    }
+    AssistantMessage {
+        content,
+        provider: provider.to_string(),
+        model_id: model.to_string(),
+        usage,
+        cost: Cost::default(),
+        stop_reason: StopReason::Stop,
+        error_message: None,
+        error_kind: None,
+        timestamp: current_ts(),
+        cache_hint: None,
+    }
+}
+
+/// Extract `RecordedToolCall`s from tool-kind spans using the conventional
+/// `<prefix>.name` / `<prefix>.arguments` attribute pair (e.g.
+/// `tool.name` / `tool.arguments` under GenAI, or `llm.tool_call.*` under
+/// OpenInference). The caller supplies the `prefix` and a span-name hint.
+fn extract_tool_calls(
+    spans: &[SpanData],
+    span_name_hint: &str,
+    name_attr: &str,
+    args_attr: &str,
+    id_attr: Option<&str>,
+) -> Vec<RecordedToolCall> {
+    let mut calls = Vec::new();
+    for span in spans {
+        if !span.name.contains(span_name_hint) {
+            continue;
+        }
+        let name = span
+            .attributes
+            .iter()
+            .find(|kv| kv.key.as_str() == name_attr)
+            .map(|kv| kv.value.as_str().into_owned());
+        let Some(name) = name else { continue };
+
+        let arguments = span
+            .attributes
+            .iter()
+            .find(|kv| kv.key.as_str() == args_attr)
+            .and_then(|kv| {
+                let raw = kv.value.as_str();
+                serde_json::from_str::<serde_json::Value>(&raw).ok()
+            })
+            .unwrap_or(serde_json::Value::Null);
+
+        let id = id_attr
+            .and_then(|k| {
+                span.attributes
+                    .iter()
+                    .find(|kv| kv.key.as_str() == k)
+                    .map(|kv| kv.value.as_str().into_owned())
+            })
+            .unwrap_or_else(|| span.span_context.span_id().to_string());
+
+        calls.push(RecordedToolCall {
+            id,
+            name,
+            arguments,
+        });
+    }
+    calls
+}
+
+/// Shared backbone: build an `Invocation` from the provided provider/model,
+/// usage, response, and tool calls. All three built-in mappers converge on
+/// this so they return consistent shapes.
+fn build_invocation(
+    spans: &[SpanData],
+    provider: String,
+    model: String,
+    usage: Usage,
+    response_text: Option<String>,
+    tool_calls: Vec<RecordedToolCall>,
+) -> Invocation {
+    let total_duration = total_duration(spans);
+    let assistant = assistant_message(&provider, &model, response_text.clone(), usage.clone());
+    let turn = TurnRecord {
+        turn_index: 0,
+        assistant_message: assistant.clone(),
+        tool_calls,
+        tool_results: Vec::new(),
+        duration: total_duration,
+    };
+    Invocation {
+        turns: vec![turn],
+        total_usage: usage,
+        total_cost: Cost::default(),
+        total_duration,
+        final_response: response_text,
+        stop_reason: assistant.stop_reason,
+        model: ModelSpec::new(provider, model),
+    }
+}
+
+// ─── OpenInferenceSessionMapper (T123) ──────────────────────────────────────
+
+/// Mapper for the OpenInference / Arize attribute vocabulary.
+///
+/// Consumed attribute keys (subset we require):
+/// * `llm.provider`, `llm.model_name` — required; absence yields
+///   [`MappingError::MissingAttribute`].
+/// * `llm.token_count.prompt`, `llm.token_count.completion` — optional usage.
+/// * `output.value` — optional final response text.
+/// * Tool spans: `tool.name`, `tool.parameters`, `tool.call_id`.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct OpenInferenceSessionMapper;
+
+impl OpenInferenceSessionMapper {
+    pub const PROVIDER_KEY: &'static str = "llm.provider";
+    pub const MODEL_KEY: &'static str = "llm.model_name";
+    pub const INPUT_TOKENS_KEY: &'static str = "llm.token_count.prompt";
+    pub const OUTPUT_TOKENS_KEY: &'static str = "llm.token_count.completion";
+    pub const RESPONSE_KEY: &'static str = "output.value";
+    pub const TOOL_NAME_KEY: &'static str = "tool.name";
+    pub const TOOL_PARAMS_KEY: &'static str = "tool.parameters";
+    pub const TOOL_ID_KEY: &'static str = "tool.call_id";
+}
+
+impl SessionMapper for OpenInferenceSessionMapper {
+    fn map(&self, raw: &RawSession) -> Result<Invocation, MappingError> {
+        let spans = spans_of(raw)?;
+
+        let provider = first_string_attr(spans, Self::PROVIDER_KEY).ok_or_else(|| {
+            MappingError::MissingAttribute {
+                name: Self::PROVIDER_KEY.to_string(),
+            }
+        })?;
+        let model =
+            first_string_attr(spans, Self::MODEL_KEY).ok_or_else(|| {
+                MappingError::MissingAttribute {
+                    name: Self::MODEL_KEY.to_string(),
+                }
+            })?;
+
+        let input = sum_u64_attr(spans, Self::INPUT_TOKENS_KEY)?;
+        let output = sum_u64_attr(spans, Self::OUTPUT_TOKENS_KEY)?;
+        let usage = Usage {
+            input,
+            output,
+            total: input.saturating_add(output),
+            ..Usage::default()
+        };
+        let response = first_string_attr(spans, Self::RESPONSE_KEY);
+
+        let tool_calls = extract_tool_calls(
+            spans,
+            "tool",
+            Self::TOOL_NAME_KEY,
+            Self::TOOL_PARAMS_KEY,
+            Some(Self::TOOL_ID_KEY),
+        );
+
+        Ok(build_invocation(spans, provider, model, usage, response, tool_calls))
+    }
+}
+
+// ─── LangChainSessionMapper (T124) ──────────────────────────────────────────
+
+/// Mapper for LangChain-OTel traces.
+///
+/// Consumed attribute keys:
+/// * `langchain.llm.provider`, `langchain.llm.model` — required.
+/// * `langchain.llm.usage.prompt_tokens`, `langchain.llm.usage.completion_tokens`
+///   — optional usage.
+/// * `langchain.llm.output_text` — optional final response.
+/// * Tool spans: `langchain.tool.name`, `langchain.tool.input`.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct LangChainSessionMapper;
+
+impl LangChainSessionMapper {
+    pub const PROVIDER_KEY: &'static str = "langchain.llm.provider";
+    pub const MODEL_KEY: &'static str = "langchain.llm.model";
+    pub const INPUT_TOKENS_KEY: &'static str = "langchain.llm.usage.prompt_tokens";
+    pub const OUTPUT_TOKENS_KEY: &'static str = "langchain.llm.usage.completion_tokens";
+    pub const RESPONSE_KEY: &'static str = "langchain.llm.output_text";
+    pub const TOOL_NAME_KEY: &'static str = "langchain.tool.name";
+    pub const TOOL_INPUT_KEY: &'static str = "langchain.tool.input";
+    pub const TOOL_ID_KEY: &'static str = "langchain.tool.run_id";
+}
+
+impl SessionMapper for LangChainSessionMapper {
+    fn map(&self, raw: &RawSession) -> Result<Invocation, MappingError> {
+        let spans = spans_of(raw)?;
+
+        let provider = first_string_attr(spans, Self::PROVIDER_KEY).ok_or_else(|| {
+            MappingError::MissingAttribute {
+                name: Self::PROVIDER_KEY.to_string(),
+            }
+        })?;
+        let model =
+            first_string_attr(spans, Self::MODEL_KEY).ok_or_else(|| {
+                MappingError::MissingAttribute {
+                    name: Self::MODEL_KEY.to_string(),
+                }
+            })?;
+
+        let input = sum_u64_attr(spans, Self::INPUT_TOKENS_KEY)?;
+        let output = sum_u64_attr(spans, Self::OUTPUT_TOKENS_KEY)?;
+        let usage = Usage {
+            input,
+            output,
+            total: input.saturating_add(output),
+            ..Usage::default()
+        };
+        let response = first_string_attr(spans, Self::RESPONSE_KEY);
+
+        let tool_calls = extract_tool_calls(
+            spans,
+            "tool",
+            Self::TOOL_NAME_KEY,
+            Self::TOOL_INPUT_KEY,
+            Some(Self::TOOL_ID_KEY),
+        );
+
+        Ok(build_invocation(spans, provider, model, usage, response, tool_calls))
+    }
+}
+
+// ─── OtelGenAiSessionMapper + version enum (T125) ───────────────────────────
+
+/// OpenTelemetry GenAI semantic-convention versions supported by
+/// [`OtelGenAiSessionMapper`] (research R-005, FR-032).
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GenAIConventionVersion {
+    /// `gen_ai.*` vocabulary as of OTel semantic conventions v1.27.
+    V1_27,
+    /// v1.30 — introduces `gen_ai.operation.name` and renames some response
+    /// attributes.
+    V1_30,
+    /// Forward-compatible bucket: the mapper consumes the v1.30 attribute
+    /// set and tolerates unknown extras.
+    Experimental,
+}
+
+/// Attribute-key lookup table for a single GenAI convention version.
+///
+/// Exposed (rather than hidden inside the mapper) so out-of-tree callers can
+/// inspect exactly which keys are consumed per version.
+#[derive(Debug, Clone)]
+pub struct GenAIAttributeTable {
+    pub system: &'static str,
+    pub request_model: &'static str,
+    pub response_model: &'static str,
+    pub input_tokens: &'static str,
+    pub output_tokens: &'static str,
+    pub finish_reasons: &'static str,
+    pub response_text: &'static str,
+    pub tool_name: &'static str,
+    pub tool_arguments: &'static str,
+    pub tool_id: &'static str,
+}
+
+impl GenAIAttributeTable {
+    /// Per-version attribute table (FR-032).
+    #[must_use]
+    pub const fn for_version(version: GenAIConventionVersion) -> Self {
+        match version {
+            GenAIConventionVersion::V1_27 => Self {
+                system: "gen_ai.system",
+                request_model: "gen_ai.request.model",
+                response_model: "gen_ai.response.model",
+                input_tokens: "gen_ai.usage.input_tokens",
+                output_tokens: "gen_ai.usage.output_tokens",
+                finish_reasons: "gen_ai.response.finish_reasons",
+                response_text: "gen_ai.completion.content",
+                tool_name: "gen_ai.tool.name",
+                tool_arguments: "gen_ai.tool.call.arguments",
+                tool_id: "gen_ai.tool.call.id",
+            },
+            GenAIConventionVersion::V1_30 | GenAIConventionVersion::Experimental => Self {
+                system: "gen_ai.system",
+                request_model: "gen_ai.request.model",
+                response_model: "gen_ai.response.model",
+                input_tokens: "gen_ai.usage.input_tokens",
+                output_tokens: "gen_ai.usage.output_tokens",
+                finish_reasons: "gen_ai.response.finish_reasons",
+                response_text: "gen_ai.output.messages",
+                tool_name: "gen_ai.tool.name",
+                tool_arguments: "gen_ai.tool.arguments",
+                tool_id: "gen_ai.tool.call.id",
+            },
+        }
+    }
+}
+
+/// Mapper for OTel GenAI semantic conventions.
+///
+/// Construction pins a [`GenAIConventionVersion`]; swapping versions requires
+/// no code change on the caller side — just re-construct with a different
+/// enum variant (FR-032 independent-test criterion).
+#[derive(Debug, Clone)]
+pub struct OtelGenAiSessionMapper {
+    /// Convention version this mapper targets.
+    pub version: GenAIConventionVersion,
+    table: GenAIAttributeTable,
+}
+
+impl OtelGenAiSessionMapper {
+    /// Build a mapper pinned to `version`.
+    #[must_use]
+    pub fn new(version: GenAIConventionVersion) -> Self {
+        Self {
+            version,
+            table: GenAIAttributeTable::for_version(version),
+        }
+    }
+
+    /// Attribute table this mapper uses.
+    #[must_use]
+    pub fn table(&self) -> &GenAIAttributeTable {
+        &self.table
+    }
+}
+
+impl Default for OtelGenAiSessionMapper {
+    fn default() -> Self {
+        Self::new(GenAIConventionVersion::V1_30)
+    }
+}
+
+impl SessionMapper for OtelGenAiSessionMapper {
+    fn map(&self, raw: &RawSession) -> Result<Invocation, MappingError> {
+        let spans = spans_of(raw)?;
+        let tbl = &self.table;
+
+        let provider = first_string_attr(spans, tbl.system).ok_or_else(|| {
+            MappingError::MissingAttribute {
+                name: tbl.system.to_string(),
+            }
+        })?;
+        let model = first_string_attr(spans, tbl.response_model)
+            .or_else(|| first_string_attr(spans, tbl.request_model))
+            .ok_or_else(|| MappingError::MissingAttribute {
+                name: tbl.request_model.to_string(),
+            })?;
+
+        let input = sum_u64_attr(spans, tbl.input_tokens)?;
+        let output = sum_u64_attr(spans, tbl.output_tokens)?;
+        let usage = Usage {
+            input,
+            output,
+            total: input.saturating_add(output),
+            ..Usage::default()
+        };
+        let response = first_string_attr(spans, tbl.response_text);
+
+        let tool_calls = extract_tool_calls(
+            spans,
+            "tool",
+            tbl.tool_name,
+            tbl.tool_arguments,
+            Some(tbl.tool_id),
+        );
+
+        // Unknown attributes are tolerated for Experimental. We surface them
+        // as a debug log but never error out.
+        if matches!(self.version, GenAIConventionVersion::Experimental) {
+            let known: [&str; 10] = [
+                tbl.system,
+                tbl.request_model,
+                tbl.response_model,
+                tbl.input_tokens,
+                tbl.output_tokens,
+                tbl.finish_reasons,
+                tbl.response_text,
+                tbl.tool_name,
+                tbl.tool_arguments,
+                tbl.tool_id,
+            ];
+            let mut seen_unknown: HashMap<String, usize> = HashMap::new();
+            for span in spans {
+                for kv in &span.attributes {
+                    let k = kv.key.as_str();
+                    if k.starts_with("gen_ai.") && !known.contains(&k) {
+                        *seen_unknown.entry(k.to_string()).or_default() += 1;
+                    }
+                }
+            }
+            if !seen_unknown.is_empty() {
+                tracing::debug!(
+                    target: "swink_agent_eval::trace::mapper",
+                    unknown = ?seen_unknown,
+                    "OtelGenAiSessionMapper (Experimental) tolerating unknown gen_ai.* attributes"
+                );
+            }
+        }
+
+        Ok(build_invocation(spans, provider, model, usage, response, tool_calls))
+    }
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opentelemetry::trace::{SpanContext, SpanId, SpanKind, Status, TraceFlags, TraceId, TraceState};
+    use opentelemetry::{InstrumentationScope, KeyValue};
+    use opentelemetry_sdk::trace::{SpanEvents, SpanLinks};
+    use std::borrow::Cow;
+    use std::time::{Duration, SystemTime};
+
+    fn make_span(name: &str, attrs: Vec<KeyValue>) -> SpanData {
+        let start = SystemTime::now();
+        SpanData {
+            span_context: SpanContext::new(
+                TraceId::from_u128(7),
+                SpanId::from_u64(7),
+                TraceFlags::default(),
+                false,
+                TraceState::default(),
+            ),
+            parent_span_id: SpanId::INVALID,
+            parent_span_is_remote: false,
+            span_kind: SpanKind::Internal,
+            name: Cow::Owned(name.to_string()),
+            start_time: start,
+            end_time: start + Duration::from_millis(5),
+            attributes: attrs,
+            dropped_attributes_count: 0,
+            events: SpanEvents::default(),
+            links: SpanLinks::default(),
+            status: Status::Unset,
+            instrumentation_scope: InstrumentationScope::builder("test").build(),
+        }
+    }
+
+    fn session(spans: Vec<SpanData>) -> RawSession {
+        RawSession::OtelSpans {
+            session_id: "s".into(),
+            spans,
+        }
+    }
+
+    #[test]
+    fn openinference_missing_provider_returns_missing_attribute() {
+        let raw = session(vec![make_span(
+            "llm",
+            vec![KeyValue::new("llm.model_name", "m")],
+        )]);
+        let err = OpenInferenceSessionMapper
+            .map(&raw)
+            .expect_err("provider absent");
+        match err {
+            MappingError::MissingAttribute { name } => {
+                assert_eq!(name, OpenInferenceSessionMapper::PROVIDER_KEY);
+            }
+            other => panic!("expected MissingAttribute, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn openinference_builds_invocation_with_usage_and_tool_calls() {
+        let llm = make_span(
+            "llm",
+            vec![
+                KeyValue::new("llm.provider", "anthropic"),
+                KeyValue::new("llm.model_name", "claude-3"),
+                KeyValue::new("llm.token_count.prompt", 10_i64),
+                KeyValue::new("llm.token_count.completion", 20_i64),
+                KeyValue::new("output.value", "hello"),
+            ],
+        );
+        let tool = make_span(
+            "tool.exec",
+            vec![
+                KeyValue::new("tool.name", "read_file"),
+                KeyValue::new("tool.parameters", r#"{"path":"/etc"}"#),
+                KeyValue::new("tool.call_id", "call_42"),
+            ],
+        );
+        let inv = OpenInferenceSessionMapper
+            .map(&session(vec![llm, tool]))
+            .unwrap();
+        assert_eq!(inv.model.provider, "anthropic");
+        assert_eq!(inv.model.model_id, "claude-3");
+        assert_eq!(inv.total_usage.input, 10);
+        assert_eq!(inv.total_usage.output, 20);
+        assert_eq!(inv.total_usage.total, 30);
+        assert_eq!(inv.final_response.as_deref(), Some("hello"));
+        assert_eq!(inv.turns.len(), 1);
+        assert_eq!(inv.turns[0].tool_calls.len(), 1);
+        assert_eq!(inv.turns[0].tool_calls[0].name, "read_file");
+        assert_eq!(inv.turns[0].tool_calls[0].id, "call_42");
+    }
+
+    #[test]
+    fn langchain_missing_model_returns_missing_attribute() {
+        let raw = session(vec![make_span(
+            "chain",
+            vec![KeyValue::new("langchain.llm.provider", "openai")],
+        )]);
+        let err = LangChainSessionMapper.map(&raw).expect_err("model absent");
+        match err {
+            MappingError::MissingAttribute { name } => {
+                assert_eq!(name, LangChainSessionMapper::MODEL_KEY);
+            }
+            other => panic!("expected MissingAttribute, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn langchain_round_trips_provider_and_tokens() {
+        let raw = session(vec![make_span(
+            "chain",
+            vec![
+                KeyValue::new("langchain.llm.provider", "openai"),
+                KeyValue::new("langchain.llm.model", "gpt-4"),
+                KeyValue::new("langchain.llm.usage.prompt_tokens", 3_i64),
+                KeyValue::new("langchain.llm.usage.completion_tokens", 4_i64),
+            ],
+        )]);
+        let inv = LangChainSessionMapper.map(&raw).unwrap();
+        assert_eq!(inv.model.provider, "openai");
+        assert_eq!(inv.model.model_id, "gpt-4");
+        assert_eq!(inv.total_usage.total, 7);
+    }
+
+    #[test]
+    fn genai_v1_27_and_v1_30_have_distinct_response_keys() {
+        let t27 = GenAIAttributeTable::for_version(GenAIConventionVersion::V1_27);
+        let t30 = GenAIAttributeTable::for_version(GenAIConventionVersion::V1_30);
+        assert_ne!(t27.response_text, t30.response_text);
+        assert_eq!(t27.system, t30.system); // `gen_ai.system` stable across versions.
+    }
+
+    #[test]
+    fn genai_missing_system_returns_missing_attribute() {
+        let raw = session(vec![make_span(
+            "llm.call",
+            vec![KeyValue::new("gen_ai.request.model", "m")],
+        )]);
+        let err = OtelGenAiSessionMapper::new(GenAIConventionVersion::V1_30)
+            .map(&raw)
+            .expect_err("system absent");
+        assert!(matches!(err, MappingError::MissingAttribute { name } if name == "gen_ai.system"));
+    }
+
+    #[test]
+    fn genai_v1_30_maps_usage_and_tool_call() {
+        let llm = make_span(
+            "llm.call",
+            vec![
+                KeyValue::new("gen_ai.system", "anthropic"),
+                KeyValue::new("gen_ai.request.model", "claude-3"),
+                KeyValue::new("gen_ai.usage.input_tokens", 5_i64),
+                KeyValue::new("gen_ai.usage.output_tokens", 6_i64),
+            ],
+        );
+        let tool = make_span(
+            "tool.call",
+            vec![
+                KeyValue::new("gen_ai.tool.name", "search"),
+                KeyValue::new("gen_ai.tool.arguments", r#"{"q":"rust"}"#),
+                KeyValue::new("gen_ai.tool.call.id", "tc_1"),
+            ],
+        );
+        let inv = OtelGenAiSessionMapper::new(GenAIConventionVersion::V1_30)
+            .map(&session(vec![llm, tool]))
+            .unwrap();
+        assert_eq!(inv.total_usage.input, 5);
+        assert_eq!(inv.total_usage.output, 6);
+        assert_eq!(inv.turns[0].tool_calls[0].name, "search");
+    }
+
+    #[test]
+    fn genai_experimental_tolerates_unknown_attributes() {
+        let llm = make_span(
+            "llm.call",
+            vec![
+                KeyValue::new("gen_ai.system", "openai"),
+                KeyValue::new("gen_ai.request.model", "gpt-5"),
+                KeyValue::new("gen_ai.wildcard.future_thing", "yes"),
+            ],
+        );
+        let inv = OtelGenAiSessionMapper::new(GenAIConventionVersion::Experimental)
+            .map(&session(vec![llm]))
+            .expect("experimental ignores unknown gen_ai.* keys");
+        assert_eq!(inv.model.provider, "openai");
+    }
+}

--- a/eval/src/trace/mapper.rs
+++ b/eval/src/trace/mapper.rs
@@ -19,9 +19,7 @@ use std::time::Duration;
 
 use opentelemetry::Value;
 use opentelemetry_sdk::trace::SpanData;
-use swink_agent::{
-    AssistantMessage, ContentBlock, Cost, ModelSpec, StopReason, Usage,
-};
+use swink_agent::{AssistantMessage, ContentBlock, Cost, ModelSpec, StopReason, Usage};
 use thiserror::Error;
 
 use crate::trace::provider::RawSession;
@@ -74,7 +72,11 @@ pub trait SessionMapper: Send + Sync {
 
 // ─── Shared helpers ─────────────────────────────────────────────────────────
 
-fn spans_of<'a>(raw: &'a RawSession) -> Result<&'a [SpanData], MappingError> {
+// `RawSession` is `#[non_exhaustive]`; keeping a `Result` return type lets
+// future backend-specific variants surface `UnsupportedShape` without
+// reshaping every caller.
+#[allow(clippy::unnecessary_wraps)]
+fn spans_of(raw: &RawSession) -> Result<&[SpanData], MappingError> {
     match raw {
         RawSession::OtelSpans { spans, .. } => Ok(spans),
     }
@@ -82,7 +84,7 @@ fn spans_of<'a>(raw: &'a RawSession) -> Result<&'a [SpanData], MappingError> {
 
 /// Find the first span carrying attribute `key` and return the attribute
 /// value as a borrowed string slice.
-fn first_string_attr<'a>(spans: &'a [SpanData], key: &str) -> Option<String> {
+fn first_string_attr(spans: &[SpanData], key: &str) -> Option<String> {
     for span in spans {
         for kv in &span.attributes {
             if kv.key.as_str() == key {
@@ -99,26 +101,27 @@ fn sum_u64_attr(spans: &[SpanData], key: &str) -> Result<u64, MappingError> {
     for span in spans {
         for kv in &span.attributes {
             if kv.key.as_str() == key {
-                let parsed = match &kv.value {
-                    Value::I64(v) => {
-                        u64::try_from(*v).map_err(|_| MappingError::InvalidAttribute {
-                            name: key.to_string(),
-                            reason: format!("negative token count: {v}"),
-                        })?
-                    }
-                    Value::String(s) => s.as_str().parse::<u64>().map_err(|e| {
-                        MappingError::InvalidAttribute {
-                            name: key.to_string(),
-                            reason: format!("not u64: {e}"),
+                let parsed =
+                    match &kv.value {
+                        Value::I64(v) => {
+                            u64::try_from(*v).map_err(|_| MappingError::InvalidAttribute {
+                                name: key.to_string(),
+                                reason: format!("negative token count: {v}"),
+                            })?
                         }
-                    })?,
-                    other => {
-                        return Err(MappingError::InvalidAttribute {
-                            name: key.to_string(),
-                            reason: format!("expected integer, got {other:?}"),
-                        });
-                    }
-                };
+                        Value::String(s) => s.as_str().parse::<u64>().map_err(|e| {
+                            MappingError::InvalidAttribute {
+                                name: key.to_string(),
+                                reason: format!("not u64: {e}"),
+                            }
+                        })?,
+                        other => {
+                            return Err(MappingError::InvalidAttribute {
+                                name: key.to_string(),
+                                reason: format!("expected integer, got {other:?}"),
+                            });
+                        }
+                    };
                 sum = sum.saturating_add(parsed);
             }
         }
@@ -137,8 +140,7 @@ fn current_ts() -> u64 {
     use std::time::{SystemTime, UNIX_EPOCH};
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map(|d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
-        .unwrap_or(0)
+        .map_or(0, |d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
 }
 
 /// Build a minimal `AssistantMessage` from a provider/model pair and optional
@@ -285,12 +287,11 @@ impl SessionMapper for OpenInferenceSessionMapper {
                 name: Self::PROVIDER_KEY.to_string(),
             }
         })?;
-        let model =
-            first_string_attr(spans, Self::MODEL_KEY).ok_or_else(|| {
-                MappingError::MissingAttribute {
-                    name: Self::MODEL_KEY.to_string(),
-                }
-            })?;
+        let model = first_string_attr(spans, Self::MODEL_KEY).ok_or_else(|| {
+            MappingError::MissingAttribute {
+                name: Self::MODEL_KEY.to_string(),
+            }
+        })?;
 
         let input = sum_u64_attr(spans, Self::INPUT_TOKENS_KEY)?;
         let output = sum_u64_attr(spans, Self::OUTPUT_TOKENS_KEY)?;
@@ -310,7 +311,9 @@ impl SessionMapper for OpenInferenceSessionMapper {
             Some(Self::TOOL_ID_KEY),
         );
 
-        Ok(build_invocation(spans, provider, model, usage, response, tool_calls))
+        Ok(build_invocation(
+            spans, provider, model, usage, response, tool_calls,
+        ))
     }
 }
 
@@ -347,12 +350,11 @@ impl SessionMapper for LangChainSessionMapper {
                 name: Self::PROVIDER_KEY.to_string(),
             }
         })?;
-        let model =
-            first_string_attr(spans, Self::MODEL_KEY).ok_or_else(|| {
-                MappingError::MissingAttribute {
-                    name: Self::MODEL_KEY.to_string(),
-                }
-            })?;
+        let model = first_string_attr(spans, Self::MODEL_KEY).ok_or_else(|| {
+            MappingError::MissingAttribute {
+                name: Self::MODEL_KEY.to_string(),
+            }
+        })?;
 
         let input = sum_u64_attr(spans, Self::INPUT_TOKENS_KEY)?;
         let output = sum_u64_attr(spans, Self::OUTPUT_TOKENS_KEY)?;
@@ -372,7 +374,9 @@ impl SessionMapper for LangChainSessionMapper {
             Some(Self::TOOL_ID_KEY),
         );
 
-        Ok(build_invocation(spans, provider, model, usage, response, tool_calls))
+        Ok(build_invocation(
+            spans, provider, model, usage, response, tool_calls,
+        ))
     }
 }
 
@@ -484,11 +488,10 @@ impl SessionMapper for OtelGenAiSessionMapper {
         let spans = spans_of(raw)?;
         let tbl = &self.table;
 
-        let provider = first_string_attr(spans, tbl.system).ok_or_else(|| {
-            MappingError::MissingAttribute {
+        let provider =
+            first_string_attr(spans, tbl.system).ok_or_else(|| MappingError::MissingAttribute {
                 name: tbl.system.to_string(),
-            }
-        })?;
+            })?;
         let model = first_string_attr(spans, tbl.response_model)
             .or_else(|| first_string_attr(spans, tbl.request_model))
             .ok_or_else(|| MappingError::MissingAttribute {
@@ -546,7 +549,9 @@ impl SessionMapper for OtelGenAiSessionMapper {
             }
         }
 
-        Ok(build_invocation(spans, provider, model, usage, response, tool_calls))
+        Ok(build_invocation(
+            spans, provider, model, usage, response, tool_calls,
+        ))
     }
 }
 
@@ -555,7 +560,9 @@ impl SessionMapper for OtelGenAiSessionMapper {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use opentelemetry::trace::{SpanContext, SpanId, SpanKind, Status, TraceFlags, TraceId, TraceState};
+    use opentelemetry::trace::{
+        SpanContext, SpanId, SpanKind, Status, TraceFlags, TraceId, TraceState,
+    };
     use opentelemetry::{InstrumentationScope, KeyValue};
     use opentelemetry_sdk::trace::{SpanEvents, SpanLinks};
     use std::borrow::Cow;
@@ -565,8 +572,8 @@ mod tests {
         let start = SystemTime::now();
         SpanData {
             span_context: SpanContext::new(
-                TraceId::from_u128(7),
-                SpanId::from_u64(7),
+                TraceId::from(7_u128),
+                SpanId::from(7_u64),
                 TraceFlags::default(),
                 false,
                 TraceState::default(),

--- a/eval/src/trace/mod.rs
+++ b/eval/src/trace/mod.rs
@@ -20,6 +20,4 @@ pub use mapper::{
     GenAIAttributeTable, GenAIConventionVersion, LangChainSessionMapper, MappingError,
     OpenInferenceSessionMapper, OtelGenAiSessionMapper, SessionMapper,
 };
-pub use provider::{
-    OtelInMemoryTraceProvider, RawSession, TraceProvider, TraceProviderError,
-};
+pub use provider::{OtelInMemoryTraceProvider, RawSession, TraceProvider, TraceProviderError};

--- a/eval/src/trace/mod.rs
+++ b/eval/src/trace/mod.rs
@@ -1,1 +1,25 @@
-//! Trace ingestion providers, mappers, and extractors.
+//! Trace ingestion providers, mappers, and extractors (spec 043 US6).
+//!
+//! Behind the `trace-ingest` feature. See:
+//! * [`provider`] — pull-side abstraction (`TraceProvider`,
+//!   `TraceProviderError`, `RawSession`, `OtelInMemoryTraceProvider`).
+//! * [`mapper`] — convert a `RawSession` into an `Invocation` per a
+//!   semantic convention (`SessionMapper`, `OpenInferenceSessionMapper`,
+//!   `LangChainSessionMapper`, `OtelGenAiSessionMapper` +
+//!   `GenAIConventionVersion`).
+//! * [`extractor`] — produce evaluator inputs at a requested
+//!   [`extractor::EvaluationLevel`] via the [`extractor::TraceExtractor`]
+//!   trait.
+
+pub mod extractor;
+pub mod mapper;
+pub mod provider;
+
+pub use extractor::{EvaluationLevel, ExtractedInput, TraceExtractor};
+pub use mapper::{
+    GenAIAttributeTable, GenAIConventionVersion, LangChainSessionMapper, MappingError,
+    OpenInferenceSessionMapper, OtelGenAiSessionMapper, SessionMapper,
+};
+pub use provider::{
+    OtelInMemoryTraceProvider, RawSession, TraceProvider, TraceProviderError,
+};

--- a/eval/src/trace/provider.rs
+++ b/eval/src/trace/provider.rs
@@ -97,10 +97,7 @@ pub trait TraceProvider: Send + Sync {
     /// Implementations MUST fail with [`TraceProviderError::SessionInProgress`]
     /// rather than silently returning a partial trace — evaluators treat the
     /// returned `RawSession` as terminal.
-    async fn fetch_session(
-        &self,
-        session_id: &str,
-    ) -> Result<RawSession, TraceProviderError>;
+    async fn fetch_session(&self, session_id: &str) -> Result<RawSession, TraceProviderError>;
 }
 
 // ─── OtelInMemoryTraceProvider ──────────────────────────────────────────────
@@ -166,24 +163,20 @@ impl OtelInMemoryTraceProvider {
 
 #[async_trait]
 impl TraceProvider for OtelInMemoryTraceProvider {
-    async fn fetch_session(
-        &self,
-        session_id: &str,
-    ) -> Result<RawSession, TraceProviderError> {
-        let all = self
-            .exporter
-            .get_finished_spans()
-            .map_err(|err| TraceProviderError::BackendFailure {
+    async fn fetch_session(&self, session_id: &str) -> Result<RawSession, TraceProviderError> {
+        let all = self.exporter.get_finished_spans().map_err(|err| {
+            TraceProviderError::BackendFailure {
                 reason: format!("in-memory exporter lock: {err}"),
-            })?;
+            }
+        })?;
 
         let key = self.session_attribute.as_ref();
         let matching: Vec<SpanData> = all
             .into_iter()
             .filter(|span| {
-                span.attributes.iter().any(|kv| {
-                    kv.key.as_str() == key && kv.value.as_str().as_ref() == session_id
-                })
+                span.attributes
+                    .iter()
+                    .any(|kv| kv.key.as_str() == key && kv.value.as_str().as_ref() == session_id)
             })
             .collect();
 
@@ -216,7 +209,9 @@ impl TraceProvider for OtelInMemoryTraceProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use opentelemetry::trace::{SpanContext, SpanId, SpanKind, Status, TraceFlags, TraceId, TraceState};
+    use opentelemetry::trace::{
+        SpanContext, SpanId, SpanKind, Status, TraceFlags, TraceId, TraceState,
+    };
     use opentelemetry::{InstrumentationScope, KeyValue};
     use opentelemetry_sdk::trace::{SpanEvents, SpanLinks};
     use std::borrow::Cow;
@@ -231,8 +226,8 @@ mod tests {
         };
         SpanData {
             span_context: SpanContext::new(
-                TraceId::from_u128(1),
-                SpanId::from_u64(1),
+                TraceId::from(1_u128),
+                SpanId::from(1_u64),
                 TraceFlags::default(),
                 false,
                 TraceState::default(),
@@ -290,17 +285,13 @@ mod tests {
     #[tokio::test]
     async fn fetch_session_uses_configured_attribute_key() {
         let exporter = InMemorySpanExporter::default();
-        let provider = OtelInMemoryTraceProvider::new(exporter.clone())
-            .with_session_attribute("custom.sid");
+        let provider =
+            OtelInMemoryTraceProvider::new(exporter.clone()).with_session_attribute("custom.sid");
         assert_eq!(provider.session_attribute(), "custom.sid");
 
         // Writing into the exporter directly simulates a recorded session.
         use opentelemetry_sdk::trace::SpanExporter;
-        let span = make_span(
-            "root",
-            vec![KeyValue::new("custom.sid", "S1")],
-            true,
-        );
+        let span = make_span("root", vec![KeyValue::new("custom.sid", "S1")], true);
         exporter.export(vec![span]).await.unwrap();
 
         let raw = provider.fetch_session("S1").await.unwrap();

--- a/eval/src/trace/provider.rs
+++ b/eval/src/trace/provider.rs
@@ -1,0 +1,314 @@
+//! `TraceProvider` trait, error type, and in-memory OTel provider.
+//!
+//! This module defines the pull-side surface for external-trace ingestion
+//! (spec 043 §FR-031): a `TraceProvider` fetches a `RawSession` from some
+//! observability backend, and a `SessionMapper` then translates that
+//! backend-specific payload into an internal `Invocation`.
+//!
+//! The always-available [`OtelInMemoryTraceProvider`] wraps
+//! `opentelemetry-sdk`'s `InMemorySpanExporter` so tests and offline eval
+//! pipelines can round-trip instrumented runs without provisioning a real
+//! backend (R-005).
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use opentelemetry_sdk::trace::{InMemorySpanExporter, SpanData};
+use thiserror::Error;
+
+// ─── RawSession ─────────────────────────────────────────────────────────────
+
+/// Backend-agnostic payload returned by a [`TraceProvider`].
+///
+/// Session mappers (see `crate::trace::mapper`) translate this into an
+/// internal `Invocation`. Currently the only shape we carry is a list of OTel
+/// spans; concrete backend providers (Langfuse, OpenSearch, CloudWatch) will
+/// add sibling variants in follow-up tasks T126–T129 without breaking
+/// existing mappers (enum is `#[non_exhaustive]`).
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub enum RawSession {
+    /// OpenTelemetry spans making up one session. Spans are in arbitrary
+    /// order; mappers MUST reconstruct parent/child relationships from
+    /// `parent_span_id`.
+    OtelSpans {
+        /// Logical session identifier as requested from the provider.
+        session_id: String,
+        /// All spans that belong to the session. Guaranteed non-empty when
+        /// returned by the provider (empty sessions surface as
+        /// [`TraceProviderError::SessionNotFound`]).
+        spans: Vec<SpanData>,
+    },
+}
+
+impl RawSession {
+    /// Session identifier this raw payload corresponds to.
+    #[must_use]
+    pub fn session_id(&self) -> &str {
+        match self {
+            Self::OtelSpans { session_id, .. } => session_id,
+        }
+    }
+}
+
+// ─── Error model ────────────────────────────────────────────────────────────
+
+/// Errors a [`TraceProvider`] can surface while fetching a session.
+#[non_exhaustive]
+#[derive(Debug, Error)]
+pub enum TraceProviderError {
+    /// The requested session id is unknown to this backend.
+    #[error("trace session `{session_id}` not found")]
+    SessionNotFound {
+        /// Session id the caller asked for.
+        session_id: String,
+    },
+
+    /// The session exists but at least one of its spans has not yet ended
+    /// (the root span is still "in progress"). Evaluators that compare
+    /// complete runs MUST NOT consume a partial session.
+    #[error("trace session `{session_id}` is still in progress ({open_spans} span(s) not ended)")]
+    SessionInProgress {
+        /// Session id the caller asked for.
+        session_id: String,
+        /// How many spans lack an `end_time` greater than `start_time`.
+        open_spans: usize,
+    },
+
+    /// The backend failed in a way unrelated to session identity (network,
+    /// auth, lock poisoning, …). String payload is free-form diagnostic.
+    #[error("trace backend failure: {reason}")]
+    BackendFailure {
+        /// Human-readable diagnostic; not part of a stable contract.
+        reason: String,
+    },
+}
+
+// ─── Trait ──────────────────────────────────────────────────────────────────
+
+/// Pull-side surface for external-trace ingestion (spec 043 FR-031).
+///
+/// Implementations SHOULD be cheap to clone (typically holding an `Arc` over
+/// their backend handle) so they can be shared across concurrent eval runs.
+#[async_trait]
+pub trait TraceProvider: Send + Sync {
+    /// Fetch the complete session identified by `session_id`.
+    ///
+    /// Implementations MUST fail with [`TraceProviderError::SessionInProgress`]
+    /// rather than silently returning a partial trace — evaluators treat the
+    /// returned `RawSession` as terminal.
+    async fn fetch_session(
+        &self,
+        session_id: &str,
+    ) -> Result<RawSession, TraceProviderError>;
+}
+
+// ─── OtelInMemoryTraceProvider ──────────────────────────────────────────────
+
+/// Always-available provider backed by
+/// [`opentelemetry_sdk::trace::InMemorySpanExporter`].
+///
+/// This provider is the round-trip fixture that backs SC-008 (OTel replay).
+/// Spans are filtered by the `session.id` attribute; any span lacking one is
+/// ignored. A span counts as "complete" when `end_time > start_time`.
+///
+/// The exporter instance is shared via `Arc`, so callers who also drive an
+/// `SdkTracerProvider` just clone the exporter and hand one clone to the
+/// tracer provider and one to this struct.
+#[derive(Clone, Debug)]
+pub struct OtelInMemoryTraceProvider {
+    /// `InMemorySpanExporter` already holds its finished-span buffer behind
+    /// an internal `Arc<Mutex<Vec<_>>>`, so cloning the exporter shares the
+    /// same span storage with whatever `SdkTracerProvider` is writing into
+    /// it. Keeping the field non-`Arc` avoids a redundant indirection.
+    exporter: InMemorySpanExporter,
+    /// Attribute key used to identify session membership. Defaults to
+    /// `"session.id"` per OTel GenAI conventions; overridable for mappers
+    /// that key on a different attribute (e.g. Langfuse `session_id`).
+    session_attribute: Arc<str>,
+}
+
+impl OtelInMemoryTraceProvider {
+    /// Wrap an existing `InMemorySpanExporter`. The exporter's finished-span
+    /// buffer is shared, so spans recorded on `exporter` after construction
+    /// are visible to subsequent `fetch_session` calls.
+    #[must_use]
+    pub fn new(exporter: InMemorySpanExporter) -> Self {
+        Self {
+            exporter,
+            session_attribute: Arc::from("session.id"),
+        }
+    }
+
+    /// Override the attribute key used to identify session membership.
+    ///
+    /// OTel GenAI conventions use `session.id`; OpenInference uses
+    /// `openinference.session.id`; custom instrumentations may differ.
+    #[must_use]
+    pub fn with_session_attribute(mut self, key: impl Into<String>) -> Self {
+        self.session_attribute = Arc::from(key.into());
+        self
+    }
+
+    /// Attribute key this provider uses to filter spans by session.
+    #[must_use]
+    pub fn session_attribute(&self) -> &str {
+        &self.session_attribute
+    }
+
+    /// Borrow the underlying exporter (escape hatch for tests that need to
+    /// drive the exporter directly).
+    #[must_use]
+    pub fn exporter(&self) -> &InMemorySpanExporter {
+        &self.exporter
+    }
+}
+
+#[async_trait]
+impl TraceProvider for OtelInMemoryTraceProvider {
+    async fn fetch_session(
+        &self,
+        session_id: &str,
+    ) -> Result<RawSession, TraceProviderError> {
+        let all = self
+            .exporter
+            .get_finished_spans()
+            .map_err(|err| TraceProviderError::BackendFailure {
+                reason: format!("in-memory exporter lock: {err}"),
+            })?;
+
+        let key = self.session_attribute.as_ref();
+        let matching: Vec<SpanData> = all
+            .into_iter()
+            .filter(|span| {
+                span.attributes.iter().any(|kv| {
+                    kv.key.as_str() == key && kv.value.as_str().as_ref() == session_id
+                })
+            })
+            .collect();
+
+        if matching.is_empty() {
+            return Err(TraceProviderError::SessionNotFound {
+                session_id: session_id.to_string(),
+            });
+        }
+
+        let open_spans = matching
+            .iter()
+            .filter(|span| span.end_time <= span.start_time)
+            .count();
+        if open_spans > 0 {
+            return Err(TraceProviderError::SessionInProgress {
+                session_id: session_id.to_string(),
+                open_spans,
+            });
+        }
+
+        Ok(RawSession::OtelSpans {
+            session_id: session_id.to_string(),
+            spans: matching,
+        })
+    }
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opentelemetry::trace::{SpanContext, SpanId, SpanKind, Status, TraceFlags, TraceId, TraceState};
+    use opentelemetry::{InstrumentationScope, KeyValue};
+    use opentelemetry_sdk::trace::{SpanEvents, SpanLinks};
+    use std::borrow::Cow;
+    use std::time::{Duration, SystemTime};
+
+    fn make_span(name: &str, attrs: Vec<KeyValue>, complete: bool) -> SpanData {
+        let start = SystemTime::now();
+        let end = if complete {
+            start + Duration::from_millis(1)
+        } else {
+            start
+        };
+        SpanData {
+            span_context: SpanContext::new(
+                TraceId::from_u128(1),
+                SpanId::from_u64(1),
+                TraceFlags::default(),
+                false,
+                TraceState::default(),
+            ),
+            parent_span_id: SpanId::INVALID,
+            parent_span_is_remote: false,
+            span_kind: SpanKind::Internal,
+            name: Cow::Owned(name.to_string()),
+            start_time: start,
+            end_time: end,
+            attributes: attrs,
+            dropped_attributes_count: 0,
+            events: SpanEvents::default(),
+            links: SpanLinks::default(),
+            status: Status::Unset,
+            instrumentation_scope: InstrumentationScope::builder("test").build(),
+        }
+    }
+
+    #[test]
+    fn raw_session_reports_session_id() {
+        let s = RawSession::OtelSpans {
+            session_id: "abc".into(),
+            spans: vec![],
+        };
+        assert_eq!(s.session_id(), "abc");
+    }
+
+    #[test]
+    fn trace_provider_error_display_includes_fields() {
+        let err = TraceProviderError::SessionNotFound {
+            session_id: "sid".into(),
+        };
+        assert!(format!("{err}").contains("sid"));
+        let err = TraceProviderError::SessionInProgress {
+            session_id: "sid".into(),
+            open_spans: 2,
+        };
+        let rendered = format!("{err}");
+        assert!(rendered.contains("sid"));
+        assert!(rendered.contains('2'));
+    }
+
+    #[tokio::test]
+    async fn fetch_session_not_found_when_no_spans_match() {
+        let exporter = InMemorySpanExporter::default();
+        let provider = OtelInMemoryTraceProvider::new(exporter);
+        let err = provider
+            .fetch_session("missing")
+            .await
+            .expect_err("empty exporter");
+        assert!(matches!(err, TraceProviderError::SessionNotFound { .. }));
+    }
+
+    #[tokio::test]
+    async fn fetch_session_uses_configured_attribute_key() {
+        let exporter = InMemorySpanExporter::default();
+        let provider = OtelInMemoryTraceProvider::new(exporter.clone())
+            .with_session_attribute("custom.sid");
+        assert_eq!(provider.session_attribute(), "custom.sid");
+
+        // Writing into the exporter directly simulates a recorded session.
+        use opentelemetry_sdk::trace::SpanExporter;
+        let span = make_span(
+            "root",
+            vec![KeyValue::new("custom.sid", "S1")],
+            true,
+        );
+        exporter.export(vec![span]).await.unwrap();
+
+        let raw = provider.fetch_session("S1").await.unwrap();
+        match raw {
+            RawSession::OtelSpans { session_id, spans } => {
+                assert_eq!(session_id, "S1");
+                assert_eq!(spans.len(), 1);
+            }
+        }
+    }
+}

--- a/eval/tests/trace_ingest_test.rs
+++ b/eval/tests/trace_ingest_test.rs
@@ -1,0 +1,175 @@
+//! Integration tests for the `trace-ingest` core surface (spec 043 T119).
+//!
+//! Covers:
+//! * `OtelInMemoryTraceProvider` round-trip (record + re-load).
+//! * Missing required attribute → `MappingError::MissingAttribute`.
+//! * Partially-written session (unfinished span) → `TraceProviderError::SessionInProgress`.
+
+#![cfg(feature = "trace-ingest")]
+
+use std::borrow::Cow;
+use std::time::{Duration, SystemTime};
+
+use opentelemetry::trace::{SpanContext, SpanId, SpanKind, Status, TraceFlags, TraceId, TraceState};
+use opentelemetry::{InstrumentationScope, KeyValue};
+use opentelemetry_sdk::trace::{
+    InMemorySpanExporter, SpanData, SpanEvents, SpanExporter, SpanLinks,
+};
+use swink_agent_eval::trace::{
+    GenAIConventionVersion, MappingError, OpenInferenceSessionMapper, OtelGenAiSessionMapper,
+    OtelInMemoryTraceProvider, RawSession, SessionMapper, TraceProvider, TraceProviderError,
+};
+
+fn span_with(
+    name: &str,
+    attrs: Vec<KeyValue>,
+    span_id: u64,
+    parent: Option<u64>,
+    complete: bool,
+) -> SpanData {
+    let start = SystemTime::now();
+    let end = if complete {
+        start + Duration::from_millis(2)
+    } else {
+        start // open span: end_time == start_time
+    };
+    SpanData {
+        span_context: SpanContext::new(
+            TraceId::from_u128(42),
+            SpanId::from_u64(span_id),
+            TraceFlags::default(),
+            false,
+            TraceState::default(),
+        ),
+        parent_span_id: parent.map(SpanId::from_u64).unwrap_or(SpanId::INVALID),
+        parent_span_is_remote: false,
+        span_kind: SpanKind::Internal,
+        name: Cow::Owned(name.to_string()),
+        start_time: start,
+        end_time: end,
+        attributes: attrs,
+        dropped_attributes_count: 0,
+        events: SpanEvents::default(),
+        links: SpanLinks::default(),
+        status: Status::Unset,
+        instrumentation_scope: InstrumentationScope::builder("integration-test").build(),
+    }
+}
+
+#[tokio::test]
+async fn otel_in_memory_trace_provider_round_trip() {
+    let exporter = InMemorySpanExporter::default();
+    let provider = OtelInMemoryTraceProvider::new(exporter.clone());
+
+    let llm = span_with(
+        "llm.call",
+        vec![
+            KeyValue::new("session.id", "sess-1"),
+            KeyValue::new("gen_ai.system", "anthropic"),
+            KeyValue::new("gen_ai.request.model", "claude-3"),
+            KeyValue::new("gen_ai.usage.input_tokens", 11_i64),
+            KeyValue::new("gen_ai.usage.output_tokens", 22_i64),
+        ],
+        1,
+        None,
+        true,
+    );
+    exporter.export(vec![llm]).await.expect("export ok");
+
+    let raw = provider
+        .fetch_session("sess-1")
+        .await
+        .expect("session found");
+    assert_eq!(raw.session_id(), "sess-1");
+
+    let inv = OtelGenAiSessionMapper::new(GenAIConventionVersion::V1_30)
+        .map(&raw)
+        .expect("map ok");
+    assert_eq!(inv.model.provider, "anthropic");
+    assert_eq!(inv.model.model_id, "claude-3");
+    assert_eq!(inv.total_usage.input, 11);
+    assert_eq!(inv.total_usage.output, 22);
+    assert_eq!(inv.total_usage.total, 33);
+}
+
+#[tokio::test]
+async fn missing_attribute_surfaces_as_mapping_error() {
+    let exporter = InMemorySpanExporter::default();
+    let provider = OtelInMemoryTraceProvider::new(exporter.clone());
+
+    // OpenInference requires `llm.provider`; omit it deliberately.
+    let llm = span_with(
+        "llm.call",
+        vec![
+            KeyValue::new("session.id", "sess-2"),
+            KeyValue::new("llm.model_name", "claude-3"),
+        ],
+        1,
+        None,
+        true,
+    );
+    exporter.export(vec![llm]).await.unwrap();
+
+    let raw = provider.fetch_session("sess-2").await.unwrap();
+    let err = OpenInferenceSessionMapper
+        .map(&raw)
+        .expect_err("provider attribute missing");
+    match err {
+        MappingError::MissingAttribute { name } => {
+            assert_eq!(name, OpenInferenceSessionMapper::PROVIDER_KEY);
+        }
+        other => panic!("expected MissingAttribute, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn partial_session_surfaces_as_session_in_progress() {
+    let exporter = InMemorySpanExporter::default();
+    let provider = OtelInMemoryTraceProvider::new(exporter.clone());
+
+    // One complete + one open span → provider MUST refuse.
+    let complete = span_with(
+        "llm.call",
+        vec![KeyValue::new("session.id", "sess-3")],
+        1,
+        None,
+        true,
+    );
+    let open = span_with(
+        "tool.call",
+        vec![KeyValue::new("session.id", "sess-3")],
+        2,
+        Some(1),
+        false,
+    );
+    exporter.export(vec![complete, open]).await.unwrap();
+
+    let err = provider
+        .fetch_session("sess-3")
+        .await
+        .expect_err("session still in progress");
+    match err {
+        TraceProviderError::SessionInProgress { session_id, open_spans } => {
+            assert_eq!(session_id, "sess-3");
+            assert!(open_spans >= 1, "at least one open span reported");
+        }
+        other => panic!("expected SessionInProgress, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn unknown_session_reports_not_found() {
+    let exporter = InMemorySpanExporter::default();
+    let provider = OtelInMemoryTraceProvider::new(exporter);
+    let err = provider.fetch_session("absent").await.expect_err("empty");
+    assert!(matches!(err, TraceProviderError::SessionNotFound { .. }));
+}
+
+#[test]
+fn raw_session_otel_variant_exposes_session_id() {
+    let raw = RawSession::OtelSpans {
+        session_id: "xyz".into(),
+        spans: vec![],
+    };
+    assert_eq!(raw.session_id(), "xyz");
+}

--- a/eval/tests/trace_ingest_test.rs
+++ b/eval/tests/trace_ingest_test.rs
@@ -10,7 +10,9 @@
 use std::borrow::Cow;
 use std::time::{Duration, SystemTime};
 
-use opentelemetry::trace::{SpanContext, SpanId, SpanKind, Status, TraceFlags, TraceId, TraceState};
+use opentelemetry::trace::{
+    SpanContext, SpanId, SpanKind, Status, TraceFlags, TraceId, TraceState,
+};
 use opentelemetry::{InstrumentationScope, KeyValue};
 use opentelemetry_sdk::trace::{
     InMemorySpanExporter, SpanData, SpanEvents, SpanExporter, SpanLinks,
@@ -35,13 +37,13 @@ fn span_with(
     };
     SpanData {
         span_context: SpanContext::new(
-            TraceId::from_u128(42),
-            SpanId::from_u64(span_id),
+            TraceId::from(42_u128),
+            SpanId::from(span_id),
             TraceFlags::default(),
             false,
             TraceState::default(),
         ),
-        parent_span_id: parent.map(SpanId::from_u64).unwrap_or(SpanId::INVALID),
+        parent_span_id: parent.map_or(SpanId::INVALID, SpanId::from),
         parent_span_is_remote: false,
         span_kind: SpanKind::Internal,
         name: Cow::Owned(name.to_string()),
@@ -149,7 +151,10 @@ async fn partial_session_surfaces_as_session_in_progress() {
         .await
         .expect_err("session still in progress");
     match err {
-        TraceProviderError::SessionInProgress { session_id, open_spans } => {
+        TraceProviderError::SessionInProgress {
+            session_id,
+            open_spans,
+        } => {
             assert_eq!(session_id, "sess-3");
             assert!(open_spans >= 1, "at least one open span reported");
         }

--- a/specs/043-evals-adv-features/tasks.md
+++ b/specs/043-evals-adv-features/tasks.md
@@ -296,13 +296,13 @@
 
 ### Core trace surface (feature `trace-ingest`)
 
-- [ ] T119 [P] [US6] Write tests in `eval/tests/trace_ingest_test.rs`: `OtelInMemoryTraceProvider` round-trip (record + re-load), missing attribute → `MappingError::MissingAttribute`, partially-written session → `TraceProviderError::SessionInProgress`
-- [ ] T120 [US6] Implement `TraceProvider` trait + `TraceProviderError` + `RawSession` in `eval/src/trace/provider.rs`
-- [ ] T121 [US6] Implement `OtelInMemoryTraceProvider` wrapping `opentelemetry-sdk`'s `InMemorySpanExporter` in `eval/src/trace/provider.rs`
-- [ ] T122 [US6] Implement `SessionMapper` trait + `MappingError` in `eval/src/trace/mapper.rs`
-- [ ] T123 [P] [US6] Implement `OpenInferenceSessionMapper` in `eval/src/trace/mapper.rs`
-- [ ] T124 [P] [US6] Implement `LangChainSessionMapper` in `eval/src/trace/mapper.rs`
-- [ ] T125 [US6] Implement `OtelGenAiSessionMapper` + `GenAIConventionVersion` enum (V1_27, V1_30, Experimental) with per-version attribute-mapping tables in `eval/src/trace/mapper.rs`
+- [x] T119 [P] [US6] Write tests in `eval/tests/trace_ingest_test.rs`: `OtelInMemoryTraceProvider` round-trip (record + re-load), missing attribute → `MappingError::MissingAttribute`, partially-written session → `TraceProviderError::SessionInProgress`
+- [x] T120 [US6] Implement `TraceProvider` trait + `TraceProviderError` + `RawSession` in `eval/src/trace/provider.rs`
+- [x] T121 [US6] Implement `OtelInMemoryTraceProvider` wrapping `opentelemetry-sdk`'s `InMemorySpanExporter` in `eval/src/trace/provider.rs`
+- [x] T122 [US6] Implement `SessionMapper` trait + `MappingError` in `eval/src/trace/mapper.rs`
+- [x] T123 [P] [US6] Implement `OpenInferenceSessionMapper` in `eval/src/trace/mapper.rs`
+- [x] T124 [P] [US6] Implement `LangChainSessionMapper` in `eval/src/trace/mapper.rs`
+- [x] T125 [US6] Implement `OtelGenAiSessionMapper` + `GenAIConventionVersion` enum (V1_27, V1_30, Experimental) with per-version attribute-mapping tables in `eval/src/trace/mapper.rs`
 
 ### Per-backend providers
 
@@ -314,7 +314,7 @@
 
 ### Extractors
 
-- [ ] T131 [US6] Implement `EvaluationLevel` enum + `TraceExtractor` trait in `eval/src/trace/extractor.rs`
+- [x] T131 [US6] Implement `EvaluationLevel` enum + `TraceExtractor` trait in `eval/src/trace/extractor.rs`
 - [ ] T132 [P] [US6] Implement `SwarmExtractor` consuming spec-040 swarm result types in `eval/src/trace/extractor.rs`
 - [ ] T133 [P] [US6] Implement `GraphExtractor` consuming spec-039 graph result types in `eval/src/trace/extractor.rs`
 - [ ] T134 [US6] Integration test in `eval/tests/us6_end_to_end_test.rs`: record in-process run via in-memory exporter; re-load via `OtelInMemoryTraceProvider` + `OpenInferenceSessionMapper`; score with deterministic evaluators; assert bit-identical scores (per SC-008)


### PR DESCRIPTION
## Summary
- TraceProvider trait + TraceProviderError + RawSession (T120)
- OtelInMemoryTraceProvider wrapping opentelemetry-sdk InMemorySpanExporter (T121)
- SessionMapper trait + MappingError (T122)
- OpenInferenceSessionMapper (T123), LangChainSessionMapper (T124), OtelGenAiSessionMapper with GenAIConventionVersion enum (T125)
- EvaluationLevel enum + TraceExtractor trait (T131)

## Tasks completed
T119, T120, T121, T122, T123, T124, T125, T131

## Deferred
T126-T130 (per-backend providers), T132-T134 (extractor impls + integration test) - follow-up PRs.

## Test plan
Worker did not run cargo; orchestrator verifies sequentially.

Part of #756

Generated with [Claude Code](https://claude.com/claude-code)