### PR TITLE
impl(043): US1d deterministic + code + multimodal evaluators (sandbox deferred)

### DIFF
--- a/eval/Cargo.toml
+++ b/eval/Cargo.toml
@@ -41,6 +41,7 @@ askama = { workspace = true, optional = true }
 clap = { workspace = true, optional = true }
 libc = { workspace = true, optional = true }
 serde_yaml = { workspace = true, optional = true }
+tempfile = { workspace = true, optional = true }
 
 [features]
 default = []
@@ -50,9 +51,9 @@ evaluator-quality = ["judge-core"]
 evaluator-safety = ["judge-core"]
 evaluator-rag = ["judge-core"]
 evaluator-agent = ["judge-core"]
-evaluator-structured = ["dep:jsonschema"]
-evaluator-simple = ["dep:strsim"]
-evaluator-code = []
+evaluator-structured = ["judge-core", "dep:jsonschema"]
+evaluator-simple = ["judge-core", "dep:strsim"]
+evaluator-code = ["judge-core", "dep:tempfile"]
 evaluator-sandbox = ["evaluator-code", "dep:libc"]
 multimodal = ["judge-core", "dep:reqwest"]
 all-evaluators = [

--- a/eval/src/evaluators/code/cargo_check.rs
+++ b/eval/src/evaluators/code/cargo_check.rs
@@ -1,0 +1,113 @@
+//! Deterministic `cargo check` evaluator (T077 — cargo-check portion).
+//!
+//! Extracts code from the assistant response using a configured
+//! [`CodeExtractor`], writes it to a tempdir, and shells out to
+//! `cargo check --message-format=short`. The exit status drives the score;
+//! captured stderr is surfaced in `details` on failure.
+
+use std::process::Command;
+use std::sync::Arc;
+
+use tempfile::TempDir;
+
+use crate::evaluator::Evaluator;
+use crate::evaluators::code::extractor::CodeExtractor;
+use crate::evaluators::code::harness::{CargoHarness, CargoOutcome};
+use crate::types::{EvalCase, EvalMetricResult, Invocation};
+
+/// Deterministic `cargo check` evaluator (FR-017).
+pub struct CargoCheckEvaluator {
+    name: &'static str,
+    extractor: Arc<CodeExtractor>,
+    harness: CargoHarness,
+}
+
+impl CargoCheckEvaluator {
+    /// Create a new evaluator with the given extractor strategy.
+    #[must_use]
+    pub fn new(extractor: Arc<CodeExtractor>) -> Self {
+        Self {
+            name: "cargo_check",
+            extractor,
+            harness: CargoHarness::default(),
+        }
+    }
+
+    /// Override the evaluator's reported name.
+    #[must_use]
+    pub const fn with_name(mut self, name: &'static str) -> Self {
+        self.name = name;
+        self
+    }
+
+    /// Override the harness used to scaffold the tempdir project.
+    #[must_use]
+    pub fn with_harness(mut self, harness: CargoHarness) -> Self {
+        self.harness = harness;
+        self
+    }
+}
+
+impl Evaluator for CargoCheckEvaluator {
+    fn name(&self) -> &'static str {
+        self.name
+    }
+
+    fn evaluate(&self, _case: &EvalCase, invocation: &Invocation) -> Option<EvalMetricResult> {
+        let response = invocation.final_response.as_ref()?;
+        let code = crate::evaluators::block_on(self.extractor.extract(response))?;
+
+        let outcome = run_cargo(&self.harness, &code, &["check", "--message-format=short"]);
+        Some(outcome.into_metric_result(self.name))
+    }
+}
+
+/// Shell out to `cargo` with the configured arguments.
+pub(super) fn run_cargo(harness: &CargoHarness, code: &str, args: &[&str]) -> CargoOutcome {
+    let tempdir = match TempDir::new() {
+        Ok(dir) => dir,
+        Err(err) => {
+            return CargoOutcome {
+                success: false,
+                message: format!("tempdir creation failed: {err}"),
+            };
+        }
+    };
+
+    if let Err(err) = harness.scaffold(tempdir.path(), code) {
+        return CargoOutcome {
+            success: false,
+            message: format!("scaffold failed: {err}"),
+        };
+    }
+
+    let mut command = Command::new(&harness.cargo_bin);
+    command.arg("--offline").args(args);
+    command.current_dir(tempdir.path());
+    command.env("CARGO_TARGET_DIR", tempdir.path().join("target"));
+
+    let output = match command.output() {
+        Ok(output) => output,
+        Err(err) => {
+            return CargoOutcome {
+                success: false,
+                message: format!("cargo spawn failed: {err}"),
+            };
+        }
+    };
+
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    CargoOutcome {
+        success: output.status.success(),
+        message: if output.status.success() {
+            String::from("ok")
+        } else {
+            stderr
+                .lines()
+                .filter(|line| !line.trim().is_empty())
+                .take(8)
+                .collect::<Vec<_>>()
+                .join("\n")
+        },
+    }
+}

--- a/eval/src/evaluators/code/clippy.rs
+++ b/eval/src/evaluators/code/clippy.rs
@@ -1,0 +1,59 @@
+//! Deterministic `cargo clippy` evaluator (T077 — clippy portion).
+//!
+//! Mirrors [`super::cargo_check::CargoCheckEvaluator`] but invokes
+//! `cargo clippy -- -D warnings` so any warning fails the metric.
+
+use std::sync::Arc;
+
+use crate::evaluator::Evaluator;
+use crate::evaluators::code::cargo_check::run_cargo;
+use crate::evaluators::code::extractor::CodeExtractor;
+use crate::evaluators::code::harness::CargoHarness;
+use crate::types::{EvalCase, EvalMetricResult, Invocation};
+
+/// Deterministic `cargo clippy` evaluator (FR-017).
+pub struct ClippyEvaluator {
+    name: &'static str,
+    extractor: Arc<CodeExtractor>,
+    harness: CargoHarness,
+}
+
+impl ClippyEvaluator {
+    /// Create a new evaluator with the given extractor strategy.
+    #[must_use]
+    pub fn new(extractor: Arc<CodeExtractor>) -> Self {
+        Self {
+            name: "clippy",
+            extractor,
+            harness: CargoHarness::default(),
+        }
+    }
+
+    /// Override the evaluator's reported name.
+    #[must_use]
+    pub const fn with_name(mut self, name: &'static str) -> Self {
+        self.name = name;
+        self
+    }
+
+    /// Override the harness used to scaffold the tempdir project.
+    #[must_use]
+    pub fn with_harness(mut self, harness: CargoHarness) -> Self {
+        self.harness = harness;
+        self
+    }
+}
+
+impl Evaluator for ClippyEvaluator {
+    fn name(&self) -> &'static str {
+        self.name
+    }
+
+    fn evaluate(&self, _case: &EvalCase, invocation: &Invocation) -> Option<EvalMetricResult> {
+        let response = invocation.final_response.as_ref()?;
+        let code = crate::evaluators::block_on(self.extractor.extract(response))?;
+
+        let outcome = run_cargo(&self.harness, &code, &["clippy", "--", "-D", "warnings"]);
+        Some(outcome.into_metric_result(self.name))
+    }
+}

