### PR TITLE
chore(deps): bump openssl from 0.10.78 to 0.10.79

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3205,15 +3205,14 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl"
-version = "0.10.78"
+version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -3237,9 +3236,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.114"
+version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
## Summary
- Bump `openssl` 0.10.78 → 0.10.79 (and `openssl-sys` 0.9.114 → 0.9.115) in `Cargo.lock`.
- Addresses Dependabot alert #14 (**HIGH**): undefined behavior in `X509Ref::ocsp_responders` for certificates with non-UTF-8 OCSP URLs (vulnerable `>= 0.9.7, < 0.10.79`).

## Why a manual PR
Dependabot's auto-generated PR #975 was auto-closed by the PR gate due to the `dependabot` vs `dependabot[bot]` username mismatch (fixed in #985). The dependabot branch was deleted on close, so `@dependabot reopen/recreate` is a no-op. Bumping by hand is faster than waiting for the next scheduled run.

## Test plan
- [ ] CI green (gate, check, msrv, features, deny, semver).
- [ ] Dependabot alert #14 closes on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)