### PR TITLE
fix(ci): correct dependabot login in pr-gate lgtm allowlist

### DIFF
--- a/.github/contributors.json
+++ b/.github/contributors.json
@@ -1,3 +1,3 @@
 {
-  "lgtm": ["jwesleye", "unseriousAI", "dependabot"]
+  "lgtm": ["jwesleye", "unseriousAI", "dependabot[bot]"]
 }


### PR DESCRIPTION
## Summary
- Replace `dependabot` with `dependabot[bot]` in `.github/contributors.json` so the PR gate's `approved.lgtm.includes(author)` matches the actual `pr.user.login` from the GitHub webhook payload.
- Without this, every Dependabot PR (verified on #976, #975, #967, #966, ...) hit Gate 1 and was auto-closed with the "maintainer approval required" comment.

## Why
`gh api /repos/.../pulls/976` returns `user.login = "dependabot[bot]"` (`Bot` type). The lgtm check uses strict string equality, and `["dependabot"].includes("dependabot[bot]")` is false.

## Test plan
- [ ] Land on `integration`; confirm next Dependabot patch-updates run is not auto-closed.
- [ ] Recreate the most recent grouped patch update (#976) and verify the gate workflow run completes without closing the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)