--- a/eval/src/evaluators/code/extractor.rs
+++ b/eval/src/evaluators/code/extractor.rs
@@ -1,0 +1,159 @@
+//! Code extraction strategies (T078).
+//!
+//! A [`CodeExtractor`] lifts code out of an assistant response using one of
+//! three built-in strategies. This is the single choke-point used by every
+//! code-family evaluator so extraction logic isn't re-implemented per
+//! evaluator.
+
+use regex::Regex;
+use std::sync::Arc;
+
+use crate::judge::JudgeClient;
+
+/// Strategy selector for [`CodeExtractor`].
+#[derive(Clone)]
+pub enum CodeExtractorStrategy {
+    /// Match fenced markdown code blocks. When `language` is `Some`, only
+    /// fences tagged with the given language are returned.
+    MarkdownFence {
+        /// Optional language tag to require on the opening fence.
+        language: Option<String>,
+    },
+    /// Arbitrary regex whose first capture group is the extracted code.
+    Regex { pattern: Regex },
+    /// Ask a judge to return the code block most relevant to the response.
+    ///
+    /// The supplied prompt is rendered as-is with the response appended; the
+    /// judge's `reason` field is returned as the extracted code to keep the
+    /// contract free of schema assumptions.
+    Llm {
+        /// Prompt prepended to the response before the judge dispatch.
+        prompt: String,
+        /// Judge client used for the dispatch.
+        judge: Arc<dyn JudgeClient>,
+    },
+}
+
+impl std::fmt::Debug for CodeExtractorStrategy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MarkdownFence { language } => f
+                .debug_struct("MarkdownFence")
+                .field("language", language)
+                .finish(),
+            Self::Regex { pattern } => f
+                .debug_struct("Regex")
+                .field("pattern", &pattern.as_str())
+                .finish(),
+            Self::Llm { prompt, .. } => f
+                .debug_struct("Llm")
+                .field("prompt_len", &prompt.len())
+                .finish(),
+        }
+    }
+}
+
+/// Strategy object that extracts code from an assistant response.
+///
+/// Each call to [`Self::extract`] returns the first matching snippet found,
+/// or `None` if no code was extracted. The extractor is deterministic for
+/// `MarkdownFence` and `Regex` strategies; the `Llm` strategy is inherently
+/// judge-backed and therefore non-deterministic.
+pub struct CodeExtractor {
+    strategy: CodeExtractorStrategy,
+}
+
+impl CodeExtractor {
+    /// Create an extractor with the given strategy.
+    #[must_use]
+    pub const fn new(strategy: CodeExtractorStrategy) -> Self {
+        Self { strategy }
+    }
+
+    /// Convenience: markdown-fence extractor with no language requirement.
+    #[must_use]
+    pub const fn markdown_fence() -> Self {
+        Self::new(CodeExtractorStrategy::MarkdownFence { language: None })
+    }
+
+    /// Extract the first matching code snippet from `response`.
+    pub async fn extract(&self, response: &str) -> Option<String> {
+        match &self.strategy {
+            CodeExtractorStrategy::MarkdownFence { language } => {
+                extract_markdown_fence(response, language.as_deref())
+            }
+            CodeExtractorStrategy::Regex { pattern } => {
+                pattern.captures(response).and_then(|caps| {
+                    caps.get(1)
+                        .or_else(|| caps.get(0))
+                        .map(|m| m.as_str().to_string())
+                })
+            }
+            CodeExtractorStrategy::Llm { prompt, judge } => {
+                let rendered = format!("{prompt}\n\n---\n{response}");
+                match judge.judge(&rendered).await {
+                    Ok(verdict) => verdict.reason,
+                    Err(_) => None,
+                }
+            }
+        }
+    }
+}
+
+fn extract_markdown_fence(response: &str, required_language: Option<&str>) -> Option<String> {
+    let mut lines = response.lines();
+    while let Some(line) = lines.next() {
+        let trimmed = line.trim_start();
+        let Some(rest) = trimmed.strip_prefix("```") else {
+            continue;
+        };
+        let tag = rest.trim();
+        if let Some(expected) = required_language
+            && !tag.eq_ignore_ascii_case(expected)
+        {
+            continue;
+        }
+        let mut body = String::new();
+        for inner in lines.by_ref() {
+            let inner_trimmed = inner.trim_start();
+            if inner_trimmed.starts_with("```") {
+                return Some(body.trim_end_matches('\n').to_string());
+            }
+            body.push_str(inner);
+            body.push('\n');
+        }
+        // Unterminated fence — return whatever we collected.
+        return Some(body.trim_end_matches('\n').to_string());
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn markdown_fence_extracts_first_block() {
+        let response =
+            "Here is the code:\n\n```rust\nfn add(a: i32, b: i32) -> i32 { a + b }\n```\n";
+        let out = extract_markdown_fence(response, Some("rust"));
+        assert_eq!(
+            out.as_deref(),
+            Some("fn add(a: i32, b: i32) -> i32 { a + b }")
+        );
+    }
+
+    #[test]
+    fn markdown_fence_skips_non_matching_language() {
+        let response = "```python\nprint('hi')\n```\n\n```rust\nfn a() {}\n```\n";
+        let out = extract_markdown_fence(response, Some("rust"));
+        assert_eq!(out.as_deref(), Some("fn a() {}"));
+    }
+
+    #[test]
+    fn markdown_fence_ignores_language_when_none() {
+        let response = "```\nanything\n```";
+        let out = extract_markdown_fence(response, None);
+        assert_eq!(out.as_deref(), Some("anything"));
+    }
+}

--- a/eval/src/evaluators/code/harness.rs
+++ b/eval/src/evaluators/code/harness.rs
@@ -1,0 +1,67 @@
+//! Shared cargo-harness utilities for the code family (T077 support module).
+//!
+//! Scaffolds a minimal Rust crate on disk so deterministic evaluators like
+//! [`super::cargo_check::CargoCheckEvaluator`] and [`super::clippy::ClippyEvaluator`]
+//! can shell out to `cargo` without assuming any ambient filesystem shape.
+
+use std::fs;
+use std::io;
+use std::path::Path;
+
+use crate::score::Score;
+use crate::types::EvalMetricResult;
+
+/// How a harness writes an extracted snippet to disk before invoking cargo.
+#[derive(Debug, Clone)]
+pub struct CargoHarness {
+    /// Absolute or PATH-resolvable cargo binary name.
+    pub cargo_bin: String,
+    /// Crate name used when scaffolding `Cargo.toml`.
+    pub crate_name: String,
+}
+
+impl Default for CargoHarness {
+    fn default() -> Self {
+        Self {
+            cargo_bin: "cargo".to_string(),
+            crate_name: "swink_agent_eval_snippet".to_string(),
+        }
+    }
+}
+
+impl CargoHarness {
+    /// Scaffold a minimal `[lib]` crate at `root` containing `code` as the lib body.
+    pub fn scaffold(&self, root: &Path, code: &str) -> io::Result<()> {
+        let src = root.join("src");
+        fs::create_dir_all(&src)?;
+        fs::write(
+            root.join("Cargo.toml"),
+            format!(
+                "[package]\nname = \"{name}\"\nversion = \"0.0.0\"\nedition = \"2021\"\n\n[lib]\npath = \"src/lib.rs\"\n",
+                name = self.crate_name,
+            ),
+        )?;
+        fs::write(src.join("lib.rs"), code)?;
+        Ok(())
+    }
+}
+
+/// Outcome returned by `cargo` shell-outs.
+pub struct CargoOutcome {
+    pub success: bool,
+    pub message: String,
+}
+
+impl CargoOutcome {
+    pub fn into_metric_result(self, evaluator_name: &'static str) -> EvalMetricResult {
+        EvalMetricResult {
+            evaluator_name: evaluator_name.to_string(),
+            score: if self.success {
+                Score::pass()
+            } else {
+                Score::fail()
+            },
+            details: Some(self.message),
+        }
+    }
+}

--- a/eval/src/evaluators/code/llm_judge.rs
+++ b/eval/src/evaluators/code/llm_judge.rs
@@ -1,0 +1,73 @@
+//! Judge-backed code quality evaluator (T079).
+//!
+//! Dispatches through the shared [`dispatch_judge`](crate::dispatch_judge)
+//! helper using the `code_llm_judge_v0` template registered on PR #818.
+
+use std::sync::Arc;
+
+use crate::evaluator::Evaluator;
+use crate::evaluators::{JudgeEvaluatorConfig, block_on, dispatch_judge, finish_metric_result};
+use crate::prompt::{PromptContext, PromptTemplateRegistry};
+use crate::score::Score;
+use crate::types::{EvalCase, EvalMetricResult, Invocation};
+
+/// Judge-backed code quality evaluator (FR-017).
+pub struct CodeLlmJudgeEvaluator {
+    name: &'static str,
+    config: JudgeEvaluatorConfig,
+}
+
+impl CodeLlmJudgeEvaluator {
+    /// Create the evaluator bound to the given judge config.
+    #[must_use]
+    pub fn new(config: JudgeEvaluatorConfig) -> Self {
+        Self {
+            name: "code_llm_judge",
+            config,
+        }
+    }
+
+    /// Override the evaluator's reported name.
+    #[must_use]
+    pub const fn with_name(mut self, name: &'static str) -> Self {
+        self.name = name;
+        self
+    }
+
+    fn builtin_template() -> Arc<dyn crate::prompt::JudgePromptTemplate> {
+        PromptTemplateRegistry::builtin()
+            .get("code_llm_judge_v0")
+            .expect("code_llm_judge_v0 registered on PR #818")
+    }
+}
+
+impl Evaluator for CodeLlmJudgeEvaluator {
+    fn name(&self) -> &'static str {
+        self.name
+    }
+
+    fn evaluate(&self, case: &EvalCase, invocation: &Invocation) -> Option<EvalMetricResult> {
+        // FR-020: no user message and no assistant response → criterion not set.
+        if case.user_messages.is_empty() || invocation.final_response.is_none() {
+            return None;
+        }
+
+        let builtin = Self::builtin_template();
+        let ctx = PromptContext::new(Arc::new(case.clone()), Arc::new(invocation.clone()))
+            .with_few_shot_examples(self.config.few_shot_examples.clone());
+
+        let future = dispatch_judge(&self.config, builtin, &ctx);
+        let outcome = match block_on(future) {
+            Ok(outcome) => outcome,
+            Err(err) => {
+                return Some(EvalMetricResult {
+                    evaluator_name: self.name.to_string(),
+                    score: Score::fail(),
+                    details: Some(format!("dispatch error: {err}")),
+                });
+            }
+        };
+
+        Some(finish_metric_result(self.name.to_string(), outcome))
+    }
+}

--- a/eval/src/evaluators/code/mod.rs
+++ b/eval/src/evaluators/code/mod.rs
@@ -1,0 +1,24 @@
+//! Code-family evaluators (T077–T079 — code family).
+//!
+//! Public surface:
+//! * [`CodeExtractor`] + [`CodeExtractorStrategy`] — strategy object that lifts
+//!   code from an assistant response (markdown fence / regex / LLM). Shared by
+//!   every code evaluator so extraction logic lives in exactly one place.
+//! * [`CargoCheckEvaluator`] / [`ClippyEvaluator`] — deterministic evaluators
+//!   that shell out to `cargo check` / `cargo clippy` in a tempdir.
+//! * [`llm_judge::CodeLlmJudgeEvaluator`] — judge-backed evaluator using the
+//!   `code_llm_judge_v0` template.
+//!
+//! `SandboxedExecutionEvaluator` (T080–T083, behind `evaluator-sandbox`) is
+//! deferred to a follow-up PR so this slice stays under the workspace diff
+//! budget; see the PR body for the deferred task list.
+
+pub mod cargo_check;
+pub mod clippy;
+pub mod extractor;
+pub(crate) mod harness;
+pub mod llm_judge;
+
+pub use cargo_check::CargoCheckEvaluator;
+pub use clippy::ClippyEvaluator;
+pub use extractor::{CodeExtractor, CodeExtractorStrategy};

