### PR TITLE
impl(043): US1a Anthropic + OpenAI judge clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4822,7 +4822,6 @@ dependencies = [
  "askama",
  "async-trait",
  "backon",
- "bincode",
  "clap",
  "futures",
  "jsonschema",
@@ -4857,6 +4856,7 @@ version = "0.8.1"
 dependencies = [
  "async-trait",
  "backon",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "swink-agent-adapters",

--- a/eval-judges/Cargo.toml
+++ b/eval-judges/Cargo.toml
@@ -27,8 +27,8 @@ all-judges = [
     "ollama",
     "proxy",
 ]
-anthropic = ["dep:swink-agent-adapters", "swink-agent-eval/judge-core"]
-openai = ["dep:swink-agent-adapters", "swink-agent-eval/judge-core"]
+anthropic = ["dep:swink-agent-adapters", "swink-agent-eval/judge-core", "dep:reqwest"]
+openai = ["dep:swink-agent-adapters", "swink-agent-eval/judge-core", "dep:reqwest"]
 bedrock = ["dep:swink-agent-adapters", "swink-agent-eval/judge-core"]
 gemini = ["dep:swink-agent-adapters", "swink-agent-eval/judge-core"]
 mistral = ["dep:swink-agent-adapters", "swink-agent-eval/judge-core"]
@@ -42,7 +42,8 @@ live-judges = []
 swink-agent-eval = { path = "../eval", version = "0.8.1", default-features = false }
 swink-agent-adapters = { path = "../adapters", version = "0.8.1", default-features = false, optional = true }
 async-trait = "0.1"
-backon.workspace = true
+backon = { workspace = true, features = ["tokio-sleep"] }
+reqwest = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
@@ -51,6 +52,8 @@ tokio-util.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+swink-agent-eval = { path = "../eval", default-features = false, features = ["judge-core"] }
+tokio = { workspace = true, features = ["full", "test-util"] }
 wiremock.workspace = true
 
 [lints]

--- a/eval-judges/Cargo.toml
+++ b/eval-judges/Cargo.toml
@@ -9,6 +9,11 @@ repository.workspace = true
 readme = "../README.md"
 keywords = ["llm", "eval", "judge", "adapter", "testing"]
 categories = ["development-tools", "api-bindings", "asynchronous"]
+# Spec 043 in-progress — the crate layout shifts between phases (stubs in
+# T008 → real impls in T038–T046 → public surface in T054). Keep unpublished
+# until Phase 12 workspace bump (T180) so semver-checks doesn't gate on
+# intermediate breaking shape changes.
+publish = false
 
 [package.metadata.docs.rs]
 all-features = true

--- a/eval-judges/src/anthropic.rs
+++ b/eval-judges/src/anthropic.rs
@@ -1,7 +1,325 @@
-//! Anthropic judge client scaffold.
+//! Anthropic Messages judge client.
+//!
+//! Wraps a plain `reqwest::Client` around the Anthropic `/v1/messages`
+//! endpoint and dispatches a single-turn user prompt, returning the JSON
+//! verdict the judge template is expected to emit. The full streaming /
+//! tool-use adapter surface in `swink-agent-adapters` is deliberately
+//! bypassed: judge calls need one request and one response, not the
+//! SSE / tool-use state machine.
+//!
+//! Error mapping (see FR-004 + research.md §R-002):
+//!
+//! * Transport failures → [`JudgeError::Transport`].
+//! * HTTP 429 / 5xx → [`JudgeError::Transport`] so the shared retry helper
+//!   in [`crate::client`] classifies them as retryable.
+//! * Non-2xx / non-retryable 4xx → [`JudgeError::Other`] (terminal).
+//! * Response body that fails JSON verdict parsing →
+//!   [`JudgeError::MalformedResponse`].
+//! * Cancellation (via the supplied [`CancellationToken`]) surfaces as
+//!   [`JudgeError::Other`] with a cancellation tag.
 
-#[derive(Debug, Clone, Default)]
-pub struct AnthropicJudgeClient;
+use std::sync::Arc;
+use std::time::Duration;
 
-#[derive(Debug, Clone, Default)]
-pub struct BlockingAnthropicJudgeClient;
+use async_trait::async_trait;
+use reqwest::{Client, StatusCode};
+use serde::{Deserialize, Serialize};
+use tokio_util::sync::CancellationToken;
+
+use swink_agent_eval::judge::{JudgeClient, JudgeError, JudgeVerdict, RetryPolicy};
+
+use crate::client::{is_retryable, parse_verdict_text, retry_with_cancel};
+
+const DEFAULT_ANTHROPIC_VERSION: &str = "2023-06-01";
+const DEFAULT_MAX_TOKENS: u32 = 1024;
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Async judge client backed by the Anthropic Messages API.
+///
+/// Constructed via [`AnthropicJudgeClient::new`]; clone is cheap (HTTP
+/// client + `Arc`-held config).
+#[derive(Clone)]
+pub struct AnthropicJudgeClient {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    base_url: String,
+    api_key: String,
+    model: String,
+    anthropic_version: String,
+    max_tokens: u32,
+    retry_policy: RetryPolicy,
+    cancel: CancellationToken,
+    http: Client,
+}
+
+impl std::fmt::Debug for AnthropicJudgeClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AnthropicJudgeClient")
+            .field("base_url", &self.inner.base_url)
+            .field("model", &self.inner.model)
+            .field("anthropic_version", &self.inner.anthropic_version)
+            .field("retry_policy", &self.inner.retry_policy)
+            .finish_non_exhaustive()
+    }
+}
+
+impl AnthropicJudgeClient {
+    /// Build a new judge client pointed at `base_url` (e.g.
+    /// `https://api.anthropic.com`). `model` is the Anthropic model id
+    /// used for every judge call.
+    #[must_use]
+    pub fn new(
+        base_url: impl Into<String>,
+        api_key: impl Into<String>,
+        model: impl Into<String>,
+    ) -> Self {
+        let http = Client::builder()
+            .timeout(DEFAULT_TIMEOUT)
+            .build()
+            .unwrap_or_else(|_| Client::new());
+        Self {
+            inner: Arc::new(Inner {
+                base_url: base_url.into().trim_end_matches('/').to_string(),
+                api_key: api_key.into(),
+                model: model.into(),
+                anthropic_version: DEFAULT_ANTHROPIC_VERSION.to_string(),
+                max_tokens: DEFAULT_MAX_TOKENS,
+                retry_policy: RetryPolicy::default(),
+                cancel: CancellationToken::new(),
+                http,
+            }),
+        }
+    }
+
+    /// Override the `anthropic-version` header.
+    #[must_use]
+    pub fn with_anthropic_version(mut self, version: impl Into<String>) -> Self {
+        Arc::make_mut(&mut self.inner).anthropic_version = version.into();
+        self
+    }
+
+    /// Override the `max_tokens` request field. Default: 1024.
+    #[must_use]
+    pub fn with_max_tokens(mut self, max_tokens: u32) -> Self {
+        Arc::make_mut(&mut self.inner).max_tokens = max_tokens;
+        self
+    }
+
+    /// Override the shared retry policy.
+    #[must_use]
+    pub fn with_retry_policy(mut self, policy: RetryPolicy) -> Self {
+        Arc::make_mut(&mut self.inner).retry_policy = policy;
+        self
+    }
+
+    /// Attach an external cancellation token. The default client owns an
+    /// internal token that is never cancelled automatically.
+    #[must_use]
+    pub fn with_cancellation(mut self, cancel: CancellationToken) -> Self {
+        Arc::make_mut(&mut self.inner).cancel = cancel;
+        self
+    }
+
+    /// Borrow the configured cancellation token.
+    #[must_use]
+    pub fn cancellation(&self) -> CancellationToken {
+        self.inner.cancel.clone()
+    }
+
+    async fn dispatch_once(&self, prompt: &str) -> Result<JudgeVerdict, JudgeError> {
+        let body = AnthropicRequest {
+            model: &self.inner.model,
+            max_tokens: self.inner.max_tokens,
+            messages: vec![AnthropicMessage {
+                role: "user",
+                content: prompt,
+            }],
+        };
+
+        let url = format!("{}/v1/messages", self.inner.base_url);
+
+        let resp = self
+            .inner
+            .http
+            .post(&url)
+            .header("x-api-key", &self.inner.api_key)
+            .header("anthropic-version", &self.inner.anthropic_version)
+            .header("content-type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| JudgeError::Transport(format!("anthropic request failed: {e}")))?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let text = resp.text().await.unwrap_or_default();
+            return Err(classify_http_error(status, &text));
+        }
+
+        let parsed: AnthropicResponse = resp.json().await.map_err(|e| {
+            JudgeError::MalformedResponse(format!("anthropic body parse failed: {e}"))
+        })?;
+
+        extract_verdict(&parsed)
+    }
+}
+
+// Clone requires `Inner` be clone-on-write via Arc::make_mut; provide impl.
+impl Clone for Inner {
+    fn clone(&self) -> Self {
+        Self {
+            base_url: self.base_url.clone(),
+            api_key: self.api_key.clone(),
+            model: self.model.clone(),
+            anthropic_version: self.anthropic_version.clone(),
+            max_tokens: self.max_tokens,
+            retry_policy: self.retry_policy.clone(),
+            cancel: self.cancel.clone(),
+            http: self.http.clone(),
+        }
+    }
+}
+
+#[async_trait]
+impl JudgeClient for AnthropicJudgeClient {
+    async fn judge(&self, prompt: &str) -> Result<JudgeVerdict, JudgeError> {
+        let this = self;
+        let prompt = prompt;
+        retry_with_cancel(
+            &self.inner.retry_policy,
+            &self.inner.cancel,
+            is_retryable,
+            || async move { this.dispatch_once(prompt).await },
+        )
+        .await
+    }
+}
+
+/// Blocking convenience wrapper around [`AnthropicJudgeClient`] for callers
+/// that cannot spin a Tokio runtime themselves.
+///
+/// Uses the *current* Tokio runtime handle (see [`crate::client::BlockingExt`])
+/// so it must be called from a thread with an active multi-thread runtime.
+#[derive(Clone, Debug)]
+pub struct BlockingAnthropicJudgeClient {
+    inner: AnthropicJudgeClient,
+}
+
+impl BlockingAnthropicJudgeClient {
+    /// Wrap an existing [`AnthropicJudgeClient`].
+    #[must_use]
+    pub const fn new(inner: AnthropicJudgeClient) -> Self {
+        Self { inner }
+    }
+
+    /// Run a single judge call synchronously on the current Tokio runtime.
+    pub fn judge(&self, prompt: &str) -> Result<JudgeVerdict, JudgeError> {
+        let client = self.inner.clone();
+        let prompt = prompt.to_string();
+        tokio::runtime::Handle::current()
+            .block_on(async move { client.judge(&prompt).await })
+    }
+
+    /// Borrow the underlying async client for mixed sync/async call sites.
+    #[must_use]
+    pub const fn inner(&self) -> &AnthropicJudgeClient {
+        &self.inner
+    }
+}
+
+// ─── Wire types ─────────────────────────────────────────────────────────────
+
+#[derive(Serialize)]
+struct AnthropicRequest<'a> {
+    model: &'a str,
+    max_tokens: u32,
+    messages: Vec<AnthropicMessage<'a>>,
+}
+
+#[derive(Serialize)]
+struct AnthropicMessage<'a> {
+    role: &'a str,
+    content: &'a str,
+}
+
+#[derive(Deserialize, Debug)]
+struct AnthropicResponse {
+    #[serde(default)]
+    content: Vec<AnthropicResponseBlock>,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(tag = "type")]
+enum AnthropicResponseBlock {
+    #[serde(rename = "text")]
+    Text { text: String },
+    #[serde(other)]
+    Other,
+}
+
+fn classify_http_error(status: StatusCode, body: &str) -> JudgeError {
+    // 429 and 5xx are retryable per R-002.
+    if status == StatusCode::TOO_MANY_REQUESTS || status.is_server_error() {
+        JudgeError::Transport(format!("anthropic http {}: {}", status.as_u16(), truncate(body)))
+    } else {
+        JudgeError::Other(format!(
+            "anthropic http {}: {}",
+            status.as_u16(),
+            truncate(body)
+        ))
+    }
+}
+
+fn truncate(body: &str) -> String {
+    const LIMIT: usize = 512;
+    if body.len() <= LIMIT {
+        body.to_string()
+    } else {
+        format!("{}…", &body[..LIMIT])
+    }
+}
+
+/// Parse the judge verdict from the first text block in the Anthropic
+/// response.
+///
+/// Accepts either a bare JSON object with the verdict fields or the same
+/// object wrapped in a markdown code fence. Anything else is surfaced as
+/// [`JudgeError::MalformedResponse`] so the retry helper classifies it as
+/// terminal.
+fn extract_verdict(resp: &AnthropicResponse) -> Result<JudgeVerdict, JudgeError> {
+    let text = resp
+        .content
+        .iter()
+        .find_map(|b| match b {
+            AnthropicResponseBlock::Text { text } => Some(text.as_str()),
+            AnthropicResponseBlock::Other => None,
+        })
+        .ok_or_else(|| JudgeError::MalformedResponse("no text block in anthropic response".into()))?;
+
+    parse_verdict_text(text)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_429_is_transport() {
+        let err = classify_http_error(StatusCode::TOO_MANY_REQUESTS, "rate");
+        assert!(matches!(err, JudgeError::Transport(_)));
+    }
+
+    #[test]
+    fn classify_500_is_transport() {
+        let err = classify_http_error(StatusCode::INTERNAL_SERVER_ERROR, "boom");
+        assert!(matches!(err, JudgeError::Transport(_)));
+    }
+
+    #[test]
+    fn classify_400_is_terminal() {
+        let err = classify_http_error(StatusCode::BAD_REQUEST, "nope");
+        assert!(matches!(err, JudgeError::Other(_)));
+    }
+}

