### PR TITLE
impl(021): cross-session full-text search foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,7 +97,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -108,7 +108,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -135,6 +135,15 @@ dependencies = [
  "percent-encoding",
  "windows-sys 0.60.2",
  "x11rb",
+]
+
+[[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -544,6 +553,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "bitpacking"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96a7139abd3d9cebf8cd6f920a389cf3dc9576172e32f4563f188cae3c3eb019"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -650,6 +668,12 @@ dependencies = [
  "libc",
  "shlex",
 ]
+
+[[package]]
+name = "census"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f4c707c6a209cbe82d10abd08e1ea8995e9ea937d2550646e02798948992be0"
 
 [[package]]
 name = "cesu8"
@@ -1026,7 +1050,7 @@ dependencies = [
  "futures-core",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -1183,6 +1207,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -1253,7 +1278,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1291,6 +1316,12 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dtoa"
@@ -1388,7 +1419,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1437,6 +1468,12 @@ dependencies = [
  "regex-automata",
  "regex-syntax",
 ]
+
+[[package]]
+name = "fastdivide"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afc2bd4d5a73106dd53d10d73d3401c2f32730ba2c0b93ddb888a8983680471"
 
 [[package]]
 name = "fastrand"
@@ -1596,6 +1633,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs4"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7e180ac76c23b45e767bd7ae9579bc0bb458618c4bc71835926e098e61d15f8"
+dependencies = [
+ "rustix 0.38.44",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1720,7 +1767,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
- "rustix",
+ "rustix 1.1.4",
  "windows-link",
 ]
 
@@ -1828,6 +1875,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -1908,6 +1957,12 @@ dependencies = [
  "log",
  "markup5ever",
 ]
+
+[[package]]
+name = "htmlescape"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9025058dae765dee5070ec375f591e2ba14638c63feff74f13805a72e523163"
 
 [[package]]
 name = "http"
@@ -2317,6 +2372,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -2340,6 +2398,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -2518,6 +2585,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "levenshtein_automata"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
+
+[[package]]
 name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2532,6 +2605,12 @@ dependencies = [
  "cfg-if",
  "windows-link",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -2553,6 +2632,12 @@ checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
  "bitflags 2.11.0",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2617,6 +2702,15 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "lru"
 version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
@@ -2629,6 +2723,12 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lz4_flex"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
 
 [[package]]
 name = "mac_address"
@@ -2667,10 +2767,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "measure_time"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbefd235b0aadd181626f281e1d684e116972988c14c264e42069d5e8a5775cc"
+dependencies = [
+ "instant",
+ "log",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memmem"
@@ -2746,6 +2865,12 @@ dependencies = [
  "num-traits",
  "pxfm",
 ]
+
+[[package]]
+name = "murmurhash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
 
 [[package]]
 name = "native-tls"
@@ -2839,7 +2964,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2936,6 +3061,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -3041,6 +3167,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oneshot"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "269bca4c2591a28585d6bf10d9ed0332b7d76900a1b02bec41bdc3a2cdcda107"
 
 [[package]]
 name = "onig"
@@ -3210,6 +3342,15 @@ name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "ownedbytes"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3a059efb063b8f425b948e042e6b9bd85edfe60e913630ed727b23e2dfcc558"
+dependencies = [
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "page_size"
@@ -3595,7 +3736,7 @@ dependencies = [
  "bitflags 2.11.0",
  "num-traits",
  "rand 0.9.4",
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
  "unarray",
@@ -3719,6 +3860,8 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -3728,7 +3871,7 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
 ]
 
@@ -3741,6 +3884,16 @@ dependencies = [
  "chacha20",
  "getrandom 0.4.2",
  "rand_core 0.10.0",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3758,6 +3911,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "rand_core"
@@ -3773,6 +3929,16 @@ name = "rand_core"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+
+[[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
 
 [[package]]
 name = "rand_xorshift"
@@ -3809,7 +3975,7 @@ dependencies = [
  "indoc",
  "itertools 0.14.0",
  "kasuari",
- "lru",
+ "lru 0.16.4",
  "strum",
  "thiserror 2.0.18",
  "unicode-segmentation",
@@ -4164,6 +4330,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-stemmers"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e46a2036019fdb888131db7a4c847a1063a7493f971ed94ea82c67eada63ca54"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4186,6 +4362,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -4193,8 +4382,8 @@ dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys",
- "windows-sys 0.52.0",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4253,7 +4442,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4600,6 +4789,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
+name = "sketches-ddsketch"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85636c14b73d81f541e525f585c0a2109e6744e1565b5c1668e31c70c10ed65c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4618,7 +4816,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4951,6 +5149,7 @@ dependencies = [
  "serde",
  "serde_json",
  "swink-agent",
+ "tantivy",
  "tempfile",
  "tokio",
  "tracing",
@@ -5129,6 +5328,147 @@ dependencies = [
 ]
 
 [[package]]
+name = "tantivy"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96599ea6fccd844fc833fed21d2eecac2e6a7c1afd9e044057391d78b1feb141"
+dependencies = [
+ "aho-corasick",
+ "arc-swap",
+ "base64 0.22.1",
+ "bitpacking",
+ "byteorder",
+ "census",
+ "crc32fast",
+ "crossbeam-channel",
+ "downcast-rs",
+ "fastdivide",
+ "fnv",
+ "fs4",
+ "htmlescape",
+ "itertools 0.12.1",
+ "levenshtein_automata",
+ "log",
+ "lru 0.12.5",
+ "lz4_flex",
+ "measure_time",
+ "memmap2",
+ "num_cpus",
+ "once_cell",
+ "oneshot",
+ "rayon",
+ "regex",
+ "rust-stemmers",
+ "rustc-hash 1.1.0",
+ "serde",
+ "serde_json",
+ "sketches-ddsketch",
+ "smallvec",
+ "tantivy-bitpacker",
+ "tantivy-columnar",
+ "tantivy-common",
+ "tantivy-fst",
+ "tantivy-query-grammar",
+ "tantivy-stacker",
+ "tantivy-tokenizer-api",
+ "tempfile",
+ "thiserror 1.0.69",
+ "time",
+ "uuid",
+ "winapi",
+]
+
+[[package]]
+name = "tantivy-bitpacker"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284899c2325d6832203ac6ff5891b297fc5239c3dc754c5bc1977855b23c10df"
+dependencies = [
+ "bitpacking",
+]
+
+[[package]]
+name = "tantivy-columnar"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12722224ffbe346c7fec3275c699e508fd0d4710e629e933d5736ec524a1f44e"
+dependencies = [
+ "downcast-rs",
+ "fastdivide",
+ "itertools 0.12.1",
+ "serde",
+ "tantivy-bitpacker",
+ "tantivy-common",
+ "tantivy-sstable",
+ "tantivy-stacker",
+]
+
+[[package]]
+name = "tantivy-common"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8019e3cabcfd20a1380b491e13ff42f57bb38bf97c3d5fa5c07e50816e0621f4"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "ownedbytes",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "tantivy-fst"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d60769b80ad7953d8a7b2c70cdfe722bbcdcac6bccc8ac934c40c034d866fc18"
+dependencies = [
+ "byteorder",
+ "regex-syntax",
+ "utf8-ranges",
+]
+
+[[package]]
+name = "tantivy-query-grammar"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "847434d4af57b32e309f4ab1b4f1707a6c566656264caa427ff4285c4d9d0b82"
+dependencies = [
+ "nom",
+]
+
+[[package]]
+name = "tantivy-sstable"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c69578242e8e9fc989119f522ba5b49a38ac20f576fc778035b96cc94f41f98e"
+dependencies = [
+ "tantivy-bitpacker",
+ "tantivy-common",
+ "tantivy-fst",
+ "zstd",
+]
+
+[[package]]
+name = "tantivy-stacker"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56d6ff5591fc332739b3ce7035b57995a3ce29a93ffd6012660e0949c956ea8"
+dependencies = [
+ "murmurhash32",
+ "rand_distr",
+ "tantivy-common",
+]
+
+[[package]]
+name = "tantivy-tokenizer-api"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0dcade25819a89cfe6f17d932c9cedff11989936bf6dd4f336d50392053b04"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5137,8 +5477,8 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
- "windows-sys 0.52.0",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5802,6 +6142,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
+name = "utf8-ranges"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcfc827f90e53a02eaef5e535ee14266c1d569214c6aa70133a624d8a3164ba"
+
+[[package]]
 name = "utf8-zero"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5828,6 +6174,7 @@ dependencies = [
  "atomic",
  "getrandom 0.4.2",
  "js-sys",
+ "serde_core",
  "sha1_smol",
  "wasm-bindgen",
 ]
@@ -6184,7 +6531,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6678,7 +7025,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
 dependencies = [
  "gethostname",
- "rustix",
+ "rustix 1.1.4",
  "x11rb-protocol",
 ]
 
@@ -6814,6 +7161,34 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "zune-core"

--- a/memory/Cargo.toml
+++ b/memory/Cargo.toml
@@ -14,6 +14,11 @@ categories = ["development-tools", "data-structures"]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
+[features]
+## Enables tantivy-backed full-text search index for `JsonlSessionStore`.
+## Without this feature, `SessionStore::search()` falls back to the linear scan.
+search = ["dep:tantivy"]
+
 [dependencies]
 swink-agent = { path = "..", version = "0.9.0", default-features = false }
 serde.workspace = true
@@ -23,6 +28,7 @@ dirs.workspace = true
 tracing.workspace = true
 chrono.workspace = true
 uuid.workspace = true
+tantivy = { version = "0.22", optional = true }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/memory/src/jsonl.rs
+++ b/memory/src/jsonl.rs
@@ -556,6 +556,9 @@ impl JsonlSessionStore {
     #[cfg(feature = "search")]
     pub fn rebuild_search_index(&self) -> io::Result<()> {
         self.with_tantivy_index(|index| {
+            // Wipe all existing docs so sessions removed outside the store API
+            // don't produce ghost hits after the rebuild.
+            index.clear_all()?;
             for meta in self.list()? {
                 let (_, entries) = self.load_entries(&meta.id)?;
                 index.index_session(&meta, &entries)?;

--- a/memory/src/jsonl.rs
+++ b/memory/src/jsonl.rs
@@ -16,7 +16,9 @@ use crate::entry::SessionEntry;
 use crate::interrupt::InterruptState;
 use crate::load_options::LoadOptions;
 use crate::meta::SessionMeta;
-use crate::search::{self, SessionHit, SessionSearchOptions};
+#[cfg(not(feature = "search"))]
+use crate::search;
+use crate::search::{SessionHit, SessionSearchOptions};
 use crate::store::SessionStore;
 use crate::time::{format_session_id, now_utc};
 
@@ -495,9 +497,26 @@ fn validate_session_id(id: &str) -> io::Result<()> {
 ///
 /// Concurrent writes to the same session may corrupt the file.
 /// Callers are expected to enforce single-writer access.
+///
+/// With the `search` feature enabled, a tantivy index is maintained in
+/// `<sessions_dir>/.search_index/` and used by
+/// [`SessionStore::search()`].  Without the feature, search falls back to a
+/// linear scan of all JSONL files.
 pub struct JsonlSessionStore {
     sessions_dir: PathBuf,
     migrators: Vec<Box<dyn crate::migrate::SessionMigrator>>,
+    /// Lazily-opened tantivy index.  Populated on first `search()` call (or
+    /// via `open_search_index()`).  Only present when the `search` feature is
+    /// enabled.
+    ///
+    /// Uses `Mutex<Option<...>>` rather than `OnceLock` because we need
+    /// fallible initialization (`OnceLock::get_or_try_init` is not stable).
+    #[cfg(feature = "search")]
+    tantivy_index: std::sync::Mutex<Option<crate::search::index::TantivyIndex>>,
+    /// Tracks whether the index has been initially populated from all JSONL
+    /// files on first search.
+    #[cfg(feature = "search")]
+    index_built: std::sync::Mutex<bool>,
 }
 
 impl JsonlSessionStore {
@@ -509,7 +528,62 @@ impl JsonlSessionStore {
         Ok(Self {
             sessions_dir,
             migrators: Vec::new(),
+            #[cfg(feature = "search")]
+            tantivy_index: std::sync::Mutex::new(None),
+            #[cfg(feature = "search")]
+            index_built: std::sync::Mutex::new(false),
         })
+    }
+
+    /// Open (or create) the tantivy search index eagerly.
+    ///
+    /// Normally the index is opened lazily on the first `search()` call.
+    /// Call this method if you want to detect index-creation errors at startup
+    /// rather than at search time.
+    ///
+    /// Only available with the `search` feature.
+    #[cfg(feature = "search")]
+    pub fn open_search_index(&self) -> io::Result<()> {
+        self.with_tantivy_index(|_| Ok(()))
+    }
+
+    /// Build (or rebuild) the tantivy index from all current JSONL files.
+    ///
+    /// Existing index data is replaced.  Use this after bulk-importing sessions
+    /// outside of the store API.
+    ///
+    /// Only available with the `search` feature.
+    #[cfg(feature = "search")]
+    pub fn rebuild_search_index(&self) -> io::Result<()> {
+        self.with_tantivy_index(|index| {
+            for meta in self.list()? {
+                let (_, entries) = self.load_entries(&meta.id)?;
+                index.index_session(&meta, &entries)?;
+            }
+            Ok(())
+        })
+    }
+
+    /// Obtain a snapshot clone of the tantivy index (creating it if needed),
+    /// then call `f` with it.
+    ///
+    /// Using a clone of `TantivyIndex` is safe because it is `Arc`-based
+    /// internally.
+    #[cfg(feature = "search")]
+    fn with_tantivy_index<T>(
+        &self,
+        f: impl FnOnce(&crate::search::index::TantivyIndex) -> io::Result<T>,
+    ) -> io::Result<T> {
+        let index_clone = {
+            let mut guard = self.tantivy_index.lock().unwrap_or_else(|e| e.into_inner());
+            if guard.is_none() {
+                *guard = Some(crate::search::index::TantivyIndex::open_or_create(
+                    &self.sessions_dir,
+                )?);
+            }
+            guard.as_ref().expect("just set").clone()
+        };
+        f(&index_clone)
     }
 
     /// Register session migrators for automatic schema upgrades on load.
@@ -673,7 +747,25 @@ impl SessionStore for JsonlSessionStore {
                 std::fs::remove_file(int_path)?;
             }
             Ok(())
-        })
+        })?;
+
+        // Remove from tantivy index (best-effort).
+        #[cfg(feature = "search")]
+        {
+            let id_owned = id.to_string();
+            let _ = self.with_tantivy_index(|index| {
+                if let Err(err) = index.delete_session(&id_owned) {
+                    tracing::warn!(
+                        session_id = %id_owned,
+                        error = %err,
+                        "failed to remove session from search index after delete"
+                    );
+                }
+                Ok(())
+            });
+        }
+
+        Ok(())
     }
 
     fn save_state(&self, id: &str, state: &serde_json::Value) -> io::Result<()> {
@@ -777,57 +869,105 @@ impl SessionStore for JsonlSessionStore {
     }
 
     fn search(&self, query: &str, options: &SessionSearchOptions) -> io::Result<Vec<SessionHit>> {
-        let terms = search::query_terms(query);
-        let limit = options.limit();
-        if terms.is_empty() || limit == 0 {
-            return Ok(Vec::new());
-        }
-
-        let session_ids = if let Some(ids) = &options.session_ids {
-            ids.iter()
-                .map(|id| {
-                    validate_session_id(id)?;
-                    Ok(id.clone())
-                })
-                .collect::<io::Result<Vec<_>>>()?
-        } else {
-            self.list()?
-                .into_iter()
-                .map(|meta| meta.id)
-                .collect::<Vec<_>>()
-        };
-
-        let mut hits = Vec::new();
-        for id in session_ids {
-            let (meta, entries) = self.load_entries(&id)?;
-            for entry in entries {
-                if !search::entry_matches_type(&entry, options)
-                    || !search::entry_matches_time_range(&entry, options)
-                {
-                    continue;
-                }
-                let Some((score, snippet)) = search::search_entry(&entry, &terms) else {
-                    continue;
-                };
-                hits.push(SessionHit {
-                    session_id: meta.id.clone(),
-                    session_title: meta.title.clone(),
-                    entry,
-                    score,
-                    snippet,
-                });
-            }
-        }
-
-        hits.sort_by(|left, right| {
-            right
-                .score
-                .cmp(&left.score)
-                .then_with(|| right.entry.timestamp().cmp(&left.entry.timestamp()))
-                .then_with(|| left.session_id.cmp(&right.session_id))
+        // When the `search` feature is enabled, delegate to the tantivy index.
+        // The index is built lazily on the first call and kept warm for
+        // subsequent calls.
+        #[cfg(feature = "search")]
+        return self.with_tantivy_index(|index| {
+            self.build_index_if_empty(index)?;
+            index.search(query, options)
         });
-        hits.truncate(limit);
-        Ok(hits)
+
+        // Fallback linear scan (no `search` feature).
+        #[cfg(not(feature = "search"))]
+        linear_search(self, query, options)
+    }
+}
+
+/// Linear (no-index) search implementation used when the `search` feature is
+/// not enabled.
+#[cfg(not(feature = "search"))]
+fn linear_search(
+    store: &JsonlSessionStore,
+    query: &str,
+    options: &SessionSearchOptions,
+) -> io::Result<Vec<SessionHit>> {
+    let terms = search::query_terms(query);
+    let limit = options.limit();
+    if terms.is_empty() || limit == 0 {
+        return Ok(Vec::new());
+    }
+
+    let session_ids = if let Some(ids) = &options.session_ids {
+        ids.iter()
+            .map(|id| {
+                validate_session_id(id)?;
+                Ok(id.clone())
+            })
+            .collect::<io::Result<Vec<_>>>()?
+    } else {
+        store
+            .list()?
+            .into_iter()
+            .map(|meta| meta.id)
+            .collect::<Vec<_>>()
+    };
+
+    let mut hits = Vec::new();
+    for id in session_ids {
+        let (meta, entries) = store.load_entries(&id)?;
+        for entry in entries {
+            if !search::entry_matches_type(&entry, options)
+                || !search::entry_matches_time_range(&entry, options)
+            {
+                continue;
+            }
+            let Some((score, snippet)) = search::search_entry(&entry, &terms) else {
+                continue;
+            };
+            hits.push(SessionHit {
+                session_id: meta.id.clone(),
+                session_title: meta.title.clone(),
+                entry,
+                score,
+                snippet,
+            });
+        }
+    }
+
+    hits.sort_by(|left, right| {
+        right
+            .score
+            .cmp(&left.score)
+            .then_with(|| right.entry.timestamp().cmp(&left.entry.timestamp()))
+            .then_with(|| left.session_id.cmp(&right.session_id))
+    });
+    hits.truncate(limit);
+    Ok(hits)
+}
+
+#[cfg(feature = "search")]
+impl JsonlSessionStore {
+    /// Index all sessions if the initial build has not yet been done.
+    ///
+    /// This provides lazy-build-on-first-search semantics: the first `search()`
+    /// call populates the index from all existing JSONL files; subsequent calls
+    /// find the index already populated.
+    fn build_index_if_empty(&self, index: &crate::search::index::TantivyIndex) -> io::Result<()> {
+        let already_built = {
+            let guard = self.index_built.lock().unwrap_or_else(|e| e.into_inner());
+            *guard
+        };
+        if already_built {
+            return Ok(());
+        }
+        // Populate from all current sessions.
+        for meta in self.list()? {
+            let (_, entries) = self.load_entries(&meta.id)?;
+            index.index_session(&meta, &entries)?;
+        }
+        *self.index_built.lock().unwrap_or_else(|e| e.into_inner()) = true;
+        Ok(())
     }
 }
 
@@ -835,6 +975,10 @@ impl JsonlSessionStore {
     /// Save a session with rich entry types.
     ///
     /// Lines 2+ are [`SessionEntry`] values serialized with an `entry_type` tag.
+    ///
+    /// When the `search` feature is enabled, the tantivy index is updated
+    /// after the file is written (best-effort — index errors are logged but
+    /// do not fail the save).
     pub fn save_entries(
         &self,
         id: &str,
@@ -843,7 +987,8 @@ impl JsonlSessionStore {
     ) -> io::Result<()> {
         validate_session_id(id)?;
         let path = session_path(&self.sessions_dir, id);
-        with_target_lock(&path, || {
+        #[allow(unused_variables)]
+        let write_meta = with_target_lock(&path, || {
             check_sequence_path(&path, id, meta.sequence)?;
 
             // Increment sequence for the write
@@ -867,8 +1012,28 @@ impl JsonlSessionStore {
                     }
                 }
                 Ok(())
-            })
-        })
+            })?;
+            Ok(write_meta)
+        })?;
+
+        // Update tantivy index (best-effort).
+        #[cfg(feature = "search")]
+        {
+            let entries_for_index: Vec<_> = entries.to_vec();
+            let meta_for_index = write_meta;
+            let _ = self.with_tantivy_index(|index| {
+                if let Err(err) = index.index_session(&meta_for_index, &entries_for_index) {
+                    tracing::warn!(
+                        session_id = %id,
+                        error = %err,
+                        "failed to update search index after save_entries"
+                    );
+                }
+                Ok(())
+            });
+        }
+
+        Ok(())
     }
 
     /// Load a session with rich entry types.

--- a/memory/src/lib.rs
+++ b/memory/src/lib.rs
@@ -52,6 +52,8 @@ pub use jsonl::JsonlSessionStore;
 pub use load_options::LoadOptions;
 pub use meta::SessionMeta;
 pub use migrate::SessionMigrator;
+#[cfg(feature = "search")]
+pub use search::index::TantivyIndex;
 pub use search::{SessionHit, SessionSearchOptions};
 pub use store::SessionStore;
 pub use store_async::{BlockingSessionStore, SessionStoreFuture};

--- a/memory/src/search.rs
+++ b/memory/src/search.rs
@@ -1,9 +1,17 @@
 //! Cross-session search types and helpers.
+//!
+//! The `search` feature gate enables a tantivy-backed full-text index stored
+//! alongside the session JSONL files.  Without the feature the module still
+//! compiles and provides the public types; `JsonlSessionStore::search()` falls
+//! back to the linear scan already implemented in `jsonl.rs`.
 
 use chrono::{DateTime, Utc};
 use swink_agent::{ContentBlock, LlmMessage};
 
 use crate::entry::SessionEntry;
+
+#[cfg(feature = "search")]
+pub(crate) mod index;
 
 const DEFAULT_MAX_RESULTS: usize = 50;
 const SNIPPET_CONTEXT_BYTES: usize = 72;
@@ -44,6 +52,7 @@ pub struct SessionHit {
     pub snippet: String,
 }
 
+#[cfg(not(feature = "search"))]
 pub(crate) fn query_terms(query: &str) -> Vec<String> {
     query
         .split_whitespace()
@@ -53,6 +62,7 @@ pub(crate) fn query_terms(query: &str) -> Vec<String> {
         .collect()
 }
 
+#[cfg(not(feature = "search"))]
 pub(crate) fn entry_matches_time_range(
     entry: &SessionEntry,
     options: &SessionSearchOptions,
@@ -74,6 +84,7 @@ pub(crate) fn entry_matches_time_range(
     true
 }
 
+#[cfg(not(feature = "search"))]
 pub(crate) fn entry_matches_type(entry: &SessionEntry, options: &SessionSearchOptions) -> bool {
     options.entry_types.as_ref().is_none_or(|types| {
         types
@@ -82,6 +93,7 @@ pub(crate) fn entry_matches_type(entry: &SessionEntry, options: &SessionSearchOp
     })
 }
 
+#[cfg(not(feature = "search"))]
 pub(crate) fn search_entry(entry: &SessionEntry, terms: &[String]) -> Option<(usize, String)> {
     if terms.is_empty() {
         return None;
@@ -103,6 +115,12 @@ pub(crate) fn search_entry(entry: &SessionEntry, terms: &[String]) -> Option<(us
     }
 
     Some((score, snippet(&text, first_match.unwrap_or(0))))
+}
+
+/// Public-crate wrapper used by the tantivy index module.
+#[cfg(feature = "search")]
+pub(crate) fn searchable_text_pub(entry: &SessionEntry) -> String {
+    searchable_text(entry)
 }
 
 fn searchable_text(entry: &SessionEntry) -> String {
@@ -199,6 +217,12 @@ fn push_part(text: &mut String, part: &str) {
         text.push(' ');
     }
     text.push_str(part);
+}
+
+/// Public-crate wrapper used by the tantivy index module.
+#[cfg(feature = "search")]
+pub(crate) fn snippet_from_text(text: &str, match_idx: usize) -> String {
+    snippet(text, match_idx)
 }
 
 fn snippet(text: &str, match_idx: usize) -> String {

--- a/memory/src/search/index.rs
+++ b/memory/src/search/index.rs
@@ -137,6 +137,21 @@ impl TantivyIndex {
         Ok(())
     }
 
+    /// Delete every document in the index, leaving it empty.
+    ///
+    /// Used by `rebuild_search_index` to guarantee replacement semantics when
+    /// sessions have been removed outside the store API.
+    pub fn clear_all(&self) -> io::Result<()> {
+        let inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        let mut writer: tantivy::IndexWriter<TantivyDocument> = inner
+            .index
+            .writer(INDEXER_HEAP_BYTES)
+            .map_err(tantivy_to_io)?;
+        writer.delete_all_documents().map_err(tantivy_to_io)?;
+        writer.commit().map_err(tantivy_to_io)?;
+        Ok(())
+    }
+
     /// Remove all indexed documents for a session.
     pub fn delete_session(&self, session_id: &str) -> io::Result<()> {
         let inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());

--- a/memory/src/search/index.rs
+++ b/memory/src/search/index.rs
@@ -1,0 +1,308 @@
+//! Tantivy-backed full-text index for cross-session search.
+//!
+//! The index is stored in `<sessions_dir>/.search_index/` alongside the JSONL
+//! session files.  It is rebuilt (or opened) lazily on the first `search()`
+//! call and updated incrementally when sessions are re-indexed via
+//! [`TantivyIndex::index_session`].
+//!
+//! ## Schema
+//!
+//! | Field          | Type | Options        | Purpose                                   |
+//! |----------------|------|----------------|-------------------------------------------|
+//! | `session_id`   | text | STORED, raw    | Filter / reconstruct hit                  |
+//! | `session_title`| text | STORED, raw    | Display title                             |
+//! | `entry_type`   | text | STORED, raw    | Type discriminator for filter             |
+//! | `timestamp`    | u64  | INDEXED, STORED| Timestamp range filter                    |
+//! | `body`         | text | TEXT (en_stem) | Tokenised full-text content               |
+//! | `entry_json`   | text | STORED         | Raw JSON for roundtrip to `SessionEntry`  |
+
+use std::io;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use tantivy::collector::TopDocs;
+use tantivy::query::QueryParser;
+use tantivy::schema::{
+    Field, IndexRecordOption, NumericOptions, Schema, TEXT, TextFieldIndexing, TextOptions, Value,
+};
+use tantivy::{Index, IndexWriter, ReloadPolicy, TantivyDocument};
+
+use crate::entry::SessionEntry;
+use crate::meta::SessionMeta;
+use crate::search::{self, SessionHit, SessionSearchOptions, snippet_from_text};
+
+/// Size of the indexer heap in bytes.
+const INDEXER_HEAP_BYTES: usize = 15_000_000;
+
+/// Sub-directory name inside the sessions directory.
+const INDEX_SUBDIR: &str = ".search_index";
+
+/// All tantivy fields used by [`TantivyIndex`].
+#[derive(Clone, Copy)]
+struct Fields {
+    session_id: Field,
+    session_title: Field,
+    entry_type: Field,
+    timestamp: Field,
+    body: Field,
+    entry_json: Field,
+}
+
+impl Fields {
+    fn register(builder: &mut tantivy::schema::SchemaBuilder) -> Self {
+        // `raw` tokenizer: no tokenization — stored as a single term.
+        let raw = TextOptions::default()
+            .set_indexing_options(
+                TextFieldIndexing::default()
+                    .set_tokenizer("raw")
+                    .set_index_option(IndexRecordOption::Basic),
+            )
+            .set_stored();
+
+        let stored_only = TextOptions::default().set_stored();
+
+        Self {
+            session_id: builder.add_text_field("session_id", raw.clone()),
+            session_title: builder.add_text_field("session_title", stored_only.clone()),
+            entry_type: builder.add_text_field("entry_type", raw),
+            timestamp: builder.add_u64_field(
+                "timestamp",
+                NumericOptions::default().set_indexed().set_stored(),
+            ),
+            body: builder.add_text_field("body", TEXT),
+            entry_json: builder.add_text_field("entry_json", stored_only),
+        }
+    }
+}
+
+/// Tantivy-backed full-text index.
+///
+/// `TantivyIndex` is internally `Arc<Mutex<_>>` so it can be shared across
+/// threads and cloned cheaply.
+#[derive(Clone)]
+pub struct TantivyIndex {
+    inner: Arc<Mutex<Inner>>,
+}
+
+struct Inner {
+    index: Index,
+    fields: Fields,
+}
+
+impl TantivyIndex {
+    /// Open an existing index or create a new one in `<sessions_dir>/.search_index/`.
+    pub fn open_or_create(sessions_dir: &Path) -> io::Result<Self> {
+        let index_dir = sessions_dir.join(INDEX_SUBDIR);
+        std::fs::create_dir_all(&index_dir)?;
+
+        let (index, fields) = open_or_create_index(&index_dir)?;
+        Ok(Self {
+            inner: Arc::new(Mutex::new(Inner { index, fields })),
+        })
+    }
+
+    /// Index (or re-index) one session.
+    ///
+    /// Deletes any previously stored documents for this session ID, then
+    /// inserts one document per `SessionEntry`.
+    pub fn index_session(&self, meta: &SessionMeta, entries: &[SessionEntry]) -> io::Result<()> {
+        let inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        let mut writer = inner
+            .index
+            .writer(INDEXER_HEAP_BYTES)
+            .map_err(tantivy_to_io)?;
+
+        delete_session_docs(&mut writer, &inner.fields, &meta.id);
+
+        for entry in entries {
+            let body = search::searchable_text_pub(entry);
+            if body.is_empty() {
+                continue;
+            }
+            let entry_json = serde_json::to_string(entry).map_err(io::Error::other)?;
+            let timestamp = entry.timestamp().unwrap_or(0);
+
+            let doc = tantivy::doc!(
+                inner.fields.session_id => meta.id.as_str(),
+                inner.fields.session_title => meta.title.as_str(),
+                inner.fields.entry_type => entry.entry_type_name(),
+                inner.fields.timestamp => timestamp,
+                inner.fields.body => body.as_str(),
+                inner.fields.entry_json => entry_json.as_str()
+            );
+            writer.add_document(doc).map_err(tantivy_to_io)?;
+        }
+
+        writer.commit().map_err(tantivy_to_io)?;
+        Ok(())
+    }
+
+    /// Remove all indexed documents for a session.
+    pub fn delete_session(&self, session_id: &str) -> io::Result<()> {
+        let inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        let mut writer = inner
+            .index
+            .writer(INDEXER_HEAP_BYTES)
+            .map_err(tantivy_to_io)?;
+        delete_session_docs(&mut writer, &inner.fields, session_id);
+        writer.commit().map_err(tantivy_to_io)?;
+        Ok(())
+    }
+
+    /// Search the index and return hits respecting `options`.
+    pub fn search(
+        &self,
+        query: &str,
+        options: &SessionSearchOptions,
+    ) -> io::Result<Vec<SessionHit>> {
+        let limit = options.limit();
+        if query.trim().is_empty() || limit == 0 {
+            return Ok(Vec::new());
+        }
+
+        let inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        let reader = inner
+            .index
+            .reader_builder()
+            .reload_policy(ReloadPolicy::Manual)
+            .try_into()
+            .map_err(tantivy_to_io)?;
+
+        reader.reload().map_err(tantivy_to_io)?;
+        let searcher = reader.searcher();
+
+        let query_parser = QueryParser::for_index(&inner.index, vec![inner.fields.body]);
+        // Sanitise the query: tantivy's default parser raises on many special chars.
+        let sanitised = sanitise_query(query);
+        let parsed_query = query_parser
+            .parse_query(&sanitised)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
+
+        // Fetch more than `limit` to allow post-filtering.
+        let fetch = (limit * 4).max(200);
+        let top_docs: Vec<(tantivy::Score, tantivy::DocAddress)> = searcher
+            .search(&parsed_query, &TopDocs::with_limit(fetch))
+            .map_err(tantivy_to_io)?;
+
+        let mut hits: Vec<SessionHit> = Vec::new();
+        for (score, doc_address) in top_docs {
+            if hits.len() >= limit {
+                break;
+            }
+
+            let doc: TantivyDocument = searcher.doc(doc_address).map_err(tantivy_to_io)?;
+
+            let session_id = get_text_field(&doc, inner.fields.session_id);
+            let session_title = get_text_field(&doc, inner.fields.session_title);
+            let entry_json = get_text_field(&doc, inner.fields.entry_json);
+            let entry_type_name = get_text_field(&doc, inner.fields.entry_type);
+            let timestamp_val: u64 = doc
+                .get_first(inner.fields.timestamp)
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+
+            // Session ID filter.
+            if options
+                .session_ids
+                .as_ref()
+                .is_some_and(|ids| !ids.contains(&session_id))
+            {
+                continue;
+            }
+            // Entry type filter.
+            if options
+                .entry_types
+                .as_ref()
+                .is_some_and(|types| !types.contains(&entry_type_name))
+            {
+                continue;
+            }
+            // Timestamp range filter.
+            if options
+                .start_time
+                .is_some_and(|start| timestamp_val < start.timestamp().cast_unsigned())
+            {
+                continue;
+            }
+            if options
+                .end_time
+                .is_some_and(|end| timestamp_val > end.timestamp().cast_unsigned())
+            {
+                continue;
+            }
+
+            // Reconstruct `SessionEntry` from stored JSON.
+            let entry: SessionEntry = match serde_json::from_str(&entry_json) {
+                Ok(e) => e,
+                Err(err) => {
+                    tracing::warn!(
+                        session_id = %session_id,
+                        error = %err,
+                        "skipping tantivy hit with undeserializable entry_json"
+                    );
+                    continue;
+                }
+            };
+
+            let body = search::searchable_text_pub(&entry);
+            let snippet = snippet_from_text(&body, 0);
+
+            hits.push(SessionHit {
+                session_id,
+                session_title,
+                entry,
+                // Convert tantivy's f32 score to a comparable usize (×1000 for ordering).
+                // score is always non-negative (BM25 score from tantivy).
+                #[allow(clippy::cast_sign_loss)]
+                score: (score.max(0.0) * 1000.0) as usize,
+                snippet,
+            });
+        }
+
+        Ok(hits)
+    }
+}
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+fn open_or_create_index(index_dir: &Path) -> io::Result<(Index, Fields)> {
+    let mut schema_builder = Schema::builder();
+    let fields = Fields::register(&mut schema_builder);
+    let schema = schema_builder.build();
+
+    let dir = tantivy::directory::MmapDirectory::open(index_dir).map_err(tantivy_to_io)?;
+    let index = Index::open_or_create(dir, schema).map_err(tantivy_to_io)?;
+    Ok((index, fields))
+}
+
+#[allow(clippy::needless_pass_by_ref_mut)]
+fn delete_session_docs(writer: &mut IndexWriter, fields: &Fields, session_id: &str) {
+    let term = tantivy::Term::from_field_text(fields.session_id, session_id);
+    writer.delete_term(term);
+}
+
+fn get_text_field(doc: &TantivyDocument, field: Field) -> String {
+    doc.get_first(field)
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string()
+}
+
+/// Remove characters that confuse tantivy's default query parser when users
+/// supply arbitrary search queries (e.g. colons, slashes, brackets).
+fn sanitise_query(query: &str) -> String {
+    query
+        .chars()
+        .map(|c| {
+            if c.is_alphanumeric() || c == ' ' || c == '-' || c == '_' {
+                c
+            } else {
+                ' '
+            }
+        })
+        .collect()
+}
+
+fn tantivy_to_io(e: impl std::fmt::Display) -> io::Error {
+    io::Error::other(e.to_string())
+}

--- a/memory/tests/search.rs
+++ b/memory/tests/search.rs
@@ -293,6 +293,41 @@ mod tantivy_tests {
         );
     }
 
+    /// `rebuild_search_index` removes ghost hits for sessions deleted outside the store API.
+    #[test]
+    fn rebuild_search_index_clears_stale_docs() {
+        let (store, dir) = make_store();
+
+        save_session_with_text(
+            &store,
+            "ghost-session",
+            "Ghost Session",
+            &["ghostly apparition unique phrase"],
+        );
+
+        // Prime the index via an initial search.
+        let before = store
+            .search("ghostly", &SessionSearchOptions::default())
+            .expect("search before");
+        assert!(!before.is_empty(), "session should be findable before removal");
+
+        // Delete the session file directly — simulating out-of-band removal.
+        let session_file = dir.path().join("ghost-session.jsonl");
+        std::fs::remove_file(&session_file).expect("remove session file");
+
+        // Rebuild must produce replacement semantics — no ghost hits.
+        store.rebuild_search_index().expect("rebuild");
+
+        let after = store
+            .search("ghostly", &SessionSearchOptions::default())
+            .expect("search after rebuild");
+        assert!(
+            after.is_empty(),
+            "rebuild should have cleared ghost hits for the deleted session, got {} hit(s)",
+            after.len()
+        );
+    }
+
     /// `TantivyIndex::search` on an empty index returns an empty vec.
     #[test]
     fn tantivy_index_search_empty_returns_empty() {

--- a/memory/tests/search.rs
+++ b/memory/tests/search.rs
@@ -1,0 +1,328 @@
+//! Integration tests for cross-session full-text search.
+//!
+//! Tests gated on the `search` feature exercise the tantivy-backed index.
+//! Tests without the gate exercise the baseline behaviour (empty default impl
+//! on the trait, or the linear scan in `JsonlSessionStore`).
+
+mod common;
+
+use swink_agent_memory::{JsonlSessionStore, SessionEntry, SessionSearchOptions, SessionStore};
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+fn make_store() -> (JsonlSessionStore, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = JsonlSessionStore::new(dir.path().to_path_buf()).expect("store");
+    (store, dir)
+}
+
+fn save_session_with_text(
+    store: &JsonlSessionStore,
+    session_id: &str,
+    title: &str,
+    texts: &[&str],
+) {
+    let meta = common::sample_meta(session_id, title);
+    let entries: Vec<SessionEntry> = texts
+        .iter()
+        .map(|t| SessionEntry::Message(common::user_message_at(t, 1_000)))
+        .collect();
+    store
+        .save_entries(session_id, &meta, &entries)
+        .expect("save_entries");
+}
+
+// ─── baseline behaviour (no feature gate) ────────────────────────────────────
+
+/// Default `SessionStore::search()` returns empty vec (backward-compat no-op).
+///
+/// This exercises the trait default; the `JsonlSessionStore` overrides it, but
+/// any custom `SessionStore` impl that does NOT override it should return `[]`.
+#[test]
+fn default_trait_search_returns_empty() {
+    use std::io;
+    use swink_agent::AgentMessage;
+    use swink_agent::CustomMessageRegistry;
+    use swink_agent_memory::{LoadOptions, SessionMeta};
+
+    struct NoOpStore;
+    impl SessionStore for NoOpStore {
+        fn save(
+            &self,
+            _id: &str,
+            _meta: &SessionMeta,
+            _messages: &[AgentMessage],
+        ) -> io::Result<()> {
+            Ok(())
+        }
+        fn append(&self, _id: &str, _messages: &[AgentMessage]) -> io::Result<()> {
+            Ok(())
+        }
+        fn load(
+            &self,
+            _id: &str,
+            _registry: Option<&CustomMessageRegistry>,
+        ) -> io::Result<(SessionMeta, Vec<AgentMessage>)> {
+            Err(io::Error::from(io::ErrorKind::NotFound))
+        }
+        fn list(&self) -> io::Result<Vec<SessionMeta>> {
+            Ok(vec![])
+        }
+        fn delete(&self, _id: &str) -> io::Result<()> {
+            Ok(())
+        }
+        fn load_with_options(
+            &self,
+            _id: &str,
+            _options: &LoadOptions,
+        ) -> io::Result<(SessionMeta, Vec<SessionEntry>)> {
+            Err(io::Error::from(io::ErrorKind::NotFound))
+        }
+    }
+
+    let store = NoOpStore;
+    let hits = store
+        .search("anything", &SessionSearchOptions::default())
+        .expect("search");
+    assert!(hits.is_empty(), "default no-op should return empty vec");
+}
+
+/// Search on an empty `JsonlSessionStore` returns empty vec.
+#[test]
+fn jsonl_search_empty_store_returns_empty() {
+    let (store, _dir) = make_store();
+    let hits = store
+        .search("hello", &SessionSearchOptions::default())
+        .expect("search");
+    assert!(hits.is_empty());
+}
+
+/// After saving entries, search finds relevant content.
+#[test]
+fn jsonl_search_finds_saved_content() {
+    let (store, _dir) = make_store();
+
+    save_session_with_text(
+        &store,
+        "session-alpha",
+        "Alpha Session",
+        &["the quick brown fox"],
+    );
+    save_session_with_text(
+        &store,
+        "session-beta",
+        "Beta Session",
+        &["lazy dog sits here"],
+    );
+
+    let hits = store
+        .search("quick fox", &SessionSearchOptions::default())
+        .expect("search");
+
+    assert!(
+        !hits.is_empty(),
+        "should find at least one hit for 'quick fox'"
+    );
+    assert!(
+        hits.iter().any(|h| h.session_id == "session-alpha"),
+        "hit should be from session-alpha"
+    );
+    assert!(
+        hits.iter().all(|h| h.session_id != "session-beta"),
+        "session-beta should not match 'quick fox'"
+    );
+}
+
+/// `max_results` option is respected.
+#[test]
+fn jsonl_search_respects_max_results() {
+    let (store, _dir) = make_store();
+
+    // Create 5 sessions each containing the word "apple".
+    for i in 0..5u32 {
+        let id = format!("session-{i}");
+        save_session_with_text(&store, &id, &format!("Session {i}"), &["apple pie recipe"]);
+    }
+
+    let opts = SessionSearchOptions {
+        max_results: Some(2),
+        ..Default::default()
+    };
+    let hits = store.search("apple", &opts).expect("search");
+    assert!(
+        hits.len() <= 2,
+        "should return at most 2 hits, got {}",
+        hits.len()
+    );
+}
+
+/// Session ID filter restricts search to specified sessions.
+#[test]
+fn jsonl_search_session_id_filter() {
+    let (store, _dir) = make_store();
+
+    save_session_with_text(
+        &store,
+        "target-session",
+        "Target",
+        &["needle in a haystack"],
+    );
+    save_session_with_text(&store, "other-session", "Other", &["needle found here too"]);
+
+    let opts = SessionSearchOptions {
+        session_ids: Some(vec!["target-session".to_string()]),
+        ..Default::default()
+    };
+    let hits = store.search("needle", &opts).expect("search");
+    assert!(
+        hits.iter().all(|h| h.session_id == "target-session"),
+        "all hits should be from target-session"
+    );
+}
+
+/// Entry type filter only returns matching entry types.
+#[test]
+fn jsonl_search_entry_type_filter_excludes_non_message_types() {
+    let (store, _dir) = make_store();
+
+    let meta = common::sample_meta("mixed-session", "Mixed");
+    let entries = vec![
+        SessionEntry::Message(common::user_message_at("unique phrase here", 1_000)),
+        SessionEntry::Label {
+            text: "unique phrase label".to_string(),
+            message_index: 0,
+            timestamp: 2_000,
+        },
+    ];
+    store
+        .save_entries("mixed-session", &meta, &entries)
+        .expect("save_entries");
+
+    // Restrict to only "message" entries.
+    let opts = SessionSearchOptions {
+        entry_types: Some(vec!["message".to_string()]),
+        ..Default::default()
+    };
+    let hits = store.search("unique phrase", &opts).expect("search");
+    assert!(
+        hits.iter().all(|h| h.entry.entry_type_name() == "message"),
+        "all hits should be message entries"
+    );
+}
+
+// ─── tantivy-specific tests (require `search` feature) ───────────────────────
+
+#[cfg(feature = "search")]
+mod tantivy_tests {
+    use super::*;
+    use swink_agent_memory::TantivyIndex;
+
+    /// Tantivy index can be opened and populated from a store.
+    #[test]
+    fn tantivy_index_open_and_search() {
+        let (store, _dir) = make_store();
+
+        save_session_with_text(
+            &store,
+            "idx-session-1",
+            "Index Session 1",
+            &["tantivy full text search works"],
+        );
+        save_session_with_text(
+            &store,
+            "idx-session-2",
+            "Index Session 2",
+            &["unrelated content about gardening"],
+        );
+
+        let hits = store
+            .search("tantivy full text", &SessionSearchOptions::default())
+            .expect("search");
+
+        assert!(!hits.is_empty(), "should find hits for 'tantivy full text'");
+        assert!(
+            hits.iter().any(|h| h.session_id == "idx-session-1"),
+            "idx-session-1 should appear in results"
+        );
+    }
+
+    /// After building the index once, subsequent searches reuse it without rebuild.
+    #[test]
+    fn tantivy_second_search_does_not_rebuild() {
+        let (store, _dir) = make_store();
+        save_session_with_text(&store, "warm-session", "Warm", &["warm cache test phrase"]);
+
+        // First search builds the index.
+        let hits1 = store
+            .search("warm cache", &SessionSearchOptions::default())
+            .expect("first search");
+
+        // Second search should return the same results.
+        let hits2 = store
+            .search("warm cache", &SessionSearchOptions::default())
+            .expect("second search");
+
+        assert_eq!(
+            hits1.len(),
+            hits2.len(),
+            "repeated search should return the same number of hits"
+        );
+    }
+
+    /// `rebuild_search_index` re-indexes all current sessions.
+    #[test]
+    fn rebuild_search_index_repopulates() {
+        let (store, _dir) = make_store();
+
+        save_session_with_text(
+            &store,
+            "rebuild-session",
+            "Rebuild Session",
+            &["rebuild index test phrase"],
+        );
+
+        store.rebuild_search_index().expect("rebuild_search_index");
+
+        let hits = store
+            .search("rebuild index", &SessionSearchOptions::default())
+            .expect("search after rebuild");
+
+        assert!(
+            !hits.is_empty(),
+            "should find hits after explicit index rebuild"
+        );
+    }
+
+    /// `TantivyIndex::search` on an empty index returns an empty vec.
+    #[test]
+    fn tantivy_index_search_empty_returns_empty() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let index = TantivyIndex::open_or_create(dir.path()).expect("open_or_create");
+        let hits = index
+            .search("anything", &SessionSearchOptions::default())
+            .expect("search");
+        assert!(hits.is_empty());
+    }
+
+    /// `TantivyIndex` respects max_results.
+    #[test]
+    fn tantivy_index_respects_max_results() {
+        let (store, _dir) = make_store();
+
+        for i in 0..5u32 {
+            let id = format!("tantivy-max-{i}");
+            save_session_with_text(&store, &id, &format!("Session {i}"), &["mango smoothie"]);
+        }
+
+        let opts = SessionSearchOptions {
+            max_results: Some(2),
+            ..Default::default()
+        };
+        let hits = store.search("mango", &opts).expect("search");
+        assert!(
+            hits.len() <= 2,
+            "tantivy search should respect max_results=2, got {}",
+            hits.len()
+        );
+    }
+}

--- a/specs/021-memory-crate/tasks.md
+++ b/specs/021-memory-crate/tasks.md
@@ -303,7 +303,7 @@
 
 - [x] T096 [P] [US10] Unit test `search_scans_across_saved_sessions` in `memory/src/jsonl.rs`: save two sessions, search for terms in only one, verify the returned `SessionHit` has the matching session ID, title, snippet, and entry.
 - [x] T097 [P] [US10] Unit test `search_respects_session_type_time_and_limit_filters` in `memory/src/jsonl.rs`: save mixed entries across sessions, search with session ID, entry type, timestamp range, and max-result filters, verify only the expected hit remains.
-- [ ] T098 [P] [US10] Add tests for indexed search rebuild/update behavior once the `search` feature and Tantivy backend are introduced.
+- [x] T098 [P] [US10] Add tests for indexed search rebuild/update behavior once the `search` feature and Tantivy backend are introduced.
 
 ### Implementation for User Story 10
 
@@ -311,7 +311,7 @@
 - [x] T100 [US10] Add default `SessionStore::search()` empty-result method for backward-compatible store implementors.
 - [x] T101 [US10] Implement JSONL-backed linear cross-session search in `JsonlSessionStore`, including session ID, entry type, timestamp range, and max-result filters.
 - [x] T102 [US10] Add async `BlockingSessionStore::search()` bridge.
-- [ ] T103 [US10] Add a `search` feature with a Tantivy-backed index, lazy index build, save/update hooks, and explicit rebuild command/API.
+- [x] T103 [US10] Add a `search` feature with a Tantivy-backed index, lazy index build, save/update hooks, and explicit rebuild command/API.
 
 **Checkpoint**: Baseline cross-session search works without an index; indexed search remains future work.
 


### PR DESCRIPTION
## Summary
- Adds `TantivyIndex` struct in `memory/src/search/index.rs` (feature-gated `search`) wrapping tantivy schema + index stored at `<sessions_dir>/.search_index/`
- `JsonlSessionStore::search()` delegates to tantivy when `--features search` is active; falls back to the existing linear scan otherwise (zero regressions on default build)
- Index lifecycle: lazy-build on first search call, incremental update on `save_entries`, removal on `delete`, explicit `rebuild_search_index()` API
- New `open_search_index()` and `rebuild_search_index()` methods on `JsonlSessionStore` (search feature only)
- `TantivyIndex` re-exported from `swink_agent_memory` crate root when feature is enabled
- Updates `specs/021-memory-crate/tasks.md`: T098 and T103 marked `[x]`

## Tasks completed
- T098: integration tests for index rebuild/update behavior
- T103: `search` feature with tantivy index, lazy build, save/update hooks, explicit rebuild API

## Test plan
- [x] `cargo test -p swink-agent-memory --features search` passes (11 search tests + 132 existing)
- [x] `cargo test -p swink-agent-memory` (no features) passes — zero regressions
- [x] `cargo clippy -p swink-agent-memory --features search -- -D warnings` clean
- [x] `cargo fmt --check -p swink-agent-memory` clean
- [x] Diff is 1279 lines (under 1500 limit)

Part of #896
🤖 Generated with [Claude Code](https://claude.com/claude-code)