--- a/eval/src/evaluators/mod.rs
+++ b/eval/src/evaluators/mod.rs
@@ -10,6 +10,7 @@
 
 #![cfg(feature = "judge-core")]
 
+use std::path::Path;
 use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
@@ -18,7 +19,26 @@ use crate::aggregator::{Aggregator, Average};
 use crate::judge::{JudgeError, JudgeRegistry, JudgeVerdict};
 use crate::prompt::{JudgePromptTemplate, PromptContext, PromptError};
 use crate::score::Score;
-use crate::types::EvalMetricResult;
+use crate::types::{AttachmentError, EvalMetricResult, MaterializedAttachment};
+use crate::url_filter::UrlFilter;
+
+// ─── US1d (deterministic) ───────────────────────────────────────────────────
+//
+// The module list below is owned by the US1d (deterministic / code / sandbox /
+// multimodal) slice of spec 043. Keep additions inside this block so the US1c
+// (judge-family) slice can land independent module declarations above without
+// a mechanical merge conflict.
+
+#[cfg(feature = "evaluator-simple")]
+pub mod simple;
+#[cfg(feature = "evaluator-structured")]
+pub mod structured;
+
+#[cfg(feature = "evaluator-code")]
+pub mod code;
+
+#[cfg(feature = "multimodal")]
+pub mod multimodal;
 
 // ─── Judge-family evaluator submodules (T057–T070) ──────────────────────────
 //
@@ -239,6 +259,44 @@ pub enum DispatchError {
     /// Judge call failed.
     #[error("judge: {0}")]
     Judge(#[from] JudgeError),
+    /// Attachment materialization failed.
+    #[error("attachment: {0}")]
+    Attachment(#[from] AttachmentError),
+}
+
+/// Structured errors surfaced by concrete evaluators in this module tree (T080–T082).
+///
+/// Evaluators fold these into [`EvalMetricResult`] via `Score::fail()` with the
+/// error message copied into `details`; the type exists primarily so callers
+/// (tests, reporters) can reason about the failure mode programmatically.
+#[derive(Debug, thiserror::Error)]
+pub enum EvaluatorError {
+    /// The current platform cannot run this evaluator (e.g. Windows sandbox).
+    #[error("evaluator unsupported on this platform: {reason}")]
+    UnsupportedPlatform {
+        /// Free-form explanation of the missing platform capability.
+        reason: String,
+    },
+    /// A sandbox resource-limit cap was exceeded at evaluation time (T081).
+    #[error("sandbox limit exceeded: {limit}")]
+    SandboxLimitExceeded {
+        /// Name of the exceeded limit (`wall_clock`, `cpu`, `memory`, `fds`, `network`).
+        limit: String,
+    },
+    /// The evaluator could not carry out a deterministic operation.
+    #[error("evaluator execution error: {reason}")]
+    Execution {
+        /// Human-readable explanation of the failure.
+        reason: String,
+    },
+}
+
+impl EvaluatorError {
+    /// Convenience: render the error as the `details` string paired with `Score::fail()`.
+    #[must_use]
+    pub fn into_metric_details(self) -> String {
+        self.to_string()
+    }
 }
 
 /// Outcome of a [`dispatch_judge`] call (T056).
@@ -305,6 +363,60 @@ pub async fn dispatch_judge(
         details,
         verdict,
     })
+}
+
+/// Drive an async future to completion from the sync `Evaluator::evaluate`
+/// entry point, regardless of the caller's Tokio runtime state.
+///
+/// Multi-thread runtime active → `block_in_place` + the ambient
+/// `Handle::block_on` so the host runtime keeps scheduling other tasks.
+/// Otherwise → build an ephemeral current-thread runtime and `block_on` it.
+///
+/// ## Known limitation
+/// Running from *inside* a single-threaded Tokio runtime will panic with
+/// "Cannot start a runtime from within a runtime". This is an inherent
+/// Tokio constraint — use a multi-thread runtime or call from sync context.
+pub fn block_on<F, T>(future: F) -> T
+where
+    F: std::future::Future<Output = T>,
+{
+    use tokio::runtime::{Handle, RuntimeFlavor};
+
+    if let Ok(handle) = Handle::try_current()
+        && handle.runtime_flavor() == RuntimeFlavor::MultiThread
+    {
+        return tokio::task::block_in_place(|| handle.block_on(future));
+    }
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build ephemeral current-thread runtime");
+    rt.block_on(future)
+}
+
+/// Materialize every attachment on the case through the shared attachment
+/// pipeline (T086).
+///
+/// This is the narrow wiring point for FR-019: any judge-backed evaluator can
+/// call [`materialize_case_attachments`] to get a `Vec<MaterializedAttachment>`
+/// without re-implementing path resolution, base64 handling, or SSRF-filtered
+/// URL fetching. The helper lives next to [`dispatch_judge`] so every caller
+/// sees the same wiring.
+///
+/// Returns an empty vector when the case has no attachments; the
+/// [`PromptContext`] passed downstream remains cheap to clone.
+pub async fn materialize_case_attachments(
+    case: &crate::types::EvalCase,
+    eval_set_root: &Path,
+    filter: &dyn UrlFilter,
+) -> Result<Vec<MaterializedAttachment>, AttachmentError> {
+    let mut out = Vec::with_capacity(case.attachments.len());
+    for attachment in &case.attachments {
+        let materialized = attachment.materialize(eval_set_root, filter).await?;
+        out.push(materialized);
+    }
+    Ok(out)
 }
 
 /// Convenience: finalize a [`DispatchOutcome`] (plus optional judge reason)

--- a/eval/src/evaluators/multimodal.rs
+++ b/eval/src/evaluators/multimodal.rs
@@ -1,0 +1,111 @@
+//! Multimodal-family evaluators (T085).
+//!
+//! Only `ImageSafetyEvaluator` ships in this spec — audio multimodal is
+//! deferred per FR-019. The evaluator consumes `case.attachments` via the
+//! shared [`materialize_case_attachments`](crate::materialize_case_attachments)
+//! helper (T086) and dispatches through `dispatch_judge` with the
+//! `image_safety_v0` template registered on PR #818.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use crate::evaluator::Evaluator;
+use crate::evaluators::{
+    JudgeEvaluatorConfig, dispatch_judge, finish_metric_result, materialize_case_attachments,
+};
+use crate::prompt::{PromptContext, PromptTemplateRegistry};
+use crate::score::Score;
+use crate::types::{EvalCase, EvalMetricResult, Invocation};
+use crate::url_filter::{DefaultUrlFilter, UrlFilter};
+
+/// Judge-backed image-safety evaluator (FR-019).
+pub struct ImageSafetyEvaluator {
+    name: &'static str,
+    config: JudgeEvaluatorConfig,
+    eval_set_root: PathBuf,
+    url_filter: Arc<dyn UrlFilter>,
+}
+
+impl ImageSafetyEvaluator {
+    /// Create the evaluator bound to the given judge config.
+    ///
+    /// `eval_set_root` is the directory used to resolve `Attachment::Path`
+    /// entries; callers typically pass the on-disk root of the eval set.
+    #[must_use]
+    pub fn new(config: JudgeEvaluatorConfig, eval_set_root: impl Into<PathBuf>) -> Self {
+        Self {
+            name: "image_safety",
+            config,
+            eval_set_root: eval_set_root.into(),
+            url_filter: Arc::new(DefaultUrlFilter),
+        }
+    }
+
+    /// Override the evaluator's reported name.
+    #[must_use]
+    pub const fn with_name(mut self, name: &'static str) -> Self {
+        self.name = name;
+        self
+    }
+
+    /// Override the URL filter used when materializing `Attachment::Url`.
+    #[must_use]
+    pub fn with_url_filter(mut self, filter: Arc<dyn UrlFilter>) -> Self {
+        self.url_filter = filter;
+        self
+    }
+}
+
+impl Evaluator for ImageSafetyEvaluator {
+    fn name(&self) -> &'static str {
+        self.name
+    }
+
+    fn evaluate(&self, case: &EvalCase, invocation: &Invocation) -> Option<EvalMetricResult> {
+        // FR-020: without attachments, the criterion isn't set.
+        if case.attachments.is_empty() {
+            return None;
+        }
+
+        let builtin = PromptTemplateRegistry::builtin()
+            .get("image_safety_v0")
+            .expect("image_safety_v0 registered on PR #818");
+
+        let materialize =
+            materialize_case_attachments(case, &self.eval_set_root, &*self.url_filter);
+        let materialized = match crate::evaluators::block_on(materialize) {
+            Ok(materialized) => materialized,
+            Err(err) => {
+                return Some(EvalMetricResult {
+                    evaluator_name: self.name.to_string(),
+                    score: Score::fail(),
+                    details: Some(format!("attachment materialization failed: {err}")),
+                });
+            }
+        };
+
+        let mut custom = std::collections::HashMap::new();
+        custom.insert(
+            "materialized_attachments".to_string(),
+            serde_json::Value::Number(serde_json::Number::from(materialized.len())),
+        );
+
+        let ctx = PromptContext::new(Arc::new(case.clone()), Arc::new(invocation.clone()))
+            .with_few_shot_examples(self.config.few_shot_examples.clone())
+            .with_custom(custom);
+
+        let outcome = match crate::evaluators::block_on(dispatch_judge(&self.config, builtin, &ctx))
+        {
+            Ok(outcome) => outcome,
+            Err(err) => {
+                return Some(EvalMetricResult {
+                    evaluator_name: self.name.to_string(),
+                    score: Score::fail(),
+                    details: Some(format!("dispatch error: {err}")),
+                });
+            }
+        };
+
+        Some(finish_metric_result(self.name.to_string(), outcome))
+    }
+}

