### PR TITLE
impl(043): US1a OllamaJudgeClient + ProxyJudgeClient (T045-T046)

### DIFF
--- a/eval-judges/Cargo.toml
+++ b/eval-judges/Cargo.toml
@@ -39,8 +39,8 @@ gemini = ["dep:swink-agent-adapters", "swink-agent-eval/judge-core", "dep:reqwes
 mistral = ["dep:swink-agent-adapters", "swink-agent-eval/judge-core", "dep:reqwest"]
 azure = ["dep:swink-agent-adapters", "swink-agent-eval/judge-core", "dep:reqwest"]
 xai = ["dep:swink-agent-adapters", "swink-agent-eval/judge-core", "dep:reqwest"]
-ollama = ["dep:swink-agent-adapters", "swink-agent-eval/judge-core"]
-proxy = ["dep:swink-agent-adapters", "swink-agent-eval/judge-core"]
+ollama = ["dep:swink-agent-adapters", "swink-agent-eval/judge-core", "dep:reqwest"]
+proxy = ["dep:swink-agent-adapters", "swink-agent-eval/judge-core", "dep:reqwest"]
 live-judges = []
 
 [dependencies]

--- a/eval-judges/src/ollama.rs
+++ b/eval-judges/src/ollama.rs
@@ -1,7 +1,265 @@
-//! Ollama judge client scaffold.
+//! Ollama judge client.
+//!
+//! Ollama exposes a local chat API at `POST /api/chat`. No authentication is
+//! required — the client relies on network-level access control instead. The
+//! response carries the assistant message inside `message.content`, which is
+//! fed through the shared verdict parser.
 
-#[derive(Debug, Clone, Default)]
-pub struct OllamaJudgeClient;
+use std::sync::Arc;
+use std::time::Duration;
 
-#[derive(Debug, Clone, Default)]
-pub struct BlockingOllamaJudgeClient;
+use async_trait::async_trait;
+use reqwest::{Client, StatusCode};
+use serde::{Deserialize, Serialize};
+use tokio_util::sync::CancellationToken;
+
+use swink_agent_eval::judge::{JudgeClient, JudgeError, JudgeVerdict, RetryPolicy};
+
+use crate::client::{BlockingExt, is_retryable, parse_verdict_text, retry_with_cancel};
+
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(120);
+const DEFAULT_TEMPERATURE: f32 = 0.0;
+
+/// Async judge client backed by a local Ollama `/api/chat` endpoint.
+#[derive(Clone)]
+pub struct OllamaJudgeClient {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    base_url: String,
+    model: String,
+    temperature: f32,
+    retry_policy: RetryPolicy,
+    cancel: CancellationToken,
+    http: Client,
+}
+
+impl Clone for Inner {
+    fn clone(&self) -> Self {
+        Self {
+            base_url: self.base_url.clone(),
+            model: self.model.clone(),
+            temperature: self.temperature,
+            retry_policy: self.retry_policy.clone(),
+            cancel: self.cancel.clone(),
+            http: self.http.clone(),
+        }
+    }
+}
+
+impl std::fmt::Debug for OllamaJudgeClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OllamaJudgeClient")
+            .field("base_url", &self.inner.base_url)
+            .field("model", &self.inner.model)
+            .field("temperature", &self.inner.temperature)
+            .field("retry_policy", &self.inner.retry_policy)
+            .finish_non_exhaustive()
+    }
+}
+
+impl OllamaJudgeClient {
+    /// Build a new Ollama judge client.
+    ///
+    /// `base_url` is typically `http://localhost:11434`. No API key is needed.
+    #[must_use]
+    pub fn new(base_url: impl Into<String>, model: impl Into<String>) -> Self {
+        let http = Client::builder()
+            .timeout(DEFAULT_TIMEOUT)
+            .build()
+            .unwrap_or_else(|_| Client::new());
+        Self {
+            inner: Arc::new(Inner {
+                base_url: base_url.into().trim_end_matches('/').to_string(),
+                model: model.into(),
+                temperature: DEFAULT_TEMPERATURE,
+                retry_policy: RetryPolicy::default(),
+                cancel: CancellationToken::new(),
+                http,
+            }),
+        }
+    }
+
+    /// Override sampling temperature. Default: 0.0 for deterministic grading.
+    #[must_use]
+    pub fn with_temperature(mut self, temperature: f32) -> Self {
+        Arc::make_mut(&mut self.inner).temperature = temperature;
+        self
+    }
+
+    /// Override the shared retry policy.
+    #[must_use]
+    pub fn with_retry_policy(mut self, policy: RetryPolicy) -> Self {
+        Arc::make_mut(&mut self.inner).retry_policy = policy;
+        self
+    }
+
+    /// Attach an external cancellation token.
+    #[must_use]
+    pub fn with_cancellation(mut self, cancel: CancellationToken) -> Self {
+        Arc::make_mut(&mut self.inner).cancel = cancel;
+        self
+    }
+
+    /// Borrow the configured cancellation token.
+    #[must_use]
+    pub fn cancellation(&self) -> CancellationToken {
+        self.inner.cancel.clone()
+    }
+
+    async fn dispatch_once(&self, prompt: &str) -> Result<JudgeVerdict, JudgeError> {
+        let body = OllamaRequest {
+            model: &self.inner.model,
+            messages: vec![OllamaMessage {
+                role: "user",
+                content: prompt,
+            }],
+            stream: false,
+        };
+        let url = format!("{}/api/chat", self.inner.base_url);
+
+        let response = self
+            .inner
+            .http
+            .post(&url)
+            .header("content-type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|error| JudgeError::Transport(format!("ollama request failed: {error}")))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let text = response.text().await.unwrap_or_default();
+            return Err(classify_http_error(status, &text));
+        }
+
+        let parsed: OllamaResponse = response.json().await.map_err(|error| {
+            JudgeError::MalformedResponse(format!("ollama body parse failed: {error}"))
+        })?;
+
+        extract_verdict(&parsed)
+    }
+}
+
+#[async_trait]
+impl JudgeClient for OllamaJudgeClient {
+    async fn judge(&self, prompt: &str) -> Result<JudgeVerdict, JudgeError> {
+        let this = self;
+        let prompt = prompt;
+        retry_with_cancel(
+            &self.inner.retry_policy,
+            &self.inner.cancel,
+            is_retryable,
+            || async move { this.dispatch_once(prompt).await },
+        )
+        .await
+    }
+}
+
+/// Blocking convenience wrapper around [`OllamaJudgeClient`].
+#[derive(Clone, Debug)]
+pub struct BlockingOllamaJudgeClient {
+    inner: OllamaJudgeClient,
+}
+
+impl BlockingOllamaJudgeClient {
+    /// Wrap an existing [`OllamaJudgeClient`].
+    #[must_use]
+    pub const fn new(inner: OllamaJudgeClient) -> Self {
+        Self { inner }
+    }
+
+    /// Run a single judge call synchronously on the current Tokio runtime.
+    pub fn judge(&self, prompt: &str) -> Result<JudgeVerdict, JudgeError> {
+        let client = self.inner.clone();
+        let prompt = prompt.to_string();
+        async move { client.judge(&prompt).await }.block_on()
+    }
+
+    /// Borrow the underlying async client for mixed sync/async call sites.
+    #[must_use]
+    pub const fn inner(&self) -> &OllamaJudgeClient {
+        &self.inner
+    }
+}
+
+#[derive(Serialize)]
+struct OllamaRequest<'a> {
+    model: &'a str,
+    messages: Vec<OllamaMessage<'a>>,
+    stream: bool,
+}
+
+#[derive(Serialize)]
+struct OllamaMessage<'a> {
+    role: &'a str,
+    content: &'a str,
+}
+
+#[derive(Deserialize, Debug)]
+struct OllamaResponse {
+    message: OllamaAssistantMessage,
+}
+
+#[derive(Deserialize, Debug)]
+struct OllamaAssistantMessage {
+    content: Option<String>,
+}
+
+fn classify_http_error(status: StatusCode, body: &str) -> JudgeError {
+    if status == StatusCode::TOO_MANY_REQUESTS || status.is_server_error() {
+        JudgeError::Transport(format!(
+            "ollama http {}: {}",
+            status.as_u16(),
+            truncate(body)
+        ))
+    } else {
+        JudgeError::Other(format!(
+            "ollama http {}: {}",
+            status.as_u16(),
+            truncate(body)
+        ))
+    }
+}
+
+fn truncate(body: &str) -> String {
+    const LIMIT: usize = 512;
+    if body.len() <= LIMIT {
+        body.to_string()
+    } else {
+        format!("{}…", &body[..LIMIT])
+    }
+}
+
+fn extract_verdict(response: &OllamaResponse) -> Result<JudgeVerdict, JudgeError> {
+    let content =
+        response.message.content.as_deref().ok_or_else(|| {
+            JudgeError::MalformedResponse("ollama message missing content".into())
+        })?;
+    parse_verdict_text(content)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_429_is_transport() {
+        let error = classify_http_error(StatusCode::TOO_MANY_REQUESTS, "slow down");
+        assert!(matches!(error, JudgeError::Transport(_)));
+    }
+
+    #[test]
+    fn classify_503_is_transport() {
+        let error = classify_http_error(StatusCode::SERVICE_UNAVAILABLE, "down");
+        assert!(matches!(error, JudgeError::Transport(_)));
+    }
+
+    #[test]
+    fn classify_401_is_terminal() {
+        let error = classify_http_error(StatusCode::UNAUTHORIZED, "bad key");
+        assert!(matches!(error, JudgeError::Other(_)));
+    }
+}

