### PR TITLE
chore(ci): move benchmarks off PR trigger to daily schedule + release tags

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,14 +1,20 @@
 name: Benchmarks
 
 on:
-  pull_request:
+  schedule:
+    # 06:00 UTC daily against the default branch (integration). Keeps
+    # regression signal without gating every PR on a flaky critcmp install.
+    - cron: '0 6 * * *'
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
 
 jobs:
   bench:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -16,53 +22,13 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      - uses: cargo-bins/cargo-binstall@dc19f1e48450eefe5a29b8da6c6b00a87d730b37 # v1.18.1
 
-      - name: Install critcmp
-        shell: bash
-        run: |
-          set -euo pipefail
-          critcmp_bin="$CARGO_HOME/bin/critcmp"
+      - name: Bench
+        run: cargo bench -p swink-agent --bench context
 
-          if [ ! -x "$critcmp_bin" ]; then
-            cargo binstall --no-confirm --force critcmp
-          fi
-
-          if [ ! -x "$critcmp_bin" ]; then
-            cargo install --locked --force critcmp
-          fi
-
-          "$critcmp_bin" --version
-
-      - name: Bench PR
-        run: cargo bench -p swink-agent --bench context -- --save-baseline pr
-
-      - name: Export PR baseline
-        run: '"$CARGO_HOME/bin/critcmp" --export pr > "$RUNNER_TEMP/pr.json"'
-
-      - name: Add base worktree
-        run: git worktree add ../bench-base ${{ github.event.pull_request.base.sha }}
-
-      - name: Bench base
-        working-directory: ../bench-base
-        run: cargo bench -p swink-agent --bench context -- --save-baseline base
-
-      - name: Export base baseline
-        working-directory: ../bench-base
-        run: '"$CARGO_HOME/bin/critcmp" --export base > "$RUNNER_TEMP/base.json"'
-
-      - name: Compare
-        run: '"$CARGO_HOME/bin/critcmp" "$RUNNER_TEMP/base.json" "$RUNNER_TEMP/pr.json" | tee bench-diff.txt'
-
-      - name: Post comment
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+      - name: Upload criterion artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          script: |
-            const fs = require('fs');
-            const diff = fs.readFileSync('bench-diff.txt', 'utf8');
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: '## Benchmark comparison\n```\n' + diff + '\n```'
-            });
+          name: criterion-${{ github.run_id }}
+          path: target/criterion
+          retention-days: 30


### PR DESCRIPTION
## Summary

Resolves the flaky critcmp install that was blocking otherwise-clean PRs. Benchmarks no longer run on \`pull_request\`; they run nightly against \`integration\` (06:00 UTC) and on \`v*\` tags, with \`workflow_dispatch\` for ad-hoc runs. Results upload as a criterion artifact (30-day retention) instead of a PR comment.

## Changes
- **Dropped**: \`pull_request\` trigger, \`cargo-binstall\` + \`critcmp\` install, PR worktree compare, PR comment step, \`pull-requests: write\` permission
- **Added**: \`schedule\` (daily cron), \`push: tags: ['v*']\`, \`workflow_dispatch\`, \`actions/upload-artifact\` for criterion results
- **Kept**: \`cargo bench -p swink-agent --bench context\`

## Acceptance criteria
- [x] Benchmark workflow no longer triggers on \`pull_request\` or \`push\` to \`integration\`/\`main\`
- [x] Benchmark workflow runs on a schedule (daily 06:00 UTC) against the default branch (integration)
- [x] Benchmark workflow runs on release tags (\`v*\`) for main
- [x] PR CI (\`check\`, \`features\`, \`deny\`, \`gate\`) is unaffected — only \`bench.yml\` is modified

## Heads-up for reviewer
If any branch protection rule currently requires "bench" to pass on PRs, it needs to be removed or the rule will block every PR indefinitely (since the job no longer runs on PRs). Worth a quick check in Settings → Branches before merging.

Closes #735

🤖 Generated with [Claude Code](https://claude.com/claude-code)