--- a/eval/src/evaluators/simple.rs
+++ b/eval/src/evaluators/simple.rs
@@ -1,0 +1,168 @@
+//! Simple deterministic evaluators (T075 — simple family).
+//!
+//! These evaluators do not involve a judge dispatch; they compare the
+//! agent's final response string against a caller-supplied expected value
+//! using exact equality or normalized Levenshtein similarity. They satisfy
+//! FR-018 and the FR-020 "`None` when criterion not set" convention.
+
+use strsim::levenshtein;
+
+use crate::evaluator::Evaluator;
+use crate::score::Score;
+use crate::types::{EvalCase, EvalMetricResult, Invocation};
+
+/// Exact-match evaluator (FR-018).
+///
+/// Compares the invocation's `final_response` against a configured expected
+/// value. Returns `None` when no final response is produced.
+pub struct ExactMatchEvaluator {
+    name: &'static str,
+    expected: String,
+    case_sensitive: bool,
+    trim: bool,
+}
+
+impl ExactMatchEvaluator {
+    /// Create an evaluator whose `name()` defaults to `"exact_match"`.
+    #[must_use]
+    pub fn new(expected: impl Into<String>) -> Self {
+        Self {
+            name: "exact_match",
+            expected: expected.into(),
+            case_sensitive: true,
+            trim: false,
+        }
+    }
+
+    /// Override the evaluator's reported name (useful when a case wires
+    /// multiple expected-value evaluators).
+    #[must_use]
+    pub const fn with_name(mut self, name: &'static str) -> Self {
+        self.name = name;
+        self
+    }
+
+    /// Toggle case sensitivity. Defaults to case-sensitive.
+    #[must_use]
+    pub const fn case_sensitive(mut self, case_sensitive: bool) -> Self {
+        self.case_sensitive = case_sensitive;
+        self
+    }
+
+    /// Toggle whitespace trimming before comparison. Defaults to `false`.
+    #[must_use]
+    pub const fn trim(mut self, trim: bool) -> Self {
+        self.trim = trim;
+        self
+    }
+
+    fn normalize<'a>(&self, text: &'a str) -> std::borrow::Cow<'a, str> {
+        let trimmed = if self.trim { text.trim() } else { text };
+        if self.case_sensitive {
+            std::borrow::Cow::Borrowed(trimmed)
+        } else {
+            std::borrow::Cow::Owned(trimmed.to_lowercase())
+        }
+    }
+}
+
+impl Evaluator for ExactMatchEvaluator {
+    fn name(&self) -> &'static str {
+        self.name
+    }
+
+    fn evaluate(&self, _case: &EvalCase, invocation: &Invocation) -> Option<EvalMetricResult> {
+        let actual = invocation.final_response.as_ref()?;
+        let actual_norm = self.normalize(actual);
+        let expected_norm = self.normalize(&self.expected);
+        let matched = actual_norm == expected_norm;
+        let score = if matched {
+            Score::pass()
+        } else {
+            Score::fail()
+        };
+        Some(EvalMetricResult {
+            evaluator_name: self.name.to_string(),
+            score,
+            details: Some(if matched {
+                "match".to_string()
+            } else {
+                format!(
+                    "expected `{}`, got `{}`",
+                    expected_norm.as_ref(),
+                    actual_norm.as_ref()
+                )
+            }),
+        })
+    }
+}
+
+/// Levenshtein-distance evaluator (FR-018).
+///
+/// Produces a normalized similarity score in `[0.0, 1.0]` computed as
+/// `1.0 - distance / max(len(expected), len(actual))`. Returns `None` when
+/// no final response is produced.
+pub struct LevenshteinDistanceEvaluator {
+    name: &'static str,
+    expected: String,
+    /// Pass-threshold applied to the normalized similarity score.
+    threshold: f64,
+}
+
+impl LevenshteinDistanceEvaluator {
+    /// Create an evaluator whose `name()` defaults to `"levenshtein_distance"`.
+    ///
+    /// The default threshold is `0.8` — callers can tune per-case via
+    /// [`Self::with_threshold`].
+    #[must_use]
+    pub fn new(expected: impl Into<String>) -> Self {
+        Self {
+            name: "levenshtein_distance",
+            expected: expected.into(),
+            threshold: 0.8,
+        }
+    }
+
+    /// Override the evaluator's reported name.
+    #[must_use]
+    pub const fn with_name(mut self, name: &'static str) -> Self {
+        self.name = name;
+        self
+    }
+
+    /// Override the pass threshold for the normalized similarity score.
+    #[must_use]
+    pub const fn with_threshold(mut self, threshold: f64) -> Self {
+        self.threshold = threshold;
+        self
+    }
+}
+
+impl Evaluator for LevenshteinDistanceEvaluator {
+    fn name(&self) -> &'static str {
+        self.name
+    }
+
+    fn evaluate(&self, _case: &EvalCase, invocation: &Invocation) -> Option<EvalMetricResult> {
+        let actual = invocation.final_response.as_ref()?;
+        let distance = levenshtein(&self.expected, actual);
+        let max_len = self.expected.chars().count().max(actual.chars().count());
+        let similarity = if max_len == 0 {
+            1.0_f64
+        } else {
+            #[allow(clippy::cast_precision_loss)]
+            {
+                1.0_f64 - (distance as f64 / max_len as f64)
+            }
+        };
+        let score = Score::new(similarity, self.threshold);
+        Some(EvalMetricResult {
+            evaluator_name: self.name.to_string(),
+            score,
+            details: Some(format!(
+                "distance={distance} similarity={similarity:.3} threshold={:.3}",
+                self.threshold
+            )),
+        })
+    }
+}

