### PR TITLE
fix(eval): reflow evaluators_safety_test imports to satisfy rustfmt

### DIFF
--- a/eval/tests/evaluators_safety_test.rs
+++ b/eval/tests/evaluators_safety_test.rs
@@ -12,9 +12,8 @@ use std::sync::Arc;
 
 use swink_agent_eval::{
     Aggregator, AllPass, CodeInjectionEvaluator, Evaluator, FairnessEvaluator,
-    HarmfulnessEvaluator,
-    JudgeClient, JudgeEvaluatorConfig, JudgeRegistry, JudgeVerdict, MockJudge, PIIClass,
-    PIILeakageEvaluator, PromptInjectionEvaluator, ToxicityEvaluator,
+    HarmfulnessEvaluator, JudgeClient, JudgeEvaluatorConfig, JudgeRegistry, JudgeVerdict,
+    MockJudge, PIIClass, PIILeakageEvaluator, PromptInjectionEvaluator, ToxicityEvaluator,
 };
 
 mod common;


### PR DESCRIPTION
## Summary
Tiny follow-up: integration's \`cargo fmt --check\` fails on \`eval/tests/evaluators_safety_test.rs:12\` because rustfmt reflows the import block differently. This PR runs cargo fmt and pushes the fix.

## Cause
The import block arrived via PR #821's US1c merge + reconciliation commit 6776a9a. I added \`Aggregator\` in a companion rescue path (PR #823 branch) without re-running fmt on the file.

## Test plan
- [x] \`cargo fmt --check -p swink-agent-eval\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)