### PR TITLE
impl(031): MemoryNudgePolicy with heuristic detection

### DIFF
--- a/policies/Cargo.toml
+++ b/policies/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 [features]
 default = ["all"]
 full = ["all"]
-all = ["budget", "max-turns", "deny-list", "sandbox", "loop-detection", "checkpoint", "prompt-guard", "pii", "content-filter", "audit"]
+all = ["budget", "max-turns", "deny-list", "sandbox", "loop-detection", "checkpoint", "prompt-guard", "pii", "content-filter", "audit", "memory-nudge"]
 budget = []
 max-turns = []
 deny-list = []
@@ -24,6 +24,7 @@ prompt-guard = ["regex"]
 pii = ["regex"]
 content-filter = ["regex"]
 audit = ["chrono", "serde", "serde_json", "unicode-truncate"]
+memory-nudge = ["serde_json"]
 
 [dependencies]
 swink-agent = { path = "..", version = "0.9.0", default-features = false }

--- a/policies/src/lib.rs
+++ b/policies/src/lib.rs
@@ -19,6 +19,7 @@
 //! - **`pii`**: `PiiRedactor` — redacts personally identifiable information from assistant responses
 //! - **`content-filter`**: `ContentFilter` — keyword/regex blocklist for assistant output
 //! - **`audit`**: `AuditLogger` — records every turn to a pluggable sink
+//! - **`memory-nudge`**: `MemoryNudgePolicy` — heuristic detection of save-worthy content in agent turns
 #[cfg(any(feature = "prompt-guard", feature = "pii", feature = "content-filter"))]
 mod patterns;
 
@@ -77,3 +78,8 @@ mod audit_logger;
 pub use audit_logger::{
     AuditCost, AuditLogger, AuditRecord, AuditSink, AuditUsage, JsonlAuditSink,
 };
+
+#[cfg(feature = "memory-nudge")]
+mod memory_nudge;
+#[cfg(feature = "memory-nudge")]
+pub use memory_nudge::{MemoryNudge, MemoryNudgeCategory, MemoryNudgePolicy, NudgeSensitivity};