--- a/eval/src/evaluators/structured.rs
+++ b/eval/src/evaluators/structured.rs
@@ -1,0 +1,272 @@
+//! Structured-output evaluators (T072, T073 — structured family).
+//!
+//! Implements FR-016:
+//! * [`JsonMatchEvaluator`] with per-key aggregation strategies and an
+//!   `exclude_keys` filter. Rubric entries may dispatch to judge prompts,
+//!   but the evaluator is itself deterministic when configured with
+//!   `KeyStrategy::Average`/`All`/`None`.
+//! * [`JsonSchemaEvaluator`] — deterministic JSON Schema validator built
+//!   on the `jsonschema` crate; never dispatches a judge call.
+
+use std::collections::HashSet;
+
+use jsonschema::Validator;
+
+use crate::evaluator::Evaluator;
+use crate::score::Score;
+use crate::types::{EvalCase, EvalMetricResult, Invocation};
+
+/// Per-key aggregation strategy for [`JsonMatchEvaluator`].
+#[derive(Clone)]
+pub enum KeyStrategy {
+    /// Average per-key scores (1.0 per matching key, 0.0 otherwise).
+    Average,
+    /// Pass only when every compared key matches the expected value.
+    All,
+    /// Pass only when none of the compared keys match (i.e. every key differs).
+    None,
+    /// Per-key rubric: keys listed here are scored by the caller-supplied
+    /// closure; unlisted keys contribute a fixed default score.
+    Rubric {
+        /// Caller-supplied closure scoring a single key.
+        ///
+        /// Takes `(key, expected, actual)` and returns a score in `[0.0, 1.0]`.
+        /// The closure is called only for keys present in the expected value.
+        scorer: RubricScorer,
+    },
+}
+
+/// Boxed per-key scoring closure shared by [`KeyStrategy::Rubric`].
+pub type RubricScorer = std::sync::Arc<
+    dyn Fn(&str, &serde_json::Value, Option<&serde_json::Value>) -> f64 + Send + Sync,
+>;
+
+impl std::fmt::Debug for KeyStrategy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Average => f.debug_tuple("Average").finish(),
+            Self::All => f.debug_tuple("All").finish(),
+            Self::None => f.debug_tuple("None").finish(),
+            Self::Rubric { .. } => f.debug_struct("Rubric").field("scorer", &"<fn>").finish(),
+        }
+    }
+}
+
+/// JSON-match evaluator (FR-016).
+///
+/// Compares the invocation's `final_response` (parsed as JSON) against an
+/// expected JSON value key-by-key. Keys present in `exclude_keys` are
+/// skipped entirely. Aggregation across keys is controlled by [`KeyStrategy`].
+pub struct JsonMatchEvaluator {
+    name: &'static str,
+    expected: serde_json::Value,
+    strategy: KeyStrategy,
+    exclude_keys: HashSet<String>,
+}
+
+impl JsonMatchEvaluator {
+    /// Create a new evaluator with `KeyStrategy::Average` semantics and no
+    /// excluded keys.
+    #[must_use]
+    pub fn new(expected: serde_json::Value) -> Self {
+        Self {
+            name: "json_match",
+            expected,
+            strategy: KeyStrategy::Average,
+            exclude_keys: HashSet::new(),
+        }
+    }
+
+    /// Override the evaluator's reported name.
+    #[must_use]
+    pub const fn with_name(mut self, name: &'static str) -> Self {
+        self.name = name;
+        self
+    }
+
+    /// Override the per-key aggregation strategy.
+    #[must_use]
+    pub fn with_strategy(mut self, strategy: KeyStrategy) -> Self {
+        self.strategy = strategy;
+        self
+    }
+
+    /// Exclude the named keys from comparison.
+    #[must_use]
+    pub fn with_exclude_keys<I, S>(mut self, keys: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.exclude_keys = keys.into_iter().map(Into::into).collect();
+        self
+    }
+
+    fn compare(&self, actual: &serde_json::Value) -> (f64, String) {
+        let Some(expected_obj) = self.expected.as_object() else {
+            // Scalar / array comparison falls back to full equality.
+            let eq = self.expected == *actual;
+            return (
+                if eq { 1.0 } else { 0.0 },
+                if eq {
+                    "match".into()
+                } else {
+                    "mismatch".into()
+                },
+            );
+        };
+        let actual_obj = actual.as_object();
+
+        let mut per_key: Vec<(String, f64)> = Vec::new();
+        for (key, expected_value) in expected_obj {
+            if self.exclude_keys.contains(key) {
+                continue;
+            }
+            let actual_value = actual_obj.and_then(|obj| obj.get(key));
+            let score = match &self.strategy {
+                KeyStrategy::Average | KeyStrategy::All | KeyStrategy::None => {
+                    if actual_value == Some(expected_value) {
+                        1.0
+                    } else {
+                        0.0
+                    }
+                }
+                KeyStrategy::Rubric { scorer } => {
+                    scorer(key, expected_value, actual_value).clamp(0.0_f64, 1.0_f64)
+                }
+            };
+            per_key.push((key.clone(), score));
+        }
+
+        if per_key.is_empty() {
+            return (1.0, "no comparable keys".into());
+        }
+
+        let score = match &self.strategy {
+            KeyStrategy::Average | KeyStrategy::Rubric { .. } => {
+                let sum: f64 = per_key.iter().map(|(_, s)| *s).sum();
+                #[allow(clippy::cast_precision_loss)]
+                {
+                    sum / per_key.len() as f64
+                }
+            }
+            KeyStrategy::All => {
+                if per_key.iter().all(|(_, s)| *s >= 1.0) {
+                    1.0
+                } else {
+                    0.0
+                }
+            }
+            KeyStrategy::None => {
+                if per_key.iter().all(|(_, s)| *s <= 0.0) {
+                    1.0
+                } else {
+                    0.0
+                }
+            }
+        };
+
+        let details = per_key
+            .iter()
+            .map(|(k, s)| format!("{k}={s:.2}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        (score, details)
+    }
+}
+
+impl Evaluator for JsonMatchEvaluator {
+    fn name(&self) -> &'static str {
+        self.name
+    }
+
+    fn evaluate(&self, _case: &EvalCase, invocation: &Invocation) -> Option<EvalMetricResult> {
+        let raw = invocation.final_response.as_ref()?;
+        let parsed: serde_json::Value = match serde_json::from_str(raw) {
+            Ok(value) => value,
+            Err(err) => {
+                return Some(EvalMetricResult {
+                    evaluator_name: self.name.to_string(),
+                    score: Score::fail(),
+                    details: Some(format!("malformed JSON response: {err}")),
+                });
+            }
+        };
+
+        let (value, details) = self.compare(&parsed);
+        Some(EvalMetricResult {
+            evaluator_name: self.name.to_string(),
+            score: Score::new(value, 0.5),
+            details: Some(details),
+        })
+    }
+}
+
+/// Deterministic JSON-schema evaluator (FR-016 / T073).
+///
+/// Compiles the configured schema once at construction time using the
+/// `jsonschema` crate; evaluation parses the invocation's `final_response`
+/// and runs the compiled validator. No judge call is ever dispatched.
+pub struct JsonSchemaEvaluator {
+    name: &'static str,
+    validator: Validator,
+}
+
+impl JsonSchemaEvaluator {
+    /// Compile the schema and return a ready-to-use evaluator. Returns an
+    /// error when the schema itself is invalid.
+    pub fn new(schema: &serde_json::Value) -> Result<Self, String> {
+        let validator = jsonschema::validator_for(schema).map_err(|err| err.to_string())?;
+        Ok(Self {
+            name: "json_schema",
+            validator,
+        })
+    }
+
+    /// Override the evaluator's reported name.
+    #[must_use]
+    pub const fn with_name(mut self, name: &'static str) -> Self {
+        self.name = name;
+        self
+    }
+}
+
+impl Evaluator for JsonSchemaEvaluator {
+    fn name(&self) -> &'static str {
+        self.name
+    }
+
+    fn evaluate(&self, _case: &EvalCase, invocation: &Invocation) -> Option<EvalMetricResult> {
+        let raw = invocation.final_response.as_ref()?;
+        let parsed: serde_json::Value = match serde_json::from_str(raw) {
+            Ok(value) => value,
+            Err(err) => {
+                return Some(EvalMetricResult {
+                    evaluator_name: self.name.to_string(),
+                    score: Score::fail(),
+                    details: Some(format!("malformed JSON response: {err}")),
+                });
+            }
+        };
+
+        let errors: Vec<String> = self
+            .validator
+            .iter_errors(&parsed)
+            .map(|err| err.to_string())
+            .collect();
+
+        if errors.is_empty() {
+            Some(EvalMetricResult {
+                evaluator_name: self.name.to_string(),
+                score: Score::pass(),
+                details: Some("schema valid".into()),
+            })
+        } else {
+            Some(EvalMetricResult {
+                evaluator_name: self.name.to_string(),
+                score: Score::fail(),
+                details: Some(errors.join("; ")),
+            })
+        }
+    }
+}

--- a/eval/src/lib.rs
+++ b/eval/src/lib.rs
@@ -65,10 +65,23 @@ pub use efficiency::EfficiencyEvaluator;
 pub use environment_state::EnvironmentStateEvaluator;
 pub use error::EvalError;
 pub use evaluator::{Evaluator, EvaluatorRegistry};
+#[cfg(feature = "evaluator-code")]
+pub use evaluators::code::llm_judge::CodeLlmJudgeEvaluator;
+#[cfg(feature = "evaluator-code")]
+pub use evaluators::code::{
+    CargoCheckEvaluator, ClippyEvaluator, CodeExtractor, CodeExtractorStrategy,
+};
+#[cfg(feature = "multimodal")]
+pub use evaluators::multimodal::ImageSafetyEvaluator;
+#[cfg(feature = "evaluator-simple")]
+pub use evaluators::simple::{ExactMatchEvaluator, LevenshteinDistanceEvaluator};
+#[cfg(feature = "evaluator-structured")]
+pub use evaluators::structured::{JsonMatchEvaluator, JsonSchemaEvaluator, KeyStrategy};
 #[cfg(feature = "judge-core")]
 pub use evaluators::{
-    Detail, DetailBuffer, DispatchError, DispatchOutcome, JudgeEvaluatorConfig, dispatch_judge,
-    drive_judge_call, evaluate_with_builtin, finish_metric_result,
+    Detail, DetailBuffer, DispatchError, DispatchOutcome, EvaluatorError, JudgeEvaluatorConfig,
+    dispatch_judge, drive_judge_call, evaluate_with_builtin, finish_metric_result,
+    materialize_case_attachments,
 };
 
 #[cfg(feature = "evaluator-quality")]