--- a/eval-judges/src/anthropic.rs
+++ b/eval-judges/src/anthropic.rs
@@ -218,8 +218,7 @@ impl BlockingAnthropicJudgeClient {
     pub fn judge(&self, prompt: &str) -> Result<JudgeVerdict, JudgeError> {
         let client = self.inner.clone();
         let prompt = prompt.to_string();
-        tokio::runtime::Handle::current()
-            .block_on(async move { client.judge(&prompt).await })
+        tokio::runtime::Handle::current().block_on(async move { client.judge(&prompt).await })
     }
 
     /// Borrow the underlying async client for mixed sync/async call sites.
@@ -262,7 +261,11 @@ enum AnthropicResponseBlock {
 fn classify_http_error(status: StatusCode, body: &str) -> JudgeError {
     // 429 and 5xx are retryable per R-002.
     if status == StatusCode::TOO_MANY_REQUESTS || status.is_server_error() {
-        JudgeError::Transport(format!("anthropic http {}: {}", status.as_u16(), truncate(body)))
+        JudgeError::Transport(format!(
+            "anthropic http {}: {}",
+            status.as_u16(),
+            truncate(body)
+        ))
     } else {
         JudgeError::Other(format!(
             "anthropic http {}: {}",
@@ -296,7 +299,9 @@ fn extract_verdict(resp: &AnthropicResponse) -> Result<JudgeVerdict, JudgeError>
             AnthropicResponseBlock::Text { text } => Some(text.as_str()),
             AnthropicResponseBlock::Other => None,
         })
-        .ok_or_else(|| JudgeError::MalformedResponse("no text block in anthropic response".into()))?;
+        .ok_or_else(|| {
+            JudgeError::MalformedResponse("no text block in anthropic response".into())
+        })?;
 
     parse_verdict_text(text)
 }

--- a/eval-judges/src/client.rs
+++ b/eval-judges/src/client.rs
@@ -88,10 +88,10 @@ where
     }
 }
 
-/// Classifier: return `true` for [`JudgeError`] variants that a judge client
-/// should retry. Transport errors are assumed transient (the provider layer
-/// tags 429 / 5xx as [`JudgeError::Transport`]); every other variant is
-/// terminal.
+/// Classifier: return `true` for [`JudgeError`] variants that a judge client should retry.
+///
+/// Transport errors are assumed transient (the provider layer tags 429 / 5xx
+/// as [`JudgeError::Transport`]); every other variant is terminal.
 #[must_use]
 pub fn is_retryable(err: &JudgeError) -> bool {
     matches!(err, JudgeError::Transport(_))
@@ -147,10 +147,7 @@ impl BatchedJudgeClient {
     /// the wrapper preserves input order and returns one `Result<_, _>` per
     /// prompt (never short-circuits on the first error) so callers can
     /// decide per-case remediation.
-    pub async fn judge_batch(
-        &self,
-        prompts: &[String],
-    ) -> Vec<Result<JudgeVerdict, JudgeError>> {
+    pub async fn judge_batch(&self, prompts: &[String]) -> Vec<Result<JudgeVerdict, JudgeError>> {
         let mut out = Vec::with_capacity(prompts.len());
         for chunk in prompts.chunks(self.batch_size) {
             for prompt in chunk {
@@ -196,10 +193,11 @@ pub const fn fast_test_policy() -> RetryPolicy {
     RetryPolicy::new(3, Duration::from_millis(50), false)
 }
 
-/// Parse a judge verdict out of an arbitrary text blob. Supports bare
-/// JSON objects or the same object wrapped in a fenced code block. Each
-/// judge client extracts the provider's text content and funnels it
-/// through this helper so the verdict schema stays identical across
+/// Parse a judge verdict out of an arbitrary text blob.
+///
+/// Supports bare JSON objects or the same object wrapped in a fenced code
+/// block. Each judge client extracts the provider's text content and funnels
+/// it through this helper so the verdict schema stays identical across
 /// providers.
 pub fn parse_verdict_text(text: &str) -> Result<JudgeVerdict, JudgeError> {
     let cleaned = strip_code_fence(text.trim());
@@ -408,6 +406,9 @@ mod tests {
         .await;
 
         assert!(matches!(result, Err(JudgeError::Transport(_))));
-        assert_eq!(attempts.load(Ordering::SeqCst), policy.max_attempts as usize);
+        assert_eq!(
+            attempts.load(Ordering::SeqCst),
+            policy.max_attempts as usize
+        );
     }
 }

--- a/eval-judges/src/client.rs
+++ b/eval-judges/src/client.rs
@@ -1,30 +1,172 @@
-//! Shared retry and blocking helpers for judge clients.
+//! Shared retry, cancellation, and batching helpers used by every judge
+//! client in this crate.
+//!
+//! The building blocks are deliberately small:
+//!
+//! * [`build_retry`] wraps [`RetryPolicy`] into a `backon::ExponentialBuilder`
+//!   pinned to the policy values from research.md §R-002 (6 attempts,
+//!   4-minute max delay, jitter on).
+//! * [`retry_with_cancel`] runs an async factory under that builder while
+//!   racing each attempt against a [`CancellationToken`], so cancellation
+//!   surfaces as [`JudgeError::Other`] rather than waiting out the backoff
+//!   schedule.
+//! * [`BatchedJudgeClient`] wraps a [`JudgeClient`] and exposes a
+//!   [`BatchedJudgeClient::judge_batch`] convenience that dispatches up to
+//!   `batch_size` prompts. Providers that do not support native batching fall
+//!   through to sequential dispatch here (FR-005).
+//! * [`BlockingExt`] is a small adapter so provider-specific `Blocking*`
+//!   wrappers can reuse a single `block_on` helper.
 
 use std::future::Future;
+use std::sync::Arc;
 use std::time::Duration;
 
-/// Shared retry policy scaffold for judge clients.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct RetryPolicy {
-    /// Maximum number of attempts, including the initial request.
-    pub max_attempts: usize,
-    /// Upper bound for backoff delay between attempts.
-    pub max_delay: Duration,
+use backon::{ExponentialBuilder, Retryable};
+use tokio_util::sync::CancellationToken;
+
+use swink_agent_eval::judge::{JudgeClient, JudgeError, JudgeVerdict, MAX_BATCH_SIZE, RetryPolicy};
+
+/// Convert a workspace [`RetryPolicy`] into a `backon::ExponentialBuilder`
+/// pinned to the research.md §R-002 schedule (jitter on by default).
+///
+/// `RetryPolicy::max_attempts` is the **total** attempts allowed (initial
+/// call plus retries), matching FR-004 ("up to 6 attempts"). Backon's
+/// `with_max_times` is the retry count, so this helper subtracts one from
+/// `max_attempts` with a floor of zero — i.e. `max_attempts = 1` means
+/// "one shot, no retries".
+#[must_use]
+pub fn build_retry(policy: &RetryPolicy) -> ExponentialBuilder {
+    let max_retries = policy.max_attempts.saturating_sub(1) as usize;
+    // Floor the per-attempt minimum at the policy's `max_delay` so tight
+    // test policies (`max_delay = 10ms`) don't inherit the backon default
+    // of 1 s. In production, `max_delay = 4 min` dominates `min_delay =
+    // 1 s` and the schedule is unaffected.
+    let min_delay = std::cmp::min(Duration::from_secs(1), policy.max_delay);
+    let mut builder = ExponentialBuilder::default()
+        .with_max_times(max_retries)
+        .with_min_delay(min_delay)
+        .with_max_delay(policy.max_delay);
+    if policy.jitter {
+        builder = builder.with_jitter();
+    }
+    builder
 }
 
-impl Default for RetryPolicy {
-    fn default() -> Self {
-        Self {
-            max_attempts: 6,
-            max_delay: Duration::from_mins(4),
-        }
+/// Run a retryable async factory under [`build_retry`] while racing each
+/// attempt against `cancel`.
+///
+/// * `should_retry` classifies [`JudgeError`] values. It must return `true`
+///   only for transient errors (e.g. HTTP 429 / 5xx). Terminal errors are
+///   bubbled through immediately so unit-test expectations stay tight.
+/// * Cancellation wins the race: if the token fires mid-attempt, the future
+///   resolves to [`JudgeError::Other`] with a cancellation tag and the
+///   builder schedule is abandoned.
+pub async fn retry_with_cancel<Fut, Factory, Retry>(
+    policy: &RetryPolicy,
+    cancel: &CancellationToken,
+    should_retry: Retry,
+    factory: Factory,
+) -> Result<JudgeVerdict, JudgeError>
+where
+    Factory: FnMut() -> Fut,
+    Fut: Future<Output = Result<JudgeVerdict, JudgeError>>,
+    Retry: Fn(&JudgeError) -> bool,
+{
+    if cancel.is_cancelled() {
+        return Err(JudgeError::Other("cancelled".to_string()));
+    }
+
+    let builder = build_retry(policy);
+    // Wrap the Retry driver in an async block so `tokio::select!` can
+    // race it against cancellation uniformly.
+    let driver = async move { factory.retry(builder).when(should_retry).await };
+
+    tokio::select! {
+        biased;
+        () = cancel.cancelled() => Err(JudgeError::Other("cancelled".to_string())),
+        res = driver => res,
     }
 }
 
-/// Returns the retry policy that downstream clients should apply.
+/// Classifier: return `true` for [`JudgeError`] variants that a judge client
+/// should retry. Transport errors are assumed transient (the provider layer
+/// tags 429 / 5xx as [`JudgeError::Transport`]); every other variant is
+/// terminal.
 #[must_use]
-pub const fn build_retry(policy: RetryPolicy) -> RetryPolicy {
-    policy
+pub fn is_retryable(err: &JudgeError) -> bool {
+    matches!(err, JudgeError::Transport(_))
+}
+
+/// Wrapper around a [`JudgeClient`] providing a batched dispatch surface.
+///
+/// Call sites ask for `judge_batch(prompts)`; this helper enforces the
+/// bounded batch size `[1, 128]` from FR-005 and falls back to sequential
+/// dispatch for providers that do not ship a native batch endpoint. When a
+/// provider later grows a native batch call it can reimplement this wrapper
+/// without disturbing callers.
+pub struct BatchedJudgeClient {
+    inner: Arc<dyn JudgeClient>,
+    batch_size: usize,
+}
+
+impl BatchedJudgeClient {
+    /// Error value returned when `batch_size` falls outside the supported
+    /// `[1, 128]` window.
+    pub const INVALID_BATCH_MESSAGE: &'static str = "batch_size must be in 1..=128";
+
+    /// Build a batching wrapper around `inner` with the supplied
+    /// `batch_size`.
+    ///
+    /// Returns [`JudgeError::Other`] when `batch_size` is outside the
+    /// supported window to match the rest of the judge-layer error model.
+    pub fn new(inner: Arc<dyn JudgeClient>, batch_size: usize) -> Result<Self, JudgeError> {
+        if !(1..=MAX_BATCH_SIZE).contains(&batch_size) {
+            return Err(JudgeError::Other(format!(
+                "{}, got {batch_size}",
+                Self::INVALID_BATCH_MESSAGE
+            )));
+        }
+        Ok(Self { inner, batch_size })
+    }
+
+    /// Bounded batch size, always in `[1, 128]`.
+    #[must_use]
+    pub const fn batch_size(&self) -> usize {
+        self.batch_size
+    }
+
+    /// Borrow the wrapped judge client.
+    #[must_use]
+    pub fn inner(&self) -> &Arc<dyn JudgeClient> {
+        &self.inner
+    }
+
+    /// Dispatch `prompts` in chunks of at most `batch_size`.
+    ///
+    /// Non-native-batch providers fall through to sequential dispatch here;
+    /// the wrapper preserves input order and returns one `Result<_, _>` per
+    /// prompt (never short-circuits on the first error) so callers can
+    /// decide per-case remediation.
+    pub async fn judge_batch(
+        &self,
+        prompts: &[String],
+    ) -> Vec<Result<JudgeVerdict, JudgeError>> {
+        let mut out = Vec::with_capacity(prompts.len());
+        for chunk in prompts.chunks(self.batch_size) {
+            for prompt in chunk {
+                out.push(self.inner.judge(prompt).await);
+            }
+        }
+        out
+    }
+}
+
+impl std::fmt::Debug for BatchedJudgeClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BatchedJudgeClient")
+            .field("batch_size", &self.batch_size)
+            .finish_non_exhaustive()
+    }
 }
 
 /// Extension trait for provider-specific blocking wrappers.
@@ -46,4 +188,226 @@ where
     F: Future + Send + 'static,
     F::Output: Send + 'static,
 {
+}
+
+/// Small policy used by tests and callers that want a tight retry schedule.
+#[must_use]
+pub const fn fast_test_policy() -> RetryPolicy {
+    RetryPolicy::new(3, Duration::from_millis(50), false)
+}
+
+/// Parse a judge verdict out of an arbitrary text blob. Supports bare
+/// JSON objects or the same object wrapped in a fenced code block. Each
+/// judge client extracts the provider's text content and funnels it
+/// through this helper so the verdict schema stays identical across
+/// providers.
+pub fn parse_verdict_text(text: &str) -> Result<JudgeVerdict, JudgeError> {
+    let cleaned = strip_code_fence(text.trim());
+    let value: serde_json::Value = serde_json::from_str(cleaned)
+        .map_err(|e| JudgeError::MalformedResponse(format!("verdict not valid JSON: {e}")))?;
+
+    let obj = value
+        .as_object()
+        .ok_or_else(|| JudgeError::MalformedResponse("verdict must be a JSON object".into()))?;
+
+    let score = obj
+        .get("score")
+        .and_then(serde_json::Value::as_f64)
+        .ok_or_else(|| JudgeError::MalformedResponse("verdict missing numeric `score`".into()))?;
+    let pass = obj
+        .get("pass")
+        .and_then(serde_json::Value::as_bool)
+        .ok_or_else(|| JudgeError::MalformedResponse("verdict missing boolean `pass`".into()))?;
+    let reason = obj
+        .get("reason")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string);
+    let label = obj
+        .get("label")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string);
+
+    Ok(JudgeVerdict {
+        score: score.clamp(0.0, 1.0),
+        pass,
+        reason,
+        label,
+    })
+}
+
+fn strip_code_fence(text: &str) -> &str {
+    let trimmed = text.trim();
+    if let Some(rest) = trimmed.strip_prefix("```json") {
+        return rest.trim().trim_end_matches("```").trim();
+    }
+    if let Some(rest) = trimmed.strip_prefix("```") {
+        return rest.trim().trim_end_matches("```").trim();
+    }
+    trimmed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct CountingJudge {
+        calls: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl JudgeClient for CountingJudge {
+        async fn judge(&self, _prompt: &str) -> Result<JudgeVerdict, JudgeError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(JudgeVerdict {
+                score: 1.0,
+                pass: true,
+                reason: None,
+                label: None,
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn batched_dispatch_preserves_order_and_chunks() {
+        let inner = Arc::new(CountingJudge {
+            calls: AtomicUsize::new(0),
+        });
+        let batched = BatchedJudgeClient::new(inner.clone(), 2).expect("valid batch size");
+        let prompts = vec![
+            "a".to_string(),
+            "b".to_string(),
+            "c".to_string(),
+            "d".to_string(),
+            "e".to_string(),
+        ];
+        let results = batched.judge_batch(&prompts).await;
+        assert_eq!(results.len(), prompts.len());
+        assert_eq!(inner.calls.load(Ordering::SeqCst), prompts.len());
+        for r in results {
+            assert!(r.is_ok());
+        }
+    }
+
+    #[test]
+    fn batch_size_zero_rejected() {
+        let inner: Arc<dyn JudgeClient> = Arc::new(CountingJudge {
+            calls: AtomicUsize::new(0),
+        });
+        let err = BatchedJudgeClient::new(inner, 0).expect_err("must reject zero");
+        match err {
+            JudgeError::Other(msg) => assert!(msg.contains("batch_size")),
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn batch_size_above_cap_rejected() {
+        let inner: Arc<dyn JudgeClient> = Arc::new(CountingJudge {
+            calls: AtomicUsize::new(0),
+        });
+        let err = BatchedJudgeClient::new(inner, MAX_BATCH_SIZE + 1).expect_err("must reject");
+        match err {
+            JudgeError::Other(msg) => assert!(msg.contains("batch_size")),
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn retry_classifier_only_retries_transport() {
+        assert!(is_retryable(&JudgeError::Transport("429".into())));
+        assert!(!is_retryable(&JudgeError::Timeout));
+        assert!(!is_retryable(&JudgeError::MalformedResponse("x".into())));
+        assert!(!is_retryable(&JudgeError::Other("x".into())));
+    }
+
+    #[tokio::test]
+    async fn retry_surfaces_cancellation_as_other() {
+        let policy = fast_test_policy();
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+
+        let result = retry_with_cancel(&policy, &cancel, is_retryable, || async {
+            Ok(JudgeVerdict {
+                score: 1.0,
+                pass: true,
+                reason: None,
+                label: None,
+            })
+        })
+        .await;
+
+        match result {
+            Err(JudgeError::Other(msg)) => assert!(msg.contains("cancel")),
+            other => panic!("expected cancellation, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn retry_bails_on_terminal_error() {
+        let policy = fast_test_policy();
+        let cancel = CancellationToken::new();
+        let attempts = AtomicUsize::new(0);
+
+        let result = retry_with_cancel(&policy, &cancel, is_retryable, || {
+            attempts.fetch_add(1, Ordering::SeqCst);
+            async { Err::<JudgeVerdict, JudgeError>(JudgeError::MalformedResponse("x".into())) }
+        })
+        .await;
+
+        assert!(matches!(result, Err(JudgeError::MalformedResponse(_))));
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn parse_verdict_plain_json() {
+        let verdict = parse_verdict_text(r#"{"score": 0.8, "pass": true, "reason": "ok"}"#)
+            .expect("verdict parses");
+        assert!((verdict.score - 0.8).abs() < f64::EPSILON);
+        assert!(verdict.pass);
+        assert_eq!(verdict.reason.as_deref(), Some("ok"));
+    }
+
+    #[test]
+    fn parse_verdict_fenced_json() {
+        let verdict =
+            parse_verdict_text("```json\n{\"score\": 0.5, \"pass\": false}\n```").expect("parse");
+        assert!(!verdict.pass);
+        assert!((verdict.score - 0.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn parse_verdict_clamps_out_of_range_score() {
+        let v = parse_verdict_text(r#"{"score": 1.8, "pass": true}"#).expect("parse");
+        assert!((v.score - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn parse_verdict_missing_pass_is_malformed() {
+        let err = parse_verdict_text(r#"{"score": 0.5}"#).expect_err("must fail");
+        assert!(matches!(err, JudgeError::MalformedResponse(_)));
+    }
+
+    #[test]
+    fn parse_verdict_non_json_is_malformed() {
+        let err = parse_verdict_text("not json at all").expect_err("must fail");
+        assert!(matches!(err, JudgeError::MalformedResponse(_)));
+    }
+
+    #[tokio::test]
+    async fn retry_retries_transport_up_to_cap() {
+        let policy = fast_test_policy();
+        let cancel = CancellationToken::new();
+        let attempts = AtomicUsize::new(0);
+
+        let result = retry_with_cancel(&policy, &cancel, is_retryable, || {
+            attempts.fetch_add(1, Ordering::SeqCst);
+            async { Err::<JudgeVerdict, JudgeError>(JudgeError::Transport("429".into())) }
+        })
+        .await;
+
+        assert!(matches!(result, Err(JudgeError::Transport(_))));
+        assert_eq!(attempts.load(Ordering::SeqCst), policy.max_attempts as usize);
+    }
 }

--- a/eval-judges/src/openai.rs
+++ b/eval-judges/src/openai.rs
@@ -39,6 +39,7 @@ pub struct OpenAiJudgeClient {
 }
 
 /// Alias for spec-doc callers that use `OpenAI` capitalization.
+#[allow(dead_code)]
 pub type OpenAIJudgeClient = OpenAiJudgeClient;
 
 struct Inner {
@@ -159,9 +160,10 @@ impl OpenAiJudgeClient {
             return Err(classify_http_error(status, &text));
         }
 
-        let parsed: OpenAiResponse = resp.json().await.map_err(|e| {
-            JudgeError::MalformedResponse(format!("openai body parse failed: {e}"))
-        })?;
+        let parsed: OpenAiResponse = resp
+            .json()
+            .await
+            .map_err(|e| JudgeError::MalformedResponse(format!("openai body parse failed: {e}")))?;
 
         extract_verdict(&parsed)
     }
@@ -199,8 +201,7 @@ impl BlockingOpenAiJudgeClient {
     pub fn judge(&self, prompt: &str) -> Result<JudgeVerdict, JudgeError> {
         let client = self.inner.clone();
         let prompt = prompt.to_string();
-        tokio::runtime::Handle::current()
-            .block_on(async move { client.judge(&prompt).await })
+        tokio::runtime::Handle::current().block_on(async move { client.judge(&prompt).await })
     }
 
     /// Borrow the underlying async client for mixed sync/async call sites.
@@ -243,9 +244,17 @@ struct OpenAiChoiceMessage {
 
 fn classify_http_error(status: StatusCode, body: &str) -> JudgeError {
     if status == StatusCode::TOO_MANY_REQUESTS || status.is_server_error() {
-        JudgeError::Transport(format!("openai http {}: {}", status.as_u16(), truncate(body)))
+        JudgeError::Transport(format!(
+            "openai http {}: {}",
+            status.as_u16(),
+            truncate(body)
+        ))
     } else {
-        JudgeError::Other(format!("openai http {}: {}", status.as_u16(), truncate(body)))
+        JudgeError::Other(format!(
+            "openai http {}: {}",
+            status.as_u16(),
+            truncate(body)
+        ))
     }
 }
 

--- a/eval-judges/src/openai.rs
+++ b/eval-judges/src/openai.rs
@@ -1,7 +1,291 @@
-//! OpenAI judge client scaffold.
+//! OpenAI Chat Completions judge client.
+//!
+//! Mirrors the shape of [`crate::anthropic::AnthropicJudgeClient`]: a
+//! single-request, single-response POST to the provider plus shared
+//! retry / cancellation via [`crate::client::retry_with_cancel`]. The
+//! full SSE / tool-use pipeline in `swink-agent-adapters::openai` is
+//! deliberately bypassed — a judge call does not need a streaming
+//! assistant loop.
+//!
+//! The exported name preserves the existing `OpenAi…` casing used by
+//! `eval-judges/src/lib.rs`; a `type OpenAIJudgeClient =
+//! OpenAiJudgeClient` alias is provided so spec documentation that uses
+//! `OpenAIJudgeClient` also compiles.
 
-#[derive(Debug, Clone, Default)]
-pub struct OpenAiJudgeClient;
+use std::sync::Arc;
+use std::time::Duration;
 
-#[derive(Debug, Clone, Default)]
-pub struct BlockingOpenAiJudgeClient;
+use async_trait::async_trait;
+use reqwest::{Client, StatusCode};
+use serde::{Deserialize, Serialize};
+use tokio_util::sync::CancellationToken;
+
+use swink_agent_eval::judge::{JudgeClient, JudgeError, JudgeVerdict, RetryPolicy};
+
+use crate::client::{is_retryable, parse_verdict_text, retry_with_cancel};
+
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(60);
+const DEFAULT_TEMPERATURE: f32 = 0.0;
+
+/// Async judge client backed by an OpenAI-compatible Chat Completions
+/// endpoint.
+///
+/// Works for OpenAI itself and any OpenAI-compatible provider with a
+/// `Bearer <api_key>` auth scheme and the `/v1/chat/completions`
+/// endpoint shape.
+#[derive(Clone)]
+pub struct OpenAiJudgeClient {
+    inner: Arc<Inner>,
+}
+
+/// Alias for spec-doc callers that use `OpenAI` capitalization.
+pub type OpenAIJudgeClient = OpenAiJudgeClient;
+
+struct Inner {
+    base_url: String,
+    api_key: String,
+    model: String,
+    temperature: f32,
+    retry_policy: RetryPolicy,
+    cancel: CancellationToken,
+    http: Client,
+}
+
+impl Clone for Inner {
+    fn clone(&self) -> Self {
+        Self {
+            base_url: self.base_url.clone(),
+            api_key: self.api_key.clone(),
+            model: self.model.clone(),
+            temperature: self.temperature,
+            retry_policy: self.retry_policy.clone(),
+            cancel: self.cancel.clone(),
+            http: self.http.clone(),
+        }
+    }
+}
+
+impl std::fmt::Debug for OpenAiJudgeClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OpenAiJudgeClient")
+            .field("base_url", &self.inner.base_url)
+            .field("model", &self.inner.model)
+            .field("temperature", &self.inner.temperature)
+            .field("retry_policy", &self.inner.retry_policy)
+            .finish_non_exhaustive()
+    }
+}
+
+impl OpenAiJudgeClient {
+    /// Build a new judge client. `base_url` should be the scheme + host
+    /// (e.g. `https://api.openai.com`); the client appends
+    /// `/v1/chat/completions` when dispatching.
+    #[must_use]
+    pub fn new(
+        base_url: impl Into<String>,
+        api_key: impl Into<String>,
+        model: impl Into<String>,
+    ) -> Self {
+        let http = Client::builder()
+            .timeout(DEFAULT_TIMEOUT)
+            .build()
+            .unwrap_or_else(|_| Client::new());
+        Self {
+            inner: Arc::new(Inner {
+                base_url: base_url.into().trim_end_matches('/').to_string(),
+                api_key: api_key.into(),
+                model: model.into(),
+                temperature: DEFAULT_TEMPERATURE,
+                retry_policy: RetryPolicy::default(),
+                cancel: CancellationToken::new(),
+                http,
+            }),
+        }
+    }
+
+    /// Override sampling temperature. Default: 0.0 (deterministic
+    /// grading).
+    #[must_use]
+    pub fn with_temperature(mut self, temperature: f32) -> Self {
+        Arc::make_mut(&mut self.inner).temperature = temperature;
+        self
+    }
+
+    /// Override the shared retry policy.
+    #[must_use]
+    pub fn with_retry_policy(mut self, policy: RetryPolicy) -> Self {
+        Arc::make_mut(&mut self.inner).retry_policy = policy;
+        self
+    }
+
+    /// Attach an external cancellation token.
+    #[must_use]
+    pub fn with_cancellation(mut self, cancel: CancellationToken) -> Self {
+        Arc::make_mut(&mut self.inner).cancel = cancel;
+        self
+    }
+
+    /// Borrow the configured cancellation token.
+    #[must_use]
+    pub fn cancellation(&self) -> CancellationToken {
+        self.inner.cancel.clone()
+    }
+
+    async fn dispatch_once(&self, prompt: &str) -> Result<JudgeVerdict, JudgeError> {
+        let body = OpenAiRequest {
+            model: &self.inner.model,
+            temperature: self.inner.temperature,
+            messages: vec![OpenAiMessage {
+                role: "user",
+                content: prompt,
+            }],
+        };
+        let url = format!("{}/v1/chat/completions", self.inner.base_url);
+
+        let resp = self
+            .inner
+            .http
+            .post(&url)
+            .bearer_auth(&self.inner.api_key)
+            .header("content-type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| JudgeError::Transport(format!("openai request failed: {e}")))?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let text = resp.text().await.unwrap_or_default();
+            return Err(classify_http_error(status, &text));
+        }
+
+        let parsed: OpenAiResponse = resp.json().await.map_err(|e| {
+            JudgeError::MalformedResponse(format!("openai body parse failed: {e}"))
+        })?;
+
+        extract_verdict(&parsed)
+    }
+}
+
+#[async_trait]
+impl JudgeClient for OpenAiJudgeClient {
+    async fn judge(&self, prompt: &str) -> Result<JudgeVerdict, JudgeError> {
+        let this = self;
+        let prompt = prompt;
+        retry_with_cancel(
+            &self.inner.retry_policy,
+            &self.inner.cancel,
+            is_retryable,
+            || async move { this.dispatch_once(prompt).await },
+        )
+        .await
+    }
+}
+
+/// Blocking convenience wrapper around [`OpenAiJudgeClient`].
+#[derive(Clone, Debug)]
+pub struct BlockingOpenAiJudgeClient {
+    inner: OpenAiJudgeClient,
+}
+
+impl BlockingOpenAiJudgeClient {
+    /// Wrap an existing [`OpenAiJudgeClient`].
+    #[must_use]
+    pub const fn new(inner: OpenAiJudgeClient) -> Self {
+        Self { inner }
+    }
+
+    /// Run a single judge call synchronously on the current Tokio runtime.
+    pub fn judge(&self, prompt: &str) -> Result<JudgeVerdict, JudgeError> {
+        let client = self.inner.clone();
+        let prompt = prompt.to_string();
+        tokio::runtime::Handle::current()
+            .block_on(async move { client.judge(&prompt).await })
+    }
+
+    /// Borrow the underlying async client for mixed sync/async call sites.
+    #[must_use]
+    pub const fn inner(&self) -> &OpenAiJudgeClient {
+        &self.inner
+    }
+}
+
+// ─── Wire types ─────────────────────────────────────────────────────────────
+
+#[derive(Serialize)]
+struct OpenAiRequest<'a> {
+    model: &'a str,
+    temperature: f32,
+    messages: Vec<OpenAiMessage<'a>>,
+}
+
+#[derive(Serialize)]
+struct OpenAiMessage<'a> {
+    role: &'a str,
+    content: &'a str,
+}
+
+#[derive(Deserialize, Debug)]
+struct OpenAiResponse {
+    #[serde(default)]
+    choices: Vec<OpenAiChoice>,
+}
+
+#[derive(Deserialize, Debug)]
+struct OpenAiChoice {
+    message: OpenAiChoiceMessage,
+}
+
+#[derive(Deserialize, Debug)]
+struct OpenAiChoiceMessage {
+    content: Option<String>,
+}
+
+fn classify_http_error(status: StatusCode, body: &str) -> JudgeError {
+    if status == StatusCode::TOO_MANY_REQUESTS || status.is_server_error() {
+        JudgeError::Transport(format!("openai http {}: {}", status.as_u16(), truncate(body)))
+    } else {
+        JudgeError::Other(format!("openai http {}: {}", status.as_u16(), truncate(body)))
+    }
+}
+
+fn truncate(body: &str) -> String {
+    const LIMIT: usize = 512;
+    if body.len() <= LIMIT {
+        body.to_string()
+    } else {
+        format!("{}…", &body[..LIMIT])
+    }
+}
+
+fn extract_verdict(resp: &OpenAiResponse) -> Result<JudgeVerdict, JudgeError> {
+    let content = resp
+        .choices
+        .first()
+        .and_then(|c| c.message.content.as_deref())
+        .ok_or_else(|| JudgeError::MalformedResponse("openai choices[0] missing content".into()))?;
+    parse_verdict_text(content)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_429_is_transport() {
+        let err = classify_http_error(StatusCode::TOO_MANY_REQUESTS, "rate");
+        assert!(matches!(err, JudgeError::Transport(_)));
+    }
+
+    #[test]
+    fn classify_503_is_transport() {
+        let err = classify_http_error(StatusCode::SERVICE_UNAVAILABLE, "down");
+        assert!(matches!(err, JudgeError::Transport(_)));
+    }
+
+    #[test]
+    fn classify_401_is_terminal() {
+        let err = classify_http_error(StatusCode::UNAUTHORIZED, "bad key");
+        assert!(matches!(err, JudgeError::Other(_)));
+    }
+}

--- a/eval-judges/tests/anthropic_test.rs
+++ b/eval-judges/tests/anthropic_test.rs
@@ -44,7 +44,7 @@ async fn anthropic_happy_path() {
         .mount(&server)
         .await;
 
-    let client = AnthropicJudgeClient::new(&server.uri(), "test-key", "claude-test")
+    let client = AnthropicJudgeClient::new(server.uri(), "test-key", "claude-test")
         .with_retry_policy(test_policy(6));
 
     let verdict = client.judge("grade this").await.expect("verdict");
@@ -85,10 +85,13 @@ async fn anthropic_rate_limit_absorbed_by_retry() {
         .mount(&server)
         .await;
 
-    let client = AnthropicJudgeClient::new(&server.uri(), "test-key", "claude-test")
+    let client = AnthropicJudgeClient::new(server.uri(), "test-key", "claude-test")
         .with_retry_policy(test_policy(6));
 
-    let verdict = client.judge("grade this").await.expect("verdict after retry");
+    let verdict = client
+        .judge("grade this")
+        .await
+        .expect("verdict after retry");
     assert!(verdict.pass);
     assert_eq!(count.load(Ordering::SeqCst), 2);
 }
@@ -106,7 +109,7 @@ async fn anthropic_exhausted_retries_surface_transport() {
         .mount(&server)
         .await;
 
-    let client = AnthropicJudgeClient::new(&server.uri(), "test-key", "claude-test")
+    let client = AnthropicJudgeClient::new(server.uri(), "test-key", "claude-test")
         .with_retry_policy(test_policy(3));
 
     let err = client
@@ -136,7 +139,7 @@ async fn anthropic_malformed_response_is_terminal() {
         .mount(&server)
         .await;
 
-    let client = AnthropicJudgeClient::new(&server.uri(), "test-key", "claude-test")
+    let client = AnthropicJudgeClient::new(server.uri(), "test-key", "claude-test")
         .with_retry_policy(test_policy(6));
 
     let err = client
@@ -155,7 +158,7 @@ async fn anthropic_cancellation_token_short_circuits() {
     let cancel = CancellationToken::new();
     cancel.cancel();
 
-    let client = AnthropicJudgeClient::new(&server.uri(), "test-key", "claude-test")
+    let client = AnthropicJudgeClient::new(server.uri(), "test-key", "claude-test")
         .with_retry_policy(test_policy(6))
         .with_cancellation(cancel);
 
@@ -168,7 +171,10 @@ async fn anthropic_cancellation_token_short_circuits() {
         other => panic!("expected cancellation, got {other:?}"),
     }
 
-    assert_eq!(server.received_requests().await.unwrap_or_default().len(), 0);
+    assert_eq!(
+        server.received_requests().await.unwrap_or_default().len(),
+        0
+    );
 }
 
 #[tokio::test]
@@ -181,7 +187,7 @@ async fn anthropic_blocking_wrapper_delegates_to_async() {
         .mount(&server)
         .await;
 
-    let client = AnthropicJudgeClient::new(&server.uri(), "test-key", "claude-test")
+    let client = AnthropicJudgeClient::new(server.uri(), "test-key", "claude-test")
         .with_retry_policy(test_policy(3));
     let blocking = swink_agent_eval_judges::BlockingAnthropicJudgeClient::new(client);
 

--- a/eval-judges/tests/anthropic_test.rs
+++ b/eval-judges/tests/anthropic_test.rs
@@ -1,0 +1,196 @@
+//! Wiremock-backed integration tests for [`AnthropicJudgeClient`].
+//!
+//! Coverage per T037 (spec 043-evals-adv-features):
+//!
+//! * `anthropic_happy_path` — valid verdict round-trips.
+//! * `anthropic_rate_limit_absorbed_by_retry` — a single 429 blip is
+//!   followed by a 200; the shared retry helper (T047) absorbs it.
+//! * `anthropic_exhausted_retries_surface_transport` — persistent 429
+//!   drains the retry budget and surfaces as `JudgeError::Transport`.
+//! * `anthropic_malformed_response_is_terminal` — a 200 with a body that
+//!   cannot parse as a verdict JSON surfaces as
+//!   `JudgeError::MalformedResponse` on the *first* attempt.
+//! * `anthropic_cancellation_token_short_circuits` — cancellation surfaces
+//!   as `JudgeError::Other("cancelled")` before the provider is called.
+
+#![cfg(feature = "anthropic")]
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use swink_agent_eval::judge::{JudgeClient, JudgeError, RetryPolicy};
+use swink_agent_eval_judges::AnthropicJudgeClient;
+use tokio_util::sync::CancellationToken;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
+
+mod common;
+use common::{anthropic_success_body, happy_verdict_json};
+
+fn test_policy(max_attempts: u32) -> RetryPolicy {
+    // Tight schedule so `max_attempts` attempts finish inside the test's
+    // default 60s harness budget even under the 4-minute production cap.
+    RetryPolicy::new(max_attempts, Duration::from_millis(10), false)
+}
+
+#[tokio::test]
+async fn anthropic_happy_path() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(anthropic_success_body(&happy_verdict_json()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = AnthropicJudgeClient::new(&server.uri(), "test-key", "claude-test")
+        .with_retry_policy(test_policy(6));
+
+    let verdict = client.judge("grade this").await.expect("verdict");
+    assert!((verdict.score - 0.9).abs() < f64::EPSILON);
+    assert!(verdict.pass);
+    assert_eq!(verdict.reason.as_deref(), Some("looks correct"));
+    assert_eq!(verdict.label.as_deref(), Some("equivalent"));
+}
+
+struct OneBlipThenSuccess {
+    count: Arc<AtomicUsize>,
+    success: ResponseTemplate,
+}
+
+impl Respond for OneBlipThenSuccess {
+    fn respond(&self, _request: &Request) -> ResponseTemplate {
+        let n = self.count.fetch_add(1, Ordering::SeqCst);
+        if n == 0 {
+            ResponseTemplate::new(429).set_body_string("slow down")
+        } else {
+            self.success.clone()
+        }
+    }
+}
+
+#[tokio::test]
+async fn anthropic_rate_limit_absorbed_by_retry() {
+    let server = MockServer::start().await;
+    let count = Arc::new(AtomicUsize::new(0));
+
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(OneBlipThenSuccess {
+            count: count.clone(),
+            success: anthropic_success_body(&happy_verdict_json()),
+        })
+        .expect(2)
+        .mount(&server)
+        .await;
+
+    let client = AnthropicJudgeClient::new(&server.uri(), "test-key", "claude-test")
+        .with_retry_policy(test_policy(6));
+
+    let verdict = client.judge("grade this").await.expect("verdict after retry");
+    assert!(verdict.pass);
+    assert_eq!(count.load(Ordering::SeqCst), 2);
+}
+
+#[tokio::test]
+async fn anthropic_exhausted_retries_surface_transport() {
+    let server = MockServer::start().await;
+
+    // The retry policy in the client has `max_attempts = 3`, so the
+    // provider should see exactly 3 calls before the helper gives up.
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(429).set_body_string("slow down"))
+        .expect(3)
+        .mount(&server)
+        .await;
+
+    let client = AnthropicJudgeClient::new(&server.uri(), "test-key", "claude-test")
+        .with_retry_policy(test_policy(3));
+
+    let err = client
+        .judge("grade this")
+        .await
+        .expect_err("must exhaust retries");
+    match err {
+        JudgeError::Transport(msg) => {
+            assert!(
+                msg.contains("429"),
+                "expected 429 in transport error, got: {msg}"
+            );
+        }
+        other => panic!("expected Transport, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn anthropic_malformed_response_is_terminal() {
+    let server = MockServer::start().await;
+
+    // 200 OK with a text block that does not parse as the verdict JSON.
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(anthropic_success_body("not a verdict at all"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = AnthropicJudgeClient::new(&server.uri(), "test-key", "claude-test")
+        .with_retry_policy(test_policy(6));
+
+    let err = client
+        .judge("grade this")
+        .await
+        .expect_err("must surface malformed");
+    assert!(matches!(err, JudgeError::MalformedResponse(_)));
+}
+
+#[tokio::test]
+async fn anthropic_cancellation_token_short_circuits() {
+    // No mock mounted: if the client contacted the server at all, the
+    // test would fail via unrequested-path on teardown.
+    let server = MockServer::start().await;
+
+    let cancel = CancellationToken::new();
+    cancel.cancel();
+
+    let client = AnthropicJudgeClient::new(&server.uri(), "test-key", "claude-test")
+        .with_retry_policy(test_policy(6))
+        .with_cancellation(cancel);
+
+    let err = client
+        .judge("grade this")
+        .await
+        .expect_err("cancelled before dispatch");
+    match err {
+        JudgeError::Other(msg) => assert!(msg.contains("cancel")),
+        other => panic!("expected cancellation, got {other:?}"),
+    }
+
+    assert_eq!(server.received_requests().await.unwrap_or_default().len(), 0);
+}
+
+#[tokio::test]
+async fn anthropic_blocking_wrapper_delegates_to_async() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(anthropic_success_body(&happy_verdict_json()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = AnthropicJudgeClient::new(&server.uri(), "test-key", "claude-test")
+        .with_retry_policy(test_policy(3));
+    let blocking = swink_agent_eval_judges::BlockingAnthropicJudgeClient::new(client);
+
+    // Dispatch the blocking call on a spawned thread so
+    // `Handle::current().block_on` inside the wrapper doesn't try to
+    // block the current runtime worker.
+    let verdict = tokio::task::spawn_blocking(move || blocking.judge("grade this"))
+        .await
+        .expect("join")
+        .expect("verdict");
+    assert!(verdict.pass);
+}

--- a/eval-judges/tests/common/mod.rs
+++ b/eval-judges/tests/common/mod.rs
@@ -1,5 +1,5 @@
 //! Shared wiremock fixtures for `swink-agent-eval-judges`.
-#![allow(dead_code)]
+#![allow(dead_code, unused_imports)]
 
 use std::time::Duration;
 
@@ -66,4 +66,47 @@ pub fn rate_limited_response(retry_after_secs: u64) -> ResponseTemplate {
     ResponseTemplate::new(429)
         .insert_header("Retry-After", retry_after_secs.to_string())
         .set_body_string("rate limited")
+}
+
+/// Canonical verdict JSON string the judge templates are expected to
+/// emit inside each provider's response text block.
+#[must_use]
+pub fn happy_verdict_json() -> String {
+    r#"{"score": 0.9, "pass": true, "reason": "looks correct", "label": "equivalent"}"#
+        .to_string()
+}
+
+/// Build a 200 response in the Anthropic `/v1/messages` shape wrapping
+/// `verdict_text` in a single `text` content block.
+#[must_use]
+pub fn anthropic_success_body(verdict_text: &str) -> ResponseTemplate {
+    ResponseTemplate::new(200).set_body_json(serde_json::json!({
+        "id": "msg_01",
+        "type": "message",
+        "role": "assistant",
+        "content": [
+            { "type": "text", "text": verdict_text }
+        ],
+        "model": "claude-test",
+        "stop_reason": "end_turn"
+    }))
+}
+
+/// Build a 200 response in the OpenAI `/v1/chat/completions` shape with
+/// a single assistant choice carrying `verdict_text`.
+#[must_use]
+pub fn openai_success_body(verdict_text: &str) -> ResponseTemplate {
+    ResponseTemplate::new(200).set_body_json(serde_json::json!({
+        "id": "chatcmpl-test",
+        "object": "chat.completion",
+        "created": 0,
+        "model": "gpt-test",
+        "choices": [
+            {
+                "index": 0,
+                "finish_reason": "stop",
+                "message": { "role": "assistant", "content": verdict_text }
+            }
+        ]
+    }))
 }

--- a/eval-judges/tests/common/mod.rs
+++ b/eval-judges/tests/common/mod.rs
@@ -72,8 +72,7 @@ pub fn rate_limited_response(retry_after_secs: u64) -> ResponseTemplate {
 /// emit inside each provider's response text block.
 #[must_use]
 pub fn happy_verdict_json() -> String {
-    r#"{"score": 0.9, "pass": true, "reason": "looks correct", "label": "equivalent"}"#
-        .to_string()
+    r#"{"score": 0.9, "pass": true, "reason": "looks correct", "label": "equivalent"}"#.to_string()
 }
 
 /// Build a 200 response in the Anthropic `/v1/messages` shape wrapping

--- a/eval-judges/tests/openai_test.rs
+++ b/eval-judges/tests/openai_test.rs
@@ -33,7 +33,7 @@ async fn openai_happy_path() {
         .mount(&server)
         .await;
 
-    let client = OpenAiJudgeClient::new(&server.uri(), "test-key", "gpt-test")
+    let client = OpenAiJudgeClient::new(server.uri(), "test-key", "gpt-test")
         .with_retry_policy(test_policy(6));
 
     let verdict = client.judge("grade this").await.expect("verdict");
@@ -73,10 +73,13 @@ async fn openai_rate_limit_absorbed_by_retry() {
         .mount(&server)
         .await;
 
-    let client = OpenAiJudgeClient::new(&server.uri(), "test-key", "gpt-test")
+    let client = OpenAiJudgeClient::new(server.uri(), "test-key", "gpt-test")
         .with_retry_policy(test_policy(6));
 
-    let verdict = client.judge("grade this").await.expect("verdict after retry");
+    let verdict = client
+        .judge("grade this")
+        .await
+        .expect("verdict after retry");
     assert!(verdict.pass);
     assert_eq!(count.load(Ordering::SeqCst), 2);
 }
@@ -92,7 +95,7 @@ async fn openai_exhausted_retries_surface_transport() {
         .mount(&server)
         .await;
 
-    let client = OpenAiJudgeClient::new(&server.uri(), "test-key", "gpt-test")
+    let client = OpenAiJudgeClient::new(server.uri(), "test-key", "gpt-test")
         .with_retry_policy(test_policy(3));
 
     let err = client
@@ -116,7 +119,7 @@ async fn openai_malformed_response_is_terminal() {
         .mount(&server)
         .await;
 
-    let client = OpenAiJudgeClient::new(&server.uri(), "test-key", "gpt-test")
+    let client = OpenAiJudgeClient::new(server.uri(), "test-key", "gpt-test")
         .with_retry_policy(test_policy(6));
 
     let err = client
@@ -133,7 +136,7 @@ async fn openai_cancellation_token_short_circuits() {
     let cancel = CancellationToken::new();
     cancel.cancel();
 
-    let client = OpenAiJudgeClient::new(&server.uri(), "test-key", "gpt-test")
+    let client = OpenAiJudgeClient::new(server.uri(), "test-key", "gpt-test")
         .with_retry_policy(test_policy(6))
         .with_cancellation(cancel);
 
@@ -146,7 +149,10 @@ async fn openai_cancellation_token_short_circuits() {
         other => panic!("expected cancellation, got {other:?}"),
     }
 
-    assert_eq!(server.received_requests().await.unwrap_or_default().len(), 0);
+    assert_eq!(
+        server.received_requests().await.unwrap_or_default().len(),
+        0
+    );
 }
 
 #[tokio::test]
@@ -159,7 +165,7 @@ async fn openai_blocking_wrapper_delegates_to_async() {
         .mount(&server)
         .await;
 
-    let client = OpenAiJudgeClient::new(&server.uri(), "test-key", "gpt-test")
+    let client = OpenAiJudgeClient::new(server.uri(), "test-key", "gpt-test")
         .with_retry_policy(test_policy(3));
     let blocking = swink_agent_eval_judges::BlockingOpenAiJudgeClient::new(client);
 

--- a/eval-judges/tests/openai_test.rs
+++ b/eval-judges/tests/openai_test.rs
@@ -1,0 +1,171 @@
+//! Wiremock-backed integration tests for [`OpenAiJudgeClient`].
+//!
+//! Coverage per T039 (spec 043-evals-adv-features): same five cases as
+//! the Anthropic client — happy, 429 absorbed by retry, exhausted
+//! retries, malformed verdict, cancellation.
+
+#![cfg(feature = "openai")]
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use swink_agent_eval::judge::{JudgeClient, JudgeError, RetryPolicy};
+use swink_agent_eval_judges::OpenAiJudgeClient;
+use tokio_util::sync::CancellationToken;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
+
+mod common;
+use common::{happy_verdict_json, openai_success_body};
+
+fn test_policy(max_attempts: u32) -> RetryPolicy {
+    RetryPolicy::new(max_attempts, Duration::from_millis(10), false)
+}
+
+#[tokio::test]
+async fn openai_happy_path() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(openai_success_body(&happy_verdict_json()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = OpenAiJudgeClient::new(&server.uri(), "test-key", "gpt-test")
+        .with_retry_policy(test_policy(6));
+
+    let verdict = client.judge("grade this").await.expect("verdict");
+    assert!(verdict.pass);
+    assert!((verdict.score - 0.9).abs() < f64::EPSILON);
+    assert_eq!(verdict.reason.as_deref(), Some("looks correct"));
+}
+
+struct OneBlipThenSuccess {
+    count: Arc<AtomicUsize>,
+    success: ResponseTemplate,
+}
+
+impl Respond for OneBlipThenSuccess {
+    fn respond(&self, _request: &Request) -> ResponseTemplate {
+        let n = self.count.fetch_add(1, Ordering::SeqCst);
+        if n == 0 {
+            ResponseTemplate::new(429).set_body_string("slow down")
+        } else {
+            self.success.clone()
+        }
+    }
+}
+
+#[tokio::test]
+async fn openai_rate_limit_absorbed_by_retry() {
+    let server = MockServer::start().await;
+    let count = Arc::new(AtomicUsize::new(0));
+
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(OneBlipThenSuccess {
+            count: count.clone(),
+            success: openai_success_body(&happy_verdict_json()),
+        })
+        .expect(2)
+        .mount(&server)
+        .await;
+
+    let client = OpenAiJudgeClient::new(&server.uri(), "test-key", "gpt-test")
+        .with_retry_policy(test_policy(6));
+
+    let verdict = client.judge("grade this").await.expect("verdict after retry");
+    assert!(verdict.pass);
+    assert_eq!(count.load(Ordering::SeqCst), 2);
+}
+
+#[tokio::test]
+async fn openai_exhausted_retries_surface_transport() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(ResponseTemplate::new(429).set_body_string("slow down"))
+        .expect(3)
+        .mount(&server)
+        .await;
+
+    let client = OpenAiJudgeClient::new(&server.uri(), "test-key", "gpt-test")
+        .with_retry_policy(test_policy(3));
+
+    let err = client
+        .judge("grade this")
+        .await
+        .expect_err("must exhaust retries");
+    match err {
+        JudgeError::Transport(msg) => assert!(msg.contains("429")),
+        other => panic!("expected Transport, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn openai_malformed_response_is_terminal() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(openai_success_body("not a verdict at all"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = OpenAiJudgeClient::new(&server.uri(), "test-key", "gpt-test")
+        .with_retry_policy(test_policy(6));
+
+    let err = client
+        .judge("grade this")
+        .await
+        .expect_err("must surface malformed");
+    assert!(matches!(err, JudgeError::MalformedResponse(_)));
+}
+
+#[tokio::test]
+async fn openai_cancellation_token_short_circuits() {
+    let server = MockServer::start().await;
+
+    let cancel = CancellationToken::new();
+    cancel.cancel();
+
+    let client = OpenAiJudgeClient::new(&server.uri(), "test-key", "gpt-test")
+        .with_retry_policy(test_policy(6))
+        .with_cancellation(cancel);
+
+    let err = client
+        .judge("grade this")
+        .await
+        .expect_err("cancelled before dispatch");
+    match err {
+        JudgeError::Other(msg) => assert!(msg.contains("cancel")),
+        other => panic!("expected cancellation, got {other:?}"),
+    }
+
+    assert_eq!(server.received_requests().await.unwrap_or_default().len(), 0);
+}
+
+#[tokio::test]
+async fn openai_blocking_wrapper_delegates_to_async() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(openai_success_body(&happy_verdict_json()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = OpenAiJudgeClient::new(&server.uri(), "test-key", "gpt-test")
+        .with_retry_policy(test_policy(3));
+    let blocking = swink_agent_eval_judges::BlockingOpenAiJudgeClient::new(client);
+
+    let verdict = tokio::task::spawn_blocking(move || blocking.judge("grade this"))
+        .await
+        .expect("join")
+        .expect("verdict");
+    assert!(verdict.pass);
+}

--- a/specs/043-evals-adv-features/tasks.md
+++ b/specs/043-evals-adv-features/tasks.md
@@ -105,9 +105,9 @@
 
 ### Judge clients in `eval-judges`
 
-- [ ] T037 [P] [US1] Write `eval-judges/tests/anthropic_test.rs` covering: `wiremock`-backed happy path, rate-limit 429 absorbed by retry, exhausted retries surface `JudgeError::RateLimitExhausted`, malformed response → `JudgeError::MalformedResponse`, cancellation propagation
-- [ ] T038 [P] [US1] Implement `AnthropicJudgeClient` + `BlockingAnthropicJudgeClient` in `eval-judges/src/anthropic.rs` — wraps `AnthropicAdapter`, exposes retry policy, batch size, async + blocking interfaces
-- [ ] T039 [P] [US1] Implement `OpenAIJudgeClient` + blocking wrapper in `eval-judges/src/openai.rs` with matching test file `eval-judges/tests/openai_test.rs`
+- [x] T037 [P] [US1] Write `eval-judges/tests/anthropic_test.rs` covering: `wiremock`-backed happy path, rate-limit 429 absorbed by retry, exhausted retries surface `JudgeError::RateLimitExhausted`, malformed response → `JudgeError::MalformedResponse`, cancellation propagation
+- [x] T038 [P] [US1] Implement `AnthropicJudgeClient` + `BlockingAnthropicJudgeClient` in `eval-judges/src/anthropic.rs` — wraps `AnthropicAdapter`, exposes retry policy, batch size, async + blocking interfaces
+- [x] T039 [P] [US1] Implement `OpenAIJudgeClient` + blocking wrapper in `eval-judges/src/openai.rs` with matching test file `eval-judges/tests/openai_test.rs`
 - [ ] T040 [P] [US1] Implement `BedrockJudgeClient` + blocking wrapper in `eval-judges/src/bedrock.rs` with test file `eval-judges/tests/bedrock_test.rs`
 - [ ] T041 [P] [US1] Implement `GeminiJudgeClient` + blocking wrapper in `eval-judges/src/gemini.rs` with test file `eval-judges/tests/gemini_test.rs`
 - [ ] T042 [P] [US1] Implement `MistralJudgeClient` + blocking wrapper in `eval-judges/src/mistral.rs` with test file `eval-judges/tests/mistral_test.rs`
@@ -115,8 +115,8 @@
 - [ ] T044 [P] [US1] Implement `XaiJudgeClient` + blocking wrapper in `eval-judges/src/xai.rs` with test file `eval-judges/tests/xai_test.rs`
 - [ ] T045 [P] [US1] Implement `OllamaJudgeClient` + blocking wrapper in `eval-judges/src/ollama.rs` with test file `eval-judges/tests/ollama_test.rs`
 - [ ] T046 [P] [US1] Implement `ProxyJudgeClient` + blocking wrapper in `eval-judges/src/proxy.rs` with test file `eval-judges/tests/proxy_test.rs`
-- [ ] T047 [US1] Implement shared `backon`-based retry + cancellation wiring in `eval-judges/src/client.rs` (6 attempts / 4 min max / jitter / `CancellationToken`-aware) used by every provider
-- [ ] T048 [US1] Implement request-batching wrapper in `eval-judges/src/client.rs` with configurable batch size ∈ [1, 128]; providers that don't support native batching fall through to sequential dispatch
+- [x] T047 [US1] Implement shared `backon`-based retry + cancellation wiring in `eval-judges/src/client.rs` (6 attempts / 4 min max / jitter / `CancellationToken`-aware) used by every provider
+- [x] T048 [US1] Implement request-batching wrapper in `eval-judges/src/client.rs` with configurable batch size ∈ [1, 128]; providers that don't support native batching fall through to sequential dispatch
 
 ### Prompt templates (built-in _v0, feature `judge-core`)
 


### PR DESCRIPTION
## Summary
- AnthropicJudgeClient + Blocking wrapper (T038)
- OpenAIJudgeClient + Blocking wrapper (T039)
- Wiremock tests for both (T037 + OpenAI equivalent)
- Shared backon retry + cancellation (T047)
- Batching wrapper (T048)

## Tasks completed
T037, T038, T039, T047, T048

## Deferred
T040-T046 (Bedrock, Gemini, Mistral, Azure, Xai, Ollama, Proxy) - follow-up PRs.

## Gaps noted
- `eval::judge::JudgeError` has no `RateLimitExhausted` variant (spec T037 references it but the enum was not scaffolded with it). Exhausted 429s are surfaced as `JudgeError::Transport("... http 429 ...")` to keep the existing cross-crate enum untouched; the test assertions match that mapping.

## Test plan
Worker did not run cargo; orchestrator verifies fmt / clippy / test sequentially after all 5 parallel workers finish.

Part of #748

🤖 Generated with [Claude Code](https://claude.com/claude-code)