--- a/eval-judges/src/proxy.rs
+++ b/eval-judges/src/proxy.rs
@@ -1,7 +1,226 @@
-//! Proxy judge client scaffold.
+//! Proxy judge client.
+//!
+//! The proxy client forwards prompts to a generic judge-compatible HTTP
+//! endpoint via `POST /judge` (the path is baked into `base_url`). The
+//! endpoint returns a raw [`JudgeVerdict`] JSON object, which is parsed
+//! directly by the shared verdict parser. Bearer auth is used for
+//! authentication.
 
-#[derive(Debug, Clone, Default)]
-pub struct ProxyJudgeClient;
+use std::sync::Arc;
+use std::time::Duration;
 
-#[derive(Debug, Clone, Default)]
-pub struct BlockingProxyJudgeClient;
+use async_trait::async_trait;
+use reqwest::{Client, StatusCode};
+use serde::Serialize;
+use tokio_util::sync::CancellationToken;
+
+use swink_agent_eval::judge::{JudgeClient, JudgeError, JudgeVerdict, RetryPolicy};
+
+use crate::client::{BlockingExt, is_retryable, parse_verdict_text, retry_with_cancel};
+
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Async judge client that forwards prompts to a generic proxy endpoint.
+///
+/// The proxy is responsible for model selection; the client sends only the
+/// prompt and receives a raw [`JudgeVerdict`] JSON payload in return.
+#[derive(Clone)]
+pub struct ProxyJudgeClient {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    base_url: String,
+    api_key: String,
+    retry_policy: RetryPolicy,
+    cancel: CancellationToken,
+    http: Client,
+}
+
+impl Clone for Inner {
+    fn clone(&self) -> Self {
+        Self {
+            base_url: self.base_url.clone(),
+            api_key: self.api_key.clone(),
+            retry_policy: self.retry_policy.clone(),
+            cancel: self.cancel.clone(),
+            http: self.http.clone(),
+        }
+    }
+}
+
+impl std::fmt::Debug for ProxyJudgeClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ProxyJudgeClient")
+            .field("base_url", &self.inner.base_url)
+            .field("retry_policy", &self.inner.retry_policy)
+            .finish_non_exhaustive()
+    }
+}
+
+impl ProxyJudgeClient {
+    /// Build a new proxy judge client.
+    ///
+    /// `base_url` should include the full path to the judge endpoint, e.g.
+    /// `https://proxy.example.com/judge`. No model selection is performed
+    /// client-side — the proxy chooses the backend model.
+    #[must_use]
+    pub fn new(base_url: impl Into<String>, api_key: impl Into<String>) -> Self {
+        let http = Client::builder()
+            .timeout(DEFAULT_TIMEOUT)
+            .build()
+            .unwrap_or_else(|_| Client::new());
+        Self {
+            inner: Arc::new(Inner {
+                base_url: base_url.into().trim_end_matches('/').to_string(),
+                api_key: api_key.into(),
+                retry_policy: RetryPolicy::default(),
+                cancel: CancellationToken::new(),
+                http,
+            }),
+        }
+    }
+
+    /// Override the shared retry policy.
+    #[must_use]
+    pub fn with_retry_policy(mut self, policy: RetryPolicy) -> Self {
+        Arc::make_mut(&mut self.inner).retry_policy = policy;
+        self
+    }
+
+    /// Attach an external cancellation token.
+    #[must_use]
+    pub fn with_cancellation(mut self, cancel: CancellationToken) -> Self {
+        Arc::make_mut(&mut self.inner).cancel = cancel;
+        self
+    }
+
+    /// Borrow the configured cancellation token.
+    #[must_use]
+    pub fn cancellation(&self) -> CancellationToken {
+        self.inner.cancel.clone()
+    }
+
+    async fn dispatch_once(&self, prompt: &str) -> Result<JudgeVerdict, JudgeError> {
+        let body = ProxyRequest { prompt };
+        let url = self.inner.base_url.clone();
+
+        let response = self
+            .inner
+            .http
+            .post(&url)
+            .bearer_auth(&self.inner.api_key)
+            .header("content-type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|error| JudgeError::Transport(format!("proxy request failed: {error}")))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let text = response.text().await.unwrap_or_default();
+            return Err(classify_http_error(status, &text));
+        }
+
+        let text = response.text().await.map_err(|error| {
+            JudgeError::MalformedResponse(format!("proxy body read failed: {error}"))
+        })?;
+
+        parse_verdict_text(&text)
+    }
+}
+
+#[async_trait]
+impl JudgeClient for ProxyJudgeClient {
+    async fn judge(&self, prompt: &str) -> Result<JudgeVerdict, JudgeError> {
+        let this = self;
+        let prompt = prompt;
+        retry_with_cancel(
+            &self.inner.retry_policy,
+            &self.inner.cancel,
+            is_retryable,
+            || async move { this.dispatch_once(prompt).await },
+        )
+        .await
+    }
+}
+
+/// Blocking convenience wrapper around [`ProxyJudgeClient`].
+#[derive(Clone, Debug)]
+pub struct BlockingProxyJudgeClient {
+    inner: ProxyJudgeClient,
+}
+
+impl BlockingProxyJudgeClient {
+    /// Wrap an existing [`ProxyJudgeClient`].
+    #[must_use]
+    pub const fn new(inner: ProxyJudgeClient) -> Self {
+        Self { inner }
+    }
+
+    /// Run a single judge call synchronously on the current Tokio runtime.
+    pub fn judge(&self, prompt: &str) -> Result<JudgeVerdict, JudgeError> {
+        let client = self.inner.clone();
+        let prompt = prompt.to_string();
+        async move { client.judge(&prompt).await }.block_on()
+    }
+
+    /// Borrow the underlying async client for mixed sync/async call sites.
+    #[must_use]
+    pub const fn inner(&self) -> &ProxyJudgeClient {
+        &self.inner
+    }
+}
+
+#[derive(Serialize)]
+struct ProxyRequest<'a> {
+    prompt: &'a str,
+}
+
+fn classify_http_error(status: StatusCode, body: &str) -> JudgeError {
+    if status == StatusCode::TOO_MANY_REQUESTS || status.is_server_error() {
+        JudgeError::Transport(format!(
+            "proxy http {}: {}",
+            status.as_u16(),
+            truncate(body)
+        ))
+    } else {
+        JudgeError::Other(format!(
+            "proxy http {}: {}",
+            status.as_u16(),
+            truncate(body)
+        ))
+    }
+}
+
+fn truncate(body: &str) -> String {
+    const LIMIT: usize = 512;
+    if body.len() <= LIMIT {
+        body.to_string()
+    } else {
+        format!("{}…", &body[..LIMIT])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_429_is_transport() {
+        let error = classify_http_error(StatusCode::TOO_MANY_REQUESTS, "slow down");
+        assert!(matches!(error, JudgeError::Transport(_)));
+    }
+
+    #[test]
+    fn classify_503_is_transport() {
+        let error = classify_http_error(StatusCode::SERVICE_UNAVAILABLE, "down");
+        assert!(matches!(error, JudgeError::Transport(_)));
+    }
+
+    #[test]
+    fn classify_401_is_terminal() {
+        let error = classify_http_error(StatusCode::UNAUTHORIZED, "bad key");
+        assert!(matches!(error, JudgeError::Other(_)));
+    }
+}

--- a/eval-judges/tests/ollama_test.rs
+++ b/eval-judges/tests/ollama_test.rs
@@ -1,0 +1,185 @@
+//! Wiremock-backed integration tests for [`OllamaJudgeClient`].
+//!
+//! Coverage per T045: happy path, 503 retry, exhausted retries, malformed
+//! verdict, cancellation, and the blocking wrapper.
+
+#![cfg(feature = "ollama")]
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use swink_agent_eval::judge::{JudgeClient, JudgeError, RetryPolicy};
+use swink_agent_eval_judges::OllamaJudgeClient;
+use tokio_util::sync::CancellationToken;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
+
+mod common;
+use common::happy_verdict_json;
+
+fn test_policy(max_attempts: u32) -> RetryPolicy {
+    RetryPolicy::new(max_attempts, Duration::from_millis(10), false)
+}
+
+/// Build a 200 response in the Ollama `/api/chat` shape wrapping
+/// `verdict_text` in `message.content`.
+fn ollama_success_body(verdict_text: &str) -> ResponseTemplate {
+    ResponseTemplate::new(200).set_body_json(serde_json::json!({
+        "model": "llama3",
+        "created_at": "2024-01-01T00:00:00Z",
+        "message": {
+            "role": "assistant",
+            "content": verdict_text
+        },
+        "done": true
+    }))
+}
+
+#[tokio::test]
+async fn ollama_happy_path() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/chat"))
+        .respond_with(ollama_success_body(&happy_verdict_json()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = OllamaJudgeClient::new(server.uri(), "llama3").with_retry_policy(test_policy(6));
+
+    let verdict = client.judge("grade this").await.expect("verdict");
+    assert!(verdict.pass);
+    assert!((verdict.score - 0.9).abs() < f64::EPSILON);
+    assert_eq!(verdict.reason.as_deref(), Some("looks correct"));
+}
+
+struct OneBlipThenSuccess {
+    count: Arc<AtomicUsize>,
+    success: ResponseTemplate,
+}
+
+impl Respond for OneBlipThenSuccess {
+    fn respond(&self, _request: &Request) -> ResponseTemplate {
+        let call_count = self.count.fetch_add(1, Ordering::SeqCst);
+        if call_count == 0 {
+            ResponseTemplate::new(503).set_body_string("service unavailable")
+        } else {
+            self.success.clone()
+        }
+    }
+}
+
+#[tokio::test]
+async fn ollama_rate_limit_absorbed_by_retry() {
+    let server = MockServer::start().await;
+    let count = Arc::new(AtomicUsize::new(0));
+
+    Mock::given(method("POST"))
+        .and(path("/api/chat"))
+        .respond_with(OneBlipThenSuccess {
+            count: count.clone(),
+            success: ollama_success_body(&happy_verdict_json()),
+        })
+        .expect(2)
+        .mount(&server)
+        .await;
+
+    let client = OllamaJudgeClient::new(server.uri(), "llama3").with_retry_policy(test_policy(6));
+
+    let verdict = client
+        .judge("grade this")
+        .await
+        .expect("verdict after retry");
+    assert!(verdict.pass);
+    assert_eq!(count.load(Ordering::SeqCst), 2);
+}
+
+#[tokio::test]
+async fn ollama_exhausted_retries_surface_transport() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/chat"))
+        .respond_with(ResponseTemplate::new(503).set_body_string("service unavailable"))
+        .expect(3)
+        .mount(&server)
+        .await;
+
+    let client = OllamaJudgeClient::new(server.uri(), "llama3").with_retry_policy(test_policy(3));
+
+    let error = client
+        .judge("grade this")
+        .await
+        .expect_err("must exhaust retries");
+    match error {
+        JudgeError::Transport(message) => assert!(message.contains("503")),
+        other => panic!("expected Transport, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn ollama_malformed_response_is_terminal() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/chat"))
+        .respond_with(ollama_success_body("not a verdict at all"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = OllamaJudgeClient::new(server.uri(), "llama3").with_retry_policy(test_policy(6));
+
+    let error = client
+        .judge("grade this")
+        .await
+        .expect_err("must surface malformed");
+    assert!(matches!(error, JudgeError::MalformedResponse(_)));
+}
+
+#[tokio::test]
+async fn ollama_cancellation_token_short_circuits() {
+    let server = MockServer::start().await;
+
+    let cancel = CancellationToken::new();
+    cancel.cancel();
+
+    let client = OllamaJudgeClient::new(server.uri(), "llama3")
+        .with_retry_policy(test_policy(6))
+        .with_cancellation(cancel);
+
+    let error = client
+        .judge("grade this")
+        .await
+        .expect_err("cancelled before dispatch");
+    match error {
+        JudgeError::Other(message) => assert!(message.contains("cancel")),
+        other => panic!("expected cancellation, got {other:?}"),
+    }
+
+    assert_eq!(
+        server.received_requests().await.unwrap_or_default().len(),
+        0
+    );
+}
+
+#[tokio::test]
+async fn ollama_blocking_wrapper_delegates_to_async() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/chat"))
+        .respond_with(ollama_success_body(&happy_verdict_json()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = OllamaJudgeClient::new(server.uri(), "llama3").with_retry_policy(test_policy(3));
+    let blocking = swink_agent_eval_judges::BlockingOllamaJudgeClient::new(client);
+
+    let verdict = tokio::task::spawn_blocking(move || blocking.judge("grade this"))
+        .await
+        .expect("join")
+        .expect("verdict");
+    assert!(verdict.pass);
+}

--- a/eval-judges/tests/proxy_test.rs
+++ b/eval-judges/tests/proxy_test.rs
@@ -1,0 +1,184 @@
+//! Wiremock-backed integration tests for [`ProxyJudgeClient`].
+//!
+//! Coverage per T046: happy path, 503 retry, exhausted retries, malformed
+//! verdict, cancellation, and the blocking wrapper.
+
+#![cfg(feature = "proxy")]
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use swink_agent_eval::judge::{JudgeClient, JudgeError, RetryPolicy};
+use swink_agent_eval_judges::ProxyJudgeClient;
+use tokio_util::sync::CancellationToken;
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
+
+mod common;
+use common::happy_verdict_json;
+
+fn test_policy(max_attempts: u32) -> RetryPolicy {
+    RetryPolicy::new(max_attempts, Duration::from_millis(10), false)
+}
+
+/// Build a 200 response with a raw JudgeVerdict JSON body.
+fn proxy_success_body(verdict_json: &str) -> ResponseTemplate {
+    ResponseTemplate::new(200)
+        .insert_header("Content-Type", "application/json")
+        .set_body_string(verdict_json.to_string())
+}
+
+#[tokio::test]
+async fn proxy_happy_path() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/judge"))
+        .and(header("authorization", "Bearer test-key"))
+        .respond_with(proxy_success_body(&happy_verdict_json()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = ProxyJudgeClient::new(format!("{}/judge", server.uri()), "test-key")
+        .with_retry_policy(test_policy(6));
+
+    let verdict = client.judge("grade this").await.expect("verdict");
+    assert!(verdict.pass);
+    assert!((verdict.score - 0.9).abs() < f64::EPSILON);
+    assert_eq!(verdict.reason.as_deref(), Some("looks correct"));
+}
+
+struct OneBlipThenSuccess {
+    count: Arc<AtomicUsize>,
+    success: ResponseTemplate,
+}
+
+impl Respond for OneBlipThenSuccess {
+    fn respond(&self, _request: &Request) -> ResponseTemplate {
+        let call_count = self.count.fetch_add(1, Ordering::SeqCst);
+        if call_count == 0 {
+            ResponseTemplate::new(503).set_body_string("service unavailable")
+        } else {
+            self.success.clone()
+        }
+    }
+}
+
+#[tokio::test]
+async fn proxy_rate_limit_absorbed_by_retry() {
+    let server = MockServer::start().await;
+    let count = Arc::new(AtomicUsize::new(0));
+
+    Mock::given(method("POST"))
+        .and(path("/judge"))
+        .respond_with(OneBlipThenSuccess {
+            count: count.clone(),
+            success: proxy_success_body(&happy_verdict_json()),
+        })
+        .expect(2)
+        .mount(&server)
+        .await;
+
+    let client = ProxyJudgeClient::new(format!("{}/judge", server.uri()), "test-key")
+        .with_retry_policy(test_policy(6));
+
+    let verdict = client
+        .judge("grade this")
+        .await
+        .expect("verdict after retry");
+    assert!(verdict.pass);
+    assert_eq!(count.load(Ordering::SeqCst), 2);
+}
+
+#[tokio::test]
+async fn proxy_exhausted_retries_surface_transport() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/judge"))
+        .respond_with(ResponseTemplate::new(503).set_body_string("service unavailable"))
+        .expect(3)
+        .mount(&server)
+        .await;
+
+    let client = ProxyJudgeClient::new(format!("{}/judge", server.uri()), "test-key")
+        .with_retry_policy(test_policy(3));
+
+    let error = client
+        .judge("grade this")
+        .await
+        .expect_err("must exhaust retries");
+    match error {
+        JudgeError::Transport(message) => assert!(message.contains("503")),
+        other => panic!("expected Transport, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn proxy_malformed_response_is_terminal() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/judge"))
+        .respond_with(proxy_success_body("not a verdict at all"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = ProxyJudgeClient::new(format!("{}/judge", server.uri()), "test-key")
+        .with_retry_policy(test_policy(6));
+
+    let error = client
+        .judge("grade this")
+        .await
+        .expect_err("must surface malformed");
+    assert!(matches!(error, JudgeError::MalformedResponse(_)));
+}
+
+#[tokio::test]
+async fn proxy_cancellation_token_short_circuits() {
+    let server = MockServer::start().await;
+
+    let cancel = CancellationToken::new();
+    cancel.cancel();
+
+    let client = ProxyJudgeClient::new(format!("{}/judge", server.uri()), "test-key")
+        .with_retry_policy(test_policy(6))
+        .with_cancellation(cancel);
+
+    let error = client
+        .judge("grade this")
+        .await
+        .expect_err("cancelled before dispatch");
+    match error {
+        JudgeError::Other(message) => assert!(message.contains("cancel")),
+        other => panic!("expected cancellation, got {other:?}"),
+    }
+
+    assert_eq!(
+        server.received_requests().await.unwrap_or_default().len(),
+        0
+    );
+}
+
+#[tokio::test]
+async fn proxy_blocking_wrapper_delegates_to_async() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/judge"))
+        .respond_with(proxy_success_body(&happy_verdict_json()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = ProxyJudgeClient::new(format!("{}/judge", server.uri()), "test-key")
+        .with_retry_policy(test_policy(3));
+    let blocking = swink_agent_eval_judges::BlockingProxyJudgeClient::new(client);
+
+    let verdict = tokio::task::spawn_blocking(move || blocking.judge("grade this"))
+        .await
+        .expect("join")
+        .expect("verdict");
+    assert!(verdict.pass);
+}


### PR DESCRIPTION
## Summary
Adds the final two judge-client implementations to `swink-agent-eval-judges`, each behind its own feature flag and sharing the retry/cancellation/batch infrastructure from #817. Follows the xAI template.

## Tasks completed
- T045 OllamaJudgeClient + BlockingOllamaJudgeClient + wiremock tests (POST /api/chat, no auth)
- T046 ProxyJudgeClient + BlockingProxyJudgeClient + wiremock tests (POST /judge, bearer auth, raw JudgeVerdict response)

## Test plan
- [x] cargo fmt clean
- [x] cargo clippy -p swink-agent-eval-judges --features ollama,proxy -- -D warnings
- [x] cargo test -p swink-agent-eval-judges --features ollama --test ollama_test (6/6 pass)
- [x] cargo test -p swink-agent-eval-judges --features proxy --test proxy_test (6/6 pass)
- [x] cargo build -p swink-agent-eval-judges --no-default-features (SC-009)
- [x] No live LLM calls (FR-050)

## Public API
New under provider-specific features only: `OllamaJudgeClient`, `BlockingOllamaJudgeClient`, `ProxyJudgeClient`, `BlockingProxyJudgeClient`.

Part of #748

https://claude.ai/code/session_01NiR2WJQk1bazVzeTSCRocB

---
_Generated by [Claude Code](https://claude.ai/code/session_01NiR2WJQk1bazVzeTSCRocB)_