### PR TITLE
impl(043): US7 EvalsTelemetry + runner span emission

### DIFF
--- a/eval/src/evaluator.rs
+++ b/eval/src/evaluator.rs
@@ -170,17 +170,43 @@ impl EvaluatorRegistry {
     /// in that list are run. Otherwise, all registered evaluators are run.
     #[must_use]
     pub fn evaluate(&self, case: &EvalCase, invocation: &Invocation) -> Vec<EvalMetricResult> {
+        self.evaluate_instrumented(case, invocation, |_name, run| run())
+    }
+
+    /// Variant of [`Self::evaluate`] that lets the caller wrap each
+    /// evaluator invocation — e.g. in an OTel span (spec 043 US7 / FR-035).
+    ///
+    /// `wrap` is invoked once per applicable evaluator with its name and a
+    /// closure that, when called, runs the evaluator under the existing
+    /// panic-isolation guard. `wrap` may return `None` to drop the metric.
+    ///
+    /// The shape is deliberately synchronous to match the existing
+    /// [`Self::evaluate`] surface and keep the observer bridge simple.
+    pub fn evaluate_instrumented<F>(
+        &self,
+        case: &EvalCase,
+        invocation: &Invocation,
+        mut wrap: F,
+    ) -> Vec<EvalMetricResult>
+    where
+        F: FnMut(&str, &mut dyn FnMut() -> Option<EvalMetricResult>) -> Option<EvalMetricResult>,
+    {
         let filter = &case.evaluators;
         self.evaluators
             .iter()
             .filter(|e| filter.is_empty() || filter.iter().any(|name| name == e.name()))
             .filter_map(|e| {
+                let name = e.name();
                 let evaluator = Arc::clone(e);
-                let case = case.clone();
-                let invocation = invocation.clone();
-                isolate_panic(evaluator.name(), move || {
-                    evaluator.evaluate(&case, &invocation)
-                })
+                let mut runner = move || {
+                    let evaluator = Arc::clone(&evaluator);
+                    let case = case.clone();
+                    let invocation = invocation.clone();
+                    isolate_panic(evaluator.name(), move || {
+                        evaluator.evaluate(&case, &invocation)
+                    })
+                };
+                wrap(name, &mut runner)
             })
             .collect()
     }

--- a/eval/src/lib.rs
+++ b/eval/src/lib.rs
@@ -90,6 +90,8 @@ pub use score::{Score, Verdict};
 pub use semantic_tool_parameter::SemanticToolParameterEvaluator;
 pub use semantic_tool_selection::SemanticToolSelectionEvaluator;
 pub use store::{EvalStore, FsEvalStore};
+#[cfg(feature = "telemetry")]
+pub use telemetry::{EvalsTelemetry, EvalsTelemetryBuilder};
 pub use testing::{MockJudge, PanickingMockJudge, SlowMockJudge};
 pub use trajectory::TrajectoryCollector;
 pub use types::{

--- a/eval/src/runner.rs
+++ b/eval/src/runner.rs
@@ -23,6 +23,8 @@ use crate::cache::{CacheKey, EvaluationDataStore, FingerprintContext};
 use crate::error::EvalError;
 use crate::evaluator::EvaluatorRegistry;
 use crate::score::{Score, Verdict};
+#[cfg(feature = "telemetry")]
+use crate::telemetry::{CaseSpan, EvalsTelemetry, RunSetSpan, RunSetSpanRef};
 use crate::trajectory::TrajectoryCollector;
 use crate::types::{
     EvalCase, EvalCaseResult, EvalMetricResult, EvalSet, EvalSetResult, EvalSummary, Invocation,
@@ -98,6 +100,8 @@ pub struct EvalRunner {
     cancel: Option<CancellationToken>,
     initial_session_file: Option<PathBuf>,
     agent_invocations: Arc<AtomicUsize>,
+    #[cfg(feature = "telemetry")]
+    telemetry: Option<Arc<EvalsTelemetry>>,
 }
 
 impl EvalRunner {
@@ -112,6 +116,8 @@ impl EvalRunner {
             cancel: None,
             initial_session_file: None,
             agent_invocations: Arc::new(AtomicUsize::new(0)),
+            #[cfg(feature = "telemetry")]
+            telemetry: None,
         }
     }
 
@@ -169,6 +175,16 @@ impl EvalRunner {
         self
     }
 
+    /// Attach an [`EvalsTelemetry`] (spec 043 US7 / FR-035). When present,
+    /// [`Self::run_set`] emits the three-level span tree
+    /// `swink.eval.run_set` → `swink.eval.case` → `swink.eval.evaluator`.
+    #[cfg(feature = "telemetry")]
+    #[must_use]
+    pub fn with_telemetry(mut self, telemetry: Arc<EvalsTelemetry>) -> Self {
+        self.telemetry = Some(telemetry);
+        self
+    }
+
     /// Number of times an agent was actually invoked (cache miss count).
     #[must_use]
     pub fn agent_invocation_count(&self) -> usize {
@@ -220,6 +236,13 @@ impl EvalRunner {
             cache = self.cache.is_some(), "running eval set"
         );
 
+        // ─── FR-035: root span for the whole run_set ──────────────────
+        #[cfg(feature = "telemetry")]
+        let run_set_span: Option<RunSetSpan> = self
+            .telemetry
+            .as_ref()
+            .map(|t| t.start_run_set_span(eval_set));
+
         let initial_session = self.load_initial_session()?;
         let initial_session_json = initial_session
             .as_ref()
@@ -245,6 +268,13 @@ impl EvalRunner {
             let initial_session_value = initial_session_json.clone();
             let agent_invocations = Arc::clone(&self.agent_invocations);
             let eval_set_id = eval_set_id.clone();
+            #[cfg(feature = "telemetry")]
+            let telemetry = self.telemetry.clone();
+            #[cfg(feature = "telemetry")]
+            let run_set_context = run_set_span.as_ref().map(|s| RunSetSpanRef {
+                context: s.context().clone(),
+                set_id: eval_set_id.clone(),
+            });
 
             futures_vec.push(async move {
                 if let Some(tok) = &cancel
@@ -262,6 +292,15 @@ impl EvalRunner {
                     drop(permit);
                     return (index, cancelled_case_result(case));
                 }
+
+                #[cfg(feature = "telemetry")]
+                let case_span: Option<CaseSpan> = match (&telemetry, &run_set_context) {
+                    (Some(t), Some(parent)) => Some(t.start_case_span_raw(parent, case)),
+                    _ => None,
+                };
+                #[cfg(feature = "telemetry")]
+                let case_start = std::time::Instant::now();
+
                 let result = execute_case(
                     case,
                     factory,
@@ -272,9 +311,19 @@ impl EvalRunner {
                     cancel.as_ref(),
                     initial_session_value.as_ref(),
                     &agent_invocations,
+                    #[cfg(feature = "telemetry")]
+                    telemetry.as_deref(),
+                    #[cfg(feature = "telemetry")]
+                    case_span.as_ref(),
                 )
                 .await
                 .unwrap_or_else(|e| error_case_result(case, &e));
+
+                #[cfg(feature = "telemetry")]
+                if let Some(span) = case_span {
+                    span.end(&result, case_start.elapsed());
+                }
+
                 drop(permit);
                 (index, result)
             });
@@ -319,6 +368,12 @@ impl EvalRunner {
             failed = summary.failed, total = summary.total_cases,
             "eval set complete"
         );
+
+        #[cfg(feature = "telemetry")]
+        if let Some(span) = run_set_span {
+            span.end(summary.passed, summary.failed);
+        }
+
         Ok(EvalSetResult {
             eval_set_id: eval_set.id.clone(),
             case_results,
@@ -358,6 +413,8 @@ async fn execute_case(
     cancel: Option<&CancellationToken>,
     initial_session_json: Option<&serde_json::Value>,
     agent_invocations: &AtomicUsize,
+    #[cfg(feature = "telemetry")] telemetry: Option<&EvalsTelemetry>,
+    #[cfg(feature = "telemetry")] case_span: Option<&CaseSpan>,
 ) -> Result<EvalCaseResult, EvalError> {
     info!(case_id = %case.id, case_name = %case.name, "running eval case");
 
@@ -393,7 +450,17 @@ async fn execute_case(
         inv
     };
 
-    let metric_results = dispatch_evaluators(registry, case, &invocation, num_runs, cancel);
+    let metric_results = dispatch_evaluators(
+        registry,
+        case,
+        &invocation,
+        num_runs,
+        cancel,
+        #[cfg(feature = "telemetry")]
+        telemetry,
+        #[cfg(feature = "telemetry")]
+        case_span,
+    );
     let verdict = if metric_results.iter().all(|r| r.score.verdict().is_pass()) {
         Verdict::Pass
     } else {
@@ -443,16 +510,27 @@ async fn invoke_agent_impl(
     Ok(invocation)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn dispatch_evaluators(
     registry: &EvaluatorRegistry,
     case: &EvalCase,
     invocation: &Invocation,
     num_runs: u32,
     cancel: Option<&CancellationToken>,
+    #[cfg(feature = "telemetry")] telemetry: Option<&EvalsTelemetry>,
+    #[cfg(feature = "telemetry")] case_span: Option<&CaseSpan>,
 ) -> Vec<EvalMetricResult> {
     debug_assert!(num_runs > 0);
     if num_runs == 1 {
-        return registry.evaluate(case, invocation);
+        return run_registry_once(
+            registry,
+            case,
+            invocation,
+            #[cfg(feature = "telemetry")]
+            telemetry,
+            #[cfg(feature = "telemetry")]
+            case_span,
+        );
     }
 
     let mut per_evaluator: std::collections::BTreeMap<String, Vec<EvalMetricResult>> =
@@ -463,7 +541,23 @@ fn dispatch_evaluators(
         {
             break;
         }
-        for metric in registry.evaluate(case, invocation) {
+        // Only the first num_runs iteration gets its evaluator spans emitted
+        // so the span tree stays proportional to evaluator count; per-run
+        // scores are still aggregated on the synthesised mean span below.
+        #[cfg(feature = "telemetry")]
+        let iteration_telemetry = if run_idx == 0 { telemetry } else { None };
+        #[cfg(feature = "telemetry")]
+        let iteration_case_span = if run_idx == 0 { case_span } else { None };
+        let iteration = run_registry_once(
+            registry,
+            case,
+            invocation,
+            #[cfg(feature = "telemetry")]
+            iteration_telemetry,
+            #[cfg(feature = "telemetry")]
+            iteration_case_span,
+        );
+        for metric in iteration {
             per_evaluator
                 .entry(metric.evaluator_name.clone())
                 .or_default()
@@ -495,6 +589,31 @@ fn dispatch_evaluators(
             }
         })
         .collect()
+}
+
+/// Invoke every applicable evaluator once. When `telemetry` + `case_span`
+/// are supplied, each evaluator call is wrapped in a `swink.eval.evaluator`
+/// span (FR-035) that inherits the case span as parent.
+fn run_registry_once(
+    registry: &EvaluatorRegistry,
+    case: &EvalCase,
+    invocation: &Invocation,
+    #[cfg(feature = "telemetry")] telemetry: Option<&EvalsTelemetry>,
+    #[cfg(feature = "telemetry")] case_span: Option<&CaseSpan>,
+) -> Vec<EvalMetricResult> {
+    #[cfg(feature = "telemetry")]
+    if let (Some(t), Some(parent)) = (telemetry, case_span) {
+        return registry.evaluate_instrumented(case, invocation, |name, run| {
+            let span = t.start_evaluator_span(parent, name);
+            let outcome = run();
+            match outcome.as_ref() {
+                Some(metric) => span.end(metric),
+                None => span.end_inapplicable(name),
+            }
+            outcome
+        });
+    }
+    registry.evaluate(case, invocation)
 }
 
 fn cancelled_case_result(case: &EvalCase) -> EvalCaseResult {

--- a/eval/src/telemetry.rs
+++ b/eval/src/telemetry.rs
@@ -1,1 +1,419 @@
-//! OpenTelemetry integration for eval runs.
+//! OpenTelemetry integration for eval runs (spec 043 US7, FR-035).
+//!
+//! When the `telemetry` feature is enabled, [`EvalsTelemetry`] can be wired
+//! into [`EvalRunner`](crate::EvalRunner) to emit a three-level span tree
+//! during `run_set`:
+//!
+//! * Root: `swink.eval.run_set` — attributes:
+//!   `swink.eval.set_id`, `swink.eval.set_name`, `swink.eval.case_count`.
+//! * Per-case child: `swink.eval.case` — attributes:
+//!   `swink.eval.set_id`, `swink.eval.case_id`, `swink.eval.case_name`,
+//!   `swink.eval.verdict`, `swink.eval.duration_ms`.
+//! * Per-evaluator grandchild: `swink.eval.evaluator` — attributes:
+//!   `swink.eval.evaluator_name`, `swink.eval.verdict`, `swink.eval.score`,
+//!   `swink.eval.score_threshold`.
+//!
+//! Failed cases (overall verdict `Fail`) record OTel `Status::error` and an
+//! `exception` event summarising the failure cause (research §R-005, §FR-035).
+//!
+//! If the caller has an active OTel context — e.g. an outer `agent.run` span
+//! — it is inherited as the parent of `swink.eval.run_set`, enabling cross-
+//! service trace correlation. Callers without an active context get a fresh
+//! root trace.
+//!
+//! ## Example
+//!
+//! ```rust,ignore
+//! use std::sync::Arc;
+//! use opentelemetry::global;
+//! use swink_agent_eval::{EvalRunner, EvaluatorRegistry};
+//! use swink_agent_eval::telemetry::EvalsTelemetry;
+//!
+//! let telemetry = EvalsTelemetry::builder()
+//!     .with_tracer(global::tracer("swink.eval"))
+//!     .build();
+//! let runner = EvalRunner::with_defaults()
+//!     .with_telemetry(Arc::new(telemetry));
+//! ```
+
+use std::borrow::Cow;
+use std::time::Duration;
+
+use opentelemetry::global::BoxedTracer;
+use opentelemetry::trace::{
+    Span, SpanBuilder, SpanKind, Status, TraceContextExt, Tracer, TracerProvider,
+};
+use opentelemetry::{Context, KeyValue, global};
+
+use crate::score::Verdict;
+use crate::types::{EvalCase, EvalCaseResult, EvalMetricResult, EvalSet};
+
+// ─── Attribute keys ─────────────────────────────────────────────────────────
+
+/// Root span name for an entire `run_set` invocation.
+pub const SPAN_RUN_SET: &str = "swink.eval.run_set";
+/// Per-case child span name.
+pub const SPAN_CASE: &str = "swink.eval.case";
+/// Per-evaluator grandchild span name.
+pub const SPAN_EVALUATOR: &str = "swink.eval.evaluator";
+
+/// Eval set identifier. Present on every span in the tree.
+pub const ATTR_SET_ID: &str = "swink.eval.set_id";
+/// Human-readable eval set name.
+pub const ATTR_SET_NAME: &str = "swink.eval.set_name";
+/// Number of cases in the eval set (root span only).
+pub const ATTR_CASE_COUNT: &str = "swink.eval.case_count";
+/// Eval case identifier.
+pub const ATTR_CASE_ID: &str = "swink.eval.case_id";
+/// Human-readable case name.
+pub const ATTR_CASE_NAME: &str = "swink.eval.case_name";
+/// Evaluator name (e.g. `trajectory`, `response`, `budget`).
+pub const ATTR_EVALUATOR_NAME: &str = "swink.eval.evaluator_name";
+/// Verdict — one of `pass` or `fail`.
+pub const ATTR_VERDICT: &str = "swink.eval.verdict";
+/// Raw numeric score on the evaluator span.
+pub const ATTR_SCORE: &str = "swink.eval.score";
+/// Pass/fail threshold used to derive the verdict.
+pub const ATTR_SCORE_THRESHOLD: &str = "swink.eval.score_threshold";
+/// Wall-clock case duration in milliseconds.
+pub const ATTR_DURATION_MS: &str = "swink.eval.duration_ms";
+/// Aggregate pass/fail counters on the root span.
+pub const ATTR_PASSED: &str = "swink.eval.passed";
+/// Aggregate failed counter on the root span.
+pub const ATTR_FAILED: &str = "swink.eval.failed";
+
+// ─── EvalsTelemetry ─────────────────────────────────────────────────────────
+
+/// Emits OTel spans for an entire `run_set` invocation.
+///
+/// Holds a [`BoxedTracer`] obtained either from a caller-supplied
+/// [`TracerProvider`] or from the global provider. Cloning is cheap — the
+/// tracer itself is reference-counted by the underlying SDK.
+///
+/// Construct via [`EvalsTelemetry::builder`].
+pub struct EvalsTelemetry {
+    tracer: BoxedTracer,
+}
+
+impl std::fmt::Debug for EvalsTelemetry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EvalsTelemetry").finish_non_exhaustive()
+    }
+}
+
+impl EvalsTelemetry {
+    /// Start a new builder.
+    #[must_use]
+    pub fn builder() -> EvalsTelemetryBuilder {
+        EvalsTelemetryBuilder::default()
+    }
+
+    /// Borrow the underlying tracer. Exposed so downstream crates can mint
+    /// auxiliary spans under the same instrumentation scope.
+    #[must_use]
+    pub fn tracer(&self) -> &BoxedTracer {
+        &self.tracer
+    }
+
+    /// Start the root `swink.eval.run_set` span.
+    ///
+    /// The parent is the active OTel [`Context`] (`Context::current()`), so a
+    /// caller-owned span — e.g. an outer `agent.run` or a scheduler tick — is
+    /// inherited automatically. When no context is active the span becomes a
+    /// new root trace.
+    pub(crate) fn start_run_set_span(&self, eval_set: &EvalSet) -> RunSetSpan {
+        let parent = Context::current();
+        let builder = SpanBuilder::from_name(Cow::Borrowed(SPAN_RUN_SET))
+            .with_kind(SpanKind::Internal)
+            .with_attributes(vec![
+                KeyValue::new(ATTR_SET_ID, eval_set.id.clone()),
+                KeyValue::new(ATTR_SET_NAME, eval_set.name.clone()),
+                KeyValue::new(ATTR_CASE_COUNT, eval_set.cases.len() as i64),
+            ]);
+        let span = self.tracer.build_with_context(builder, &parent);
+        let cx = parent.with_span(span);
+        RunSetSpan {
+            context: cx,
+            set_id: eval_set.id.clone(),
+        }
+    }
+
+    /// Start a per-case span as a child of the supplied run-set context.
+    ///
+    /// Accepts a cloneable [`RunSetSpanRef`] so per-case futures in
+    /// `join_all` can each carry their own copy of the parent context
+    /// without borrowing across await points.
+    pub(crate) fn start_case_span_raw(&self, parent: &RunSetSpanRef, case: &EvalCase) -> CaseSpan {
+        let builder = SpanBuilder::from_name(Cow::Borrowed(SPAN_CASE))
+            .with_kind(SpanKind::Internal)
+            .with_attributes(vec![
+                KeyValue::new(ATTR_SET_ID, parent.set_id.clone()),
+                KeyValue::new(ATTR_CASE_ID, case.id.clone()),
+                KeyValue::new(ATTR_CASE_NAME, case.name.clone()),
+            ]);
+        let span = self.tracer.build_with_context(builder, &parent.context);
+        let cx = parent.context.with_span(span);
+        CaseSpan {
+            context: cx,
+            set_id: parent.set_id.clone(),
+            case_id: case.id.clone(),
+        }
+    }
+
+    /// Start a per-evaluator span as a child of the supplied case context.
+    pub(crate) fn start_evaluator_span(
+        &self,
+        parent: &CaseSpan,
+        evaluator_name: &str,
+    ) -> EvaluatorSpan {
+        let builder = SpanBuilder::from_name(Cow::Borrowed(SPAN_EVALUATOR))
+            .with_kind(SpanKind::Internal)
+            .with_attributes(vec![
+                KeyValue::new(ATTR_SET_ID, parent.set_id.clone()),
+                KeyValue::new(ATTR_CASE_ID, parent.case_id.clone()),
+                KeyValue::new(ATTR_EVALUATOR_NAME, evaluator_name.to_string()),
+            ]);
+        let span = self.tracer.build_with_context(builder, &parent.context);
+        let cx = parent.context.with_span(span);
+        EvaluatorSpan { context: cx }
+    }
+}
+
+// ─── Span handles ───────────────────────────────────────────────────────────
+
+/// RAII-style handle for the root `swink.eval.run_set` span.
+pub(crate) struct RunSetSpan {
+    context: Context,
+    set_id: String,
+}
+
+/// Cloneable reference to the run-set context used by per-case futures.
+///
+/// The owned [`RunSetSpan`] lives in the outer `run_set` frame; each future
+/// in `join_all` gets its own copy of this ref so it can mint child spans
+/// without borrowing across await points.
+#[derive(Clone)]
+pub(crate) struct RunSetSpanRef {
+    pub(crate) context: Context,
+    pub(crate) set_id: String,
+}
+
+impl RunSetSpan {
+    pub(crate) fn context(&self) -> &Context {
+        &self.context
+    }
+
+    /// Record aggregate counters and end the span.
+    pub(crate) fn end(self, passed: usize, failed: usize) {
+        let span = self.context.span();
+        span.set_attribute(KeyValue::new(ATTR_PASSED, passed as i64));
+        span.set_attribute(KeyValue::new(ATTR_FAILED, failed as i64));
+        if failed > 0 {
+            span.set_status(Status::error(format!("{failed} case(s) failed")));
+        } else {
+            span.set_status(Status::Ok);
+        }
+        span.end();
+    }
+}
+
+/// RAII-style handle for a `swink.eval.case` span.
+pub(crate) struct CaseSpan {
+    context: Context,
+    set_id: String,
+    case_id: String,
+}
+
+impl CaseSpan {
+    /// Borrow the underlying OTel [`Context`]. Exposed so the runner can
+    /// parent evaluator spans off the case span.
+    #[allow(dead_code)]
+    pub(crate) fn context(&self) -> &Context {
+        &self.context
+    }
+
+    /// Record the final verdict + duration and end the span. On failure the
+    /// span receives `Status::error` plus an `exception` event whose message
+    /// summarises every failing metric (FR-035).
+    pub(crate) fn end(self, result: &EvalCaseResult, duration: Duration) {
+        let span = self.context.span();
+        span.set_attribute(KeyValue::new(ATTR_VERDICT, verdict_str(result.verdict)));
+        #[allow(clippy::cast_possible_truncation)]
+        span.set_attribute(KeyValue::new(
+            ATTR_DURATION_MS,
+            duration.as_millis().min(i64::MAX as u128) as i64,
+        ));
+
+        if !result.verdict.is_pass() {
+            let failing: Vec<String> = result
+                .metric_results
+                .iter()
+                .filter(|m| !m.score.verdict().is_pass())
+                .map(|m| {
+                    let detail = m.details.clone().unwrap_or_default();
+                    if detail.is_empty() {
+                        m.evaluator_name.clone()
+                    } else {
+                        format!("{}: {}", m.evaluator_name, detail)
+                    }
+                })
+                .collect();
+            let message = if failing.is_empty() {
+                format!("case `{}` failed", result.case_id)
+            } else {
+                format!("case `{}` failed: {}", result.case_id, failing.join(" | "))
+            };
+            span.add_event(
+                Cow::Borrowed("exception"),
+                vec![
+                    KeyValue::new("exception.type", "EvalCaseFailure"),
+                    KeyValue::new("exception.message", message.clone()),
+                ],
+            );
+            span.set_status(Status::error(message));
+        } else {
+            span.set_status(Status::Ok);
+        }
+        span.end();
+    }
+}
+
+/// RAII-style handle for a `swink.eval.evaluator` span.
+pub(crate) struct EvaluatorSpan {
+    context: Context,
+}
+
+impl EvaluatorSpan {
+    /// Record the metric result and end the span. Failing metrics receive
+    /// `Status::error` so observability backends show the evaluator as the
+    /// responsible child of a failing case.
+    pub(crate) fn end(self, metric: &EvalMetricResult) {
+        let span = self.context.span();
+        let verdict = metric.score.verdict();
+        span.set_attribute(KeyValue::new(ATTR_VERDICT, verdict_str(verdict)));
+        span.set_attribute(KeyValue::new(ATTR_SCORE, metric.score.value));
+        span.set_attribute(KeyValue::new(ATTR_SCORE_THRESHOLD, metric.score.threshold));
+        if let Some(detail) = &metric.details {
+            span.set_attribute(KeyValue::new("swink.eval.details", detail.clone()));
+        }
+        if !verdict.is_pass() {
+            let message = metric
+                .details
+                .clone()
+                .unwrap_or_else(|| format!("evaluator `{}` failed", metric.evaluator_name));
+            span.add_event(
+                Cow::Borrowed("exception"),
+                vec![
+                    KeyValue::new("exception.type", "EvaluatorFailure"),
+                    KeyValue::new("exception.message", message.clone()),
+                ],
+            );
+            span.set_status(Status::error(message));
+        } else {
+            span.set_status(Status::Ok);
+        }
+        span.end();
+    }
+
+    /// End the span without a metric (evaluator returned `None` — inapplicable
+    /// to the case). The span is closed with `Status::Ok` to signal a no-op.
+    pub(crate) fn end_inapplicable(self, evaluator_name: &str) {
+        let span = self.context.span();
+        span.set_attribute(KeyValue::new(
+            ATTR_EVALUATOR_NAME,
+            evaluator_name.to_string(),
+        ));
+        span.set_attribute(KeyValue::new(ATTR_VERDICT, "inapplicable"));
+        span.set_status(Status::Ok);
+        span.end();
+    }
+}
+
+fn verdict_str(verdict: Verdict) -> &'static str {
+    if verdict.is_pass() { "pass" } else { "fail" }
+}
+
+// ─── Builder ────────────────────────────────────────────────────────────────
+
+/// Builder for [`EvalsTelemetry`].
+///
+/// Defaults to the globally-installed OTel [`TracerProvider`], which a
+/// caller-supplied tracer can override. Use this in production to pick up
+/// whatever provider is already wired (OTLP, stdout, …); in tests,
+/// [`Self::with_tracer`] lets you inject a tracer backed by an
+/// `InMemorySpanExporter`.
+#[derive(Default)]
+pub struct EvalsTelemetryBuilder {
+    tracer: Option<BoxedTracer>,
+}
+
+impl EvalsTelemetryBuilder {
+    /// Use a caller-supplied tracer. Most direct path for tests; wire a
+    /// `SdkTracerProvider` with an `InMemorySpanExporter` and pass
+    /// `provider.tracer("swink.eval")` through here.
+    #[must_use]
+    pub fn with_tracer(mut self, tracer: BoxedTracer) -> Self {
+        self.tracer = Some(tracer);
+        self
+    }
+
+    /// Derive a tracer from an arbitrary [`TracerProvider`]. The tracer is
+    /// named `swink.eval`, matching the span-name prefix.
+    #[must_use]
+    pub fn with_tracer_provider<S, T, P>(mut self, provider: &P) -> Self
+    where
+        S: opentelemetry::trace::Span + Send + Sync + 'static,
+        T: Tracer<Span = S> + Send + Sync + 'static,
+        P: TracerProvider<Tracer = T>,
+    {
+        // Any `T: Tracer<Span = S>` with the Send+Sync+'static bounds implements
+        // `ObjectSafeTracer` via the blanket impl in `opentelemetry::global`.
+        let tracer = provider.tracer("swink.eval");
+        self.tracer = Some(BoxedTracer::new(Box::new(tracer)));
+        self
+    }
+
+    /// Build the [`EvalsTelemetry`]. If no tracer has been supplied, derive
+    /// one from the globally-installed provider.
+    #[must_use]
+    pub fn build(self) -> EvalsTelemetry {
+        let tracer = self.tracer.unwrap_or_else(|| global::tracer("swink.eval"));
+        EvalsTelemetry { tracer }
+    }
+}
+
+// ─── Unit tests ─────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider};
+
+    fn fresh_provider() -> (SdkTracerProvider, InMemorySpanExporter) {
+        let exporter = InMemorySpanExporter::default();
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(exporter.clone())
+            .build();
+        (provider, exporter)
+    }
+
+    #[test]
+    fn builder_uses_injected_tracer() {
+        let (provider, exporter) = fresh_provider();
+        let telemetry = EvalsTelemetry::builder()
+            .with_tracer_provider(&provider)
+            .build();
+        // Emit a span via the configured tracer to confirm it flows through.
+        let mut span = telemetry.tracer().start("selftest");
+        span.end();
+        provider.force_flush().expect("flush ok");
+        let spans = exporter.get_finished_spans().expect("get spans");
+        assert!(spans.iter().any(|s| s.name == "selftest"));
+    }
+
+    #[test]
+    fn verdict_str_rendering() {
+        assert_eq!(verdict_str(Verdict::Pass), "pass");
+        assert_eq!(verdict_str(Verdict::Fail), "fail");
+    }
+}

--- a/eval/tests/telemetry_test.rs
+++ b/eval/tests/telemetry_test.rs
@@ -1,0 +1,354 @@
+//! Spec 043 US7 / T135: unit tests for `EvalsTelemetry` span emission.
+//!
+//! Covers FR-035:
+//! * Three-level tree: `swink.eval.run_set` → `swink.eval.case` →
+//!   `swink.eval.evaluator`.
+//! * Standardised attributes on every span (`set_id`, `case_id`, `verdict`,
+//!   `score`, `evaluator_name`).
+//! * Failed case → `Status::error` + an `exception` event on the case span.
+//! * When a parent OTel span is active, the run-set span inherits it.
+
+#![cfg(feature = "telemetry")]
+
+use std::sync::Arc;
+
+use opentelemetry::Context;
+use opentelemetry::trace::{
+    SpanContext, SpanId, Status, TraceContextExt, TraceFlags, TraceId, TraceState,
+};
+use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider, SpanData};
+use tokio_util::sync::CancellationToken;
+
+use swink_agent::{Agent, AgentOptions, ModelSpec, testing::SimpleMockStreamFn};
+use swink_agent_eval::{
+    AgentFactory, EvalCase, EvalError, EvalRunner, EvalSet, EvalsTelemetry, Evaluator,
+    EvaluatorRegistry,
+};
+
+mod common;
+
+// ─── Fixtures ───────────────────────────────────────────────────────────────
+
+struct StubFactory {
+    responses: Vec<String>,
+}
+
+impl StubFactory {
+    fn new(response: impl Into<String>) -> Self {
+        Self {
+            responses: vec![response.into()],
+        }
+    }
+}
+
+impl AgentFactory for StubFactory {
+    fn create_agent(&self, case: &EvalCase) -> Result<(Agent, CancellationToken), EvalError> {
+        let options = AgentOptions::new_simple(
+            &case.system_prompt,
+            ModelSpec::new("test", "test-model"),
+            Arc::new(SimpleMockStreamFn::new(self.responses.clone())),
+        );
+        Ok((Agent::new(options), CancellationToken::new()))
+    }
+}
+
+/// Deterministic "always pass" evaluator.
+struct AlwaysPass;
+
+impl Evaluator for AlwaysPass {
+    fn name(&self) -> &'static str {
+        "always_pass"
+    }
+    fn evaluate(
+        &self,
+        _case: &EvalCase,
+        _invocation: &swink_agent_eval::Invocation,
+    ) -> Option<swink_agent_eval::EvalMetricResult> {
+        Some(swink_agent_eval::EvalMetricResult {
+            evaluator_name: "always_pass".to_string(),
+            score: swink_agent_eval::Score::new(1.0, 0.5),
+            details: Some("ok".into()),
+        })
+    }
+}
+
+/// Deterministic "always fail" evaluator.
+struct AlwaysFail;
+
+impl Evaluator for AlwaysFail {
+    fn name(&self) -> &'static str {
+        "always_fail"
+    }
+    fn evaluate(
+        &self,
+        _case: &EvalCase,
+        _invocation: &swink_agent_eval::Invocation,
+    ) -> Option<swink_agent_eval::EvalMetricResult> {
+        Some(swink_agent_eval::EvalMetricResult {
+            evaluator_name: "always_fail".to_string(),
+            score: swink_agent_eval::Score::new(0.1, 0.5),
+            details: Some("simulated regression".into()),
+        })
+    }
+}
+
+fn fresh_telemetry() -> (Arc<EvalsTelemetry>, InMemorySpanExporter, SdkTracerProvider) {
+    let exporter = InMemorySpanExporter::default();
+    let provider = SdkTracerProvider::builder()
+        .with_simple_exporter(exporter.clone())
+        .build();
+    let telemetry = EvalsTelemetry::builder()
+        .with_tracer_provider(&provider)
+        .build();
+    (Arc::new(telemetry), exporter, provider)
+}
+
+fn find_by_name<'a>(spans: &'a [SpanData], name: &str) -> Vec<&'a SpanData> {
+    spans.iter().filter(|s| s.name == name).collect()
+}
+
+fn attr<'a>(span: &'a SpanData, key: &str) -> Option<&'a opentelemetry::Value> {
+    span.attributes
+        .iter()
+        .find(|kv| kv.key.as_str() == key)
+        .map(|kv| &kv.value)
+}
+
+fn one_case_set(id: &str) -> EvalSet {
+    EvalSet {
+        id: "set-1".into(),
+        name: "Set One".into(),
+        description: None,
+        cases: vec![common::make_case(id)],
+    }
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn three_level_span_tree_is_emitted() {
+    let (telemetry, exporter, provider) = fresh_telemetry();
+    let mut registry = EvaluatorRegistry::new();
+    registry.register(AlwaysPass);
+
+    let runner = EvalRunner::new(registry).with_telemetry(Arc::clone(&telemetry));
+    let set = one_case_set("case-a");
+    let factory = StubFactory::new("ok");
+    let result = runner.run_set(&set, &factory).await.unwrap();
+    assert!(result.case_results[0].verdict.is_pass());
+
+    provider.force_flush().expect("flush");
+    let spans = exporter.get_finished_spans().expect("spans");
+
+    let run_sets = find_by_name(&spans, "swink.eval.run_set");
+    let cases = find_by_name(&spans, "swink.eval.case");
+    let evaluators = find_by_name(&spans, "swink.eval.evaluator");
+
+    assert_eq!(run_sets.len(), 1, "one run_set span");
+    assert_eq!(cases.len(), 1, "one case span");
+    assert_eq!(evaluators.len(), 1, "one evaluator span");
+
+    // Parent linkage: case.parent == run_set.span_id; evaluator.parent == case.span_id.
+    let root_id = run_sets[0].span_context.span_id();
+    assert_eq!(cases[0].parent_span_id, root_id);
+    let case_id = cases[0].span_context.span_id();
+    assert_eq!(evaluators[0].parent_span_id, case_id);
+
+    // All three share the same trace.
+    let trace = run_sets[0].span_context.trace_id();
+    assert_eq!(cases[0].span_context.trace_id(), trace);
+    assert_eq!(evaluators[0].span_context.trace_id(), trace);
+
+    // FR-035 attributes on root.
+    assert_eq!(
+        attr(run_sets[0], "swink.eval.set_id").map(|v| v.as_str().to_string()),
+        Some("set-1".into())
+    );
+    assert_eq!(
+        attr(run_sets[0], "swink.eval.case_count").map(|v| v.to_string()),
+        Some("1".into())
+    );
+
+    // FR-035 attributes on case.
+    assert_eq!(
+        attr(cases[0], "swink.eval.case_id").map(|v| v.as_str().to_string()),
+        Some("case-a".into())
+    );
+    assert_eq!(
+        attr(cases[0], "swink.eval.verdict").map(|v| v.as_str().to_string()),
+        Some("pass".into())
+    );
+
+    // FR-035 attributes on evaluator.
+    assert_eq!(
+        attr(evaluators[0], "swink.eval.evaluator_name").map(|v| v.as_str().to_string()),
+        Some("always_pass".into())
+    );
+    let score = attr(evaluators[0], "swink.eval.score")
+        .map(|v| v.to_string())
+        .unwrap_or_default();
+    assert!(
+        score.starts_with('1'),
+        "evaluator span carries a numeric score, got {score}"
+    );
+    assert_eq!(
+        attr(evaluators[0], "swink.eval.verdict").map(|v| v.as_str().to_string()),
+        Some("pass".into())
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn failed_case_records_status_error_and_exception_event() {
+    let (telemetry, exporter, provider) = fresh_telemetry();
+    let mut registry = EvaluatorRegistry::new();
+    registry.register(AlwaysFail);
+
+    let runner = EvalRunner::new(registry).with_telemetry(Arc::clone(&telemetry));
+    let set = one_case_set("failing-case");
+    let factory = StubFactory::new("oops");
+    let result = runner.run_set(&set, &factory).await.unwrap();
+    assert!(
+        !result.case_results[0].verdict.is_pass(),
+        "seed case must fail so the telemetry error path is exercised"
+    );
+
+    provider.force_flush().expect("flush");
+    let spans = exporter.get_finished_spans().expect("spans");
+
+    let cases = find_by_name(&spans, "swink.eval.case");
+    assert_eq!(cases.len(), 1);
+    let case_span = cases[0];
+    // FR-035: failed case → OTel status error.
+    match &case_span.status {
+        Status::Error { description } => {
+            assert!(
+                description.contains("failing-case"),
+                "status description mentions case id, got `{description}`"
+            );
+        }
+        other => panic!("expected Status::Error on failed case span, got {other:?}"),
+    }
+    // FR-035: failed case → exception event.
+    let has_exception = case_span
+        .events
+        .iter()
+        .any(|e| e.name.as_ref() == "exception");
+    assert!(
+        has_exception,
+        "failed case span records an `exception` event"
+    );
+
+    // Evaluator span also errors.
+    let evaluators = find_by_name(&spans, "swink.eval.evaluator");
+    assert_eq!(evaluators.len(), 1);
+    assert!(
+        matches!(evaluators[0].status, Status::Error { .. }),
+        "failing evaluator span is marked Status::Error"
+    );
+
+    // Run-set span rolls up failed count.
+    let run_sets = find_by_name(&spans, "swink.eval.run_set");
+    assert_eq!(run_sets.len(), 1);
+    assert_eq!(
+        attr(run_sets[0], "swink.eval.failed").map(|v| v.to_string()),
+        Some("1".into())
+    );
+    assert!(matches!(run_sets[0].status, Status::Error { .. }));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn run_set_inherits_active_parent_span() {
+    let (telemetry, exporter, provider) = fresh_telemetry();
+    let mut registry = EvaluatorRegistry::new();
+    registry.register(AlwaysPass);
+
+    // Seed a parent OTel context with a known SpanContext — mimicking an
+    // outer `agent.run` or scheduler tick.
+    let parent_trace_id = TraceId::from(0x0f0f_0f0f_0f0f_0f0f_0f0f_0f0f_0f0f_0f0fu128);
+    let parent_span_id = SpanId::from(0x1234_5678_9abc_def0u64);
+    let parent_cx = Context::new().with_remote_span_context(SpanContext::new(
+        parent_trace_id,
+        parent_span_id,
+        TraceFlags::SAMPLED,
+        true,
+        TraceState::default(),
+    ));
+
+    let runner = EvalRunner::new(registry).with_telemetry(Arc::clone(&telemetry));
+    let set = one_case_set("case-with-parent");
+    let factory = StubFactory::new("ok");
+
+    // Attach the parent context for the duration of `run_set`.
+    let _guard = parent_cx.attach();
+    let result = runner.run_set(&set, &factory).await.unwrap();
+    drop(_guard);
+    assert!(result.case_results[0].verdict.is_pass());
+
+    provider.force_flush().expect("flush");
+    let spans = exporter.get_finished_spans().expect("spans");
+    let run_sets = find_by_name(&spans, "swink.eval.run_set");
+    assert_eq!(run_sets.len(), 1);
+    assert_eq!(
+        run_sets[0].span_context.trace_id(),
+        parent_trace_id,
+        "root span inherits the active parent trace id"
+    );
+    assert_eq!(
+        run_sets[0].parent_span_id, parent_span_id,
+        "root span's parent is the active span at run_set entry"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn telemetry_is_opt_in_and_default_is_no_op() {
+    // No `with_telemetry(...)` → no spans emitted. We prove this by running
+    // with a fresh exporter that has NOT been wired to any provider the
+    // runner knows about; the runner must not leak spans to the global
+    // tracer provider either.
+    let exporter = InMemorySpanExporter::default();
+    let _provider = SdkTracerProvider::builder()
+        .with_simple_exporter(exporter.clone())
+        .build();
+    // Intentionally do NOT set as global.
+
+    let mut registry = EvaluatorRegistry::new();
+    registry.register(AlwaysPass);
+    let runner = EvalRunner::new(registry);
+    let set = one_case_set("case-x");
+    let factory = StubFactory::new("ok");
+    let _ = runner.run_set(&set, &factory).await.unwrap();
+    let spans = exporter.get_finished_spans().expect("spans");
+    assert!(
+        spans.iter().all(|s| !s.name.starts_with("swink.eval.")),
+        "no spans should be emitted when telemetry is not attached"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn multi_evaluator_case_emits_one_span_per_evaluator() {
+    let (telemetry, exporter, provider) = fresh_telemetry();
+    let mut registry = EvaluatorRegistry::new();
+    registry.register(AlwaysPass);
+    registry.register(AlwaysFail);
+
+    let runner = EvalRunner::new(registry).with_telemetry(Arc::clone(&telemetry));
+    let set = one_case_set("two-evaluator-case");
+    let factory = StubFactory::new("ok");
+    let _ = runner.run_set(&set, &factory).await.unwrap();
+
+    provider.force_flush().expect("flush");
+    let spans = exporter.get_finished_spans().expect("spans");
+    let evaluators = find_by_name(&spans, "swink.eval.evaluator");
+    let names: Vec<String> = evaluators
+        .iter()
+        .filter_map(|s| {
+            s.attributes
+                .iter()
+                .find(|kv| kv.key.as_str() == "swink.eval.evaluator_name")
+                .map(|kv| kv.value.as_str().to_string())
+        })
+        .collect();
+    assert_eq!(evaluators.len(), 2, "one span per evaluator");
+    assert!(names.contains(&"always_pass".to_string()));
+    assert!(names.contains(&"always_fail".to_string()));
+}

--- a/eval/tests/us7_end_to_end_test.rs
+++ b/eval/tests/us7_end_to_end_test.rs
@@ -1,0 +1,250 @@
+//! Spec 043 US7 / T138: end-to-end assertion of the US7 user story.
+//!
+//! Runs a mixed eval set (some passing, some regressing on `correctness`) and
+//! confirms:
+//!
+//! 1. A full three-level span tree is emitted:
+//!    `swink.eval.run_set` → `swink.eval.case`* → `swink.eval.evaluator`*.
+//! 2. A regression at a known case surfaces on its `swink.eval.case` span as
+//!    `Status::error` + `exception` event — per US7 scenario 3 in
+//!    `specs/043-evals-adv-features/spec.md`.
+
+#![cfg(feature = "telemetry")]
+
+use std::sync::Arc;
+
+use opentelemetry::trace::{Status, TracerProvider};
+use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider, SpanData};
+use tokio_util::sync::CancellationToken;
+
+use swink_agent::{Agent, AgentOptions, ModelSpec, testing::SimpleMockStreamFn};
+use swink_agent_eval::{
+    AgentFactory, EvalCase, EvalError, EvalMetricResult, EvalRunner, EvalSet, EvalsTelemetry,
+    Evaluator, EvaluatorRegistry, Invocation, Score,
+};
+
+mod common;
+
+// ─── Fixture: a "correctness" evaluator that regresses on a known case ──────
+
+/// Emits a passing score for every case except those in `regressed_ids`,
+/// which receive a failing score — emulating a real regression in
+/// `correctness` surfacing through `EvalsTelemetry` (US7 scenario 3).
+struct CorrectnessEvaluator {
+    regressed_ids: Vec<String>,
+}
+
+impl Evaluator for CorrectnessEvaluator {
+    fn name(&self) -> &'static str {
+        "correctness"
+    }
+    fn evaluate(&self, case: &EvalCase, _invocation: &Invocation) -> Option<EvalMetricResult> {
+        let regressed = self.regressed_ids.iter().any(|id| id == &case.id);
+        let score = if regressed {
+            Score::new(0.2, 0.7)
+        } else {
+            Score::new(0.95, 0.7)
+        };
+        Some(EvalMetricResult {
+            evaluator_name: "correctness".to_string(),
+            score,
+            details: if regressed {
+                Some(format!("regression on case `{}`", case.id))
+            } else {
+                None
+            },
+        })
+    }
+}
+
+struct EchoFactory;
+
+impl AgentFactory for EchoFactory {
+    fn create_agent(&self, case: &EvalCase) -> Result<(Agent, CancellationToken), EvalError> {
+        let options = AgentOptions::new_simple(
+            &case.system_prompt,
+            ModelSpec::new("test", "test-model"),
+            Arc::new(SimpleMockStreamFn::new(vec!["done".to_string()])),
+        );
+        Ok((Agent::new(options), CancellationToken::new()))
+    }
+}
+
+fn find_by_name<'a>(spans: &'a [SpanData], name: &str) -> Vec<&'a SpanData> {
+    spans.iter().filter(|s| s.name == name).collect()
+}
+
+fn case_id_attr(span: &SpanData) -> Option<String> {
+    span.attributes
+        .iter()
+        .find(|kv| kv.key.as_str() == "swink.eval.case_id")
+        .map(|kv| kv.value.as_str().to_string())
+}
+
+fn evaluator_name_attr(span: &SpanData) -> Option<String> {
+    span.attributes
+        .iter()
+        .find(|kv| kv.key.as_str() == "swink.eval.evaluator_name")
+        .map(|kv| kv.value.as_str().to_string())
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn us7_full_run_produces_expected_span_tree() {
+    let exporter = InMemorySpanExporter::default();
+    let provider = SdkTracerProvider::builder()
+        .with_simple_exporter(exporter.clone())
+        .build();
+    let tracer = provider.tracer("us7-smoke");
+    let telemetry = EvalsTelemetry::builder()
+        .with_tracer(opentelemetry::global::BoxedTracer::new(Box::new(tracer)))
+        .build();
+
+    let mut registry = EvaluatorRegistry::new();
+    registry.register(CorrectnessEvaluator {
+        regressed_ids: vec![], // happy path — no regressions
+    });
+
+    let set = EvalSet {
+        id: "us7-smoke".into(),
+        name: "US7 smoke".into(),
+        description: None,
+        cases: (0..3)
+            .map(|i| common::make_case(&format!("case-{i:02}")))
+            .collect(),
+    };
+
+    let runner = EvalRunner::new(registry)
+        .with_parallelism(2)
+        .with_telemetry(Arc::new(telemetry));
+    let factory = EchoFactory;
+
+    let result = runner.run_set(&set, &factory).await.unwrap();
+    assert_eq!(result.summary.passed, 3);
+    assert_eq!(result.summary.failed, 0);
+
+    provider.force_flush().expect("flush");
+    let spans = exporter.get_finished_spans().expect("spans");
+
+    let run_sets = find_by_name(&spans, "swink.eval.run_set");
+    let cases = find_by_name(&spans, "swink.eval.case");
+    let evaluators = find_by_name(&spans, "swink.eval.evaluator");
+    assert_eq!(run_sets.len(), 1);
+    assert_eq!(cases.len(), 3);
+    assert_eq!(evaluators.len(), 3);
+
+    // Each case span is a child of the run-set span.
+    let root_id = run_sets[0].span_context.span_id();
+    for case_span in &cases {
+        assert_eq!(case_span.parent_span_id, root_id);
+    }
+
+    // Each evaluator span is a child of a case span.
+    let case_ids: std::collections::HashSet<_> =
+        cases.iter().map(|s| s.span_context.span_id()).collect();
+    for ev in &evaluators {
+        assert!(
+            case_ids.contains(&ev.parent_span_id),
+            "evaluator span's parent must be a case span"
+        );
+    }
+
+    // Every span shares the same trace id.
+    let trace = run_sets[0].span_context.trace_id();
+    for s in spans.iter().filter(|s| s.name.starts_with("swink.eval.")) {
+        assert_eq!(s.span_context.trace_id(), trace);
+    }
+
+    // No errors on a fully-passing run.
+    assert!(matches!(run_sets[0].status, Status::Ok | Status::Unset));
+    for case_span in &cases {
+        assert!(matches!(case_span.status, Status::Ok));
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn us7_regression_on_known_case_surfaces_as_errored_span() {
+    let exporter = InMemorySpanExporter::default();
+    let provider = SdkTracerProvider::builder()
+        .with_simple_exporter(exporter.clone())
+        .build();
+    let telemetry = EvalsTelemetry::builder()
+        .with_tracer_provider(&provider)
+        .build();
+
+    let regressed = "case-01".to_string();
+    let mut registry = EvaluatorRegistry::new();
+    registry.register(CorrectnessEvaluator {
+        regressed_ids: vec![regressed.clone()],
+    });
+
+    let set = EvalSet {
+        id: "us7-regression".into(),
+        name: "US7 regression".into(),
+        description: None,
+        cases: (0..3)
+            .map(|i| common::make_case(&format!("case-{i:02}")))
+            .collect(),
+    };
+
+    let runner = EvalRunner::new(registry)
+        .with_parallelism(2)
+        .with_telemetry(Arc::new(telemetry));
+    let factory = EchoFactory;
+
+    let result = runner.run_set(&set, &factory).await.unwrap();
+    assert_eq!(result.summary.passed, 2);
+    assert_eq!(result.summary.failed, 1);
+
+    provider.force_flush().expect("flush");
+    let spans = exporter.get_finished_spans().expect("spans");
+
+    let cases = find_by_name(&spans, "swink.eval.case");
+    let evaluators = find_by_name(&spans, "swink.eval.evaluator");
+
+    // Exactly the regressed case has Status::Error and an exception event.
+    let failing_case_spans: Vec<&&SpanData> = cases
+        .iter()
+        .filter(|s| matches!(s.status, Status::Error { .. }))
+        .collect();
+    assert_eq!(
+        failing_case_spans.len(),
+        1,
+        "exactly one failing case span on a single-regression run"
+    );
+    assert_eq!(case_id_attr(failing_case_spans[0]), Some(regressed.clone()));
+    assert!(
+        failing_case_spans[0]
+            .events
+            .iter()
+            .any(|e| e.name.as_ref() == "exception"),
+        "failed case span carries an `exception` event (per US7 scenario 3)"
+    );
+
+    // The failing evaluator span is marked Error + carries the correct name.
+    let failing_evaluator_spans: Vec<&&SpanData> = evaluators
+        .iter()
+        .filter(|s| matches!(s.status, Status::Error { .. }))
+        .collect();
+    assert_eq!(
+        failing_evaluator_spans.len(),
+        1,
+        "exactly one failing evaluator span"
+    );
+    assert_eq!(
+        evaluator_name_attr(failing_evaluator_spans[0]),
+        Some("correctness".to_string())
+    );
+
+    // Passing cases remain Ok.
+    let passing_cases: Vec<&&SpanData> = cases
+        .iter()
+        .filter(|s| matches!(s.status, Status::Ok))
+        .collect();
+    assert_eq!(
+        passing_cases.len(),
+        2,
+        "non-regressed cases stay at Status::Ok"
+    );
+}

--- a/specs/043-evals-adv-features/tasks.md
+++ b/specs/043-evals-adv-features/tasks.md
@@ -331,10 +331,10 @@
 
 *Depends on US2 (extends `EvalRunner`).*
 
-- [ ] T135 [P] [US7] Write tests in `eval/tests/telemetry_test.rs` using `opentelemetry-sdk::testing::trace::InMemorySpanExporter`: root `swink.eval.run_set`, per-case `swink.eval.case`, per-evaluator `swink.eval.evaluator`; failed case records OTel status-error + exception event; parent span is inherited when one exists
-- [ ] T136 [US7] Implement `EvalsTelemetry` + `EvalsTelemetryBuilder` in `eval/src/telemetry.rs` (feature `telemetry`)
-- [ ] T137 [US7] Wire `EvalsTelemetry` into `EvalRunner::run_set` in `eval/src/runner.rs`: emit the three-level span tree; attach standardized attributes per FR-035; honor existing parent span when one is active
-- [ ] T138 [US7] Integration test in `eval/tests/us7_end_to_end_test.rs`: full run produces the expected span tree; regression in `correctness` at a known case surfaces as an errored span (per US7 scenario 3)
+- [x] T135 [P] [US7] Write tests in `eval/tests/telemetry_test.rs` using `opentelemetry-sdk::testing::trace::InMemorySpanExporter`: root `swink.eval.run_set`, per-case `swink.eval.case`, per-evaluator `swink.eval.evaluator`; failed case records OTel status-error + exception event; parent span is inherited when one exists
+- [x] T136 [US7] Implement `EvalsTelemetry` + `EvalsTelemetryBuilder` in `eval/src/telemetry.rs` (feature `telemetry`)
+- [x] T137 [US7] Wire `EvalsTelemetry` into `EvalRunner::run_set` in `eval/src/runner.rs`: emit the three-level span tree; attach standardized attributes per FR-035; honor existing parent span when one is active
+- [x] T138 [US7] Integration test in `eval/tests/us7_end_to_end_test.rs`: full run produces the expected span tree; regression in `correctness` at a known case surfaces as an errored span (per US7 scenario 3)
 
 **Checkpoint**: Eval runs emit OTel spans.
 


### PR DESCRIPTION
## Summary
- EvalsTelemetry + EvalsTelemetryBuilder (T136)
- Wired into EvalRunner::run_set: swink.eval.run_set → swink.eval.case → swink.eval.evaluator span tree (T137)
- Parent span inheritance when one is active
- Failed cases record OTel status-error + exception event
- Regression + integration tests (T135, T138)

## Tasks completed
T135–T138

## Stacking
Originally intended to stack on PR #819 (US2 EvalRunner upgrades), but #819 has already merged to integration. Rebased onto integration.

## Test plan
Worker did not run cargo; orchestrator verifies sequentially after all workers finish.

Part of #757

🤖 Generated with [Claude Code](https://claude.com/claude-code)