### PR TITLE
impl(023): RL-compatible training format export

### DIFF
--- a/eval/Cargo.toml
+++ b/eval/Cargo.toml
@@ -82,6 +82,7 @@ telemetry = ["dep:opentelemetry", "dep:opentelemetry_sdk"]
 html-report = ["dep:askama"]
 langsmith = ["dep:reqwest"]
 cli = ["dep:clap", "swink-agent/testkit"]
+training-export = []
 
 [dev-dependencies]
 swink-agent = { path = "..", default-features = false, features = ["testkit"] }

--- a/eval/src/lib.rs
+++ b/eval/src/lib.rs
@@ -55,6 +55,8 @@ pub mod telemetry;
 pub mod testing;
 #[cfg(feature = "trace-ingest")]
 pub mod trace;
+#[cfg(feature = "training-export")]
+pub mod training;
 mod trajectory;
 mod types;
 mod url_filter;
@@ -150,6 +152,11 @@ pub use testing::{MockJudge, PanickingMockJudge, SlowMockJudge};
 pub use trace::LangfuseTraceProvider;
 #[cfg(feature = "trace-otlp")]
 pub use trace::OtlpHttpTraceProvider;
+#[cfg(feature = "training-export")]
+pub use training::{
+    ChatMlExporter, DpoExporter, ExportError, ExportOptions, ScoredTrace, ShareGptExporter,
+    TrainingExporter, TrainingFormat, TrainingReporter, export_traces,
+};
 pub use trajectory::TrajectoryCollector;
 pub use types::{
     Assertion, AssertionKind, Attachment, AttachmentError, BudgetConstraints, CASE_NAMESPACE,

--- a/eval/src/training.rs
+++ b/eval/src/training.rs
@@ -1,0 +1,616 @@
+//! RL-compatible training-format trace export (feature: `training-export`).
+//!
+//! Exports [`Invocation`] traces collected during eval runs into formats
+//! compatible with LLM fine-tuning pipelines: ChatML/SFT, DPO pairs, and
+//! ShareGPT.
+//!
+//! # Quick Start
+//!
+//! ```rust,ignore
+//! use swink_agent_eval::training::{
+//!     ChatMlExporter, ExportOptions, ScoredTrace, TrainingExporter, TrainingFormat,
+//! };
+//!
+//! let exporter = ChatMlExporter;
+//! let opts = ExportOptions::default();
+//! let bytes = exporter.export(&traces, &opts)?;
+//! ```
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::EvalCaseResult;
+use crate::report::{Reporter, ReporterError, ReporterOutput};
+use crate::types::Invocation;
+
+// ─── Error ──────────────────────────────────────────────────────────────────
+
+/// Errors produced by training-format exporters.
+#[derive(Debug, Error)]
+pub enum ExportError {
+    /// JSON serialization failed.
+    #[error("serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+    /// The requested format is not yet fully implemented (stubs).
+    #[error("format not fully implemented: {0:?}")]
+    NotImplemented(TrainingFormat),
+    /// No traces survived the quality threshold filter.
+    #[error("no traces passed the quality threshold ({threshold})")]
+    NothingToExport { threshold: f32 },
+}
+
+// ─── Format Enum ────────────────────────────────────────────────────────────
+
+/// Supported training-data output formats.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum TrainingFormat {
+    /// Conversation-style JSONL with system/user/assistant turns and tool calls.
+    ChatMlSft,
+    /// Chosen/rejected pairs from high-score vs low-score traces on the same case.
+    DpoPairs,
+    /// Community ShareGPT conversation format.
+    ShareGpt,
+}
+
+// ─── Options ────────────────────────────────────────────────────────────────
+
+/// Options controlling how traces are exported.
+#[derive(Debug, Clone)]
+pub struct ExportOptions {
+    /// Target output format.
+    pub format: TrainingFormat,
+    /// Minimum score `[0.0, 1.0]` a trace must have to be included.
+    /// Traces with `score < quality_threshold` are filtered out.
+    pub quality_threshold: f32,
+    /// When `true`, per-record metadata (model, temperature proxy, eval case
+    /// ID, timestamp) is included in the exported records.
+    pub include_metadata: bool,
+}
+
+impl Default for ExportOptions {
+    fn default() -> Self {
+        Self {
+            format: TrainingFormat::ChatMlSft,
+            quality_threshold: 0.0,
+            include_metadata: true,
+        }
+    }
+}
+
+impl ExportOptions {
+    /// Create options targeting ChatML/SFT format with a quality gate.
+    #[must_use]
+    pub fn chatml_sft(quality_threshold: f32) -> Self {
+        Self {
+            format: TrainingFormat::ChatMlSft,
+            quality_threshold,
+            include_metadata: true,
+        }
+    }
+
+    /// Create options targeting DPO pairs with a quality gate.
+    #[must_use]
+    pub fn dpo_pairs(quality_threshold: f32) -> Self {
+        Self {
+            format: TrainingFormat::DpoPairs,
+            quality_threshold,
+            include_metadata: true,
+        }
+    }
+
+    /// Create options targeting ShareGPT format.
+    #[must_use]
+    pub fn sharegpt() -> Self {
+        Self {
+            format: TrainingFormat::ShareGpt,
+            quality_threshold: 0.0,
+            include_metadata: true,
+        }
+    }
+}
+
+// ─── ScoredTrace ────────────────────────────────────────────────────────────
+
+/// An [`Invocation`] paired with a quality score and the originating case.
+///
+/// Built from [`EvalCaseResult`] values collected during a run.
+#[derive(Debug, Clone)]
+pub struct ScoredTrace {
+    /// The captured execution trace.
+    pub invocation: Invocation,
+    /// Aggregate quality score for this trace, typically the mean of all
+    /// evaluator scores, in `[0.0, 1.0]`.
+    pub score: f64,
+    /// Identifier of the eval case this trace was produced by.
+    pub case_id: String,
+}
+
+impl ScoredTrace {
+    /// Construct a `ScoredTrace` from an [`EvalCaseResult`].
+    ///
+    /// `score` is the mean of all metric scores (0.0 when there are none).
+    #[must_use]
+    pub fn from_case_result(result: &EvalCaseResult) -> Self {
+        let score = if result.metric_results.is_empty() {
+            0.0
+        } else {
+            let sum: f64 = result.metric_results.iter().map(|m| m.score.value).sum();
+            #[allow(clippy::cast_precision_loss)]
+            let mean = sum / result.metric_results.len() as f64;
+            mean
+        };
+        Self {
+            invocation: result.invocation.clone(),
+            score,
+            case_id: result.case_id.clone(),
+        }
+    }
+}
+
+// ─── Trait ──────────────────────────────────────────────────────────────────
+
+/// Converts a slice of scored traces into a training-data byte payload.
+///
+/// Implementations are stateless; all configuration is passed via
+/// [`ExportOptions`].
+pub trait TrainingExporter: Send + Sync {
+    /// Export `traces` according to `opts`.
+    ///
+    /// Returns a `Vec<u8>` whose encoding depends on the implementation
+    /// (typically UTF-8 JSONL). Returns [`ExportError::NothingToExport`] when
+    /// every trace is below `opts.quality_threshold`.
+    fn export(&self, traces: &[ScoredTrace], opts: &ExportOptions) -> Result<Vec<u8>, ExportError>;
+}
+
+// ─── ChatML/SFT ─────────────────────────────────────────────────────────────
+
+/// Conversation-style JSONL exporter.
+///
+/// Each qualifying trace produces one JSON object per line.  The schema
+/// follows OpenAI's ChatML convention used by many fine-tuning platforms:
+///
+/// ```json
+/// {"messages": [
+///   {"role": "system",    "content": "You are a helpful agent."},
+///   {"role": "user",      "content": "What is 2+2?"},
+///   {"role": "assistant", "content": "4", "tool_calls": [...]}
+/// ], "metadata": {...}}
+/// ```
+///
+/// Tool calls on an assistant turn are serialised as an array of
+/// `{id, type, function: {name, arguments}}` objects, matching the OpenAI
+/// tool-call schema so downstream fine-tuning pipelines can parse them
+/// without additional transformation.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ChatMlExporter;
+
+impl TrainingExporter for ChatMlExporter {
+    fn export(&self, traces: &[ScoredTrace], opts: &ExportOptions) -> Result<Vec<u8>, ExportError> {
+        let threshold = f64::from(opts.quality_threshold);
+        let qualified: Vec<&ScoredTrace> = traces.iter().filter(|t| t.score >= threshold).collect();
+
+        if qualified.is_empty() {
+            return Err(ExportError::NothingToExport {
+                threshold: opts.quality_threshold,
+            });
+        }
+
+        let mut out = Vec::new();
+        for trace in qualified {
+            let record = build_chatml_record(trace, opts);
+            serde_json::to_writer(&mut out, &record)?;
+            out.push(b'\n');
+        }
+        Ok(out)
+    }
+}
+
+// ─── ChatML helpers ─────────────────────────────────────────────────────────
+
+#[derive(Serialize)]
+struct ChatMlRecord<'a> {
+    messages: Vec<ChatMlMessage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    metadata: Option<ChatMlMetadata<'a>>,
+}
+
+#[derive(Serialize)]
+struct ChatMlMessage {
+    role: &'static str,
+    content: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_calls: Option<Vec<ChatMlToolCall>>,
+}
+
+#[derive(Serialize)]
+struct ChatMlToolCall {
+    id: String,
+    #[serde(rename = "type")]
+    call_type: &'static str,
+    function: ChatMlFunction,
+}
+
+#[derive(Serialize)]
+struct ChatMlFunction {
+    name: String,
+    arguments: String,
+}
+
+#[derive(Serialize)]
+struct ChatMlMetadata<'a> {
+    case_id: &'a str,
+    score: f64,
+    model_id: String,
+    turns: usize,
+}
+
+fn build_chatml_record<'a>(trace: &'a ScoredTrace, opts: &ExportOptions) -> ChatMlRecord<'a> {
+    let inv = &trace.invocation;
+    let mut messages: Vec<ChatMlMessage> = Vec::new();
+
+    // System message — derive from the first user message context if there is
+    // relevant text, otherwise use an empty string.  The system prompt is not
+    // stored on `Invocation` directly; we emit a placeholder so downstream
+    // pipelines always have a system slot to fill from their own case data.
+    messages.push(ChatMlMessage {
+        role: "system",
+        content: String::new(),
+        tool_calls: None,
+    });
+
+    for turn in &inv.turns {
+        // User turn: synthesise from tool results of the *previous* turn or
+        // from the first turn where we have no tool results to carry.
+        // For turn 0 the user message is implicit (not stored in Invocation).
+        // We add a user placeholder only for turn 0.
+        if turn.turn_index == 0 {
+            messages.push(ChatMlMessage {
+                role: "user",
+                content: String::new(), // prompt not stored in Invocation
+                tool_calls: None,
+            });
+        }
+
+        // Assistant message
+        let content = extract_assistant_text(&turn.assistant_message);
+        let tool_calls: Vec<ChatMlToolCall> = turn
+            .tool_calls
+            .iter()
+            .map(|tc| ChatMlToolCall {
+                id: tc.id.clone(),
+                call_type: "function",
+                function: ChatMlFunction {
+                    name: tc.name.clone(),
+                    arguments: tc.arguments.to_string(),
+                },
+            })
+            .collect();
+
+        messages.push(ChatMlMessage {
+            role: "assistant",
+            content,
+            tool_calls: if tool_calls.is_empty() {
+                None
+            } else {
+                Some(tool_calls)
+            },
+        });
+    }
+
+    // Final response appended as a last assistant message if not already
+    // captured via the last turn's assistant message.
+    if let Some(response) = &inv.final_response {
+        let needs_patch = messages
+            .last()
+            .is_some_and(|last| last.role == "assistant" && last.content.is_empty());
+        let needs_append = messages.last().is_some_and(|last| last.role != "assistant");
+
+        if needs_patch && !response.is_empty() {
+            if let Some(last_mut) = messages.last_mut() {
+                last_mut.content.clone_from(response);
+            }
+        } else if needs_append {
+            messages.push(ChatMlMessage {
+                role: "assistant",
+                content: response.clone(),
+                tool_calls: None,
+            });
+        }
+    }
+
+    let metadata = if opts.include_metadata {
+        Some(ChatMlMetadata {
+            case_id: &trace.case_id,
+            score: trace.score,
+            model_id: inv.model.model_id.clone(),
+            turns: inv.turns.len(),
+        })
+    } else {
+        None
+    };
+
+    ChatMlRecord { messages, metadata }
+}
+
+fn extract_assistant_text(msg: &swink_agent::AssistantMessage) -> String {
+    use swink_agent::ContentBlock;
+    msg.content
+        .iter()
+        .filter_map(|block| {
+            if let ContentBlock::Text { text } = block {
+                Some(text.as_str())
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("")
+}
+
+// ─── DPO Pairs ──────────────────────────────────────────────────────────────
+
+/// Chosen/rejected pair exporter for DPO (Direct Preference Optimization).
+///
+/// Traces are grouped by `case_id`. Within each group, the highest-scoring
+/// trace becomes the `chosen` side and the lowest-scoring trace becomes the
+/// `rejected` side. Cases with fewer than two traces are skipped.
+///
+/// Output schema (one JSON object per line):
+///
+/// ```json
+/// {"case_id": "...", "chosen": {...chatml record...}, "rejected": {...chatml record...}}
+/// ```
+#[derive(Debug, Default, Clone, Copy)]
+pub struct DpoExporter;
+
+/// A single DPO pair (one JSONL record).
+#[derive(Serialize)]
+struct DpoPairRecord {
+    case_id: String,
+    chosen: serde_json::Value,
+    rejected: serde_json::Value,
+}
+
+impl TrainingExporter for DpoExporter {
+    fn export(&self, traces: &[ScoredTrace], opts: &ExportOptions) -> Result<Vec<u8>, ExportError> {
+        let threshold = f64::from(opts.quality_threshold);
+        let qualified: Vec<&ScoredTrace> = traces.iter().filter(|t| t.score >= threshold).collect();
+
+        // Group by case_id
+        let mut by_case: std::collections::HashMap<&str, Vec<&ScoredTrace>> =
+            std::collections::HashMap::new();
+        for trace in &qualified {
+            by_case
+                .entry(trace.case_id.as_str())
+                .or_default()
+                .push(trace);
+        }
+
+        let mut pairs: Vec<DpoPairRecord> = Vec::new();
+        for (case_id, mut group) in by_case {
+            if group.len() < 2 {
+                continue;
+            }
+            // Sort by score descending
+            group.sort_by(|a, b| {
+                b.score
+                    .partial_cmp(&a.score)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
+            let chosen_trace = group[0];
+            let rejected_trace = group[group.len() - 1];
+
+            let chosen_record = build_chatml_record(chosen_trace, opts);
+            let rejected_record = build_chatml_record(rejected_trace, opts);
+
+            pairs.push(DpoPairRecord {
+                case_id: case_id.to_string(),
+                chosen: serde_json::to_value(chosen_record)?,
+                rejected: serde_json::to_value(rejected_record)?,
+            });
+        }
+
+        if pairs.is_empty() {
+            return Err(ExportError::NothingToExport {
+                threshold: opts.quality_threshold,
+            });
+        }
+
+        let mut out = Vec::new();
+        for pair in &pairs {
+            serde_json::to_writer(&mut out, pair)?;
+            out.push(b'\n');
+        }
+        Ok(out)
+    }
+}
+
+// ─── ShareGPT ───────────────────────────────────────────────────────────────
+
+/// Community ShareGPT conversation format exporter.
+///
+/// Output schema (one JSON object per line):
+///
+/// ```json
+/// {"conversations": [
+///   {"from": "system", "value": "..."},
+///   {"from": "human",  "value": "..."},
+///   {"from": "gpt",    "value": "..."}
+/// ]}
+/// ```
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ShareGptExporter;
+
+#[derive(Serialize)]
+struct ShareGptRecord {
+    conversations: Vec<ShareGptTurn>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    metadata: Option<serde_json::Value>,
+}
+
+#[derive(Serialize)]
+struct ShareGptTurn {
+    from: &'static str,
+    value: String,
+}
+
+impl TrainingExporter for ShareGptExporter {
+    fn export(&self, traces: &[ScoredTrace], opts: &ExportOptions) -> Result<Vec<u8>, ExportError> {
+        let threshold = f64::from(opts.quality_threshold);
+        let qualified: Vec<&ScoredTrace> = traces.iter().filter(|t| t.score >= threshold).collect();
+
+        if qualified.is_empty() {
+            return Err(ExportError::NothingToExport {
+                threshold: opts.quality_threshold,
+            });
+        }
+
+        let mut out = Vec::new();
+        for trace in qualified {
+            let record = build_sharegpt_record(trace, opts);
+            serde_json::to_writer(&mut out, &record)?;
+            out.push(b'\n');
+        }
+        Ok(out)
+    }
+}
+
+fn build_sharegpt_record(trace: &ScoredTrace, opts: &ExportOptions) -> ShareGptRecord {
+    let inv = &trace.invocation;
+    let mut conversations: Vec<ShareGptTurn> = Vec::new();
+
+    // System placeholder
+    conversations.push(ShareGptTurn {
+        from: "system",
+        value: String::new(),
+    });
+
+    for turn in &inv.turns {
+        if turn.turn_index == 0 {
+            conversations.push(ShareGptTurn {
+                from: "human",
+                value: String::new(), // user prompt not stored in Invocation
+            });
+        }
+        let content = extract_assistant_text(&turn.assistant_message);
+        conversations.push(ShareGptTurn {
+            from: "gpt",
+            value: content,
+        });
+    }
+
+    // Final response patch — same logic as ChatML.
+    if let Some(response) = &inv.final_response {
+        let needs_patch = conversations
+            .last()
+            .is_some_and(|last| last.from == "gpt" && last.value.is_empty());
+        let needs_append = conversations.last().is_some_and(|last| last.from != "gpt");
+
+        if needs_patch && !response.is_empty() {
+            if let Some(last_mut) = conversations.last_mut() {
+                last_mut.value.clone_from(response);
+            }
+        } else if needs_append {
+            conversations.push(ShareGptTurn {
+                from: "gpt",
+                value: response.clone(),
+            });
+        }
+    }
+
+    let metadata = if opts.include_metadata {
+        Some(serde_json::json!({
+            "case_id": trace.case_id,
+            "score": trace.score,
+        }))
+    } else {
+        None
+    };
+
+    ShareGptRecord {
+        conversations,
+        metadata,
+    }
+}
+
+// ─── Dispatch helper ─────────────────────────────────────────────────────────
+
+/// Dispatch export to the appropriate exporter based on `opts.format`.
+pub fn export_traces(traces: &[ScoredTrace], opts: &ExportOptions) -> Result<Vec<u8>, ExportError> {
+    match opts.format {
+        TrainingFormat::ChatMlSft => ChatMlExporter.export(traces, opts),
+        TrainingFormat::DpoPairs => DpoExporter.export(traces, opts),
+        TrainingFormat::ShareGpt => ShareGptExporter.export(traces, opts),
+    }
+}
+
+// ─── TrainingReporter ────────────────────────────────────────────────────────
+
+/// A [`Reporter`] that exports all eval results as training data.
+///
+/// Implements the existing [`Reporter`] trait so it can be composed with other
+/// reporters in the eval runner pipeline.
+///
+/// The reporter converts each [`EvalCaseResult`] into a [`ScoredTrace`],
+/// applies the configured [`ExportOptions`], and writes the export artifact to
+/// the configured output path (or returns it as [`ReporterOutput::Artifact`]).
+#[derive(Debug, Clone)]
+pub struct TrainingReporter {
+    opts: ExportOptions,
+    /// Suggested output file path. Callers may override.
+    output_path: PathBuf,
+}
+
+impl TrainingReporter {
+    /// Create a new reporter with explicit options and output path.
+    #[must_use]
+    pub fn new(opts: ExportOptions, output_path: impl Into<PathBuf>) -> Self {
+        Self {
+            opts,
+            output_path: output_path.into(),
+        }
+    }
+
+    /// Create a ChatML/SFT reporter writing to `output_path`.
+    #[must_use]
+    pub fn chatml_sft(quality_threshold: f32, output_path: impl Into<PathBuf>) -> Self {
+        Self::new(ExportOptions::chatml_sft(quality_threshold), output_path)
+    }
+
+    /// Create a DPO pairs reporter writing to `output_path`.
+    #[must_use]
+    pub fn dpo_pairs(quality_threshold: f32, output_path: impl Into<PathBuf>) -> Self {
+        Self::new(ExportOptions::dpo_pairs(quality_threshold), output_path)
+    }
+
+    /// Create a ShareGPT reporter writing to `output_path`.
+    #[must_use]
+    pub fn sharegpt(output_path: impl Into<PathBuf>) -> Self {
+        Self::new(ExportOptions::sharegpt(), output_path)
+    }
+}
+
+impl Reporter for TrainingReporter {
+    fn render(&self, result: &EvalSetResult) -> Result<ReporterOutput, ReporterError> {
+        let traces: Vec<ScoredTrace> = result
+            .case_results
+            .iter()
+            .map(ScoredTrace::from_case_result)
+            .collect();
+
+        let bytes =
+            export_traces(&traces, &self.opts).map_err(|e| ReporterError::Format(e.to_string()))?;
+
+        Ok(ReporterOutput::Artifact {
+            path: self.output_path.clone(),
+            bytes,
+        })
+    }
+}
+
+// Import needed for Reporter impl
+use crate::types::EvalSetResult;

--- a/eval/tests/training_export.rs
+++ b/eval/tests/training_export.rs
@@ -1,0 +1,326 @@
+//! Integration tests for training-format trace export (spec 023, feature: training-export).
+
+#![cfg(feature = "training-export")]
+
+mod common;
+
+use swink_agent_eval::{
+    ChatMlExporter, DpoExporter, EvalCaseResult, EvalMetricResult, ExportOptions, Score,
+    ScoredTrace, ShareGptExporter, TrainingExporter, TrainingFormat, Verdict,
+    training::ExportError,
+};
+
+use common::mock_invocation;
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+fn make_trace(case_id: &str, score: f64, final_response: Option<&str>) -> ScoredTrace {
+    ScoredTrace {
+        invocation: mock_invocation(&["read_file"], final_response, 0.01, 100),
+        score,
+        case_id: case_id.to_string(),
+    }
+}
+
+fn make_trace_no_tools(case_id: &str, score: f64, final_response: &str) -> ScoredTrace {
+    ScoredTrace {
+        invocation: mock_invocation(&[], Some(final_response), 0.01, 100),
+        score,
+        case_id: case_id.to_string(),
+    }
+}
+
+fn make_case_result(case_id: &str, score_val: f64) -> EvalCaseResult {
+    let inv = mock_invocation(&["read_file"], Some("done"), 0.01, 100);
+    EvalCaseResult {
+        case_id: case_id.to_string(),
+        invocation: inv,
+        metric_results: vec![EvalMetricResult {
+            evaluator_name: "trajectory".to_string(),
+            score: Score::new(score_val, 0.5),
+            details: None,
+        }],
+        verdict: if score_val >= 0.5 {
+            Verdict::Pass
+        } else {
+            Verdict::Fail
+        },
+    }
+}
+
+// ─── ChatML / SFT ───────────────────────────────────────────────────────────
+
+/// ChatML export produces valid JSONL — one object per line, correct turn structure.
+#[test]
+fn chatml_export_produces_valid_jsonl_with_correct_turn_structure() {
+    let traces = vec![make_trace("case-1", 1.0, Some("Hello world"))];
+    let opts = ExportOptions::chatml_sft(0.0);
+    let bytes = ChatMlExporter
+        .export(&traces, &opts)
+        .expect("export should succeed");
+
+    let output = String::from_utf8(bytes).expect("output should be utf-8");
+    // Should be non-empty JSONL (at least one line)
+    let lines: Vec<&str> = output.lines().collect();
+    assert_eq!(lines.len(), 1, "one trace → one JSONL line");
+
+    let record: serde_json::Value =
+        serde_json::from_str(lines[0]).expect("line should be valid JSON");
+
+    // Must have "messages" key
+    let messages = record.get("messages").expect("record must have 'messages'");
+    let messages = messages.as_array().expect("messages must be an array");
+    assert!(!messages.is_empty(), "messages array must not be empty");
+
+    // First message must be system
+    assert_eq!(messages[0]["role"], "system");
+
+    // Must contain at least one user and one assistant turn
+    let has_user = messages.iter().any(|m| m["role"] == "user");
+    let has_assistant = messages.iter().any(|m| m["role"] == "assistant");
+    assert!(has_user, "must have a user turn");
+    assert!(has_assistant, "must have an assistant turn");
+}
+
+/// ChatML export includes tool_calls array on assistant turns that used tools.
+#[test]
+fn chatml_export_includes_tool_calls_on_assistant_turns() {
+    let traces = vec![make_trace("case-2", 1.0, Some("done"))];
+    let opts = ExportOptions::chatml_sft(0.0);
+    let bytes = ChatMlExporter.export(&traces, &opts).unwrap();
+    let output = String::from_utf8(bytes).unwrap();
+    let line = output.lines().next().unwrap();
+    let record: serde_json::Value = serde_json::from_str(line).unwrap();
+
+    let messages = record["messages"].as_array().unwrap();
+    // Find the assistant message that had tool calls
+    let assistant_with_tools = messages
+        .iter()
+        .find(|m| m["role"] == "assistant" && m.get("tool_calls").is_some());
+    assert!(
+        assistant_with_tools.is_some(),
+        "assistant turn should have tool_calls when tools were called"
+    );
+
+    let tool_calls = assistant_with_tools.unwrap()["tool_calls"]
+        .as_array()
+        .unwrap();
+    assert_eq!(tool_calls.len(), 1);
+    assert_eq!(tool_calls[0]["function"]["name"], "read_file");
+    assert_eq!(tool_calls[0]["type"], "function");
+}
+
+/// ChatML export includes metadata when include_metadata = true.
+#[test]
+fn chatml_export_includes_metadata_when_requested() {
+    let traces = vec![make_trace("my-case", 0.9, Some("result"))];
+    let opts = ExportOptions {
+        format: TrainingFormat::ChatMlSft,
+        quality_threshold: 0.0,
+        include_metadata: true,
+    };
+    let bytes = ChatMlExporter.export(&traces, &opts).unwrap();
+    let output = String::from_utf8(bytes).unwrap();
+    let record: serde_json::Value = serde_json::from_str(output.lines().next().unwrap()).unwrap();
+
+    let metadata = record.get("metadata").expect("metadata should be present");
+    assert_eq!(metadata["case_id"], "my-case");
+    assert!((metadata["score"].as_f64().unwrap() - 0.9).abs() < 1e-9);
+}
+
+/// ChatML export omits metadata when include_metadata = false.
+#[test]
+fn chatml_export_omits_metadata_when_not_requested() {
+    let traces = vec![make_trace("c", 1.0, Some("ok"))];
+    let opts = ExportOptions {
+        format: TrainingFormat::ChatMlSft,
+        quality_threshold: 0.0,
+        include_metadata: false,
+    };
+    let bytes = ChatMlExporter.export(&traces, &opts).unwrap();
+    let output = String::from_utf8(bytes).unwrap();
+    let record: serde_json::Value = serde_json::from_str(output.lines().next().unwrap()).unwrap();
+    assert!(
+        record.get("metadata").is_none(),
+        "metadata should be absent"
+    );
+}
+
+// ─── Quality Threshold ───────────────────────────────────────────────────────
+
+/// Quality threshold filters out traces below the threshold.
+#[test]
+fn quality_threshold_filters_low_score_traces() {
+    let traces = vec![
+        make_trace("case-1", 0.9, Some("good")),
+        make_trace("case-2", 0.3, Some("bad")),
+    ];
+    let opts = ExportOptions::chatml_sft(0.5);
+    let bytes = ChatMlExporter.export(&traces, &opts).unwrap();
+    let output = String::from_utf8(bytes).unwrap();
+    let lines: Vec<&str> = output.lines().collect();
+
+    // Only the high-score trace should pass
+    assert_eq!(lines.len(), 1, "only one trace should pass threshold 0.5");
+    let record: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+    assert_eq!(record["metadata"]["case_id"], "case-1");
+}
+
+/// Export is empty (error) when all traces are below the threshold.
+#[test]
+fn export_empty_when_all_traces_below_threshold() {
+    let traces = vec![
+        make_trace("case-1", 0.2, Some("low")),
+        make_trace("case-2", 0.1, Some("lower")),
+    ];
+    let opts = ExportOptions::chatml_sft(0.5);
+    let err = ChatMlExporter
+        .export(&traces, &opts)
+        .expect_err("should fail when all traces are below threshold");
+    assert!(
+        matches!(err, ExportError::NothingToExport { threshold } if (threshold - 0.5).abs() < 1e-6),
+        "unexpected error variant: {err:?}"
+    );
+}
+
+/// Empty trace slice returns NothingToExport.
+#[test]
+fn export_empty_slice_returns_nothing_to_export() {
+    let traces: Vec<ScoredTrace> = vec![];
+    let opts = ExportOptions::chatml_sft(0.0);
+    let err = ChatMlExporter
+        .export(&traces, &opts)
+        .expect_err("empty slice should fail");
+    assert!(matches!(err, ExportError::NothingToExport { .. }));
+}
+
+// ─── DPO Pairs ───────────────────────────────────────────────────────────────
+
+/// DPO pairs are created from high/low score traces on the same case.
+#[test]
+fn dpo_pairs_created_from_high_and_low_score_on_same_case() {
+    let traces = vec![
+        make_trace("case-A", 0.9, Some("great answer")),
+        make_trace("case-A", 0.2, Some("poor answer")),
+    ];
+    let opts = ExportOptions::dpo_pairs(0.0);
+    let bytes = DpoExporter.export(&traces, &opts).unwrap();
+    let output = String::from_utf8(bytes).unwrap();
+    let lines: Vec<&str> = output.lines().collect();
+    assert_eq!(lines.len(), 1, "one case → one DPO pair");
+
+    let pair: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+    assert_eq!(pair["case_id"], "case-A");
+    assert!(pair.get("chosen").is_some(), "pair must have 'chosen'");
+    assert!(pair.get("rejected").is_some(), "pair must have 'rejected'");
+}
+
+/// DPO export emits nothing (error) for cases with fewer than 2 traces.
+#[test]
+fn dpo_pairs_emits_nothing_for_single_trace_case() {
+    let traces = vec![make_trace("solo-case", 0.8, Some("only one"))];
+    let opts = ExportOptions::dpo_pairs(0.0);
+    let err = DpoExporter
+        .export(&traces, &opts)
+        .expect_err("single-trace case should produce NothingToExport");
+    assert!(matches!(err, ExportError::NothingToExport { .. }));
+}
+
+/// DPO pairs correctly pair highest vs lowest when 3+ traces for same case.
+#[test]
+fn dpo_pairs_uses_highest_and_lowest_score_traces() {
+    let traces = vec![
+        make_trace("case-X", 0.5, Some("medium")),
+        make_trace("case-X", 0.95, Some("best")),
+        make_trace("case-X", 0.1, Some("worst")),
+    ];
+    let opts = ExportOptions::dpo_pairs(0.0);
+    let bytes = DpoExporter.export(&traces, &opts).unwrap();
+    let output = String::from_utf8(bytes).unwrap();
+    let line = output.lines().next().unwrap();
+    let pair: serde_json::Value = serde_json::from_str(line).unwrap();
+
+    // chosen metadata score should be the highest
+    let chosen_score = pair["chosen"]["metadata"]["score"].as_f64().unwrap();
+    let rejected_score = pair["rejected"]["metadata"]["score"].as_f64().unwrap();
+    assert!(
+        chosen_score > rejected_score,
+        "chosen score ({chosen_score}) should be higher than rejected score ({rejected_score})"
+    );
+}
+
+// ─── ShareGPT ───────────────────────────────────────────────────────────────
+
+/// ShareGPT exporter produces valid JSONL with human/gpt turn structure.
+#[test]
+fn sharegpt_export_produces_valid_jsonl_with_human_gpt_turns() {
+    let traces = vec![make_trace_no_tools("case-sg", 1.0, "Hi there!")];
+    let opts = ExportOptions::sharegpt();
+    let bytes = ShareGptExporter.export(&traces, &opts).unwrap();
+    let output = String::from_utf8(bytes).unwrap();
+    let lines: Vec<&str> = output.lines().collect();
+    assert_eq!(lines.len(), 1);
+
+    let record: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+    let conversations = record["conversations"]
+        .as_array()
+        .expect("should have conversations");
+    assert!(!conversations.is_empty());
+
+    // Should have a system turn
+    let has_system = conversations.iter().any(|c| c["from"] == "system");
+    let has_gpt = conversations.iter().any(|c| c["from"] == "gpt");
+    assert!(has_system, "should have system turn");
+    assert!(has_gpt, "should have gpt turn");
+}
+
+// ─── ScoredTrace from EvalCaseResult ────────────────────────────────────────
+
+/// ScoredTrace::from_case_result correctly averages metric scores.
+#[test]
+fn scored_trace_from_case_result_averages_metric_scores() {
+    let result = make_case_result("test-case", 0.8);
+    let trace = ScoredTrace::from_case_result(&result);
+    assert_eq!(trace.case_id, "test-case");
+    assert!(
+        (trace.score - 0.8).abs() < 1e-9,
+        "score should be 0.8, got {}",
+        trace.score
+    );
+}
+
+/// ScoredTrace::from_case_result handles zero metric results gracefully.
+#[test]
+fn scored_trace_from_case_result_handles_no_metrics() {
+    let inv = mock_invocation(&[], Some("done"), 0.0, 0);
+    let result = EvalCaseResult {
+        case_id: "empty".to_string(),
+        invocation: inv,
+        metric_results: vec![],
+        verdict: Verdict::Fail,
+    };
+    let trace = ScoredTrace::from_case_result(&result);
+    assert!((trace.score - 0.0).abs() < 1e-9);
+}
+
+// ─── Multiple traces, multiple cases ────────────────────────────────────────
+
+/// Multiple traces for different cases produce the correct number of JSONL lines.
+#[test]
+fn chatml_multiple_traces_produce_one_line_each() {
+    let traces = vec![
+        make_trace("a", 1.0, Some("resp-a")),
+        make_trace("b", 1.0, Some("resp-b")),
+        make_trace("c", 1.0, Some("resp-c")),
+    ];
+    let opts = ExportOptions::chatml_sft(0.0);
+    let bytes = ChatMlExporter.export(&traces, &opts).unwrap();
+    let output = String::from_utf8(bytes).unwrap();
+    let lines: Vec<&str> = output.lines().collect();
+    assert_eq!(lines.len(), 3);
+
+    // All lines must be valid JSON
+    for line in &lines {
+        serde_json::from_str::<serde_json::Value>(line).expect("each line must be valid JSON");
+    }
+}

--- a/specs/023-eval-trajectory-matching/spec.md
+++ b/specs/023-eval-trajectory-matching/spec.md
@@ -148,6 +148,43 @@ An evaluator wants to assert that the agent's actions produced the expected side
 
 ---
 
+---
+
+### User Story 8 — Training-format Trace Export (Priority: P3)
+
+An evaluator wants to export collected execution traces as fine-tuning data for
+LLMs (SFT, DPO, RLHF). After running an eval suite the evaluator selects a
+format (ChatML/SFT, DPO pairs, ShareGPT), applies a quality threshold to filter
+low-score traces, and exports a JSONL file suitable for uploading to a
+fine-tuning pipeline. This closes the loop between evaluation and model
+improvement without requiring manual data wrangling.
+
+**Why this priority**: Useful for teams running RL/SFT fine-tuning on top of
+eval results, but not required for basic evaluation or deployment gating (P3).
+
+**Independent Test**: Run an eval suite, collect `EvalCaseResult` values,
+convert to `ScoredTrace` via `ScoredTrace::from_case_result`, export with
+`ChatMlExporter`, and assert the output is valid JSONL with the correct role
+structure.
+
+**Acceptance Scenarios**:
+
+1. **Given** a list of scored traces above the quality threshold, **When**
+   exported as ChatML/SFT, **Then** the output is valid JSONL with
+   system/user/assistant turns and tool_calls entries for turns that used tools.
+2. **Given** a list of scored traces with a quality threshold set, **When**
+   exported, **Then** only traces whose score ≥ threshold appear in the output.
+3. **Given** two scored traces for the same case (one high-score, one
+   low-score), **When** exported as DPO pairs, **Then** the output contains one
+   JSON object with `chosen` (high-score) and `rejected` (low-score) sides.
+4. **Given** all traces are below the quality threshold, **When** exported,
+   **Then** the exporter returns `ExportError::NothingToExport`.
+5. **Given** a list of scored traces, **When** exported as ShareGPT, **Then**
+   the output contains `conversations` arrays with `from: "human"` /
+   `from: "gpt"` turns.
+
+---
+
 ### Edge Cases
 
 - **Empty golden path (no expected steps)**: Behavior varies by match mode. Exact: returns 0.0 if actual has any steps (length mismatch), 0.0 if both empty (0/1 matched). InOrder/AnyOrder: returns pass (vacuous truth — all zero expected calls were found). This follows standard evaluation framework semantics.

--- a/specs/023-eval-trajectory-matching/tasks.md
+++ b/specs/023-eval-trajectory-matching/tasks.md
@@ -245,6 +245,51 @@
 
 ---
 
+## Phase 14: User Story 8 — Training-format Trace Export (Priority: P3)
+
+**Purpose**: Export `Invocation` traces as fine-tuning data for LLM training
+pipelines (SFT, DPO, RLHF). Extends the eval crate with a new
+`training-export` feature gate.
+
+**Scope**: `eval/src/training.rs` + `eval/tests/training_export.rs` + spec
+artifacts. CLI `--export-training` flag is out of scope (future work).
+
+- [x] T095 Add `training-export` feature to `eval/Cargo.toml` (no additional deps required — all serialization uses existing `serde_json`).
+- [x] T096 Create `eval/src/training.rs` (feature-gated) with:
+  - `TrainingFormat` enum: `ChatMlSft`, `DpoPairs`, `ShareGpt`
+  - `ExportOptions` struct: `format`, `quality_threshold: f32`, `include_metadata: bool`
+  - `ScoredTrace` struct: `invocation: Invocation`, `score: f64`, `case_id: String`
+  - `ScoredTrace::from_case_result(result: &EvalCaseResult) -> Self` (averages metric scores)
+  - `TrainingExporter` trait: `fn export(&self, traces: &[ScoredTrace], opts: &ExportOptions) -> Result<Vec<u8>, ExportError>`
+  - `ExportError` enum: `Serialization`, `NotImplemented`, `NothingToExport`
+- [x] T097 Implement `ChatMlExporter` (full): JSONL with ChatML role/content/tool_calls schema per OpenAI convention, quality threshold filtering, optional metadata record.
+- [x] T098 Implement `DpoExporter`: group by `case_id`, pair highest vs lowest scoring trace per case as chosen/rejected; emit `NothingToExport` when no case has ≥ 2 traces.
+- [x] T099 Implement `ShareGptExporter`: `conversations` array with `from: system/human/gpt` turns; optional metadata; quality threshold filtering.
+- [x] T100 Implement `TrainingReporter` implementing the existing `Reporter` trait: converts `EvalSetResult.case_results` → `Vec<ScoredTrace>`, calls `export_traces`, returns `ReporterOutput::Artifact`.
+- [x] T101 Add `training` module and public re-exports to `eval/src/lib.rs` (behind `#[cfg(feature = "training-export")]`).
+- [x] T102 Write integration tests in `eval/tests/training_export.rs` (feature-gated):
+  - `chatml_export_produces_valid_jsonl_with_correct_turn_structure`
+  - `chatml_export_includes_tool_calls_on_assistant_turns`
+  - `chatml_export_includes_metadata_when_requested`
+  - `chatml_export_omits_metadata_when_not_requested`
+  - `quality_threshold_filters_low_score_traces`
+  - `export_empty_when_all_traces_below_threshold`
+  - `export_empty_slice_returns_nothing_to_export`
+  - `dpo_pairs_created_from_high_and_low_score_on_same_case`
+  - `dpo_pairs_emits_nothing_for_single_trace_case`
+  - `dpo_pairs_uses_highest_and_lowest_score_traces`
+  - `sharegpt_export_produces_valid_jsonl_with_human_gpt_turns`
+  - `scored_trace_from_case_result_averages_metric_scores`
+  - `scored_trace_from_case_result_handles_no_metrics`
+  - `chatml_multiple_traces_produce_one_line_each`
+- [x] T103 Verify `cargo test -p swink-agent-eval --features training-export` passes (14 new tests).
+- [x] T104 Verify `cargo test -p swink-agent-eval` (no features) passes — zero regressions.
+- [x] T105 Verify `cargo clippy -p swink-agent-eval --features training-export -- -D warnings` is clean.
+
+**Checkpoint**: `TrainingExporter` trait + ChatML/SFT (full), DPO pairs, ShareGPT exporters delivered. `TrainingReporter` integrates with existing `Reporter` trait. Score-based quality gate via `ExportOptions.quality_threshold`. All feature-gated under `training-export`.
+
+---
+
 ## Dependencies & Execution Order
 
 ### Phase Dependencies

--- a/specs/024-eval-runner-governance/spec.md
+++ b/specs/024-eval-runner-governance/spec.md
@@ -153,6 +153,7 @@ An evaluator wants to check whether agent runs stayed within acceptable resource
 ### Key Entities
 
 - **EvalRunner**: The orchestrator that executes an evaluation suite, applying evaluators to each case and producing aggregate results.
+- **TrainingReporter** (feature: `training-export`, spec 023 Phase 14): A [`Reporter`] implementation that converts an `EvalSetResult` into fine-tuning data (ChatML/SFT, DPO pairs, ShareGPT). Activated by composing it alongside other reporters. The export format and quality threshold are configured via `ExportOptions`. See `swink-agent-eval::training` for full documentation.
 - **EvalCase**: A single test case definition containing a prompt, expected behavior, and metadata. Loaded from a structured data file.
 - **Evaluator**: The abstraction for a scoring strategy. Receives a trajectory and produces a score. Custom implementations can be registered.
 - **EvaluatorRegistry**: A collection of evaluators applied to each case. Pre-populated with built-in defaults and extensible with custom evaluators.


### PR DESCRIPTION
## Summary
- `TrainingExporter` trait for exporting `Invocation` traces as fine-tuning data
- ChatML/SFT exporter: conversation-style JSONL with tool calls
- DPO pair generator: chosen/rejected from high/low-score traces per case
- ShareGPT exporter: community-format conversations
- `TrainingReporter` integrating with existing `Reporter` trait
- Score-based quality filtering via `ExportOptions.quality_threshold`
- Feature-gated: `training-export` in eval crate
- Updates spec 023 and 024 with training export user story and tasks

## Tasks completed
- TrainingFormat enum / ScoredTrace / ExportOptions types
- TrainingExporter trait
- ChatML/SFT exporter (full)
- DPO pair generator
- ShareGPT exporter
- TrainingReporter (Reporter impl)
- Integration tests (14 tests)

## Test plan
- [x] cargo test -p swink-agent-eval --features training-export passes (14 new tests)
- [x] cargo test -p swink-agent-eval (no features) passes — no regressions
- [x] cargo clippy --features training-export -- -D warnings clean
- [x] cargo fmt --check clean

Part of #899
🤖 Generated with [Claude Code](https://claude.com/claude-code)