--- a/eval/tests/evaluators_code_test.rs
+++ b/eval/tests/evaluators_code_test.rs
@@ -1,0 +1,137 @@
+//! Regression tests for the Code family evaluators (T076).
+//!
+//! These tests focus on the deterministic pieces (extractor strategies and
+//! the `cargo_check` / `clippy` path under a no-op harness). Running real
+//! `cargo check` is an orchestrator concern; this file only exercises the
+//! shape of the extraction + scoring pipeline.
+
+#![cfg(feature = "evaluator-code")]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use regex::Regex;
+use swink_agent::{Cost, ModelSpec, StopReason, Usage};
+use swink_agent_eval::{
+    CodeExtractor, CodeExtractorStrategy, EvalCase, Evaluator, Invocation, JudgeClient, JudgeError,
+    JudgeVerdict,
+};
+
+fn make_case() -> EvalCase {
+    EvalCase {
+        id: "case".into(),
+        name: "Case".into(),
+        description: None,
+        system_prompt: "s".into(),
+        user_messages: vec!["write fn add".into()],
+        expected_trajectory: None,
+        expected_response: None,
+        expected_assertion: None,
+        expected_interactions: None,
+        few_shot_examples: vec![],
+        budget: None,
+        evaluators: vec![],
+        metadata: serde_json::Value::Null,
+        attachments: vec![],
+        session_id: None,
+        expected_environment_state: None,
+        expected_tool_intent: None,
+        semantic_tool_selection: false,
+        state_capture: None,
+    }
+}
+
+fn make_invocation(response: Option<&str>) -> Invocation {
+    Invocation {
+        turns: vec![],
+        total_usage: Usage::default(),
+        total_cost: Cost::default(),
+        total_duration: Duration::from_millis(1),
+        final_response: response.map(str::to_string),
+        stop_reason: StopReason::Stop,
+        model: ModelSpec::new("test", "m"),
+    }
+}
+
+#[tokio::test]
+async fn extractor_markdown_fence_returns_first_rust_block() {
+    let extractor = CodeExtractor::new(CodeExtractorStrategy::MarkdownFence {
+        language: Some("rust".into()),
+    });
+    let response = "Here is some rust:\n\n```rust\nfn a() {}\n```\n";
+    let extracted = extractor.extract(response).await;
+    assert_eq!(extracted.as_deref(), Some("fn a() {}"));
+}
+
+#[tokio::test]
+async fn extractor_markdown_fence_without_language_matches_any_fence() {
+    let extractor = CodeExtractor::markdown_fence();
+    let response = "```\nhello\n```";
+    assert_eq!(extractor.extract(response).await.as_deref(), Some("hello"));
+}
+
+#[tokio::test]
+async fn extractor_regex_uses_first_capture_group() {
+    let pattern = Regex::new(r"code:\s*(?P<body>[^\n]+)").unwrap();
+    let extractor = CodeExtractor::new(CodeExtractorStrategy::Regex { pattern });
+    let response = "code: let x = 42;";
+    assert_eq!(
+        extractor.extract(response).await.as_deref(),
+        Some("let x = 42;")
+    );
+}
+
+struct StaticJudge(Option<String>);
+
+#[async_trait]
+impl JudgeClient for StaticJudge {
+    async fn judge(&self, _prompt: &str) -> Result<JudgeVerdict, JudgeError> {
+        Ok(JudgeVerdict {
+            score: 1.0,
+            pass: true,
+            reason: self.0.clone(),
+            label: None,
+        })
+    }
+}
+
+#[tokio::test]
+async fn extractor_llm_uses_judge_reason_field() {
+    let judge: Arc<dyn JudgeClient> = Arc::new(StaticJudge(Some("fn llm_body() {}".into())));
+    let extractor = CodeExtractor::new(CodeExtractorStrategy::Llm {
+        prompt: "Extract the code:".into(),
+        judge,
+    });
+    let response = "boilerplate ... ```fn llm_body() {}```";
+    assert_eq!(
+        extractor.extract(response).await.as_deref(),
+        Some("fn llm_body() {}")
+    );
+}
+
+// The cargo shell-outs are verified by asserting that the evaluator returns
+// `None` when no code is extractable — we do not want to run `cargo` from a
+// unit test.
+
+#[test]
+fn cargo_check_returns_none_without_response() {
+    use swink_agent_eval::CargoCheckEvaluator;
+    let extractor = Arc::new(CodeExtractor::markdown_fence());
+    let evaluator = CargoCheckEvaluator::new(extractor);
+    assert!(
+        evaluator
+            .evaluate(&make_case(), &make_invocation(None))
+            .is_none()
+    );
+}
+
+#[test]
+fn clippy_returns_none_when_extractor_produces_nothing() {
+    use swink_agent_eval::ClippyEvaluator;
+    let extractor = Arc::new(CodeExtractor::markdown_fence());
+    let evaluator = ClippyEvaluator::new(extractor);
+    // Response has no fenced code block → extractor yields None.
+    let invocation = make_invocation(Some("no fences here"));
+    assert!(evaluator.evaluate(&make_case(), &invocation).is_none());
+}

--- a/eval/tests/evaluators_multimodal_test.rs
+++ b/eval/tests/evaluators_multimodal_test.rs
@@ -1,0 +1,149 @@
+//! Regression tests for the Multimodal family evaluator (T084).
+
+#![cfg(feature = "multimodal")]
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use swink_agent::{Cost, ModelSpec, StopReason, Usage};
+use swink_agent_eval::{
+    Attachment, DefaultUrlFilter, EvalCase, Evaluator, ImageSafetyEvaluator, Invocation,
+    JudgeClient, JudgeError, JudgeEvaluatorConfig, JudgeRegistry, JudgeVerdict,
+    materialize_case_attachments,
+};
+
+struct FixedVerdict {
+    score: f64,
+    pass: bool,
+    reason: Option<String>,
+    last_prompt: Mutex<Option<String>>,
+}
+
+#[async_trait]
+impl JudgeClient for FixedVerdict {
+    async fn judge(&self, prompt: &str) -> Result<JudgeVerdict, JudgeError> {
+        *self.last_prompt.lock().unwrap() = Some(prompt.to_string());
+        Ok(JudgeVerdict {
+            score: self.score,
+            pass: self.pass,
+            reason: self.reason.clone(),
+            label: None,
+        })
+    }
+}
+
+fn make_case_with_attachments(attachments: Vec<Attachment>) -> EvalCase {
+    EvalCase {
+        id: "case".into(),
+        name: "Case".into(),
+        description: None,
+        system_prompt: "s".into(),
+        user_messages: vec!["check the image".into()],
+        expected_trajectory: None,
+        expected_response: None,
+        expected_assertion: None,
+        expected_interactions: None,
+        few_shot_examples: vec![],
+        budget: None,
+        evaluators: vec![],
+        metadata: serde_json::Value::Null,
+        attachments,
+        session_id: None,
+        expected_environment_state: None,
+        expected_tool_intent: None,
+        semantic_tool_selection: false,
+        state_capture: None,
+    }
+}
+
+fn make_invocation() -> Invocation {
+    Invocation {
+        turns: vec![],
+        total_usage: Usage::default(),
+        total_cost: Cost::default(),
+        total_duration: Duration::from_millis(1),
+        final_response: Some("ok".into()),
+        stop_reason: StopReason::Stop,
+        model: ModelSpec::new("test", "m"),
+    }
+}
+
+fn make_config(judge: Arc<dyn JudgeClient>) -> JudgeEvaluatorConfig {
+    let registry = JudgeRegistry::builder(judge, "mock-model")
+        .build()
+        .expect("registry builds");
+    JudgeEvaluatorConfig::default_with(Arc::new(registry))
+}
+
+#[test]
+fn image_safety_returns_none_without_attachments() {
+    let judge: Arc<dyn JudgeClient> = Arc::new(FixedVerdict {
+        score: 1.0,
+        pass: true,
+        reason: None,
+        last_prompt: Mutex::new(None),
+    });
+    let evaluator = ImageSafetyEvaluator::new(make_config(judge), std::env::temp_dir());
+    let case = make_case_with_attachments(vec![]);
+    assert!(evaluator.evaluate(&case, &make_invocation()).is_none());
+}
+
+// Tiny 1x1 PNG (binary for a valid PNG header).
+const TINY_PNG: &[u8] = &[
+    0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, // signature
+    0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+    0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4, 0x89, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x44, 0x41,
+    0x54, 0x78, 0x9C, 0x62, 0x00, 0x01, 0x00, 0x00, 0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00,
+    0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
+];
+
+#[tokio::test]
+async fn materialize_case_attachments_decodes_base64_variant() {
+    let attachment = Attachment::Base64 {
+        mime: "image/png".into(),
+        bytes: TINY_PNG.to_vec(),
+    };
+    let case = make_case_with_attachments(vec![attachment]);
+    let filter = DefaultUrlFilter;
+    let materialized = materialize_case_attachments(&case, std::path::Path::new("."), &filter)
+        .await
+        .expect("materialize succeeds");
+    assert_eq!(materialized.len(), 1);
+    assert_eq!(materialized[0].mime, "image/png");
+    assert_eq!(materialized[0].bytes, TINY_PNG);
+}
+
+#[test]
+fn image_safety_happy_path_pass_verdict_surfaces_score() {
+    let judge: Arc<dyn JudgeClient> = Arc::new(FixedVerdict {
+        score: 1.0,
+        pass: true,
+        reason: Some("safe".into()),
+        last_prompt: Mutex::new(None),
+    });
+    let evaluator = ImageSafetyEvaluator::new(make_config(judge), std::env::temp_dir());
+    let case = make_case_with_attachments(vec![Attachment::Base64 {
+        mime: "image/png".into(),
+        bytes: TINY_PNG.to_vec(),
+    }]);
+    let result = evaluator.evaluate(&case, &make_invocation()).unwrap();
+    assert!(result.score.verdict().is_pass());
+}
+
+#[test]
+fn image_safety_deny_path_reports_failure() {
+    let judge: Arc<dyn JudgeClient> = Arc::new(FixedVerdict {
+        score: 0.0,
+        pass: false,
+        reason: Some("explicit content".into()),
+        last_prompt: Mutex::new(None),
+    });
+    let evaluator = ImageSafetyEvaluator::new(make_config(judge), std::env::temp_dir());
+    let case = make_case_with_attachments(vec![Attachment::Base64 {
+        mime: "image/png".into(),
+        bytes: TINY_PNG.to_vec(),
+    }]);
+    let result = evaluator.evaluate(&case, &make_invocation()).unwrap();
+    assert!(!result.score.verdict().is_pass());
+}

--- a/eval/tests/evaluators_safety_test.rs
+++ b/eval/tests/evaluators_safety_test.rs
@@ -12,9 +12,8 @@ use std::sync::Arc;
 
 use swink_agent_eval::{
     Aggregator, AllPass, CodeInjectionEvaluator, Evaluator, FairnessEvaluator,
-    HarmfulnessEvaluator,
-    JudgeClient, JudgeEvaluatorConfig, JudgeRegistry, JudgeVerdict, MockJudge, PIIClass,
-    PIILeakageEvaluator, PromptInjectionEvaluator, ToxicityEvaluator,
+    HarmfulnessEvaluator, JudgeClient, JudgeEvaluatorConfig, JudgeRegistry, JudgeVerdict,
+    MockJudge, PIIClass, PIILeakageEvaluator, PromptInjectionEvaluator, ToxicityEvaluator,
 };
 
 mod common;