--- a/policies/src/memory_nudge.rs
+++ b/policies/src/memory_nudge.rs
@@ -1,0 +1,677 @@
+//! Memory nudge policy — heuristic detection of save-worthy content in agent turns.
+//!
+//! [`MemoryNudgePolicy`] implements [`PostTurnPolicy`] and scans the assistant message
+//! text for four categories of save-worthy content:
+//!
+//! - **Correction** — user corrections ("no, actually…", "don't do X", "use Y instead")
+//! - **ExplicitSave** — direct save requests ("remember this", "note that", "keep in mind")
+//! - **Decision** — decision statements ("we decided to…", "the plan is…")
+//! - **Preference** — configuration/preference declarations ("I prefer", "always use")
+//!
+//! When a match is found above the configured sensitivity threshold, the policy returns
+//! [`PolicyVerdict::Inject`] carrying a single [`AgentMessage`] with a
+//! `ContentBlock::Extension { type_name: "memory_nudge", data: <JSON MemoryNudge> }`.
+//! The caller is responsible for consuming the extension block and persisting it.
+//!
+//! # Feature gate
+//!
+//! This module is only compiled when the `memory-nudge` feature is enabled.
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use swink_agent_policies::{MemoryNudgePolicy, NudgeSensitivity};
+//! use std::sync::Arc;
+//!
+//! let policy = Arc::new(
+//!     MemoryNudgePolicy::new().with_sensitivity(NudgeSensitivity::High),
+//! );
+//! // Add to agent's post_turn_policies slot:
+//! // options.with_post_turn_policy(policy)
+//! ```
+
+#![forbid(unsafe_code)]
+use swink_agent::{
+    AgentMessage, ContentBlock, LlmMessage, PolicyContext, PolicyVerdict, PostTurnPolicy,
+    TurnPolicyContext, UserMessage,
+};
+
+// ─── Category ───────────────────────────────────────────────────────────────
+
+/// The category of save-worthy content detected by [`MemoryNudgePolicy`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MemoryNudgeCategory {
+    /// A user correction — the user (or assistant relaying a correction) clarifies
+    /// that a previous assumption, approach, or fact was wrong.
+    ///
+    /// Example phrases: "no, actually", "don't do that", "use X instead".
+    Correction,
+
+    /// An explicit request to save information for future recall.
+    ///
+    /// Example phrases: "remember this", "note that", "keep in mind".
+    ExplicitSave,
+
+    /// A decision or plan statement about how to proceed.
+    ///
+    /// Example phrases: "we decided to", "the plan is", "going forward".
+    Decision,
+
+    /// A configuration or style preference the user has stated.
+    ///
+    /// Example phrases: "I prefer", "always use", "my preference is".
+    Preference,
+}
+
+impl MemoryNudgeCategory {
+    /// Return a stable lowercase string name for serialization.
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Correction => "correction",
+            Self::ExplicitSave => "explicit_save",
+            Self::Decision => "decision",
+            Self::Preference => "preference",
+        }
+    }
+}
+
+// ─── Nudge payload ──────────────────────────────────────────────────────────
+
+/// A structured payload emitted when save-worthy content is detected in a turn.
+///
+/// Serialized as JSON inside a `ContentBlock::Extension { type_name: "memory_nudge" }`.
+/// Callers should deserialize the `data` field to recover this struct.
+#[derive(Debug, Clone)]
+pub struct MemoryNudge {
+    /// Which category of save-worthy content was detected.
+    pub category: MemoryNudgeCategory,
+    /// A short summary of the detected content (≤ 200 characters).
+    pub summary: String,
+    /// Heuristic confidence score in [0.0, 1.0].
+    pub confidence: f32,
+    /// Zero-based index of the turn in which the nudge was detected.
+    pub turn_number: usize,
+}
+
+impl MemoryNudge {
+    /// Serialize `self` to a [`serde_json::Value`] for embedding in a content block.
+    pub fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "category": self.category.as_str(),
+            "summary": self.summary,
+            "confidence": self.confidence,
+            "turn_number": self.turn_number,
+        })
+    }
+}
+
+// ─── Sensitivity ────────────────────────────────────────────────────────────
+
+/// Controls how aggressively [`MemoryNudgePolicy`] flags borderline content.
+///
+/// Each level maps to a minimum confidence threshold: matches with a confidence
+/// score strictly below the threshold are suppressed (no nudge emitted).
+///
+/// | Level  | Threshold | Behavior                                        |
+/// |--------|-----------|-------------------------------------------------|
+/// | Low    | 0.75      | Only high-confidence, unambiguous matches       |
+/// | Medium | 0.55      | Balanced — default for most use cases           |
+/// | High   | 0.35      | Catch borderline / partial matches too          |
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum NudgeSensitivity {
+    /// Only high-confidence matches (threshold 0.75).
+    Low,
+    /// Balanced detection — default (threshold 0.55).
+    #[default]
+    Medium,
+    /// Aggressive detection — catches borderline patterns (threshold 0.35).
+    High,
+}
+
+impl NudgeSensitivity {
+    /// Return the minimum confidence score required to emit a nudge.
+    pub const fn threshold(self) -> f32 {
+        match self {
+            Self::Low => 0.75,
+            Self::Medium => 0.55,
+            Self::High => 0.35,
+        }
+    }
+}
+
+// ─── Policy ─────────────────────────────────────────────────────────────────
+
+/// A `PostTurnPolicy` that detects save-worthy content via heuristic pattern matching.
+///
+/// When a match is found above the configured [`NudgeSensitivity`] threshold,
+/// the policy returns [`PolicyVerdict::Inject`] with an extension content block
+/// (`type_name: "memory_nudge"`) containing a serialized [`MemoryNudge`].
+///
+/// The policy never returns `Stop` — it is purely additive and non-blocking.
+/// Callers are responsible for consuming injected extension blocks.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let policy = MemoryNudgePolicy::new().with_sensitivity(NudgeSensitivity::High);
+/// ```
+#[derive(Debug, Clone)]
+pub struct MemoryNudgePolicy {
+    sensitivity: NudgeSensitivity,
+}
+
+impl MemoryNudgePolicy {
+    /// Create a `MemoryNudgePolicy` with [`NudgeSensitivity::Medium`] (default).
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            sensitivity: NudgeSensitivity::Medium,
+        }
+    }
+
+    /// Set the sensitivity level.
+    #[must_use]
+    pub const fn with_sensitivity(mut self, sensitivity: NudgeSensitivity) -> Self {
+        self.sensitivity = sensitivity;
+        self
+    }
+}
+
+impl Default for MemoryNudgePolicy {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ─── Heuristic detectors ────────────────────────────────────────────────────
+
+/// Phrase patterns for each category.
+///
+/// Each entry is a `(phrase, base_confidence)` pair. The policy does a
+/// case-insensitive substring search; the first hit wins for that category.
+const CORRECTION_PATTERNS: &[(&str, f32)] = &[
+    ("no, actually", 0.90),
+    ("don't do that", 0.85),
+    ("don't do this", 0.85),
+    ("use x instead", 0.80),
+    ("use y instead", 0.80),
+    ("instead of that", 0.75),
+    ("that's wrong", 0.80),
+    ("that is wrong", 0.80),
+    ("incorrect, ", 0.78),
+    ("not quite right", 0.75),
+    ("actually, ", 0.60),
+    ("rather than that", 0.65),
+    ("instead, use", 0.70),
+    ("you should use", 0.65),
+    ("please use", 0.60),
+];
+
+const EXPLICIT_SAVE_PATTERNS: &[(&str, f32)] = &[
+    ("remember this", 0.95),
+    ("remember that", 0.90),
+    ("note that", 0.85),
+    ("keep in mind", 0.85),
+    ("make a note", 0.90),
+    ("save this", 0.90),
+    ("don't forget", 0.80),
+    ("important to remember", 0.85),
+    ("worth noting", 0.80),
+    ("for future reference", 0.85),
+    ("bear in mind", 0.80),
+    ("take note", 0.85),
+];
+
+const DECISION_PATTERNS: &[(&str, f32)] = &[
+    ("we decided to", 0.90),
+    ("we've decided to", 0.90),
+    ("we have decided to", 0.90),
+    ("the plan is", 0.85),
+    ("the decision is", 0.88),
+    ("going forward, ", 0.80),
+    ("going forward we", 0.80),
+    ("from now on", 0.80),
+    ("we will use", 0.70),
+    ("we are going to", 0.72),
+    ("we agreed to", 0.85),
+    ("we've agreed to", 0.85),
+    ("the approach is", 0.75),
+    ("our decision:", 0.88),
+    ("decided on", 0.75),
+];
+
+const PREFERENCE_PATTERNS: &[(&str, f32)] = &[
+    ("i prefer ", 0.90),
+    ("my preference is", 0.92),
+    ("always use", 0.80),
+    ("i like to use", 0.82),
+    ("i want to use", 0.78),
+    ("please always", 0.75),
+    ("i always use", 0.82),
+    ("i'd like to use", 0.80),
+    ("i would like to use", 0.80),
+    ("my style is", 0.85),
+    ("my convention is", 0.85),
+    ("i use ", 0.55),
+    ("our convention is", 0.82),
+    ("our style is", 0.82),
+    ("prefer to use", 0.80),
+];
+
+/// Detect a correction in `text`. Returns `Some(confidence)` on first match.
+fn detect_correction(text: &str) -> Option<f32> {
+    detect_any(text, CORRECTION_PATTERNS)
+}
+
+/// Detect an explicit save request in `text`. Returns `Some(confidence)` on first match.
+fn detect_explicit_save(text: &str) -> Option<f32> {
+    detect_any(text, EXPLICIT_SAVE_PATTERNS)
+}
+
+/// Detect a decision statement in `text`. Returns `Some(confidence)` on first match.
+fn detect_decision(text: &str) -> Option<f32> {
+    detect_any(text, DECISION_PATTERNS)
+}
+
+/// Detect a preference declaration in `text`. Returns `Some(confidence)` on first match.
+fn detect_preference(text: &str) -> Option<f32> {
+    detect_any(text, PREFERENCE_PATTERNS)
+}
+
+/// Case-insensitive substring search across a slice of `(phrase, confidence)` pairs.
+fn detect_any(text: &str, patterns: &[(&str, f32)]) -> Option<f32> {
+    let lower = text.to_lowercase();
+    for (phrase, confidence) in patterns {
+        if lower.contains(*phrase) {
+            return Some(*confidence);
+        }
+    }
+    None
+}
+
+/// Truncate `text` to at most `max_chars` Unicode scalar values.
+fn truncate_summary(text: &str, max_chars: usize) -> String {
+    let mut chars = text.char_indices();
+    if let Some((idx, _)) = chars.nth(max_chars) {
+        format!("{}…", &text[..idx])
+    } else {
+        text.to_string()
+    }
+}
+
+/// Build a `MemoryNudge` and wrap it in an `AgentMessage` extension block.
+fn nudge_message(
+    category: MemoryNudgeCategory,
+    summary: &str,
+    confidence: f32,
+    turn_number: usize,
+) -> AgentMessage {
+    let nudge = MemoryNudge {
+        category,
+        summary: truncate_summary(summary, 200),
+        confidence,
+        turn_number,
+    };
+    let data = nudge.to_json();
+    // Embed the nudge as an extension block inside a user message so it can
+    // be stored in the message history without being forwarded to the LLM
+    // (extension blocks are stripped during message conversion).
+    AgentMessage::Llm(LlmMessage::User(UserMessage {
+        content: vec![ContentBlock::Extension {
+            type_name: "memory_nudge".to_string(),
+            data,
+        }],
+        timestamp: 0,
+        cache_hint: None,
+    }))
+}
+
+// ─── PostTurnPolicy impl ─────────────────────────────────────────────────────
+
+impl PostTurnPolicy for MemoryNudgePolicy {
+    fn name(&self) -> &str {
+        "memory-nudge"
+    }
+
+    fn evaluate(&self, ctx: &PolicyContext<'_>, turn: &TurnPolicyContext<'_>) -> PolicyVerdict {
+        let text = ContentBlock::extract_text(&turn.assistant_message.content);
+        if text.is_empty() {
+            return PolicyVerdict::Continue;
+        }
+
+        let threshold = self.sensitivity.threshold();
+        let mut messages: Vec<AgentMessage> = Vec::new();
+
+        // Check each category in priority order; emit one nudge per matching category.
+        type Detector = fn(&str) -> Option<f32>;
+        let detectors: &[(Detector, MemoryNudgeCategory)] = &[
+            (detect_correction, MemoryNudgeCategory::Correction),
+            (detect_explicit_save, MemoryNudgeCategory::ExplicitSave),
+            (detect_decision, MemoryNudgeCategory::Decision),
+            (detect_preference, MemoryNudgeCategory::Preference),
+        ];
+
+        for (detector, category) in detectors {
+            if let Some(confidence) = detector(&text)
+                && confidence >= threshold
+            {
+                messages.push(nudge_message(
+                    category.clone(),
+                    &text,
+                    confidence,
+                    ctx.turn_index,
+                ));
+            }
+        }
+
+        if messages.is_empty() {
+            PolicyVerdict::Continue
+        } else {
+            PolicyVerdict::Inject(messages)
+        }
+    }
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use swink_agent::{
+        AssistantMessage, ContentBlock, Cost, LlmMessage, PolicyContext, PolicyVerdict, StopReason,
+        ToolResultMessage, TurnPolicyContext, Usage, UserMessage,
+    };
+
+    // ── Test helpers ─────────────────────────────────────────────────────
+
+    fn make_assistant(text: &str) -> AssistantMessage {
+        AssistantMessage {
+            content: vec![ContentBlock::Text {
+                text: text.to_string(),
+            }],
+            provider: String::new(),
+            model_id: String::new(),
+            usage: Usage::default(),
+            cost: Cost::default(),
+            stop_reason: StopReason::Stop,
+            error_message: None,
+            error_kind: None,
+            timestamp: 0,
+            cache_hint: None,
+        }
+    }
+
+    fn make_turn_ctx<'a>(
+        assistant: &'a AssistantMessage,
+        tool_results: &'a [ToolResultMessage],
+        context_messages: &'a [AgentMessage],
+    ) -> TurnPolicyContext<'a> {
+        static MODEL: std::sync::LazyLock<swink_agent::ModelSpec> =
+            std::sync::LazyLock::new(|| swink_agent::ModelSpec::new("test", "test-model"));
+        TurnPolicyContext {
+            assistant_message: assistant,
+            tool_results,
+            stop_reason: StopReason::Stop,
+            system_prompt: "",
+            model_spec: &MODEL,
+            context_messages,
+        }
+    }
+
+    fn make_policy_ctx<'a>(
+        usage: &'a Usage,
+        cost: &'a Cost,
+        state: &'a swink_agent::SessionState,
+    ) -> PolicyContext<'a> {
+        PolicyContext {
+            turn_index: 3,
+            accumulated_usage: usage,
+            accumulated_cost: cost,
+            message_count: 10,
+            overflow_signal: false,
+            new_messages: &[],
+            state,
+        }
+    }
+
+    fn evaluate_text(text: &str, sensitivity: NudgeSensitivity) -> PolicyVerdict {
+        let policy = MemoryNudgePolicy::new().with_sensitivity(sensitivity);
+        let assistant = make_assistant(text);
+        let usage = Usage::default();
+        let cost = Cost::default();
+        let state = swink_agent::SessionState::new();
+        let ctx = make_policy_ctx(&usage, &cost, &state);
+        let turn = make_turn_ctx(&assistant, &[], &[]);
+        PostTurnPolicy::evaluate(&policy, &ctx, &turn)
+    }
+
+    fn expect_inject_category(verdict: PolicyVerdict, expected: &str) {
+        match verdict {
+            PolicyVerdict::Inject(msgs) => {
+                assert!(!msgs.is_empty(), "expected at least one injected message");
+                let msg = &msgs[0];
+                if let AgentMessage::Llm(LlmMessage::User(UserMessage { content, .. })) = msg {
+                    if let Some(ContentBlock::Extension { type_name, data }) = content.first() {
+                        assert_eq!(type_name, "memory_nudge");
+                        let category = data["category"].as_str().expect("category must be string");
+                        assert_eq!(
+                            category, expected,
+                            "expected category {expected}, got {category}"
+                        );
+                        let confidence = data["confidence"].as_f64().expect("confidence required");
+                        assert!(
+                            confidence > 0.0 && confidence <= 1.0,
+                            "confidence out of range: {confidence}"
+                        );
+                    } else {
+                        panic!("expected Extension content block, got: {content:?}");
+                    }
+                } else {
+                    panic!("expected User message, got: {msg:?}");
+                }
+            }
+            other => panic!("expected Inject verdict, got: {other:?}"),
+        }
+    }
+
+    // ── T094 unit tests ───────────────────────────────────────────────────
+
+    #[test]
+    fn correction_phrase_triggers_correction_nudge() {
+        let verdict = evaluate_text(
+            "No, actually you should use serde_json for that.",
+            NudgeSensitivity::Medium,
+        );
+        expect_inject_category(verdict, "correction");
+    }
+
+    #[test]
+    fn dont_do_that_triggers_correction_nudge() {
+        let verdict = evaluate_text(
+            "Don't do that, use the builder pattern instead.",
+            NudgeSensitivity::Medium,
+        );
+        expect_inject_category(verdict, "correction");
+    }
+
+    #[test]
+    fn remember_this_triggers_explicit_save() {
+        let verdict = evaluate_text(
+            "Remember this: always run cargo fmt before committing.",
+            NudgeSensitivity::Medium,
+        );
+        expect_inject_category(verdict, "explicit_save");
+    }
+
+    #[test]
+    fn note_that_triggers_explicit_save() {
+        let verdict = evaluate_text(
+            "Note that the database password is rotated monthly.",
+            NudgeSensitivity::Medium,
+        );
+        expect_inject_category(verdict, "explicit_save");
+    }
+
+    #[test]
+    fn we_decided_triggers_decision() {
+        let verdict = evaluate_text(
+            "We decided to use Postgres for the primary datastore.",
+            NudgeSensitivity::Medium,
+        );
+        expect_inject_category(verdict, "decision");
+    }
+
+    #[test]
+    fn the_plan_is_triggers_decision() {
+        let verdict = evaluate_text(
+            "The plan is to migrate to async/await across the board.",
+            NudgeSensitivity::Medium,
+        );
+        expect_inject_category(verdict, "decision");
+    }
+
+    #[test]
+    fn i_prefer_triggers_preference() {
+        let verdict = evaluate_text(
+            "I prefer dark mode for all my editors.",
+            NudgeSensitivity::Medium,
+        );
+        expect_inject_category(verdict, "preference");
+    }
+
+    #[test]
+    fn always_use_triggers_preference() {
+        let verdict = evaluate_text(
+            "Always use snake_case for variable names.",
+            NudgeSensitivity::Medium,
+        );
+        expect_inject_category(verdict, "preference");
+    }
+
+    #[test]
+    fn no_signal_returns_continue() {
+        let verdict = evaluate_text(
+            "The function takes two arguments and returns a string.",
+            NudgeSensitivity::Medium,
+        );
+        assert!(
+            matches!(verdict, PolicyVerdict::Continue),
+            "ordinary text should return Continue, got: {verdict:?}"
+        );
+    }
+
+    #[test]
+    fn empty_text_returns_continue() {
+        let verdict = evaluate_text("", NudgeSensitivity::High);
+        assert!(
+            matches!(verdict, PolicyVerdict::Continue),
+            "empty text should return Continue"
+        );
+    }
+
+    #[test]
+    fn below_threshold_returns_continue() {
+        // "i use " has base confidence 0.55 — below Low threshold of 0.75
+        let verdict = evaluate_text(
+            "In this project, I use a custom allocator.",
+            NudgeSensitivity::Low,
+        );
+        assert!(
+            matches!(verdict, PolicyVerdict::Continue),
+            "low-confidence match should be suppressed at Low sensitivity, got: {verdict:?}"
+        );
+    }
+
+    #[test]
+    fn high_sensitivity_triggers_on_borderline() {
+        // "i use " has base confidence 0.55 — above High threshold of 0.35
+        let verdict = evaluate_text(
+            "In this project, I use a custom allocator.",
+            NudgeSensitivity::High,
+        );
+        expect_inject_category(verdict, "preference");
+    }
+
+    #[test]
+    fn turn_number_stored_in_nudge() {
+        let policy = MemoryNudgePolicy::new();
+        let assistant = make_assistant("Remember this: always validate input.");
+        let usage = Usage::default();
+        let cost = Cost::default();
+        let state = swink_agent::SessionState::new();
+        let ctx = PolicyContext {
+            turn_index: 7,
+            accumulated_usage: &usage,
+            accumulated_cost: &cost,
+            message_count: 20,
+            overflow_signal: false,
+            new_messages: &[],
+            state: &state,
+        };
+        let turn = make_turn_ctx(&assistant, &[], &[]);
+        match PostTurnPolicy::evaluate(&policy, &ctx, &turn) {
+            PolicyVerdict::Inject(msgs) => {
+                let msg = &msgs[0];
+                if let AgentMessage::Llm(LlmMessage::User(UserMessage { content, .. })) = msg {
+                    if let Some(ContentBlock::Extension { data, .. }) = content.first() {
+                        let turn_number =
+                            data["turn_number"].as_u64().expect("turn_number required");
+                        assert_eq!(turn_number, 7, "turn_number should match ctx.turn_index");
+                    }
+                }
+            }
+            other => panic!("expected Inject, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn summary_truncated_at_200_chars() {
+        let long_text = format!("Remember this: {}", "x".repeat(300));
+        let truncated = truncate_summary(&long_text, 200);
+        // The unicode scalar count should be at most 201 (200 chars + ellipsis char)
+        let char_count = truncated.chars().count();
+        assert!(
+            char_count <= 201,
+            "summary should be truncated to ≤201 chars, got {char_count}"
+        );
+        assert!(
+            truncated.ends_with('…'),
+            "truncated summary should end with ellipsis"
+        );
+    }
+
+    #[test]
+    fn nudge_sensitivity_thresholds() {
+        assert!((NudgeSensitivity::Low.threshold() - 0.75).abs() < f32::EPSILON);
+        assert!((NudgeSensitivity::Medium.threshold() - 0.55).abs() < f32::EPSILON);
+        assert!((NudgeSensitivity::High.threshold() - 0.35).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn category_as_str_values() {
+        assert_eq!(MemoryNudgeCategory::Correction.as_str(), "correction");
+        assert_eq!(MemoryNudgeCategory::ExplicitSave.as_str(), "explicit_save");
+        assert_eq!(MemoryNudgeCategory::Decision.as_str(), "decision");
+        assert_eq!(MemoryNudgeCategory::Preference.as_str(), "preference");
+    }
+
+    #[test]
+    fn multiple_categories_emit_multiple_nudges() {
+        // A message that triggers both ExplicitSave and Decision
+        let verdict = evaluate_text(
+            "Remember this: we decided to use axum for the web layer.",
+            NudgeSensitivity::Medium,
+        );
+        match verdict {
+            PolicyVerdict::Inject(msgs) => {
+                assert!(
+                    msgs.len() >= 2,
+                    "expected nudges for both ExplicitSave and Decision, got {} messages",
+                    msgs.len()
+                );
+            }
+            other => panic!("expected Inject, got: {other:?}"),
+        }
+    }
+}

--- a/specs/031-policy-slots/spec.md
+++ b/specs/031-policy-slots/spec.md
@@ -166,6 +166,28 @@ A library consumer implements their own policy by creating a struct that impleme
 - **SC-006**: The AgentLoopConfig has fewer top-level fields after migration (4 policy vecs replace 5+ individual option fields).
 - **SC-007**: All built-in policy implementations pass unit tests demonstrating correct verdict generation for their respective scenarios.
 
+---
+
+### User Story 7 - Memory Nudge Detection (Priority: P2)
+
+A library consumer wants to capture save-worthy knowledge that emerges during agent turns—user corrections, explicit save requests, decision statements, and configuration preferences—without polling every message manually. They add a `MemoryNudgePolicy` to the `post_turn` slot. When the policy detects a matching pattern in the turn's assistant message or new user messages, it returns `PolicyVerdict::Inject` carrying a structured `MemoryNudge` payload as a `ContentBlock::Extension` so that an upstream event subscriber or custom sink can persist it. The consumer configures sensitivity (Low/Medium/High) to tune how aggressively borderline content is flagged.
+
+**Why this priority**: Proactive knowledge capture reduces the burden on consumers to manually scan every turn. It fills a gap between "the agent runs" and "important information is retained" that no existing policy covers.
+
+**Independent Test**: Can be fully tested by constructing a `MemoryNudgePolicy` with a given sensitivity, passing `PostTurnPolicy::evaluate` a `TurnPolicyContext` whose `assistant_message` contains a correction, save-request, decision, or preference phrase, and asserting the returned verdict is `PolicyVerdict::Inject` containing a single `AgentMessage` with a `ContentBlock::Extension { type_name: "memory_nudge", ... }`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `MemoryNudgePolicy` (Medium sensitivity) in post_turn policies, **When** the assistant turn contains "no, actually you should use X instead", **Then** the policy returns Inject with a `MemoryNudge` of category `Correction` and confidence ≥ threshold.
+2. **Given** a `MemoryNudgePolicy` in post_turn policies, **When** the turn contains "remember this for later", **Then** the policy returns Inject with a `MemoryNudge` of category `ExplicitSave`.
+3. **Given** a `MemoryNudgePolicy` in post_turn policies, **When** the turn contains "we decided to use Postgres", **Then** the policy returns Inject with a `MemoryNudge` of category `Decision`.
+4. **Given** a `MemoryNudgePolicy` in post_turn policies, **When** the turn contains "I prefer dark mode", **Then** the policy returns Inject with a `MemoryNudge` of category `Preference`.
+5. **Given** a `MemoryNudgePolicy` with Low sensitivity, **When** a borderline match produces confidence below the Low threshold, **Then** the policy returns Continue (no nudge emitted).
+6. **Given** a `MemoryNudgePolicy` with High sensitivity, **When** the same borderline content produces confidence above the High threshold, **Then** the policy returns Inject.
+7. **Given** a `MemoryNudgePolicy` in post_turn policies, **When** the turn contains only ordinary assistant text with no save-worthy signals, **Then** the policy returns Continue.
+
+---
+
 ## Clarifications
 
 ### Session 2026-03-24

--- a/specs/031-policy-slots/tasks.md
+++ b/specs/031-policy-slots/tasks.md
@@ -329,6 +329,33 @@
 
 ---
 
+## Phase 14: User Story 7 - Memory Nudge Detection (Priority: P2)
+
+**Goal**: `MemoryNudgePolicy` detects save-worthy content in agent turns and emits structured nudge verdicts.
+Feature gate: `memory-nudge` in `swink-agent-policies`.
+
+**Independent Test**: Construct `MemoryNudgePolicy`, call `PostTurnPolicy::evaluate` with a turn containing each pattern category, verify Inject verdict with Extension content block.
+
+### Tests
+
+- [x] T094 [P] [US7] Write unit tests in `policies/src/memory_nudge.rs` `#[cfg(test)]`: `correction_phrase_triggers_correction_nudge`, `remember_this_triggers_explicit_save`, `we_decided_triggers_decision`, `i_prefer_triggers_preference`, `below_threshold_returns_continue`, `high_sensitivity_triggers_on_borderline`, `no_signal_returns_continue`
+
+### Implementation
+
+- [x] T095 [US7] Define `MemoryNudgeCategory` enum: `Correction`, `ExplicitSave`, `Decision`, `Preference` — with `Debug`, `Clone`, `PartialEq` derives in `policies/src/memory_nudge.rs`
+- [x] T096 [US7] Define `MemoryNudge` struct: `category: MemoryNudgeCategory`, `summary: String`, `confidence: f32`, `turn_number: usize` — with `Debug`, `Clone` derives
+- [x] T097 [US7] Define `NudgeSensitivity` enum: `Low`, `Medium`, `High` — with `Debug`, `Clone`, `Copy`, `PartialEq` derives; implement `threshold() -> f32` method
+- [x] T098 [US7] Define `MemoryNudgePolicy` struct: `sensitivity: NudgeSensitivity` with `new()` and `with_sensitivity()` builder methods
+- [x] T099 [US7] Implement heuristic detectors: `detect_correction()`, `detect_explicit_save()`, `detect_decision()`, `detect_preference()` — each returns `Option<f32>` confidence
+- [x] T100 [US7] Implement `PostTurnPolicy` for `MemoryNudgePolicy`: scan assistant message text for each category, collect matches above threshold, return Inject with Extension blocks or Continue
+- [x] T101 [US7] Add `memory-nudge` feature gate to `policies/Cargo.toml`: no extra deps (pure string matching, no regex dep for this policy)
+- [x] T102 [US7] Wire into `policies/src/lib.rs`: `#[cfg(feature = "memory-nudge")]` gate, re-export `MemoryNudgeCategory`, `MemoryNudge`, `NudgeSensitivity`, `MemoryNudgePolicy`
+- [x] T103 [US7] Add `memory-nudge` to `all` feature list in `policies/Cargo.toml`
+
+**Checkpoint**: MemoryNudgePolicy emits structured Inject verdicts. All unit tests pass. Feature-gated compilation verified.
+
+---
+
 ## Notes
 
 - [P] tasks = different files, no dependencies

--- a/specs/032-policy-recipes-crate/spec.md
+++ b/specs/032-policy-recipes-crate/spec.md
@@ -64,6 +64,26 @@ An agent operator configures a content filter with keyword and regex blocklists 
 
 ---
 
+### User Story 5 - Memory Nudge Detection (Priority: P2)
+
+An agent operator wants to capture save-worthy knowledge that surfaces during agent turns without manually inspecting every message. They add a `MemoryNudgePolicy` to the `post_turn` slot. When heuristic detectors identify a correction, explicit save request, decision statement, or configuration preference, the policy returns `PolicyVerdict::Inject` carrying a `MemoryNudge` payload serialized as a `ContentBlock::Extension`. Upstream event subscribers or the caller's own sink can consume the injected extension block to persist the nugget to any store.
+
+**Why this priority**: Automated knowledge capture bridges the gap between "the agent runs" and "important context is retained." It is a passive, non-blocking policy that enriches observability without altering agent flow.
+
+**Independent Test**: Can be tested by configuring an agent with only the `MemoryNudgePolicy` in the `post_turn` slot and triggering turns that contain each of the four pattern categories — the returned verdict must be `Inject` with a `ContentBlock::Extension { type_name: "memory_nudge", ... }` whose JSON data deserializes to a valid `MemoryNudge`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `MemoryNudgePolicy` (Medium sensitivity) in post_turn, **When** the assistant message contains a correction phrase ("no, actually..." / "don't do X" / "use Y instead"), **Then** the verdict is Inject with `MemoryNudgeCategory::Correction` and confidence ≥ 0.5.
+2. **Given** a `MemoryNudgePolicy` in post_turn, **When** the assistant message contains an explicit save request ("remember this", "note that", "keep in mind"), **Then** the verdict is Inject with `MemoryNudgeCategory::ExplicitSave`.
+3. **Given** a `MemoryNudgePolicy` in post_turn, **When** the assistant message contains a decision statement ("we decided to", "the plan is"), **Then** the verdict is Inject with `MemoryNudgeCategory::Decision`.
+4. **Given** a `MemoryNudgePolicy` in post_turn, **When** the assistant message contains a preference declaration ("I prefer", "always use"), **Then** the verdict is Inject with `MemoryNudgeCategory::Preference`.
+5. **Given** a `MemoryNudgePolicy` with Low sensitivity, **When** a borderline match produces confidence below the Low threshold, **Then** the verdict is Continue.
+6. **Given** a `MemoryNudgePolicy` with High sensitivity, **When** the same borderline content produces confidence above the High threshold, **Then** the verdict is Inject.
+7. **Given** a `MemoryNudgePolicy` in post_turn, **When** the turn contains only ordinary text with no save-worthy signals, **Then** the verdict is Continue.
+
+---
+
 ### User Story 4 - Audit Logging for Observability (Priority: P2)
 
 An agent operator configures an audit logger so that every assistant turn is recorded to a JSONL file for observability, debugging, and compliance purposes. The operator can also implement a custom sink for their own storage backend.
@@ -105,7 +125,7 @@ An agent operator configures an audit logger so that every assistant turn is rec
 ### Functional Requirements
 
 - **FR-001**: The crate MUST be a new workspace member named `swink-agent-policies` that depends only on `swink-agent`'s public API (re-exported types from `lib.rs`) — no `pub(crate)` or internal module imports.
-- **FR-002**: Each policy MUST be independently feature-gated (`prompt-guard`, `pii`, `content-filter`, `audit`) with an `all` feature that enables everything, defaulting to `all`.
+- **FR-002**: Each policy MUST be independently feature-gated (`prompt-guard`, `pii`, `content-filter`, `audit`, `memory-nudge`) with an `all` feature that enables everything, defaulting to `all`.
 - **FR-003**: *(Prerequisite — completed in 031-policy-slots.)* `PolicyContext` in core includes `new_messages: &[AgentMessage]` containing only messages added since the last evaluation. For PreTurn, this is the pending batch. Already implemented and merged.
 - **FR-004**: `PromptInjectionGuard` MUST implement both `PreTurnPolicy` and `PostTurnPolicy` traits. In PreTurn, it filters `ctx.new_messages` for `AgentMessage::Llm(LlmMessage::User(...))` variants and scans their text content for injection patterns. In PostTurn, it scans text content from `TurnPolicyContext.tool_results`. Operators can register it in either or both slots.
 - **FR-005**: `PromptInjectionGuard` MUST ship with a default set of regex patterns covering common injection phrases (e.g., "ignore all previous instructions", "disregard your system prompt", "you are now a", role-reassignment attempts).
@@ -122,12 +142,19 @@ An agent operator configures an audit logger so that every assistant turn is rec
 - **FR-016**: `JsonlAuditSink` MUST handle write errors gracefully by logging via `tracing` and never panicking or returning a non-Continue verdict.
 - **FR-017**: All policies MUST be constructable via builder pattern (`new()` + `with_*()` chain) consistent with the project's style conventions.
 - **FR-018**: `lib.rs` MUST re-export all enabled policies and the `AuditSink` trait so consumers never reach into submodules.
+- **FR-019**: `MemoryNudgePolicy` MUST implement `PostTurnPolicy` and scan the assistant message text content for four heuristic categories: corrections, explicit save requests, decisions, and preferences.
+- **FR-020**: `MemoryNudgePolicy` MUST emit `PolicyVerdict::Inject` carrying a single `AgentMessage` whose content contains a `ContentBlock::Extension { type_name: "memory_nudge", data: <JSON MemoryNudge> }`.
+- **FR-021**: `MemoryNudge` payload MUST include: `category` (string name of `MemoryNudgeCategory`), `summary` (extracted text snippet, ≤ 200 chars), `confidence` (0.0–1.0 f32), `turn_number` (zero-based usize).
+- **FR-022**: `NudgeSensitivity` MUST define three threshold levels: Low (0.75), Medium (0.55), High (0.35). When a match's confidence is below the active threshold, the policy MUST return Continue.
+- **FR-023**: `MemoryNudgePolicy` MUST use pure string/substring pattern matching — no regex dependency — to keep compile time and binary size minimal.
 
 ### Key Entities
 
 - **Policy Pattern**: A regex pattern with optional metadata (name, category, enabled flag) used by `PromptInjectionGuard`, `PiiRedactor`, and `ContentFilter`.
 - **Audit Record**: A structured data type containing timestamp, turn index, content summary, tool call names, token usage, and cost for a single completed turn.
 - **Audit Sink**: A trait defining how audit records are persisted, with one built-in implementation (JSONL file writer).
+- **MemoryNudge**: A structured payload emitted when save-worthy content is detected — includes category, summary, confidence, and turn_number.
+- **NudgeSensitivity**: An enum controlling the confidence threshold below which nudges are suppressed — Low (0.75), Medium (0.55), High (0.35).
 
 ## Success Criteria *(mandatory)*
 
@@ -141,6 +168,8 @@ An agent operator configures an audit logger so that every assistant turn is rec
 - **SC-006**: All policies can be composed together in the same agent configuration (e.g., PromptInjectionGuard in pre_turn, PiiRedactor + ContentFilter + AuditLogger in post_turn) without interference.
 - **SC-007**: Each policy can be compiled independently via its feature gate — disabling unused policies adds zero code or dependencies to the binary.
 - **SC-008**: The crate serves as a reference example: each policy's source is self-contained and demonstrates how to implement the corresponding policy trait from scratch.
+- **SC-009**: `MemoryNudgePolicy` correctly identifies all four pattern categories (Correction, ExplicitSave, Decision, Preference) and returns Continue for ordinary text with no save-worthy signals.
+- **SC-010**: `MemoryNudgePolicy` sensitivity thresholds correctly suppress low-confidence matches at Low sensitivity and permit them at High sensitivity.
 
 ## Assumptions
 


### PR DESCRIPTION
## Summary
- `MemoryNudgePolicy` implementing `PostTurnPolicy` with 4 heuristic detectors
- `MemoryNudge` payload struct with category, summary, confidence, turn_number
- `NudgeSensitivity` enum (Low/Medium/High) for configurable thresholds
- Feature-gated: `memory-nudge` in policies crate
- Updates spec 031 and 032 with new user story and tasks

## Tasks completed
- MemoryNudge / NudgeSensitivity / MemoryNudgeCategory types
- MemoryNudgePolicy PostTurnPolicy implementation
- Heuristic detectors for 4 pattern categories (Correction, ExplicitSave, Decision, Preference)
- Unit tests for all detectors and sensitivity thresholds

## Test plan
- [x] cargo test -p swink-agent-policies --features memory-nudge passes (84 tests)
- [x] cargo test -p swink-agent-policies (no features / default all) passes — no regressions
- [x] cargo clippy --features memory-nudge -- -D warnings clean
- [x] cargo fmt --check clean

Part of #897
🤖 Generated with [Claude Code](https://claude.com/claude-code)