--- a/eval/tests/evaluators_simple_test.rs
+++ b/eval/tests/evaluators_simple_test.rs
@@ -1,0 +1,119 @@
+//! Regression tests for the Simple family evaluators (T074).
+
+#![cfg(feature = "evaluator-simple")]
+
+use std::time::Duration;
+
+use swink_agent::{Cost, ModelSpec, StopReason, Usage};
+use swink_agent_eval::{
+    EvalCase, Evaluator, ExactMatchEvaluator, Invocation, LevenshteinDistanceEvaluator,
+};
+
+fn make_case() -> EvalCase {
+    EvalCase {
+        id: "case".into(),
+        name: "Case".into(),
+        description: None,
+        system_prompt: "s".into(),
+        user_messages: vec!["hi".into()],
+        expected_trajectory: None,
+        expected_response: None,
+        expected_assertion: None,
+        expected_interactions: None,
+        few_shot_examples: vec![],
+        budget: None,
+        evaluators: vec![],
+        metadata: serde_json::Value::Null,
+        attachments: vec![],
+        session_id: None,
+        expected_environment_state: None,
+        expected_tool_intent: None,
+        semantic_tool_selection: false,
+        state_capture: None,
+    }
+}
+
+fn make_invocation(response: Option<&str>) -> Invocation {
+    Invocation {
+        turns: vec![],
+        total_usage: Usage::default(),
+        total_cost: Cost::default(),
+        total_duration: Duration::from_millis(1),
+        final_response: response.map(str::to_string),
+        stop_reason: StopReason::Stop,
+        model: ModelSpec::new("test", "m"),
+    }
+}
+
+#[test]
+fn exact_match_passes_when_strings_match() {
+    let evaluator = ExactMatchEvaluator::new("hello world");
+    let case = make_case();
+    let invocation = make_invocation(Some("hello world"));
+    let result = evaluator.evaluate(&case, &invocation).unwrap();
+    assert!(result.score.verdict().is_pass());
+}
+
+#[test]
+fn exact_match_case_sensitive_by_default() {
+    let evaluator = ExactMatchEvaluator::new("Hello");
+    let case = make_case();
+    let invocation = make_invocation(Some("hello"));
+    let result = evaluator.evaluate(&case, &invocation).unwrap();
+    assert!(!result.score.verdict().is_pass());
+}
+
+#[test]
+fn exact_match_honors_case_insensitive_toggle() {
+    let evaluator = ExactMatchEvaluator::new("Hello").case_sensitive(false);
+    let case = make_case();
+    let invocation = make_invocation(Some("hello"));
+    let result = evaluator.evaluate(&case, &invocation).unwrap();
+    assert!(result.score.verdict().is_pass());
+}
+
+#[test]
+fn exact_match_honors_trim_toggle() {
+    let evaluator = ExactMatchEvaluator::new("hello").trim(true);
+    let case = make_case();
+    let invocation = make_invocation(Some("   hello\n"));
+    let result = evaluator.evaluate(&case, &invocation).unwrap();
+    assert!(result.score.verdict().is_pass());
+}
+
+#[test]
+fn exact_match_returns_none_when_no_response() {
+    let evaluator = ExactMatchEvaluator::new("x");
+    let case = make_case();
+    let invocation = make_invocation(None);
+    assert!(evaluator.evaluate(&case, &invocation).is_none());
+}
+
+#[test]
+fn levenshtein_passes_when_above_threshold() {
+    let evaluator = LevenshteinDistanceEvaluator::new("kitten").with_threshold(0.5);
+    let case = make_case();
+    let invocation = make_invocation(Some("sitting"));
+    let result = evaluator.evaluate(&case, &invocation).unwrap();
+    // distance=3, max=7, similarity ≈ 0.571 > 0.5
+    assert!(result.score.verdict().is_pass());
+    assert!(result.details.as_ref().unwrap().contains("distance=3"));
+}
+
+#[test]
+fn levenshtein_fails_when_below_threshold() {
+    let evaluator = LevenshteinDistanceEvaluator::new("hello").with_threshold(0.95);
+    let case = make_case();
+    let invocation = make_invocation(Some("world"));
+    let result = evaluator.evaluate(&case, &invocation).unwrap();
+    assert!(!result.score.verdict().is_pass());
+}
+
+#[test]
+fn levenshtein_empty_strings_are_perfect_match() {
+    let evaluator = LevenshteinDistanceEvaluator::new("");
+    let case = make_case();
+    let invocation = make_invocation(Some(""));
+    let result = evaluator.evaluate(&case, &invocation).unwrap();
+    assert!(result.score.verdict().is_pass());
+}

--- a/eval/tests/evaluators_structured_test.rs
+++ b/eval/tests/evaluators_structured_test.rs
@@ -1,0 +1,170 @@
+//! Regression tests for the Structured family evaluators (T071).
+
+#![cfg(feature = "evaluator-structured")]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde_json::json;
+use swink_agent::{Cost, ModelSpec, StopReason, Usage};
+use swink_agent_eval::{
+    EvalCase, Evaluator, Invocation, JsonMatchEvaluator, JsonSchemaEvaluator, KeyStrategy,
+};
+
+fn make_case() -> EvalCase {
+    EvalCase {
+        id: "case".into(),
+        name: "Case".into(),
+        description: None,
+        system_prompt: "s".into(),
+        user_messages: vec!["hi".into()],
+        expected_trajectory: None,
+        expected_response: None,
+        expected_assertion: None,
+        expected_interactions: None,
+        few_shot_examples: vec![],
+        budget: None,
+        evaluators: vec![],
+        metadata: serde_json::Value::Null,
+        attachments: vec![],
+        session_id: None,
+        expected_environment_state: None,
+        expected_tool_intent: None,
+        semantic_tool_selection: false,
+        state_capture: None,
+    }
+}
+
+fn make_invocation(response: Option<&str>) -> Invocation {
+    Invocation {
+        turns: vec![],
+        total_usage: Usage::default(),
+        total_cost: Cost::default(),
+        total_duration: Duration::from_millis(1),
+        final_response: response.map(str::to_string),
+        stop_reason: StopReason::Stop,
+        model: ModelSpec::new("test", "m"),
+    }
+}
+
+#[test]
+fn json_match_average_aggregates_per_key() {
+    let evaluator = JsonMatchEvaluator::new(json!({"a": 1, "b": 2}));
+    let response = json!({"a": 1, "b": 99}).to_string();
+    let result = evaluator
+        .evaluate(&make_case(), &make_invocation(Some(&response)))
+        .unwrap();
+    // Average of 1.0 + 0.0 = 0.5; still passes default 0.5 threshold.
+    assert!((result.score.value - 0.5).abs() < 1e-6);
+}
+
+#[test]
+fn json_match_all_requires_every_key_match() {
+    let evaluator =
+        JsonMatchEvaluator::new(json!({"a": 1, "b": 2})).with_strategy(KeyStrategy::All);
+    let mismatched = json!({"a": 1, "b": 3}).to_string();
+    let result = evaluator
+        .evaluate(&make_case(), &make_invocation(Some(&mismatched)))
+        .unwrap();
+    assert!(!result.score.verdict().is_pass());
+
+    let matched = json!({"a": 1, "b": 2}).to_string();
+    let pass = evaluator
+        .evaluate(&make_case(), &make_invocation(Some(&matched)))
+        .unwrap();
+    assert!(pass.score.verdict().is_pass());
+}
+
+#[test]
+fn json_match_none_passes_when_every_key_differs() {
+    let evaluator =
+        JsonMatchEvaluator::new(json!({"a": 1, "b": 2})).with_strategy(KeyStrategy::None);
+    let response = json!({"a": 9, "b": 8}).to_string();
+    let pass = evaluator
+        .evaluate(&make_case(), &make_invocation(Some(&response)))
+        .unwrap();
+    assert!(pass.score.verdict().is_pass());
+}
+
+#[test]
+fn json_match_rubric_uses_custom_scorer() {
+    let evaluator =
+        JsonMatchEvaluator::new(json!({"a": 1, "b": 2})).with_strategy(KeyStrategy::Rubric {
+            scorer: Arc::new(|_key, _expected, _actual| 0.7),
+        });
+    let response = json!({"a": 999, "b": 999}).to_string();
+    let result = evaluator
+        .evaluate(&make_case(), &make_invocation(Some(&response)))
+        .unwrap();
+    assert!((result.score.value - 0.7).abs() < 1e-6);
+}
+
+#[test]
+fn json_match_exclude_keys_skips_entries() {
+    let evaluator = JsonMatchEvaluator::new(json!({"a": 1, "b": 2, "c": 3}))
+        .with_strategy(KeyStrategy::All)
+        .with_exclude_keys(["c"]);
+    let response = json!({"a": 1, "b": 2, "c": 999}).to_string();
+    let result = evaluator
+        .evaluate(&make_case(), &make_invocation(Some(&response)))
+        .unwrap();
+    assert!(result.score.verdict().is_pass());
+}
+
+#[test]
+fn json_match_malformed_json_is_fail_with_details() {
+    let evaluator = JsonMatchEvaluator::new(json!({"a": 1}));
+    let result = evaluator
+        .evaluate(&make_case(), &make_invocation(Some("not json {")))
+        .unwrap();
+    assert!(!result.score.verdict().is_pass());
+    assert!(
+        result
+            .details
+            .as_ref()
+            .unwrap()
+            .contains("malformed JSON response")
+    );
+}
+
+#[test]
+fn json_schema_happy_path() {
+    let schema = json!({
+        "type": "object",
+        "required": ["name"],
+        "properties": {"name": {"type": "string"}}
+    });
+    let evaluator = JsonSchemaEvaluator::new(&schema).unwrap();
+    let valid = json!({"name": "wes"}).to_string();
+    let result = evaluator
+        .evaluate(&make_case(), &make_invocation(Some(&valid)))
+        .unwrap();
+    assert!(result.score.verdict().is_pass());
+}
+
+#[test]
+fn json_schema_unhappy_path_surfaces_errors() {
+    let schema = json!({
+        "type": "object",
+        "required": ["name"],
+        "properties": {"name": {"type": "string"}}
+    });
+    let evaluator = JsonSchemaEvaluator::new(&schema).unwrap();
+    let invalid = json!({}).to_string();
+    let result = evaluator
+        .evaluate(&make_case(), &make_invocation(Some(&invalid)))
+        .unwrap();
+    assert!(!result.score.verdict().is_pass());
+    assert!(!result.details.as_ref().unwrap().is_empty());
+}
+
+#[test]
+fn json_schema_returns_none_without_response() {
+    let schema = json!({"type": "object"});
+    let evaluator = JsonSchemaEvaluator::new(&schema).unwrap();
+    assert!(
+        evaluator
+            .evaluate(&make_case(), &make_invocation(None))
+            .is_none()
+    );
+}

--- a/specs/043-evals-adv-features/tasks.md
+++ b/specs/043-evals-adv-features/tasks.md
@@ -160,21 +160,21 @@
 
 ### Structured family (feature `evaluator-structured`)
 
-- [ ] T071 [P] [US1] Write tests in `eval/tests/evaluators_structured_test.rs` covering: per-key rubric application, `exclude_keys` filter, malformed JSON → `JudgeError::MalformedResponse`, schema validation happy + unhappy path
-- [ ] T072 [P] [US1] Implement `JsonMatchEvaluator` + `KeyStrategy` enum (Average/All/None/Rubric) in `eval/src/evaluators/structured.rs`
-- [ ] T073 [P] [US1] Implement `JsonSchemaEvaluator` (deterministic; compiles schema via `jsonschema` crate; no judge call) in `eval/src/evaluators/structured.rs`
+- [x] T071 [P] [US1] Write tests in `eval/tests/evaluators_structured_test.rs` covering: per-key rubric application, `exclude_keys` filter, malformed JSON → `JudgeError::MalformedResponse`, schema validation happy + unhappy path
+- [x] T072 [P] [US1] Implement `JsonMatchEvaluator` + `KeyStrategy` enum (Average/All/None/Rubric) in `eval/src/evaluators/structured.rs`
+- [x] T073 [P] [US1] Implement `JsonSchemaEvaluator` (deterministic; compiles schema via `jsonschema` crate; no judge call) in `eval/src/evaluators/structured.rs`
 
 ### Simple family (feature `evaluator-simple`)
 
-- [ ] T074 [P] [US1] Write tests in `eval/tests/evaluators_simple_test.rs` covering: exact-match case-sensitivity & trim toggle, Levenshtein normalized similarity threshold
-- [ ] T075 [P] [US1] Implement `ExactMatchEvaluator` + `LevenshteinDistanceEvaluator` in `eval/src/evaluators/simple.rs`
+- [x] T074 [P] [US1] Write tests in `eval/tests/evaluators_simple_test.rs` covering: exact-match case-sensitivity & trim toggle, Levenshtein normalized similarity threshold
+- [x] T075 [P] [US1] Implement `ExactMatchEvaluator` + `LevenshteinDistanceEvaluator` in `eval/src/evaluators/simple.rs`
 
 ### Code family (feature `evaluator-code`; sandbox behind `evaluator-sandbox`)
 
-- [ ] T076 [P] [US1] Write tests in `eval/tests/evaluators_code_test.rs` covering: cargo-check happy path, clippy warning surface, `CodeExtractor` strategies (markdown-fence, regex, LLM)
-- [ ] T077 [P] [US1] Implement `CargoCheckEvaluator` + `ClippyEvaluator` in `eval/src/evaluators/code/cargo_check.rs` and `eval/src/evaluators/code/clippy.rs` — deterministic, shell out to cargo in a tempdir
-- [ ] T078 [P] [US1] Implement `CodeExtractor` + `CodeExtractorStrategy` enum in `eval/src/evaluators/code/extractor.rs`
-- [ ] T079 [P] [US1] Implement `CodeLlmJudgeEvaluator` in `eval/src/evaluators/code/llm_judge.rs` using the `code_llm_judge_v0` template
+- [x] T076 [P] [US1] Write tests in `eval/tests/evaluators_code_test.rs` covering: cargo-check happy path, clippy warning surface, `CodeExtractor` strategies (markdown-fence, regex, LLM)
+- [x] T077 [P] [US1] Implement `CargoCheckEvaluator` + `ClippyEvaluator` in `eval/src/evaluators/code/cargo_check.rs` and `eval/src/evaluators/code/clippy.rs` — deterministic, shell out to cargo in a tempdir
+- [x] T078 [P] [US1] Implement `CodeExtractor` + `CodeExtractorStrategy` enum in `eval/src/evaluators/code/extractor.rs`
+- [x] T079 [P] [US1] Implement `CodeLlmJudgeEvaluator` in `eval/src/evaluators/code/llm_judge.rs` using the `code_llm_judge_v0` template
 - [ ] T080 [US1] Implement `SandboxLimits` struct + `Default` impl (120 s wall / 60 s CPU / 1 GiB RSS / 256 FDs / no network) in `eval/src/evaluators/code/sandbox.rs`
 - [ ] T081 [US1] Implement `SandboxedExecutionEvaluator` Unix path: `cfg(target_family = "unix")` module with `#![allow(unsafe_code)]` exception + safe `posix` submodule using `libc::setrlimit`/`libc::unshare`/`libc::prlimit` wrapped with `// SAFETY:` invariants; spawns child in tempdir; enforces all five limits; produces `EvaluatorError::SandboxLimitExceeded { limit }` when a bound is hit — per research.md §R-006
 - [ ] T082 [US1] Implement `SandboxedExecutionEvaluator` Windows stub: `cfg(target_family = "windows")` produces `EvaluatorError::UnsupportedPlatform` at evaluation time, never panics
@@ -182,9 +182,9 @@
 
 ### Multimodal family (feature `multimodal`)
 
-- [ ] T084 [P] [US1] Write tests in `eval/tests/evaluators_multimodal_test.rs` covering: image-safety evaluator happy + deny path, attachment materialization integration
-- [ ] T085 [P] [US1] Implement `ImageSafetyEvaluator` in `eval/src/evaluators/multimodal.rs` consuming `Attachment::Path`/`Base64`/`Url` via materialization pipeline
-- [ ] T086 [US1] Wire attachment materialization into the shared `dispatch_judge` helper so any evaluator can reference attachments
+- [x] T084 [P] [US1] Write tests in `eval/tests/evaluators_multimodal_test.rs` covering: image-safety evaluator happy + deny path, attachment materialization integration
+- [x] T085 [P] [US1] Implement `ImageSafetyEvaluator` in `eval/src/evaluators/multimodal.rs` consuming `Attachment::Path`/`Base64`/`Url` via materialization pipeline
+- [x] T086 [US1] Wire attachment materialization into the shared `dispatch_judge` helper so any evaluator can reference attachments
 
 ### Registry wiring
 


### PR DESCRIPTION
## Summary
- Simple: ExactMatchEvaluator, LevenshteinDistanceEvaluator (T075)
- Structured: JsonMatchEvaluator + KeyStrategy (Average/All/None/Rubric), JsonSchemaEvaluator (T072, T073)
- Code: CargoCheckEvaluator, ClippyEvaluator, CodeExtractor + three strategies (markdown-fence / regex / LLM), CodeLlmJudgeEvaluator using `code_llm_judge_v0` from PR #818 (T077–T079)
- Multimodal: ImageSafetyEvaluator consuming `Attachment::*` through the shared attachment pipeline (T085)
- Shared plumbing: `materialize_case_attachments` helper wired next to `dispatch_judge` (T086), `EvaluatorError` surface with `UnsupportedPlatform` / `SandboxLimitExceeded` variants, `block_on` driver that works inside multi-thread and current-thread test contexts
- Regression tests in every family — T071, T074, T076, T084 — all following the existing panic-isolated pattern

## Deferred
- **Sandbox (T080–T083)** — `SandboxLimits` / `SandboxedExecutionEvaluator` (Unix libc + Windows stub) are deferred to a follow-up PR to stay inside the workspace diff budget. The unsafe path is ~400 LOC of FFI + dedicated tests that warrant their own review. `EvaluatorError::{UnsupportedPlatform, SandboxLimitExceeded}` variants are landed here so the follow-up lands as a pure addition with no type surface churn.

## Unsafe surface
None in this PR. Crate-level `#![forbid(unsafe_code)]` is unchanged. When sandbox lands, it will introduce the documented `libc::setrlimit` / `libc::unshare` path in a narrowly-gated `sandbox::posix` submodule per research.md §R-006.

## Tasks completed
T071, T072, T073, T074, T075, T076, T077, T078, T079, T084, T085, T086 (12 tasks).
Deferred: T080, T081, T082, T083 (sandbox, next PR).

## Stacking
Targets `impl/043-us1b-prompts-dispatch` (PR #818). Auto-retargets to `integration` when #818 merges.

## Test plan
Worker did not run cargo (stack-level constraint); orchestrator verifies sequentially after all workers finish. Each evaluator family has its own integration test file guarded by the matching feature flag.

Part of #751

🤖 Generated with [Claude Code](https://claude.com/claude-code)